### PR TITLE
Fix details URL breaking when setting `id` attribute more than once

### DIFF
--- a/pytx/pytx/common.py
+++ b/pytx/pytx/common.py
@@ -69,8 +69,8 @@ class Common(object):
         """
 
         object.__setattr__(self, name, value)
-        if name == c.ID and value not in self._DETAILS:
-            self._DETAILS = self._DETAILS + value + '/'
+        if name == c.ID:
+            self._DETAILS = t.URL + value + '/'
             self._RELATED = self._DETAILS + t.RELATED
         if name not in self._changed and name in self._fields:
             self._changed.append(name)


### PR DESCRIPTION
Found this little gem while doing testing in my previous PR:

```python
>>> from pytx import Malware
>>> m = Malware()
>>> m.id
>>> m.id = "12345"
>>> m._DETAILS
'https://graph.facebook.com/12345/'
>>> m.id = "12315343"
>>> m._DETAILS
'https://graph.facebook.com/12345/12315343/'
>>>
```

This fixes it so instead of appending to the URL, we recreate it from scratch with the new `id` value:

```python
>>> from pytx import Malware
>>> m = Malware()
>>> m.id
>>> m.id = "12345"
>>> m._DETAILS
'https://graph.facebook.com/12345/'
>>> m.id = "12315343"
>>> m._DETAILS
'https://graph.facebook.com/12315343/'
>>>
```