### PR TITLE
Capture error responses better

### DIFF
--- a/pytx/docs/quickstart.rst
+++ b/pytx/docs/quickstart.rst
@@ -204,3 +204,28 @@ The Broker will also allow you to POST and DELETE if you need to.
 One thing you might notice is the constant use of vocabulary. pytx comes with a
 vocabulary which will allow you to write your code using class attributes so if
 ThreatExchange ever changes a string your code will still function properly.
+
+Error responses can be acquired and leveraged as a dictionary. Here is an
+example:
+
+.. code-block :: python
+
+   from pytx import Malware
+   from pytx.errors import pytxFetchError
+
+   m = Malware()
+   m.id = "12345"
+   response = None
+   try:
+      m.details()
+   except pytxFetchError, e:
+      response = e.message
+
+The response variable above will be a dictionary with the following keys:
+
+    - code: the TX response code
+    - fbtrace_id: the TX trace id for the request
+    - message: the TX server message (what went wrong)
+    - status_code: the server response status code
+    - type: the TX error type
+    - url: the request URL that generated the error

--- a/pytx/docs/quickstart.rst
+++ b/pytx/docs/quickstart.rst
@@ -214,7 +214,7 @@ example:
    from pytx.errors import pytxFetchError
 
    m = Malware()
-   m.id = "12345"
+   m.id = "19374-19841-4813-408"
    response = None
    try:
       m.details()

--- a/pytx/pytx/request.py
+++ b/pytx/pytx/request.py
@@ -10,6 +10,7 @@ from logger import do_log, log_message
 from vocabulary import ThreatExchange as t
 from vocabulary import Paging as p
 from vocabulary import PagingCursor as pc
+from vocabulary import Response as R
 from errors import (
     pytxFetchError,
     pytxValueError
@@ -116,11 +117,16 @@ class Broker(object):
         """
 
         if resp.status_code != 200:
-            raise pytxFetchError('Response code: %s: %s, URL: %s' % (
-                resp.status_code,
-                resp.text,
-                resp.url)
-            )
+            error = json.loads(resp.text).get(R.ERROR, None)
+            response = {}
+            response['status_code'] = resp.status_code
+            response['url'] = resp.url
+            if error:
+                response[R.MESSAGE] = error.get(R.MESSAGE, None)
+                response[R.TYPE] = error.get(R.TYPE, None)
+                response[R.CODE] = error.get(R.CODE, None)
+                response[R.FBTRACE_ID] = error.get(R.FBTRACE_ID, None)
+            raise pytxFetchError(response)
         try:
             results = json.loads(resp.text)
         except:

--- a/pytx/pytx/vocabulary.py
+++ b/pytx/pytx/vocabulary.py
@@ -156,6 +156,11 @@ class Response(object):
 
     SUCCESS = 'success'
     ID = 'id'
+    ERROR = 'error'
+    MESSAGE = 'message'
+    TYPE = 'type'
+    CODE = 'code'
+    FBTRACE_ID = 'fbtrace_id'
 
 
 class ThreatExchangeMember(object):


### PR DESCRIPTION
I was annoyed duplicating #93 and having to manually parse the
response string which wasn't already JSON the way pytx was
returning.

When an error occurs, we capture the contents of it. We now build up a
dictionary containing all of the error contents from the server response
and we add in the `status_code` and the `url` that the request was made
to. This should make it much easier to parse out and automatically use
within scripts since it's already a dictionary, not a large string that
isn't in JSON.

Example:

```python
from pytx import Malware
from pytx.errors import pytxFetchError

m = Malware()
m.id = "19374-19841-4813-408"
response = None
try:
    m.details()
except pytxFetchError, e:
    response = e.message
```

The `response` dictionary looks like this:

```python
{
    'code': 803,
    'fbtrace_id': 'BTS22ImzDvd',
    'message': '(#803) Some of the aliases you requested do not exist: 19374-19841-4813-408',
    'status_code': 404,
    'type': 'OAuthException',
    'url': 'https://graph.facebook.com/v2.5/19374-19841-4813-408/?access_token=555|aSdF123GhK'
}
```