### PR TITLE
Add page_limit for a maximum num of page results

### DIFF
--- a/pytx/pytx/access_token.py
+++ b/pytx/pytx/access_token.py
@@ -15,7 +15,7 @@ def _read_token_file(token_file):
     :param token_file: The full path and filename where to find the access token.
     :type token_file: str
     :returns: str
-    :raises: :class:`errors.pytxIniterror`    
+    :raises: :class:`errors.pytxIniterror`
     """
     try:
         with open(token_file, 'r') as infile:

--- a/pytx/pytx/common.py
+++ b/pytx/pytx/common.py
@@ -137,7 +137,7 @@ class Common(object):
     @classmethod
     def objects(cls, text=None, strict_text=False, type_=None, threat_type=None,
                 fields=None, limit=None, since=None, until=None, __raw__=None,
-                full_response=False, dict_generator=False):
+                page_limit=None, full_response=False, dict_generator=False):
         """
         Get objects from ThreatExchange.
 
@@ -160,6 +160,8 @@ class Common(object):
         :param __raw__: Provide a dictionary to force as GET parameters.
                         Overrides all other arguments.
         :type __raw__: dict
+        :param page_limit: The maximum number of objects to return on a page of results.
+        :type page_limit: int, str
         :param full_response: Return the full response instead of the generator.
                               Takes precedence over dict_generator.
         :type full_response: bool
@@ -181,6 +183,7 @@ class Common(object):
                 threat_type=threat_type,
                 fields=fields,
                 limit=limit,
+                page_limit=page_limit,
                 since=since,
                 until=until,
             )

--- a/pytx/pytx/request.py
+++ b/pytx/pytx/request.py
@@ -59,6 +59,26 @@ class Broker(object):
         return True
 
     @staticmethod
+    def validate_page_limit(page_limit):
+        """
+        Verifies the page limit provided is valid and within the max limit Facebook
+        will allow you to use.
+
+        :param page_limit: Value to verify is a valid limit. Max is 1000.
+        :type page_limit: int, str
+        :returns: :class:`pytxValueError` if invalid.
+        """
+
+        try:
+            page_limit = int(page_limit)
+        except ValueError, e:
+            raise pytxValueError(e)
+
+        if page_limit > 1000:
+            raise pytxValueError(e)
+        return
+
+    @staticmethod
     def validate_limit(limit):
         """
         Verifies the limit provided is valid and within the max limit Facebook
@@ -122,7 +142,7 @@ class Broker(object):
         return results
 
     @classmethod
-    def validate_get(cls, limit, since, until):
+    def validate_get(cls, limit, since, until, page_limit):
         """
         Executes validation for the GET parameters: limit, since, until.
 
@@ -140,10 +160,13 @@ class Broker(object):
             cls.is_timestamp(until)
         if limit:
             cls.validate_limit(limit)
+        if page_limit:
+            cls.validate_page_limit(page_limit)
 
     @classmethod
-    def build_get_parameters(cls, text=None, strict_text=None, type_=None, threat_type=None,
-                             fields=None, limit=None, since=None, until=None):
+    def build_get_parameters(cls, text=None, strict_text=None, type_=None,
+                             threat_type=None, fields=None, limit=None,
+                             page_limit=None, since=None, until=None):
         """
         Validate arguments and convert them into GET parameters.
 
@@ -157,7 +180,9 @@ class Broker(object):
         :type threat_type: str
         :param fields: Select specific fields to pull
         :type fields: str, list
-        :param limit: The maximum number of objects to return.
+        :param limit: The maximum number of objects to return, not used, here for legacy reasons.
+        :type limit: int, str
+        :param page_limit: The maximum number of objects to return on a page of results.
         :type limit: int, str
         :param since: The timestamp to limit the beginning of the search.
         :type since: str
@@ -166,7 +191,7 @@ class Broker(object):
         :returns: dict
         """
 
-        cls.validate_get(limit, since, until)
+        cls.validate_get(limit, since, until, page_limit)
         strict = cls.sanitize_strict(strict_text)
         params = {}
         if text:
@@ -179,8 +204,8 @@ class Broker(object):
             params[t.THREAT_TYPE] = threat_type
         if fields:
             params[t.FIELDS] = ','.join(fields) if isinstance(fields, list) else fields
-        if limit:
-            params[t.LIMIT] = limit
+        if page_limit:
+            params[t.LIMIT] = page_limit
         if since:
             params[t.SINCE] = since
         if until:

--- a/pytx/tests/threat_descriptors_test.py
+++ b/pytx/tests/threat_descriptors_test.py
@@ -1,0 +1,33 @@
+from contextlib import nested
+from mock import patch
+import pytest
+
+from pytx import access_token
+from pytx import ThreatDescriptor
+
+class TestInit:
+    def test_page_limit(self):
+        """
+        Don't see a way to test that it is actually sending this along,
+        so this test just makes sure that the function call works as expected.
+
+        Limit will still limit the total results, page_limit
+        """
+        try:
+            access_token.init()
+        except:
+            #Need a valid access token for these tests.
+            return
+
+        page_limit = 10
+
+        results = ThreatDescriptor.objects(type_='IP_ADDRESS',
+                                           page_limit=page_limit,
+                                           limit=5,
+                                           text='proxy')
+        num_of_results = 0
+
+        for result in results:
+            num_of_results += 1
+
+        assert 5 == num_of_results


### PR DESCRIPTION
"limit - Defines the maximum size of a page of results. The maximum is 1,000/"
https://developers.facebook.com/docs/threat-exchange/reference/apis/threat-descriptors

The limit parameter when making a call directly to the Graph API limits
the number of results on a single page that is returned.

Limit as used in objects limits the total number of objects returned.

I've added a parameter to the `objects` method that allows you to set a
page result limit - `page_limit` - which will be the parameter passed to
`limit`. The original `limit` will continue to function as it had.

Shout out to everyone that maintains pytx - huge help!