### PR TITLE
Re-prioritize how access_token() finds the token to use

### DIFF
--- a/pytx/pytx/access_token.py
+++ b/pytx/pytx/access_token.py
@@ -85,27 +85,28 @@ def access_token(app_id=None, app_secret=None, token_file=None):
     """
     global __ACCESS_TOKEN
 
-    # 1. Use the value of the 'TX_ACCESS_TOKEN' environment variable.
+
+    # 1. Use the concatenation of the app_id and app_secret parameters
+    if app_id and app_secret:
+        __ACCESS_TOKEN = app_id + '|' + app_secret
+        return
+
+    # 2. Use the value of the 'TX_ACCESS_TOKEN' environment variable.
     __ACCESS_TOKEN = os.environ.get(te.TX_ACCESS_TOKEN, None)
     if __ACCESS_TOKEN:
         return
 
-    # 2. Use the concatenation of the 'TX_APP_ID' and 'TX_APP_SECRET' environment variables.
+    # 3. Use the concatenation of the 'TX_APP_ID' and 'TX_APP_SECRET' environment variables.
     env_app_id = os.environ.get(te.TX_APP_ID, None)
     env_app_secret = os.environ.get(te.TX_APP_SECRET, None)
     if env_app_id and env_app_secret:
         __ACCESS_TOKEN = env_app_id + '|' + env_app_secret
         return
 
-    # 3. Use the first line of the file '$PWD/.pytx' or ~/.pytx'
+    # 4. Use the first line of the file '$PWD/.pytx' or ~/.pytx'
     filepath = _find_token_file()
     if filepath:
         __ACCESS_TOKEN = _read_token_file(filepath)
-        return
-
-    # 4. Use the concatenation of the app_id and app_secret parameters
-    if app_id and app_secret:
-        __ACCESS_TOKEN = app_id + '|' + app_secret
         return
 
     # 5. Use the first line of the file 'token_file'


### PR DESCRIPTION
This makes access_token() use the passed params first, before looking
in environment variables and files.

Making this change to handle the case when you usually are happy with
your env vars or file, but want to use a different token as a one-off
when testing.