### PR TITLE
Removing HAS_BLACKLIST from vocabulary.

### DIFF
--- a/pytx/pytx/vocabulary.py
+++ b/pytx/pytx/vocabulary.py
@@ -310,7 +310,6 @@ class PrivacyType(object):
 
     VISIBLE         = "VISIBLE"
     HAS_WHITELIST    = "HAS_WHITELIST"
-    HAS_BACKLIST     = "HAS_BLACKLIST"
 
 
 class Role(object):


### PR DESCRIPTION
HAS_BLACKLIST is being removed as an option from the system.