### PR TITLE
Have pytx use TLS1.0+ to avoid bad SSL warnings and avoid using bad SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pytx/build
 pytx/dist
 pytx/pytx.egg-info
 pytx/docs/_build
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ pytx/dist
 pytx/pytx.egg-info
 pytx/docs/_build
 .DS_Store
+.tox/
+.coverage

--- a/pytx/Makefile
+++ b/pytx/Makefile
@@ -1,0 +1,15 @@
+.DELETE_ON_ERROR:
+
+all:
+	echo >&2 "Must specify target."
+
+test:
+	tox
+
+clean:
+	rm -rf build/ dist/ *.egg-info/ .tox/
+	rm -f .coverage
+	find . -name '*.pyc' -delete
+	find . -name '__pycache__' -delete
+
+.PHONY: all test clean

--- a/pytx/requirements-dev.txt
+++ b/pytx/requirements-dev.txt
@@ -1,0 +1,3 @@
+-e .
+coverage
+pytest

--- a/pytx/requirements.txt
+++ b/pytx/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests[security]

--- a/pytx/setup.py
+++ b/pytx/setup.py
@@ -29,7 +29,7 @@ setup(
     keywords="facebook threatexchange",
     url='https://www.github.com/facebook/ThreatExchange',
     packages=find_packages(exclude=['docs', 'tests']),
-    install_requires=['requests'],
+    install_requires=['requests[security]'],
     scripts=['scripts/get_compromised_credentials.py',
              'scripts/get_indicators.py',
              'scripts/get_members.py',

--- a/pytx/tox.ini
+++ b/pytx/tox.ini
@@ -1,0 +1,15 @@
+# This tox file mainly ensures that requirements properly install with many versions of python
+[tox]
+project = pytx
+envlist = py26,py27,py33,py34
+
+[testenv]
+install_command = pip install --use-wheel {opts} {packages}
+deps = -rrequirements-dev.txt
+commands = 
+    {envpython} --version
+    {envpython} setup.py test
+    coverage --version
+    coverage erase
+    coverage run --omit=.tox/*,{envdir}/* -m pytest {posargs:tests}
+    coverage report -m


### PR DESCRIPTION
**Let's use TLS!**
This is issue #32

The fix here is real simple. Install the option `secure` requirements for the `requests` package.
See more @ http://stackoverflow.com/questions/29099404/ssl-insecureplatform-error-when-using-requests-package

**.gitignore**
Quick update. Add `.DS_Store` which OSX likes to litter the filesystem with.