### PR TITLE
Enforcing PRIVACY_TYPE in pytx/UI

### DIFF
--- a/pytx/pytx/malware.py
+++ b/pytx/pytx/malware.py
@@ -1,3 +1,7 @@
+import base64
+import cStringIO
+import zipfile
+
 from common import Common
 from vocabulary import Malware as m
 from vocabulary import ThreatExchange as t
@@ -27,3 +31,54 @@ class Malware(Common):
         m.VICTIM_COUNT,
         m.XPI
     ]
+
+    _unique = [
+        'zfh',
+        'zf',
+        'rfh',
+        'rf',
+    ]
+
+    @property
+    def zfh(self):
+        """
+        Return a file handle of the base64-decoded sample in a zip file.
+        """
+
+        if self.get(m.SAMPLE) is None:
+            self.details()
+        zfh = cStringIO.StringIO()
+        zfh.write(base64.b64decode(self.get(m.SAMPLE)))
+        zfh.seek(0)
+        return zfh
+
+    @property
+    def zf(self):
+        """
+        Return the base64-decoded sample in a zip file.
+        """
+
+        return self.zfh.read()
+
+    @property
+    def rfh(self):
+        """
+        Return a file handle of the base64-decoded and unzipped sample.
+        """
+
+        zfh = self.zfh
+        rfh = cStringIO.StringIO()
+        with zipfile.ZipFile(zfh, 'r') as zf:
+            for entry in zf.infolist():
+                rfh.write(zf.read(entry.filename,
+                                  self.get(m.PASSWORD)))
+                rfh.seek(0)
+        return rfh
+
+    @property
+    def rf(self):
+        """
+        Return the base64-decoded and unzipped sample.
+        """
+
+        return self.rfh.read()

--- a/pytx/pytx/threat_exchange_member.py
+++ b/pytx/pytx/threat_exchange_member.py
@@ -20,6 +20,9 @@ class ThreatExchangeMember(object):
         tem.NAME
     ]
 
+    _unique = [
+    ]
+
     _access_token = None
 
     def __init__(self, **kwargs):

--- a/pytx/pytx/threat_indicator.py
+++ b/pytx/pytx/threat_indicator.py
@@ -28,3 +28,6 @@ class ThreatIndicator(Common):
         ti.THREAT_TYPES,
         ti.TYPE
     ]
+
+    _unique = [
+    ]

--- a/pytx/pytx/vocabulary.py
+++ b/pytx/pytx/vocabulary.py
@@ -4,7 +4,7 @@ class ThreatExchange(object):
     """
 
     URL             = 'https://graph.facebook.com/'
-    VERSION         = 'v2.3/'
+    VERSION         = '' #'v2.3/'
     ACCESS_TOKEN    = 'access_token'
     DEFAULT_LIMIT   = 500
     MAX_LIMIT       = 1000

--- a/pytx/pytx/vocabulary.py
+++ b/pytx/pytx/vocabulary.py
@@ -4,7 +4,7 @@ class ThreatExchange(object):
     """
 
     URL             = 'https://graph.facebook.com/'
-    VERSION         = '' #'v2.3/'
+    VERSION         = 'v2.3/'
     ACCESS_TOKEN    = 'access_token'
     DEFAULT_LIMIT   = 500
     MAX_LIMIT       = 1000

--- a/ui/js/dashboard.js
+++ b/ui/js/dashboard.js
@@ -317,14 +317,17 @@ $(document).ready(function() {
             $('#add-new-object-form [data-field]').each(function(i, obj) {
                 var field = $(obj).attr('data-field');
                 var value = $(obj).val();
-                if (!!value && value.length > 0
-                    && field != 'privacy_type'
-                    && field != 'privacy_members') {
+                if (!!value && value.length > 0) {
                     data[field] = value;
                 }
             });
-            var url = fbte_url + $(this).attr('data-id') + "/"
-            post_request(url, data, $('span#add-new-object-results'));
+            var res_obj = $('span#add-new-object-results');
+            if ("privacy_type" in data) {
+                var url = fbte_url + $(this).attr('data-id') + "/"
+                post_request(url, data, res_obj);
+            } else {
+                res_obj.text("Must have a privacy type!");
+            }
             return false;
         }
     });
@@ -346,8 +349,13 @@ $(document).ready(function() {
                     data[field] = value;
                 }
             });
-            var url = threat_indicators;
-            post_request(url, data, $('span#add-new-object-results'));
+            var res_obj = $('span#add-new-object-results');
+            if ("privacy_type" in data) {
+                var url = threat_indicators;
+                post_request(url, data, res_obj);
+            } else {
+                res_obj.text("Must have a privacy type!");
+            }
             return false;
         }
     });

--- a/ui/js/vocabulary.js
+++ b/ui/js/vocabulary.js
@@ -1,6 +1,6 @@
 var v_ThreatExchange = {
     URL             : "https://graph.facebook.com/",
-    VERSION         : "", //"v2.4/",
+    VERSION         : "v2.3/",
     ACCESS_TOKEN    : "access_token",
     DEFAULT_LIMIT   : 500,
     MAX_LIMIT       : 5000,

--- a/ui/js/vocabulary.js
+++ b/ui/js/vocabulary.js
@@ -1,6 +1,6 @@
 var v_ThreatExchange = {
     URL             : "https://graph.facebook.com/",
-    VERSION         : "v2.0/",
+    VERSION         : "", //"v2.4/",
     ACCESS_TOKEN    : "access_token",
     DEFAULT_LIMIT   : 500,
     MAX_LIMIT       : 5000,


### PR DESCRIPTION
Enforce the PRIVACY_TYPE requirement for submitting new Indicators in pytx and perform a quick check in the UI (which pre-populates the PRIVACY_TYPE dropdown anyways so unless someone is abusing the JS it should already work).

Added some helper properties to the Malware object:

    .zfh - return a file handle for the b64 decoded zip file
    .zf  - return the raw b64 decoded zip file
    .rfh - return a file handle for the b64 decoded and unzipped file
    .rf  - return the raw b64 decoded and unzipped file

These properties should be flexible enough for people who want to utilize the sample without having to do the decode/unzip dance at whatever stage they are looking to get to. Required adding a `_unique` class attribute to track properties we don't want people to change.

Fixed a couple other bugs with saving objects to ThreatExchange in pytx:

- Don't keep adding the ID to `_DETAILS` making it an invalid URL.
- Use the Broker to submit new content to ThreatExchange.
- `.save()` does not require a url to be passed in.
- Remove the hard version set for pytx/UI to take advantage of the features in newer versions.