### PR TITLE
Allow get_samples.py to run on Python 2.6

### DIFF
--- a/malware/get_samples.py
+++ b/malware/get_samples.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import argparse
 import base64
+import contextlib
 import cStringIO
 import hashlib
 import json
@@ -79,7 +80,7 @@ def run_query(url):
 def process_results(outdir, pass_zipped_content, password):
     zipfilehandle = cStringIO.StringIO()
     zipfilehandle.write(base64.b64decode(pass_zipped_content))
-    with zipfile.ZipFile(zipfilehandle, 'r') as zf:
+    with contextlib.closing(zipfile.ZipFile(zipfilehandle, 'r')) as zf:
         entry = zf.infolist()[0]  # There should only ever be one entry
         try:
           hashobj = hashlib.new('md5', zf.read(entry.filename, password))


### PR DESCRIPTION
Tested that it works in both Python 2.6 and 2.7 now.