### PR TITLE
Remove requests[security] to just reqeusts

### DIFF
--- a/pytx/requirements.txt
+++ b/pytx/requirements.txt
@@ -1,1 +1,1 @@
-requests[security]==2.7.0
+requests==2.7.0

--- a/pytx/setup.py
+++ b/pytx/setup.py
@@ -29,7 +29,7 @@ setup(
     keywords='facebook threatexchange',
     url='https://www.github.com/facebook/ThreatExchange',
     packages=find_packages(exclude=['docs', 'tests']),
-    install_requires=['requests[security]==2.7.0'],
+    install_requires=['requests==2.7.0'],
     scripts=['scripts/get_compromised_credentials.py',
              'scripts/get_indicators.py',
              'scripts/get_members.py',


### PR DESCRIPTION
We don't need the requests[security] package as far as I can tell, unless @mgoffin knows something I don't. Worked fine on my build. 