### PR TITLE
Remove HAS_BLACKLIST from UI dropdown.

### DIFF
--- a/ui/js/vocabulary.js
+++ b/ui/js/vocabulary.js
@@ -230,7 +230,6 @@ var v_AVStatus = {
 var v_PrivacyType = {
     VISIBLE         : "VISIBLE",
     HAS_WHITELIST    : "HAS_WHITELIST",
-    HAS_BACKLIST     : "HAS_BLACKLIST",
 }
 
 var v_Role = {


### PR DESCRIPTION
HAS_BLACKLIST is being removed from the system. This removes it from the
UI dropdown when adding/editing a Threat Indicator.

Should have added this in the previous PR. My bad! :)