### PR TITLE
Privacy Type is mandatory for IOC submissions now in ruby library

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ThreatExchange (0.0.8)
+    ThreatExchange (0.0.9)
       json
       rest-client
 

--- a/ruby/example/ThreatExchangeTest.rb
+++ b/ruby/example/ThreatExchangeTest.rb
@@ -25,7 +25,8 @@ spinner{ parse(TEClient.indicator_pq(query)) }
 banner('Example #5 IOC Submission')
 iocdata = {indicator: '63E070B2B434D07226C73A5773BFCC8D', type: 'HASH_MD5',
            description: 'API Test Ignore MD5sum of mcgrew',
-           status: 'NON_MALICIOUS' }
+           status: 'NON_MALICIOUS',
+           privacy_type: 'VISIBLE' }
 spinner{ parse(TEClient.new_ioc(iocdata)) }
 #------------------------------------------------------------------------------
 banner('Example #6 IOC Update')

--- a/ruby/lib/ThreatExchange.rb
+++ b/ruby/lib/ThreatExchange.rb
@@ -132,11 +132,15 @@ module ThreatExchange
 
     def new_ioc(data={})
       data[:access_token] = @access_token
-      begin
-        response = RestClient.post "#{@baseurl}/threat_indicators", data
-        return response
-      rescue => e
-        e.inspect
+      if data.has_key?(:privacy_type)
+        begin
+          response = RestClient.post "#{@baseurl}/threat_indicators", data
+          return response
+        rescue => e
+          e.inspect
+        end
+      else 
+        puts "You must set a privacy_type in your query"
       end
     end
 

--- a/ruby/lib/ThreatExchange/version.rb
+++ b/ruby/lib/ThreatExchange/version.rb
@@ -1,3 +1,3 @@
 module ThreatExchange
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end


### PR DESCRIPTION
All IOC submissions must contain a privacy type key in the hash submitted to the method now.