### PR TITLE
Fix acquiring members for privacy groups.

### DIFF
--- a/pytx/pytx/threat_privacy_group.py
+++ b/pytx/pytx/threat_privacy_group.py
@@ -99,7 +99,7 @@ class ThreatPrivacyGroup(Common):
         :returns: list
         """
 
-        url = self._DETAILS + '/' + tpg.MEMBERS
+        url = self._DETAILS + tpg.MEMBERS
         results = Broker.get(url,
                              retries=retries,
                              headers=headers,


### PR DESCRIPTION
The URL was bad so the members list being returned was always an empty string.