### PR TITLE
Add golang client and examples for ThreatExchange

### DIFF
--- a/golang/threatexchange/README.md
+++ b/golang/threatexchange/README.md
@@ -14,7 +14,7 @@ The ThreatExchange library provides a base set of abstractions for the ThreatExc
 client, err = threatexchange.New(
 	appID,
 	appSecert,
-	log.New(conf.LogWriter, "ThreatExchange: ", log.Lshortfile),
+	log.New(logrus.StandardLogger().Writer(), "ThreatExchange: ", log.Lshortfile),
 )
 
 ```
@@ -25,23 +25,14 @@ To query the ThreatExchange API you use the client functions
 ResultAsStruct, resultJson, err := client.GetMalwareAnalyses("TEXT_TO_SEARCH", "yesterday", "now", 500, map[string]string)
 ```
 
-The result will return 3 objects,the firs tis an object that represent the result,
+The result will return 3 objects,the first is an object that represent the result,
 the second is the raw json of that result, and last is the error(nil if all went well).
 
 Params for this func:
-1. "text" : to search by
-2. "startTime" : filter results by start time.
-3. "endTime" : filter results by end time.
-4. "limit" : results limits (if zero, will be ignored)
-5. "Additional params" : to add to the query.
+1. Text : to search by
+2. StartTime : filter results by start time.
+3. EndTime : filter results by end time.
+4. Limit : results limits (if zero, will be ignored)
+5. Additional params : to add to the query.
 
 Look into the test file for more examples of usage.
-
-
-## Contributing
-
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request

--- a/golang/threatexchange/README.md
+++ b/golang/threatexchange/README.md
@@ -1,0 +1,47 @@
+# golang-threatexchange
+
+A golang library to interface with Facebook ThreatExchange API. This is still very much in development so feel free to contribute :)
+
+## Installation
+``` go get github.com/meirwah/ThreatExchange/golang/threatexchange```
+
+## Usage
+
+The ThreatExchange library provides a base set of abstractions for the ThreatExchange API. You instantiate a new ThreatExchange Client and provide it with your appID and secret.
+
+```golang
+
+client, err = threatexchange.New(
+	appID,
+	appSecert,
+	log.New(conf.LogWriter, "ThreatExchange: ", log.Lshortfile),
+)
+
+```
+To query the ThreatExchange API you use the client functions
+
+```golang
+
+ResultAsStruct, resultJson, err := client.GetMalwareAnalyses("TEXT_TO_SEARCH", "yesterday", "now", 500, map[string]string)
+```
+
+The result will return 3 objects,the firs tis an object that represent the result,
+the second is the raw json of that result, and last is the error(nil if all went well).
+
+Params for this func:
+1. "text" : to search by
+2. "startTime" : filter results by start time.
+3. "endTime" : filter results by end time.
+4. "limit" : results limits (if zero, will be ignored)
+5. "Additional params" : to add to the query.
+
+Look into the test file for more examples of usage.
+
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request

--- a/golang/threatexchange/threatexchange.go
+++ b/golang/threatexchange/threatexchange.go
@@ -185,7 +185,7 @@ func (c *Client) query(apiVersion string, resource string, startTime string, end
 	text string, limit int, extraParams map[string]string, result interface{}) (string, error) {
 	u, err := url.Parse(DefaultURL)
 	if err != nil {
-		c.errorf("Could not parse url %s",u.String())
+		c.errorf("Could not parse url %s", u.String())
 		return "", err
 	}
 
@@ -231,7 +231,7 @@ func (c *Client) query(apiVersion string, resource string, startTime string, end
 	}
 	err = json.Unmarshal(byteRes, result)
 	if err != nil {
-		c.errorf("Could not Unmarshal response body : %s, for resource : %s", string(byteRes),resource)
+		c.errorf("Could not Unmarshal response body : %s, for resource : %s", string(byteRes), resource)
 		return "", err
 	}
 	return string(byteRes), nil

--- a/golang/threatexchange/threatexchange.go
+++ b/golang/threatexchange/threatexchange.go
@@ -1,0 +1,237 @@
+package threatexchange
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+const (
+	// DefaultURL is the URL for the API endpoint
+	DefaultURL = "https://graph.facebook.com"
+	apiVersion = "v2.5"
+)
+
+// Client interacts with the services provided by TE
+type Client struct {
+	appId     string
+	appSecret string
+	logger    *log.Logger
+	c         *http.Client
+}
+
+type MalwareFamiliesResults struct {
+	Data   []MalwareFamilyResult `json:"data"`
+	Paging ResultPaging          `json:"paging,omitempty"`
+	Next   string                `json:"next,omitempty"`
+}
+
+type MalwareFamilyResult struct {
+	ID             string   `json:"id"`
+	Aliases        []string `json:"aliases,omitempty"`
+	AddedOn        string   `json:"added_on,omitempty"`
+	Description    string   `json:"description,omitempty"`
+	FamilyType     string   `json:"family_type,omitempty"`
+	Malicious      string   `json:"malicious,omitempty"`
+	Name           string   `json:"name,omitempty"`
+	SampleCount    int      `json:"sample_count,omitempty"`
+	SubmitterCount int      `json:"submitter_count,omitempty"`
+}
+type MalwareResults struct {
+	Data   []MalwareResult `json:"data"`
+	Paging ResultPaging    `json:"paging,omitempty"`
+	Next   string          `json:"next,omitempty"`
+}
+
+type MalwareResult struct {
+	ID             string `json:"id"`
+	Crx            string `json:"crx,omitempty"`
+	PEHash         string `json:"imphash,omitempty"`
+	MD5            string `json:"md5,omitempty"`
+	Password       string `json:"password,omitempty"`
+	PEHeader       string `json:"pe_rich_header,omitempty"`
+	Sample         string `json:"sample,omitempty"`
+	SampleType     string `json:"sample_type,omitempty"`
+	Sha1           string `json:"sha1,omitempty"`
+	Sha256         string `json:"sha256,omitempty"`
+	ShareLevel     string `json:"share_level,omitempty"`
+	Ssdeep         string `json:"ssdeep,omitempty"`
+	SubmitterCount string `json:"submitter_count,omitempty"`
+	VictimCount    int    `json:"victim_count,omitempty"`
+	xpi            string `json:"xpi,omitempty"`
+	Status         string `json:"status,omitempty"`
+	AddedOn        string `json:"added_on,omitempty"`
+	PrivacyType    string `json:"privacy_type,omitempty"`
+}
+
+type ThreatDescriptorResults struct {
+	Data   []ThreatDescriptor `json:"data"`
+	Paging ResultPaging       `json:"paging,omitempty"`
+	Next   string             `json:"next,omitempty"`
+}
+
+type ResultPaging struct {
+	Cursors Cursors `json:"cursors"`
+}
+
+type Cursors struct {
+	Before string `json:"before,omitempty"`
+	After  string `json:"after,omitempty"`
+}
+
+type ThreatDescriptor struct {
+	ID           string          `json:"id"`
+	Indicator    IndicatorResult `json:"indicator,omitempty"`
+	Owner        TEOwner         `json:"owner,omitempty"`
+	Type         string          `json:"type,omitempty"`
+	RawIndicator string          `json:"raw_indicator,omitempty"`
+	Description  string          `json:"description,omitempty"`
+	Status       string          `json:"status,omitempty"`
+	PrivacyType  string          `json:"privacy_type,omitempty"`
+	ShareLevel   string          `json:"share_level,omitempty"`
+	AddedOn      string          `json:"added_on,omitempty"`
+	Confidence   int             `json:"confidence,omitempty"`
+	ExpiredOn    int             `json:"expired_on,omitempty"`
+	LastUpdated  string          `json:"last_updated,omitempty"`
+	SourceUri    string          `json:"source_uri,omitempty"`
+}
+
+type IndicatorResult struct {
+	ID        string `json:"id,omitempty"`
+	Indicator string `json:"indicator,omitempty"`
+	Type      string `json:"type,omitempty"`
+}
+
+type TEOwner struct {
+	ID    string `json:"id,omitempty"`
+	Email string `json:"email,omitempty"`
+	Name  string `json:"name,omitempty"`
+}
+
+type TEOwnersResults struct {
+	Data   []TEOwner    `json:"data"`
+	Paging ResultPaging `json:"paging,omitempty"`
+	Next   string       `json:"next,omitempty"`
+}
+
+// New - will create a new ThreatExchange Go client, log param may be nil.
+func New(appID, appSecret string, log *log.Logger) (*Client, error) {
+	c := &Client{
+		appId:     appID,
+		appSecret: appSecret,
+		logger:    log,
+		c:         http.DefaultClient,
+	}
+	return c, nil
+}
+
+// GetThreatIndicators - is a query to retrieve ThreatIndicators, will return ThreatDescriptorResults to hold results, and raw json of that
+// limit of size <=0 will be ignored
+func (c *Client) GetThreatIndicators(resourceType, text, startTime, endTime string, limit int,
+	extraParams map[string]string) (*ThreatDescriptorResults, string, error) {
+	res, err := c.query(apiVersion, "threat_descriptors", startTime, endTime, resourceType, text, limit, extraParams)
+	if err != nil {
+		return nil, "", err
+	}
+	var result ThreatDescriptorResults
+	err = json.Unmarshal([]byte(res), &result)
+	if err != nil {
+		return nil, "", err
+	}
+	return &result, res, nil
+}
+
+// GetMalwareAnalyses - is a query to retrieve Malware Analyses, will return MalwareResults to hold results, and raw json of that
+func (c *Client) GetMalwareAnalyses(text, startTime, endTime string, limit int,
+	extraParams map[string]string) (*MalwareResults, string, error) {
+	res, err := c.query(apiVersion, "malware_analyses", startTime, endTime, "", text, limit, extraParams)
+	if err != nil {
+		return nil, "", err
+	}
+	var result MalwareResults
+	err = json.Unmarshal([]byte(res), &result)
+	if err != nil {
+		return nil, "", err
+	}
+	return &result, res, nil
+}
+
+// GetMalwareFamilies - is a query to retrieve ThreatIndicators, will return MalwareFamiliesResults to hold results, and raw json of that
+func (c *Client) GetMalwareFamilies(text, startTime, endTime string, limit int,
+	extraParams map[string]string) (*MalwareFamiliesResults, string, error) {
+	res, err := c.query(apiVersion, "malware_families", startTime, endTime, "", text, limit, extraParams)
+	if err != nil {
+		return nil, "", err
+	}
+	var result MalwareFamiliesResults
+	err = json.Unmarshal([]byte(res), &result)
+	if err != nil {
+		return nil, "", err
+	}
+	return &result, res, nil
+}
+
+// GetThreatExchangeMembers - is a query to retrieve ThreatExchange members, will return TEOwnersResults to hold results, and raw json of that
+func (c *Client) GetThreatExchangeMembers() (*TEOwnersResults, string, error) {
+	res, err := c.query(apiVersion, "threat_exchange_members", "", "", "", "", 0, map[string]string{})
+	if err != nil {
+		return nil, "", err
+	}
+	var result TEOwnersResults
+	err = json.Unmarshal([]byte(res), &result)
+	if err != nil {
+		return nil, "", err
+	}
+	return &result, res, nil
+}
+
+func (c *Client) query(apiVersion string, resource string, startTime string, endTime string, resourceType string,
+	text string, limit int, extraParams map[string]string) (string, error) {
+	u, err := url.Parse(DefaultURL)
+	if err != nil {
+		return "", err
+	}
+
+	parameters := url.Values{}
+	parameters.Add("access_token", fmt.Sprintf("%s|%s", c.appId, c.appSecret))
+	if len(startTime) > 0 {
+		parameters.Add("since", startTime)
+	}
+	if len(endTime) > 0 {
+		parameters.Add("until", endTime)
+	}
+	if len(resourceType) > 0 {
+		parameters.Add("type", resourceType)
+	}
+	if len(resourceType) > 0 {
+		parameters.Add("text", text)
+	}
+	if limit > 0 {
+		parameters.Add("limit", fmt.Sprintf("%d", limit))
+	}
+	for k, v := range extraParams {
+		parameters.Add(k, v)
+	}
+	u.RawQuery = parameters.Encode()
+	u.Path += fmt.Sprintf("/%s/%s/", apiVersion, resource)
+
+	res, err := http.Get(u.String())
+	if err != nil {
+		return "", err
+	}
+	if res.Body == nil {
+		return "", fmt.Errorf("Empty body for query :", u.String())
+	}
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Wrong http return code, got : %d", res.StatusCode)
+	}
+	defer res.Body.Close()
+	byteRes, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(byteRes), nil
+}

--- a/golang/threatexchange/threatexchange.go
+++ b/golang/threatexchange/threatexchange.go
@@ -200,7 +200,7 @@ func (c *Client) query(apiVersion string, resource string, startTime string, end
 	if len(resourceType) > 0 {
 		parameters.Add("type", resourceType)
 	}
-	if len(resourceType) > 0 {
+	if len(text) > 0 {
 		parameters.Add("text", text)
 	}
 	if limit > 0 {

--- a/golang/threatexchange/threatexchange_test.go
+++ b/golang/threatexchange/threatexchange_test.go
@@ -1,0 +1,101 @@
+package threatexchange
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const (
+	appId     = "" // Fill this to make tests run
+	appSecret = "" // Fill this to make tests run
+)
+
+func TestQueryThreatDescriptorsOfIpsProxy(t *testing.T) {
+	if len(appId) == 0 || len(appSecret) == 0 {
+		t.SkipNow()
+	}
+	c, err := New(appId, appSecret, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, rawJson, err := c.GetThreatIndicators("IP_ADDRESS", "proxy", "", "", 0, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotEmpty(t, res)
+	assert.NotEmpty(t, rawJson)
+	assert.NotEmpty(t, res.Data)
+
+}
+
+func TestQueryThreatDescriptorsOfIpsProxyByFBAdminOwner(t *testing.T) {
+	if len(appId) == 0 || len(appSecret) == 0 {
+		t.SkipNow()
+	}
+	c, err := New(appId, appSecret, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, rawJson, err := c.GetThreatIndicators("IP_ADDRESS", "proxy", "", "", 0, map[string]string{"owner_app_id": "820763734618599"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotEmpty(t, res)
+	assert.NotEmpty(t, rawJson)
+	assert.NotEmpty(t, res.Data)
+}
+
+func TestQueryMalwareAnalysesInTimeRange(t *testing.T) {
+	if len(appId) == 0 || len(appSecret) == 0 {
+		t.SkipNow()
+	}
+	c, err := New(appId, appSecret, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, rawJson, err := c.GetMalwareAnalyses("", "1391813489", "1391856689", 500, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotEmpty(t, res)
+	assert.NotEmpty(t, rawJson)
+	assert.NotEmpty(t, res.Data)
+
+	assert.EqualValues(t, 266, len(res.Data))
+}
+
+func TestQueryMalwareFamiliesInTimeRange(t *testing.T) {
+	if len(appId) == 0 || len(appSecret) == 0 {
+		t.SkipNow()
+	}
+	c, err := New(appId, appSecret, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, rawJson, err := c.GetMalwareFamilies("", "yesterday", "now", 500, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotEmpty(t, res)
+	assert.NotEmpty(t, rawJson)
+	assert.NotEmpty(t, res.Data)
+
+}
+
+func TestQueryGetAllMembers(t *testing.T) {
+	if len(appId) == 0 || len(appSecret) == 0 {
+		t.SkipNow()
+	}
+	c, err := New(appId, appSecret, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, rawJson, err := c.GetThreatExchangeMembers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotEmpty(t, res)
+	assert.NotEmpty(t, rawJson)
+	assert.NotEmpty(t, res.Data)
+
+}


### PR DESCRIPTION
This PR is too add GO client for ThreatExchange API's.
It includes examples on usage.
And tests to verify client is correct.

Small thing to note, i'm pointing to my local github repo in README (```go get github.com/meirwah/ThreatExchange/golang/threatexchange```)
because only after this PR merge, I will be able to change this link to the official repo (``` go get github.com/facebook/ThreatExchange/golang/threatexchange ```) .
