### PR TITLE
Add Attack Type field on ThreatDescriptor

### DIFF
--- a/pytx/pytx/threat_descriptor.py
+++ b/pytx/pytx/threat_descriptor.py
@@ -11,6 +11,7 @@ class ThreatDescriptor(Common):
 
     _fields = [
         td.ADDED_ON,
+        td.ATTACK_TYPE,
         td.CONFIDENCE,
         td.DESCRIPTION,
         td.EXPIRED_ON,
@@ -35,6 +36,7 @@ class ThreatDescriptor(Common):
 
     _default_fields = [
         td.ADDED_ON,
+        td.ATTACK_TYPE,
         td.CONFIDENCE,
         td.DESCRIPTION,
         td.EXPIRED_ON,

--- a/pytx/pytx/vocabulary.py
+++ b/pytx/pytx/vocabulary.py
@@ -278,6 +278,7 @@ class ThreatDescriptor(object):
     """
 
     ADDED_ON = 'added_on'
+    ATTACK_TYPE = 'attack_type'
     CONFIDENCE = 'confidence'
     DESCRIPTION = 'description'
     EXPIRED_ON = 'expired_on'


### PR DESCRIPTION
We recently added support for setting/getting an AttackType on a
descriptor.  It’s intent is to describe the class of attack an
indicator was associated with (e.g. Malware, Phishing, etc)

AttackType docs:
https://developers.facebook.com/docs/threat-exchange/reference/apis/attack-type/