### PR TITLE
Add support for retries

### DIFF
--- a/pytx/pytx/__init__.py
+++ b/pytx/pytx/__init__.py
@@ -1,4 +1,5 @@
 from access_token import init
+from logger import setup_logger
 from request import Broker
 from malware import Malware
 from malware_family import MalwareFamily
@@ -8,6 +9,7 @@ from threat_indicator import ThreatIndicator
 
 __all__ = [
     'init',
+    'setup_logger',
     'Broker',
     'Malware',
     'MalwareFamily',

--- a/pytx/pytx/access_token.py
+++ b/pytx/pytx/access_token.py
@@ -15,7 +15,7 @@ def _read_token_file(token_file):
     :param token_file: The full path and filename where to find the access token.
     :type token_file: str
     :returns: str
-    :raises: :class:`errors.pytxIniterror`    
+    :raises: :class:`errors.pytxIniterror`
     """
     try:
         with open(token_file, 'r') as infile:

--- a/pytx/pytx/common.py
+++ b/pytx/pytx/common.py
@@ -309,7 +309,7 @@ class Common(object):
         )
 
     @classmethod
-    def new(cls, params):
+    def new(cls, params, retries=None):
         """
         Submit params to the graph to add an object. We will submit to the
         object URL used for creating new objects in the graph. When submitting
@@ -318,6 +318,8 @@ class Common(object):
 
         :param params: The parameters to submit.
         :type params: dict
+        :param retries: Number of retries to submit before stopping.
+        :type retries: bool
         :returns: dict (using json.loads())
         """
 
@@ -328,9 +330,9 @@ class Common(object):
             if (params[td.PRIVACY_TYPE] != pt.VISIBLE and
                     len(params[td.PRIVACY_MEMBERS].split(',')) < 1):
                 raise pytxValueError('Must provide %s' % td.PRIVACY_MEMBERS)
-        return Broker.post(cls._URL, params=params)
+        return Broker.post(cls._URL, params=params, retries=retries)
 
-    def save(self, params=None):
+    def save(self, params=None, retries=None):
         """
         Submit changes to the graph to update an object. We will determine the
         Details URL and submit there (used for updating an existing object). If
@@ -339,12 +341,14 @@ class Common(object):
 
         :param params: The parameters to submit.
         :type params: dict
+        :param retries: Number of retries to submit before stopping.
+        :type retries: bool
         :returns: dict (using json.loads())
         """
 
         if params is None:
             params = self.get_changed()
-        return Broker.post(self._DETAILS, params=params)
+        return Broker.post(self._DETAILS, params=params, retries=retries)
 
     @class_or_instance_method
     def send(cls_or_self, id_=None, params=None, type_=None, retries=None):
@@ -362,7 +366,7 @@ class Common(object):
         :type params: dict
         :param type_: GET or POST
         :type type_: str
-        :param retries: Number of retries to fetch a page before stopping.
+        :param retries: Number of retries to submit before stopping.
         :type retries: bool
 
         :returns: dict (using json.loads())
@@ -385,60 +389,70 @@ class Common(object):
         else:
             return Broker.post(url, params=params, retries=retries)
 
-    def expire(self, timestamp):
+    def expire(self, timestamp, retries=None):
         """
         Expire by setting the 'expired_on' timestamp.
 
         :param timestamp: The timestamp to set for an expiration date.
         :type timestamp: str
+        :param retries: Number of retries to submit before stopping.
+        :type retries: bool
+        :returns: dict (using json.loads())
         """
 
         Broker.is_timestamp(timestamp)
         params = {
             td.EXPIRED_ON: timestamp
         }
-        return Broker.post(self._DETAILS, params=params)
+        return Broker.post(self._DETAILS, params=params, retries=retries)
 
-    def false_positive(self, object_id):
+    def false_positive(self, object_id, retries=None):
         """
         Mark an object as a false positive by setting the status to
         UNKNOWN.
 
         :param object_id: The object-id of the object to mark.
         :type object_id: str
+        :param retries: Number of retries to submit before stopping.
+        :type retries: bool
+        :returns: dict (using json.loads())
         """
 
         params = {
             c.STATUS: s.UNKNOWN
         }
-        return Broker.post(self._DETAILS, params=params)
+        return Broker.post(self._DETAILS, params=params, retries=retries)
 
-    def add_connection(self, object_id):
+    def add_connection(self, object_id, retries=None):
         """
         Use HTTP POST and add a connection between two objects.
 
         :param object_id: The other object-id in the connection.
         :type object_id: str
+        :param retries: Number of retries to submit before stopping.
+        :type retries: bool
         :returns: dict (using json.loads())
         """
 
         params = {
             t.RELATED_ID: object_id
         }
-        return Broker.post(self._RELATED, params=params)
+        return Broker.post(self._RELATED, params=params, retries=retries)
 
     # DELETE REQUESTS
 
-    def delete_connection(self, object_id):
+    def delete_connection(self, object_id, retries=None):
         """
         Use HTTP DELETE and remove the connection to another object.
 
         :param object_id: The other object-id in the connection.
         :type object_id: str
+        :param retries: Number of retries to submit before stopping.
+        :type retries: bool
         :returns: dict (using json.loads())
         """
 
         params = {
             t.RELATED_ID: object_id
         }
-        return Broker.delete(self._RELATED, params=params)
+        return Broker.delete(self._RELATED, params=params, retries=retries)

--- a/pytx/pytx/common.py
+++ b/pytx/pytx/common.py
@@ -168,7 +168,7 @@ class Common(object):
                                object.
         :type dict_generator: bool
         :param retries: Number of retries to fetch a page before stopping.
-        :type retries: bool
+        :type retries: int
         :returns: Generator, dict (using json.loads())
         """
 
@@ -236,7 +236,7 @@ class Common(object):
                                object.
         :type dict_generator: bool
         :param retries: Number of retries to fetch a page before stopping.
-        :type retries: bool
+        :type retries: int
         :param metadata: Get extra metadata in the response.
         :type metadata: bool
         :returns: Generator, dict, class
@@ -317,7 +317,7 @@ class Common(object):
         :param params: The parameters to submit.
         :type params: dict
         :param retries: Number of retries to submit before stopping.
-        :type retries: bool
+        :type retries: int
         :returns: dict (using json.loads())
         """
 
@@ -340,7 +340,7 @@ class Common(object):
         :param params: The parameters to submit.
         :type params: dict
         :param retries: Number of retries to submit before stopping.
-        :type retries: bool
+        :type retries: int
         :returns: dict (using json.loads())
         """
 
@@ -365,7 +365,7 @@ class Common(object):
         :param type_: GET or POST
         :type type_: str
         :param retries: Number of retries to submit before stopping.
-        :type retries: bool
+        :type retries: int
 
         :returns: dict (using json.loads())
         """
@@ -394,7 +394,7 @@ class Common(object):
         :param timestamp: The timestamp to set for an expiration date.
         :type timestamp: str
         :param retries: Number of retries to submit before stopping.
-        :type retries: bool
+        :type retries: int
         :returns: dict (using json.loads())
         """
 
@@ -412,7 +412,7 @@ class Common(object):
         :param object_id: The object-id of the object to mark.
         :type object_id: str
         :param retries: Number of retries to submit before stopping.
-        :type retries: bool
+        :type retries: int
         :returns: dict (using json.loads())
         """
 
@@ -428,7 +428,7 @@ class Common(object):
         :param object_id: The other object-id in the connection.
         :type object_id: str
         :param retries: Number of retries to submit before stopping.
-        :type retries: bool
+        :type retries: int
         :returns: dict (using json.loads())
         """
 
@@ -446,7 +446,7 @@ class Common(object):
         :param object_id: The other object-id in the connection.
         :type object_id: str
         :param retries: Number of retries to submit before stopping.
-        :type retries: bool
+        :type retries: int
         :returns: dict (using json.loads())
         """
 

--- a/pytx/pytx/common.py
+++ b/pytx/pytx/common.py
@@ -193,7 +193,6 @@ class Common(object):
         else:
             return Broker.get_generator(cls,
                                         cls._URL,
-                                        limit,
                                         to_dict=dict_generator,
                                         params=params,
                                         retries=retries)
@@ -280,7 +279,6 @@ class Common(object):
                 klass = conns.get(connection, None)
                 return Broker.get_generator(klass,
                                             url,
-                                            t.NO_TOTAL,
                                             to_dict=dict_generator,
                                             params=params,
                                             retries=retries)

--- a/pytx/pytx/common.py
+++ b/pytx/pytx/common.py
@@ -138,7 +138,7 @@ class Common(object):
     @classmethod
     def objects(cls, text=None, strict_text=False, type_=None, threat_type=None,
                 fields=None, limit=None, since=None, until=None, __raw__=None,
-                full_response=False, dict_generator=False):
+                full_response=False, dict_generator=False, retries=None):
         """
         Get objects from ThreatExchange.
 
@@ -166,6 +166,9 @@ class Common(object):
         :type full_response: bool
         :param dict_generator: Return a dictionary instead of an instantiated
                                object.
+        :type dict_generator: bool
+        :param retries: Number of retries to fetch a page before stopping.
+        :type retries: bool
         :returns: Generator, dict (using json.loads())
         """
 
@@ -186,17 +189,19 @@ class Common(object):
                 until=until,
             )
         if full_response:
-            return Broker.get(cls._URL, params=params)
+            return Broker.get(cls._URL, params=params, retries=retries)
         else:
             return Broker.get_generator(cls,
                                         cls._URL,
                                         limit,
                                         to_dict=dict_generator,
-                                        params=params)
+                                        params=params,
+                                        retries=retries)
 
     @class_or_instance_method
     def details(cls_or_self, id=None, fields=None, connection=None,
-                full_response=False, dict_generator=False, metadata=False):
+                full_response=False, dict_generator=False, retries=None,
+                metadata=False):
         """
         Get object details. Allows you to limit the fields returned in the
         object's details. Also allows you to provide a connection. If a
@@ -231,6 +236,8 @@ class Common(object):
         :param dict_generator: Return a dictionary instead of an instantiated
                                object.
         :type dict_generator: bool
+        :param retries: Number of retries to fetch a page before stopping.
+        :type retries: bool
         :param metadata: Get extra metadata in the response.
         :type metadata: bool
         :returns: Generator, dict, class
@@ -252,7 +259,7 @@ class Common(object):
         if metadata:
             params[t.METADATA] = 1
         if full_response:
-            return Broker.get(url, params=params)
+            return Broker.get(url, params=params, retries=retries)
         else:
             if connection:
                 # Avoid circular imports
@@ -275,14 +282,18 @@ class Common(object):
                                             url,
                                             t.NO_TOTAL,
                                             to_dict=dict_generator,
-                                            params=params)
+                                            params=params,
+                                            retries=retries)
             else:
                 if isinstance(cls_or_self, type):
                     return Broker.get_new(cls_or_self,
                                           Broker.get(url,
-                                                     params=params))
+                                                     params=params,
+                                                     retries=retries))
                 else:
-                    cls_or_self.populate(Broker.get(url, params=params))
+                    cls_or_self.populate(Broker.get(url,
+                                                    params=params,
+                                                    retries=retries))
                     cls_or_self._changed = []
 
     def get_changed(self):
@@ -336,7 +347,7 @@ class Common(object):
         return Broker.post(self._DETAILS, params=params)
 
     @class_or_instance_method
-    def send(cls_or_self, id_=None, params=None, type_=None):
+    def send(cls_or_self, id_=None, params=None, type_=None, retries=None):
         """
         Send custom params to the object URL. If `id` is provided it will be
         appended to the URL. If this is an uninstantiated class we will use the
@@ -351,6 +362,8 @@ class Common(object):
         :type params: dict
         :param type_: GET or POST
         :type type_: str
+        :param retries: Number of retries to fetch a page before stopping.
+        :type retries: bool
 
         :returns: dict (using json.loads())
         """
@@ -368,9 +381,9 @@ class Common(object):
         if params is None:
             params = {}
         if type_ == 'GET':
-            return Broker.get(url, params=params)
+            return Broker.get(url, params=params, retries=retries)
         else:
-            return Broker.post(url, params=params)
+            return Broker.post(url, params=params, retries=retries)
 
     def expire(self, timestamp):
         """

--- a/pytx/pytx/errors.py
+++ b/pytx/pytx/errors.py
@@ -1,3 +1,6 @@
+from logger import log_message
+
+
 class pytxException(Exception):
 
     """
@@ -8,6 +11,7 @@ class pytxException(Exception):
         self.message = message
 
     def __str__(self):
+        log_message(self.message)
         return self.message
 
 

--- a/pytx/pytx/logger.py
+++ b/pytx/pytx/logger.py
@@ -1,0 +1,45 @@
+import logging
+
+__LOG = None
+
+
+def do_log():
+    """
+    Should we log?
+    """
+    global __LOG
+    if __LOG is None:
+        return False
+    else:
+        return True
+
+
+def log_message(message):
+    """
+    Logs a message to the logger.
+    """
+
+    if do_log():
+        __LOG.debug(message)
+    return
+
+
+def setup_logger(log_file=None):
+    """
+    Set a log file to log messages to. Useful for debugging.
+
+    :param log_file: A file to log to.
+    :type log_file: str
+    """
+    global __LOG
+
+    if log_file is not None:
+        __LOG = logging.getLogger('pytx')
+        __LOG.setLevel(logging.DEBUG)
+        fh = logging.FileHandler(log_file)
+        fh.setLevel(logging.DEBUG)
+        formatter = logging.Formatter(
+            '%(asctime)s : %(name)s : %(levelname)s : %(message)s'
+        )
+        fh.setFormatter(formatter)
+        __LOG.addHandler(fh)

--- a/pytx/pytx/request.py
+++ b/pytx/pytx/request.py
@@ -1,6 +1,8 @@
 import json
 import requests
 
+from requests.packages.urllib3.util import Retry
+
 from access_token import get_access_token
 
 from vocabulary import ThreatExchange as t
@@ -201,7 +203,11 @@ class Broker(object):
             retries = 0
         session = requests.Session()
         session.mount('https://',
-                      requests.adapters.HTTPAdapter(max_retries=retries))
+                      requests.adapters.HTTPAdapter(
+                          max_retries=Retry(total=retries,
+                                            status_forcelist=[500, 503]
+                                            )
+                      ))
         return session
 
     @classmethod


### PR DESCRIPTION
Retries in `requests` is a bit of a pain, but this should expose the ability for people to retry GET, POST, and DELETE requests as often as they feel they need to in order for the request to succeed. By default we still try and fail after one attempt. This propagates into the generator so for example if we perform a query which will end up with 15 pages and a retry of `3`, we will try to fetch each page as we need to and individually they can be retried up to 3 times before failing.

Failing here is defined by what requests fails on. We create a urllib3 Retry object and specify 500 and 503 responses as ones we will retry.

This PR also adds a logging feature (necessary if people are going to be doing retries and random stuff and want to inspect what pytx is doing/thinking). You can now do something like this:

```python
from pytx import setup_logger

setup_logger("/path/to/my/log/file")
```
After this, any pytx code will log to this file. Any pytx errors thrown will log there, and the generator now has logging to show you the current cursors, number of results in the `data` field, and will let you know if `next` is not in the pager (meaning the generator is over) or `paging` is not in the response (meaning something entirely different?).

I do not know if this will fix the issues people have mentioned about timeouts and putting things in while loops with try/except. If people can reliably generate those issues and can test with this PR to see if it fixes or helps, that would be great! If it does not (in the case where data gets submitted fine and the server returns a valid response with an internal timeout error) then we might have some other work to do but this PR could still be valid.