### PR TITLE
Add privacy_type as a mandatory field

### DIFF
--- a/doc/threat_exchange.md
+++ b/doc/threat_exchange.md
@@ -369,7 +369,7 @@ ISO 8601 date format;
 * **indicator** - The indicator data being submitted.
 * passwords - The MD5s of passwords associated with this indicator. Intended
 for compromised credentials.
-* privacy\_type - The kind of privacy for the indicator, see values
+* **privacy\_type** - The kind of privacy for the indicator, see values
   defined below.
 * privacy\_members - Some types of privacy require you to specify who can
   or cannot see the indicator.
@@ -394,6 +394,7 @@ Example submission of a malicious domain:
       &threat_type=MALICIOUS_DOMAIN
       &status=MALICIOUS
       &description=This%20domain%20was%20hosting%20malware
+      &privacy_type=VISIBLE
 
 
 Data returned:
@@ -405,8 +406,9 @@ Data returned:
 
 ## Setting Privacy In ThreatExchange
 
-All submissions to the ThreatExchange API allow for limiting the visibility of
-any indicator.  Currently, ThreatExchange supports three levels of visibility: 
+All submissions to the ThreatExchange API require setting a privacy type.
+This choice can limit the visibility of any indicator, if desired.
+ThreatExchange supports three levels of visibility:
 
 * allow all members;
 * allow specific members; and
@@ -431,7 +433,7 @@ while the rest of the member community can.
 
 * A comma-delimited list of AppIDs allowed or prohibited from viewing an indicator in
 accordance with the PRIVACY\_TYPE.  NOTE:  When limiting visibility, it is not necessary
-to include your own AppID.
+to include your own AppID. It will be added automatically if necessary.
 
 
 Example submission of a malicious domain with the privacy set to just two members
@@ -447,7 +449,6 @@ Example submission of a malicious domain with the privacy set to just two member
       &privacy_type=HAS_WHITELIST
       &privacy_members=123456789,9012345678
 
-Currently, all submissions default to a PRIVACY\_TYPE of VISIBLE.
 
 ## Editing Exisiting Data
 

--- a/php/BaseUpload.php
+++ b/php/BaseUpload.php
@@ -16,15 +16,15 @@ require_once(__ROOT__.'/ThreatExchangeConfig.php');
 ThreatExchangeConfig::init();
 
 abstract class BaseUpload {
-  
+
   private $fields = null;
 
   public abstract function getEndpoint();
-  
+
   protected abstract function getTypeSpecificFields();
-  
+
   protected abstract function getPostDataFromCSV($data_row);
-  
+
   public function getFields() {
     if (!$this->fields) {
       $this->fields = array(
@@ -37,7 +37,7 @@ abstract class BaseUpload {
         'status',
       );
       $this->fields = array_merge(
-        $this->fields, 
+        $this->fields,
         $this->getTypeSpecificFields()
       );
     }
@@ -71,7 +71,7 @@ abstract class BaseUpload {
   public function hasValidOptions($options) {
     return !isset($options['h']) && isset($options['f']);
   }
-  
+
   public function parseDataFile($file_name, $options) {
     if (!file_exists($file_name)) {
       throw new Exception(
@@ -82,8 +82,8 @@ abstract class BaseUpload {
     $header = null;
     $entries = array();
     $def_privacy_data = $this->getPrivacyDataFromOptions($options);
-    $def_description = (isset($options['d'])) 
-      ? $options['d'] 
+    $def_description = (isset($options['d']))
+      ? $options['d']
       : 'No description provided';
     $def_tag = (isset($options['g'])) ? $options['g'] : '';
     while (($row = fgetcsv($fh)) !== FALSE) {
@@ -93,14 +93,14 @@ abstract class BaseUpload {
       if (strpos($row[0], '#') === 0) {
         continue; // skip lines with comments
       }
-      
+
       if (!$header) {
         $header = $row;
         continue;
       }
-      
+
       $post_data = $this->getPostDataFromCSV(array_combine($header, $row));
-      
+
       // fold in the defaults provided
       if (!isset($post_data['description'])) {
         $post_data['description'] = $def_description;
@@ -111,12 +111,12 @@ abstract class BaseUpload {
       if (!isset($post_data['privacy_type']) && count($def_privacy_data) > 0) {
         $post_data = array_merge($post_data, $def_privacy_data);
       }
-      
+
       $entries[] = $post_data;
     }
     return $entries;
   }
-  
+
   private function getPrivacyDataFromOptions($options) {
     $privacy_data = array();
     if (isset($options['p'])) {
@@ -130,7 +130,9 @@ abstract class BaseUpload {
           $privacy_data['privacy_type'] = 'HAS_WHITELIST';
           break;
         default:
-          // do nothing
+          throw new Exception(
+            'You must set a privacy type!'
+          );
           break;
       }
     }
@@ -152,7 +154,7 @@ abstract class BaseUpload {
 
     return $uri;
   }
-  
+
   public function getResultsAsCSV($results) {
     var_dump($results);
     $csv = "# ThreatExchange Results - uploaded at ".strftime('%c')."\n".

--- a/threat_indicators/post_compromised_credentials.py
+++ b/threat_indicators/post_compromised_credentials.py
@@ -59,7 +59,9 @@ def parse_args(args):
         raise Exception('You must specify a description')
 
     privacy_members = None
-    if args.privacy_type is None or args.privacy_type == 'VISIBLE':
+    if args.privacy_type is None:
+        raise Exception('You must specify a privacy_type')
+    if args.privacy_type == 'VISIBLE':
         privacy_type = 'VISIBLE'
         share_level = 'GREEN'
     elif args.privacy_type == 'HAS_WHITELIST' or \


### PR DESCRIPTION
We are going to require an explicit privacy_type setting on all requests starting next week. This pull request updates the documentation and the PHP and Python code to meet this requirement.