### PR TITLE
add fields selection to object pull

### DIFF
--- a/pytx/pytx/common.py
+++ b/pytx/pytx/common.py
@@ -145,7 +145,7 @@ class Common(object):
 
     @classmethod
     def objects(cls, text=None, strict_text=False, type_=None, threat_type=None,
-                limit=None, since=None, until=None, __raw__=None,
+                fields=None, limit=None, since=None, until=None, __raw__=None,
                 full_response=False, dict_generator=False):
         """
         Get objects from ThreatExchange.
@@ -158,6 +158,8 @@ class Common(object):
         :type type_: str
         :param threat_type: The Threat type to limit to.
         :type threat_type: str
+        :param fields: Select specific fields to pull
+        :type fields: str, list
         :param limit: The maximum number of objects to return.
         :type limit: int, str
         :param since: The timestamp to limit the beginning of the search.
@@ -186,6 +188,7 @@ class Common(object):
                 strict_text=strict_text,
                 type_=type_,
                 threat_type=threat_type,
+                fields=fields,
                 limit=limit,
                 since=since,
                 until=until,

--- a/pytx/pytx/request.py
+++ b/pytx/pytx/request.py
@@ -67,8 +67,9 @@ class Broker(object):
     @staticmethod
     def validate_limit(limit):
         """
-        Verifies the limit provided is valid and within the max limit Facebook
-        will allow you to use.
+        Verifies the limit provided is a valid number, use -1 to fetch everything.
+        If the limit is greater than 1,000 the generator will still fetch 1,000
+        results at a time, but will stop at the defined limit.
 
         :param limit: Value to verify is a valid limit.
         :type limit: int, str
@@ -79,11 +80,6 @@ class Broker(object):
             int(limit)
         except ValueError, e:
             raise pytxValueError(e)
-        if limit > t.MAX_LIMIT:
-            raise pytxValueError(
-                "limit cannot exceed %s (default: %s)" % (t.MAX_LIMIT,
-                                                          t.DEFAULT_LIMIT)
-            )
         return
 
     @staticmethod
@@ -276,9 +272,11 @@ class Broker(object):
             params = dict()
 
         if total is None:
-            total = t.NO_TOTAL
+            total = t.DEFAULT_LIMIT
         if total == t.MIN_TOTAL:
             yield None
+        if total == t.NO_TOTAL:
+            params['limit'] = t.MAX_LIMIT
         next_ = True
         while next_:
             results = cls.get(url, params)

--- a/pytx/pytx/request.py
+++ b/pytx/pytx/request.py
@@ -151,7 +151,7 @@ class Broker(object):
 
     @classmethod
     def build_get_parameters(cls, text=None, strict_text=None, type_=None, threat_type=None,
-                             limit=None, since=None, until=None):
+                             fields=None, limit=None, since=None, until=None):
         """
         Validate arguments and convert them into GET parameters.
 
@@ -162,7 +162,9 @@ class Broker(object):
         :param type_: The Indicator type to limit to.
         :type type_: str
         :param threat_type: The Threat type to limit to.
-        :type threat_type: str      
+        :type threat_type: str
+        :param fields: Select specific fields to pull
+        :type fields: str, list
         :param limit: The maximum number of objects to return.
         :type limit: int, str
         :param since: The timestamp to limit the beginning of the search.
@@ -183,6 +185,8 @@ class Broker(object):
             params[t.TYPE] = type_
         if threat_type:
             params[t.THREAT_TYPE] = threat_type
+        if fields:
+            params[t.FIELDS] = ','.join(fields) if isinstance(fields, list) else fields
         if limit:
             params[t.LIMIT] = limit
         if since:

--- a/pytx/pytx/vocabulary.py
+++ b/pytx/pytx/vocabulary.py
@@ -6,7 +6,7 @@ class ThreatExchange(object):
     URL             = 'https://graph.facebook.com/'
     VERSION         = 'v2.3/'
     ACCESS_TOKEN    = 'access_token'
-    DEFAULT_LIMIT   = 500
+    DEFAULT_LIMIT   = 25
     MAX_LIMIT       = 1000
 
     # GET

--- a/pytx/pytx/vocabulary.py
+++ b/pytx/pytx/vocabulary.py
@@ -6,8 +6,7 @@ class ThreatExchange(object):
     URL             = 'https://graph.facebook.com/'
     VERSION         = 'v2.3/'
     ACCESS_TOKEN    = 'access_token'
-    DEFAULT_LIMIT   = 25
-    MAX_LIMIT       = 1000
+    MAX_LIMIT       = 500
 
     # GET
     MALWARE_ANALYSES        = 'malware_analyses/'

--- a/pytx/scripts/get_compromised_credentials.py
+++ b/pytx/scripts/get_compromised_credentials.py
@@ -82,8 +82,15 @@ def get_parser():
 if __name__ == '__main__':
     args = get_parser().parse_args()
     
-    handle = open(args.output, 'w') if args.output else None
-    args.limit = te.DEFAULT_LIMIT if args.limit is None or not args.limit.isdigit() else int(args.limit)
+    if args.output is not None:
+        handle = open(args.output, 'w')
+    else:
+        handle = None    
+
+    if args.limit is None or not args.limit.isdigit():
+        args.limit = te.DEFAULT_LIMIT
+    else: 
+        int(args.limit)
 
     start = int(time.time())
     run_query(args, handle)


### PR DESCRIPTION
Allow fields selection for object pull, so you can fetch fields that are not pulled by default like passwords
This is useful for large fetches to avoid using ThreatIndicator.details() for each IOC

Also fixed DEFAULT_LIMIT to meet the actual default on the graph api, and then modernized the sample and made some use of DEFAULT_LIMIT