### PR TITLE
Removes blacklist from privacy options

### DIFF
--- a/doc/threat_exchange.md
+++ b/doc/threat_exchange.md
@@ -429,8 +429,6 @@ fields at the time of a create or edit submission to the API:
 * VISIBLE - All members of ThreatExchange can see the indicator
 * HAS\_WHITELIST - Only those AppIDs specified in PRIVACY\_MEMBERS can see the
 indicator.
-* HAS\_BLACKLIST - The AppIDs specified in PRIVACY\_MEMBERS cannot see the indicator,
-while the rest of the member community can.
 
 **Name: PRIVACY\_MEMBERS**  
 **Type: list of App IDs**  


### PR DESCRIPTION
We are removing the option HAS_BLACKLIST. Effective 9 Jun, this option will be removed from the system. Any indicators set to this value will be changed to HAS_WHITELIST, with a whitelist of the submitters of that indicator.