### PR TITLE
Add member email to pytx and UI.

### DIFF
--- a/pytx/pytx/threat_exchange_member.py
+++ b/pytx/pytx/threat_exchange_member.py
@@ -17,7 +17,8 @@ class ThreatExchangeMember(object):
 
     _fields = [
         tem.ID,
-        tem.NAME
+        tem.NAME,
+        tem.EMAIL
     ]
 
     _unique = [

--- a/pytx/pytx/vocabulary.py
+++ b/pytx/pytx/vocabulary.py
@@ -123,6 +123,7 @@ class ThreatExchangeMember(object):
 
     ID      = Common.ID
     NAME    = 'name'
+    EMAIL   = 'email'
 
 
 class ThreatIndicator(object):

--- a/ui/js/api.js
+++ b/ui/js/api.js
@@ -107,7 +107,8 @@ function get_members() {
                 .css('max-height', '500px')
                 .css('overflow-y', 'auto');
             $.each(json.data, function(idx, member){
-                html.append(member.name + "<br />");
+                var mailto = '<a href="mailto:' + member.email + '">' + member.name + '</a>';
+                html.append(mailto + "<br />");
             });
             $('#member-popover-content').html(html);
             $('#member-popover').popover('show');


### PR DESCRIPTION
I had a quick second :)

Exposes the email of a ThreatExchangeMember in pytx. Also when you drop
the Members menu down in the UI it will create a mailto link with the
POC email address.