### PR TITLE
No more access tokens in code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pytx/docs/_build
 .DS_Store
 .tox/
 .coverage
+.pytx

--- a/pytx/docs/quickstart.rst
+++ b/pytx/docs/quickstart.rst
@@ -128,11 +128,9 @@ leveraging the classes you can do so:
 
 .. code-block :: python
 
-   from pytx import init
    from pytx.request import Broker
    from pytx.vocabulary import ThreatExchange as te
 
-   init()
    b = Broker()
    url = te.URL + te.THREAT_INDICATORS
    params = {te.TEXT: "www.facebook.com"}

--- a/pytx/docs/quickstart.rst
+++ b/pytx/docs/quickstart.rst
@@ -11,30 +11,31 @@ the form of:
 The app-id is public knowledge but your app-secret is sensitive. These values
 are provided to you once you've obtained access to ThreatExchange.
 
-pytx comes with an init() that allows you to provide your access token in
-several ways. You *must* init() before pytx will function as the rest of pytx
-will need your access token to make requests properly. Here are some examples of
-how to provide your access token:
+pytx will try to find an access token to use or an access token can be passed to
+pytx.access_token.init(). pytx needs an access token before it will function and
+can properly make requests properly. Here are some examples of how to provide
+your access token:
 
 .. code-block :: python
 
-   from pytx import init
+  from pytx import init
 
-   # Provide your app-id and app-secret individually
-   init(app_id='<app-id>', app_secret='<app-secret>')
+  # Use environment variables to build the access token.
+  # 1. Use the value of the 'TX_ACCESS_TOKEN' environment variable.
+  # 2. Use the concatenation of the 'TX_APP_ID' and 'TX_APP_SECRET' environment variables.
+  # There is no need to call init() if the environment variables are set.
 
-   # Provide a file which contains your app-id and app-secret.
-   # File should be in the format of:
-   # - app-id and app-secret on separate lines, or
-   # - app-id|app-secret on one line
-   init(token_file='/path/to/token/file')
+  # Use a .pytx file which contains your app-id and app-secret.
+  # File should be: 'app-id|app-secret' on one line
+  # pytx will use either '$PWD/.pytx' or ~/.pytx' if they are found.
+  # There is no need to call init() if the environment variables are set.
 
-   # Use environment variables to build the access token.
-   # - TX_ACCESS_TOKEN: The fully-formatted access token to use.
-   # - TX_APP_ID: The app-id to use.
-   # - TX_APP_SECRET: The app-secret to use.
-   # If TX_ACCESS_TOKEN is found it will be used first.
-   init()
+  # 4. Use the concatenation of the app_id and app_secret parameters
+  init(app_id='<app-id>', app_secret='<app-secret>')
+
+  # 5. Use the first line of the file 'token_file'
+  init(token_file='/path/to/token/file')
+
 
 If you need to get the value of the access token pytx is using programmatically,
 you can do something like the following:

--- a/pytx/pytx/access_token.py
+++ b/pytx/pytx/access_token.py
@@ -14,12 +14,12 @@ def _read_token_file(token_file):
 
     :param token_file: The full path and filename where to find the access token.
     :type token_file: str
-    :returns: enumerable of strs
+    :returns: str
     :raises: :class:`errors.pytxIniterror`    
     """
     try:
         with open(token_file, 'r') as infile:
-            return [line.strip() for line in infile.readlines()]
+            return infile.readline().strip()
     except IOError as e:
         raise pytxInitError(str(e))
 
@@ -42,22 +42,26 @@ def get_access_token():
     return __ACCESS_TOKEN
 
 
+def _find_token_file():
+    for loc in [os.curdir, os.path.expanduser('~')]:
+        filepath = os.path.join(loc, '.pytx')
+        if os.path.exists(filepath):
+            return filepath
+
+    return None
+
+
 def init(app_id=None, app_secret=None, token_file=None):
     """
     Use the app_id and app_secret to store the access_token globally for all
     instantiated objects to leverage.
 
-    If you use token_file, you can either:
-        - put the app_id and app_token on separate lines
-        - combine them with a "|" in between on a single line
-
-    If no options are passed into this function, it will check for the following
-    environment variables:
-        - TX_APP_ID
-        - TX_APP_SECRET
-        - TX_ACCESS_TOKEN
-
-    The latter is the combined app_id and app_secret with a "|" in between.
+    There are many ways to specify the app_id and app_secret. In order, init will try:
+     1. Use the value of the 'TX_ACCESS_TOKEN' environment variable.
+     2. Use the concatenation of the 'TX_APP_ID' and 'TX_APP_SECRET' environment variables.
+     3. Use the first line of the file '$PWD/.pytx' or ~/.pytx'
+     4. Use the concatenation of the app_id and app_secret parameters
+     5. Use the first line of the file 'token_file'
 
     :param app_id: The APP-ID to use.
     :type app_id: str
@@ -69,29 +73,32 @@ def init(app_id=None, app_secret=None, token_file=None):
     """
     global __ACCESS_TOKEN
 
+    # 1. Use the value of the 'TX_ACCESS_TOKEN' environment variable.
+    __ACCESS_TOKEN = os.environ.get(te.TX_ACCESS_TOKEN, None)
+    if __ACCESS_TOKEN:
+        return
+
+    # 2. Use the concatenation of the 'TX_APP_ID' and 'TX_APP_SECRET' environment variables.
+    env_app_id = os.environ.get(te.TX_APP_ID, None)
+    env_app_secret = os.environ.get(te.TX_APP_SECRET, None)
+    if env_app_id and env_app_secret:
+        __ACCESS_TOKEN = env_app_id + '|' + env_app_secret
+        return
+
+    # 3. Use the first line of the file '$PWD/.pytx' or ~/.pytx'
+    filepath = _find_token_file()
+    if filepath:
+        __ACCESS_TOKEN = _read_token_file(filepath)
+        return
+
+    # 4. Use the concatenation of the app_id and app_secret parameters
     if app_id and app_secret:
         __ACCESS_TOKEN = app_id + '|' + app_secret
-    elif token_file:
-        token_list = _read_token_file(token_file)
+        return
 
-        if len(token_list) == 1:
-            __ACCESS_TOKEN = token_list[0]
-        elif len(token_list) == 2:
-            __ACCESS_TOKEN = token_list[0] + '|' + token_list[1]
-        else:
-            raise pytxInitError(
-                'Error generating access token from file: %s' % token_file
-            )
-    else:
-        access_token = os.environ.get(te.TX_ACCESS_TOKEN, None)
-        if access_token is None:
-            app_id = os.environ.get(te.TX_APP_ID, None)
-            app_secret = os.environ.get(te.TX_APP_SECRET, None)
-            if app_id is None or app_secret is None:
-                raise pytxInitError(
-                    'Environment variables not set.'
-                )
-            else:
-                access_token = app_id.strip() + '|' + app_secret.strip()
-        __ACCESS_TOKEN = access_token.strip()
-    return
+    # 5. Use the first line of the file 'token_file'
+    if token_file:
+        __ACCESS_TOKEN = _read_token_file(token_file)
+        return
+
+    raise pytxInitError('Unable to set access token.')

--- a/pytx/scripts/get_compromised_credentials.py
+++ b/pytx/scripts/get_compromised_credentials.py
@@ -1,20 +1,12 @@
 #!/usr/bin/env python
 
 import argparse
-import sys
 import time
 
-from pytx import init
 from pytx import ThreatIndicator
 from pytx.vocabulary import ThreatExchange as te
 from pytx.vocabulary import ThreatType as tt
 from pytx.vocabulary import Types as t
-
-
-app_id = '<app-id>'
-app_secret = '<app-secret>'
-
-init(app_id, app_secret)
 
 
 def get_results(options):
@@ -46,51 +38,40 @@ def process_result(handle, result):
 
 
 def run_query(options, handle):
-    try:
-        start = int(time.time())
-        print 'READING %s%s' % (te.URL, te.THREAT_INDICATORS)
-        results = get_results(options)
-    except Exception, e:
-        print str(e)
-        sys.exit(1)
+    start = int(time.time())
+    print 'READING %s%s' % (te.URL, te.THREAT_INDICATORS)
+    results = get_results(options)
 
     count = 0
     for result in results:
         process_result(handle, result)
         count += 1
 
-    try:
-        end = int(time.time())
-        print ('SUCCESS: Got %d indicators in %d seconds' %
-               (count, end - start))
-
-        if handle:
-            handle.close()
-    except Exception as e:
-        print (str(e))
+    end = int(time.time())
+    print ('SUCCESS: Got %d indicators in %d seconds' %
+           (count, end - start))
 
     return
 
 
-def get_parser():
-    parser = argparse.ArgumentParser(
-        description='Query ThreatExchange for Compromised Credentials',
-    )
-    parser.add_argument('-o', '--output')
-    parser.add_argument('-s', '--since')
-    parser.add_argument('-u', '--until')
-    parser.add_argument('-l', '--limit')
+def get_args():
+    parser = argparse.ArgumentParser(description='Query ThreatExchange for Compromised Credentials')
+    parser.add_argument('-o', '--output', default='/dev/stdout',
+                        help='[OPTIONAL] output file path.')
+    parser.add_argument('-s', '--since',
+                        help='[OPTIONAL] Start time for search')
+    parser.add_argument('-u', '--until',
+                        help='[OPTIONAL] End time for search')
+    parser.add_argument('-l', '--limit',
+                        help='[OPTIONAL] Maximum number of results')
 
-    return parser
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+    with open(args.output, 'w') as fp:
+        run_query(args, fp)
 
 if __name__ == '__main__':
-    args = get_parser().parse_args()
-    if args.output is not None:
-        handle = open(args.output, 'w')
-    else:
-        handle = None
-
-    start = int(time.time())
-    run_query(args, handle)
-    end = int(time.time())
-    print ('Total time elapsed: %d seconds' % (end - start))
+    main()

--- a/pytx/scripts/get_indicators.py
+++ b/pytx/scripts/get_indicators.py
@@ -2,41 +2,10 @@
 
 import argparse
 import json
-import sys
 import time
 
-from pytx import init
 from pytx import ThreatIndicator
 from pytx.vocabulary import ThreatExchange as te
-
-
-app_id = '<your-app-id>'
-app_secret = '<your-app-secret>'
-
-init(app_id, app_secret)
-
-
-def get_query(options):
-    '''
-    Builds a query string based on the specified options
-    '''
-
-    if options.type is None and options.text is None:
-        raise Exception('You must specify either a type or text')
-
-    fields = {}
-    if options.type is not None:
-        fields['type'] = options.type
-    if options.threat_type is not None:
-        fields['threat_type'] = options.threat_type
-    if options.text is not None:
-        fields['text'] = options.text
-    if options.since is not None:
-        fields['since'] = options.since
-    if options.until is not None:
-        fields['until'] = options.until
-
-    return fields
 
 
 def process_results(handle, data):
@@ -45,59 +14,54 @@ def process_results(handle, data):
     writes the indicators to the output file specified by 'handle', if any.
     Indicators are written one per line, formatted in JSON.
     '''
-    if handle is None:
-        return
-
     handle.write(json.dumps(data))
     handle.write('\n')
 
 
 def run_query(options, handle):
-    try:
-        start = int(time.time())
-        print 'READING %s%s' % (te.URL, te.THREAT_INDICATORS)
-        query = get_query(options)
-    except Exception, e:
-        print str(e)
-        sys.exit(1)
+    start = int(time.time())
+    print 'READING %s%s' % (te.URL, te.THREAT_INDICATORS)
+
+    # query = get_query(options)
+    if not options.type and not options.text:
+        raise Exception('You must specify either a type or text')
 
     count = 0
-    results = ThreatIndicator.objects(__raw__=query, dict_generator=True)
+    results = ThreatIndicator.objects(__raw__=options.__dict__, dict_generator=True)
     for result in results:
         process_results(handle, result)
         count += 1
 
-    try:
-        end = int(time.time())
-        print ('SUCCESS: Got %d indicators in %d seconds' %
-               (count, end - start))
-
-        if handle:
-            handle.close()
-    except Exception as e:
-        print (str(e))
+    end = int(time.time())
+    print ('SUCCESS: Got %d indicators in %d seconds' %
+           (count, end - start))
 
     return
 
 
-def get_parser():
+def get_args():
     parser = argparse.ArgumentParser(description='Query ThreatExchange')
-    parser.add_argument('-t', '--type')
-    parser.add_argument('-y', '--threat-type')
-    parser.add_argument('-x', '--text')
-    parser.add_argument('-o', '--output')
-    parser.add_argument('-s', '--since')
-    parser.add_argument('-u', '--until')
+    parser.add_argument('-t', '--type',
+                        help='[OPTIONAL] ThreatExchane type')
+    parser.add_argument('-y', '--threat-type',
+                        help='[OPTIONAL] ThreatExchane threat-type')
+    parser.add_argument('-x', '--text',
+                        help='[OPTIONAL] ThreatExchane search text')
+    parser.add_argument('-o', '--output', default='/dev/stdout',
+                        help='[OPTIONAL] output file path.')
+    parser.add_argument('-s', '--since',
+                        help='[OPTIONAL] Start time for search')
+    parser.add_argument('-u', '--until',
+                        help='[OPTIONAL] End time for search')
 
-    return parser
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+
+    with open(args.output, 'w') as fp:
+        run_query(args, fp)
 
 if __name__ == '__main__':
-    args = get_parser().parse_args()
-    if args.output is not None:
-        handle = open(args.output, 'w')
-    else:
-        handle = None
-    start = int(time.time())
-    run_query(args, handle)
-    end = int(time.time())
-    print ('Total time elapsed: %d seconds' % (end - start))
+    main()

--- a/pytx/scripts/get_members.py
+++ b/pytx/scripts/get_members.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python
 
-from pytx import init
 from pytx import ThreatExchangeMember
 from pytx.vocabulary import ThreatExchangeMember as tem
 
-app_id = '<your-app-id>'
-app_secret = '<your-app-secret>'
 
-init(app_id, app_secret)
+def run():
+    results = ThreatExchangeMember.objects()
+    for result in results:
+        print '"%s","%s"' % (result.get(tem.NAME),
+                             result.get(tem.ID))
 
-results = ThreatExchangeMember.objects()
-for result in results:
-    print '"%s","%s"' % (result.get(tem.NAME),
-                         result.get(tem.ID))
+
+def main():
+    run()
+
+if __name__ == '__main__':
+    main()

--- a/pytx/scripts/malware_api.py
+++ b/pytx/scripts/malware_api.py
@@ -1,14 +1,35 @@
 #!/usr/bin/env python
 
-from pytx import init
+import argparse
 from pytx import Malware
 
-md5s = ['681f1b31baa671a81e4b803dbf8a9f10']
 
-app_id = '<your-app-id>'
-app_secret = '<your-app-secret>'
+def run(md5s):
+    """
+    Print the malware object for each md5 hash passed in.
 
-init(app_id, app_secret)
+    :param md5s: A list of hashes
+    :type md5s: enumerable strs
+    """
+    for md5 in md5s:
+        print Malware.objects(text=md5, strict_text=True, full_response=True)
 
-for md5 in md5s:
-    print Malware.objects(text=md5, strict_text=True, full_response=True)
+
+def get_args():
+    parser = argparse.ArgumentParser(description='Grab Malware Objects from ThreatExchange')
+    parser.add_argument('-m', '--md5s', default=[], action='append',
+                        help='[OPTIONAL] md5 hash to lookup. May be specified more than once.')
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+
+    # Set a default hash if none was specified
+    if not args.md5s:
+        args.md5s = ['681f1b31baa671a81e4b803dbf8a9f10']
+
+    run(args.md5s)
+
+if __name__ == '__main__':
+    main()

--- a/pytx/scripts/malware_grabber.py
+++ b/pytx/scripts/malware_grabber.py
@@ -1,42 +1,66 @@
 #!/usr/bin/env python
 
+import argparse
 import base64
 import cStringIO
 import os
 import zipfile
 
-from pytx import init
 from pytx import Malware
 from pytx.vocabulary import Malware as m
 
-input_md5s_filename = 'md5s.txt'
-output_dir = 'out'
 
-app_id = '<your-app-id>'
-app_secret = '<your-app-secret>'
+def run(md5s, output_dir):
 
-init(app_id, app_secret)
+    print('Fetching %d MD5s' % len(md5s))
 
-md5s = []
-with open(input_md5s_filename) as f:
-    for l in f:
-        md5s.append(l.strip())
+    for md5 in md5s:
+        results = Malware.objects(text=md5, strict_text=True)
+        for result in results:
+            result.details()
+            try:
+                zipfilehandle = cStringIO.StringIO()
+                zipfilehandle.write(base64.b64decode(result.get(m.SAMPLE)))
+                with zipfile.ZipFile(zipfilehandle, 'r') as zf:
+                    for entry in zf.infolist():
 
-print('Fetching %d MD5s' % len(md5s))
+                        if not os.path.exists(output_dir):
+                            os.path.makedirs(output_dir)
 
-for md5 in md5s:
-    results = Malware.objects(text=md5, strict_text=True)
-    for result in results:
-        result.details()
-        try:
-            zipfilehandle = cStringIO.StringIO()
-            zipfilehandle.write(base64.b64decode(result.get(m.SAMPLE)))
-            with zipfile.ZipFile(zipfilehandle, 'r') as zf:
-                for entry in zf.infolist():
-                    with open(os.path.join(output_dir,
-                                           entry.filename), 'w') as f:
-                        print('Writing to %s' % entry.filename)
-                        f.write(zf.read(entry.filename,
-                                        result.get(m.PASSWORD)))
-        except Exception, e:
-            print str(e)
+                        with open(os.path.join(output_dir,
+                                               entry.filename), 'w') as f:
+                            print('Writing to %s' % entry.filename)
+                            f.write(zf.read(entry.filename,
+                                            result.get(m.PASSWORD)))
+            except Exception, e:
+                print str(e)
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description='Download Malware Samples from ThreatExchange')
+    parser.add_argument('-m', '--md5s', default=[], action='append',
+                        help='[OPTIONAL] md5 hash to lookup. May be specified more than once.')
+    parser.add_argument('-f', '--hash-file', default='md5s.txt',
+                        help='[OPTIONAL] file path for a file with one md5 hash per line')
+    parser.add_argument('-o', '--output-dir', default='out',
+                        help='[OPTIONAL] director for storing output.')
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+
+    # If the file doesn't exist, no big deal
+    if os.path.exists(args.hash_file):
+        with open(args.hash_file) as fp:
+            for line in fp.readlines():
+                args.md5s.append(line.strip())
+
+    # Set a default hash if none was specified
+    if not args.md5s:
+        args.md5s = ['681f1b31baa671a81e4b803dbf8a9f10']
+
+    run(args.md5s, args.output_dir)
+
+if __name__ == '__main__':
+    main()

--- a/pytx/tests/access_token_test.py
+++ b/pytx/tests/access_token_test.py
@@ -1,3 +1,4 @@
+from contextlib import nested
 from mock import patch
 import pytest
 
@@ -11,44 +12,55 @@ class TestInit:
     def verify_token(self, expected_token):
         assert expected_token == access_token.get_access_token()
 
-    def test_no_params(self):
-        with pytest.raises(pytxInitError):
+    def test_no_token(self):
+        with nested(
+            pytest.raises(pytxInitError),
+            patch('pytx.access_token._find_token_file', return_value=None)
+        ):
             access_token.init()
 
     def test_only_app_id(self):
-        with pytest.raises(pytxInitError):
+        with nested(
+            pytest.raises(pytxInitError),
+            patch('pytx.access_token._find_token_file', return_value=None)
+        ):
             access_token.init(app_id='app_id')
 
     def test_only_app_secret(self):
-        with pytest.raises(pytxInitError):
+        with nested(
+            pytest.raises(pytxInitError),
+            patch('pytx.access_token._find_token_file', return_value=None)
+        ):
             access_token.init(app_secret='app_secret')
 
     def test_app_id_and_secret(self):
         expected_token = 'app_id|app_secret'
 
-        access_token.init(app_id='app_id', app_secret='app_secret')
-        self.verify_token(expected_token)
+        with patch('pytx.access_token._find_token_file', return_value=None):
+            access_token.init(app_id='app_id', app_secret='app_secret')
+            self.verify_token(expected_token)
 
-    def verify_token_file(self, expected_token, file_contents):
-        with patch('pytx.access_token._read_token_file', return_value=file_contents):
+    def test_implicit_token_file(self):
+        expected_token = 'app_id|app_secret'
+        file_contents = 'app_id|app_secret'
+
+        with nested(
+            patch('pytx.access_token._find_token_file', return_value='/foobar/mocked/away'),
+            patch('pytx.access_token._read_token_file', return_value=file_contents)
+        ):
             access_token.init(token_file='/foobar/mocked/away')
             self.verify_token(expected_token)
 
-    def test_1_line_token_file(self):
+    def test_explicit_token_file(self):
         expected_token = 'app_id|app_secret'
-        file_contents = ['app_id|app_secret']
-        self.verify_token_file(expected_token, file_contents)
+        file_contents = 'app_id|app_secret'
 
-    def test_2_line_token_file(self):
-        expected_token = 'app_id|app_secret'
-        file_contents = ['app_id', 'app_secret']
-        self.verify_token_file(expected_token, file_contents)
-
-    def test_3_line_token_file(self):
-        expected_token = 'app_id|app_secret'
-        file_contents = ['app_id', 'app_secret', 'whoops_extra_line']
-        with pytest.raises(pytxInitError):
-            self.verify_token_file(expected_token, file_contents)
+        with nested(
+            patch('pytx.access_token._find_token_file', return_value=None),
+            patch('pytx.access_token._read_token_file', return_value=file_contents)
+        ):
+            access_token.init(token_file='/foobar/mocked/away')
+            self.verify_token(expected_token)
 
     def test_single_env_var(self, monkeypatch):
         expected_token = 'app_id|app_secret'


### PR DESCRIPTION
**Motivation**
- I *almost* checked my access token into the sample scripts twice already. 
- The graph documentation is pretty explicit - don't put your access token in code.
*However*, the sample scripts all require you to add your access token to the code. :-1: 

**The Change**
Speaking with @mgoffin we came up with these rules for how `pytx.access_token.init` should work:
     1. Use the value of the 'TX_ACCESS_TOKEN' environment variable.
     2. Use the concatenation of the 'TX_APP_ID' and 'TX_APP_SECRET' environment variables.
     3. Use the first line of the file '$PWD/.pytx' or ~/.pytx'
     4. Use the concatenation of the app_id and app_secret parameters
     5. Use the first line of the file 'token_file'
So now `pytx.access_token.init` works that way. For the first 3 cases, there is no need to explicitly call `pytx.access_token.init` anymore.

**Script Updates**
Quick cleanup of the scripts such that they all have a clean `main` and have some stuff like help strings for the command line arguments.

**How I Know It Works**
Tests pass.
All scripts work.
A smurf told me.