### PR TITLE
Fix .save() for new ThreatIndicator objects

### DIFF
--- a/pytx/pytx/common.py
+++ b/pytx/pytx/common.py
@@ -1,6 +1,7 @@
 from request import Broker
 
 from vocabulary import Common as c
+from vocabulary import Response as r
 from vocabulary import Status as s
 from vocabulary import ThreatExchange as t
 from vocabulary import ThreatIndicator as ti
@@ -283,7 +284,10 @@ class Common(object):
                 if (params[ti.PRIVACY_TYPE] != pt.VISIBLE and
                         len(params[ti.PRIVACY_MEMBERS].split(',')) < 1):
                     raise pytxValueError('Must provide %s' % ti.PRIVACY_MEMBERS)
-            return Broker.post(self._URL, params=params)
+            result = Broker.post(self._URL, params=params)
+            if r.ID in result:
+                self.set(ti.ID, result[r.ID])
+            return result
         else:
             params = dict(
                 (n, getattr(self, n)) for n in self._changed if n != c.ID

--- a/pytx/pytx/vocabulary.py
+++ b/pytx/pytx/vocabulary.py
@@ -34,7 +34,7 @@ class ThreatExchange(object):
     DEC_TOTAL = 1
 
     # POST
-    RELATED = 'related/'
+    RELATED = 'related'
     RELATED_ID = 'related_id'
 
     # Environment Variables for init()
@@ -124,6 +124,16 @@ class PagingCursor(object):
 
     BEFORE = 'before'
     AFTER = 'after'
+
+
+class Response(object):
+
+    """
+    Vocabulary for describing server responses.
+    """
+
+    SUCCESS = 'success'
+    ID = 'id'
 
 
 class ThreatExchangeMember(object):


### PR DESCRIPTION
When saving new `ThreatIndicator` objects, consume the response and look for an `id` returned in the response. If we get one, set the id of our `ThreatIndicator` object so we can immediately use it for other things (adding connections, etc.).