### PR TITLE
Adding sort order and updating vocab.

### DIFF
--- a/pytx/pytx/common.py
+++ b/pytx/pytx/common.py
@@ -245,7 +245,7 @@ class Common(object):
                 status=status,
                 review_status=review_status,
                 share_level=share_level,
-                sort_order=sort_order
+                sort_order=sort_order,
             )
         if request_dict:
             return Broker.request_dict('GET',

--- a/pytx/pytx/common.py
+++ b/pytx/pytx/common.py
@@ -153,6 +153,7 @@ class Common(object):
                 status=None,
                 review_status=None,
                 share_level=None,
+                sort_order=None,
                 __raw__=None,
                 full_response=False,
                 dict_generator=False,
@@ -197,6 +198,8 @@ class Common(object):
         :type review_status: str
         :param share_level: The share level to limit to.
         :type share_level: str
+        :param sort_order: The sort order for results.
+        :type sort_order: str
         :param __raw__: Provide a dictionary to force as GET parameters.
                         Overrides all other arguments.
         :type __raw__: dict
@@ -241,7 +244,8 @@ class Common(object):
                 owner=owner,
                 status=status,
                 review_status=review_status,
-                share_level=share_level
+                share_level=share_level,
+                sort_order=sort_order
             )
         if request_dict:
             return Broker.request_dict('GET',

--- a/pytx/pytx/request.py
+++ b/pytx/pytx/request.py
@@ -171,7 +171,8 @@ class Broker(object):
                              owner=None,
                              status=None,
                              review_status=None,
-                             share_level=None):
+                             share_level=None,
+                             sort_order=None):
         """
         Validate arguments and convert them into GET parameters.
 
@@ -208,6 +209,8 @@ class Broker(object):
         :type review_status: str
         :param share_level: The share level to limit to.
         :type share_level: str
+        :param sort_order: The sort order for results.
+        :type sort_order: str
         :returns: dict
         """
 
@@ -247,6 +250,8 @@ class Broker(object):
             params[t.REVIEW_STATUS] = review_status
         if share_level:
             params[t.SHARE_LEVEL] = share_level
+        if sort_order in (t.ASCENDING, t.DESCENDING):
+            params[t.SORT_ORDER] = sort_order
         return params
 
     @classmethod

--- a/pytx/pytx/vocabulary.py
+++ b/pytx/pytx/vocabulary.py
@@ -5,7 +5,7 @@ class ThreatExchange(object):
     """
 
     URL = 'https://graph.facebook.com/'
-    VERSION = 'v2.5/'
+    VERSION = 'v2.6/'
     ACCESS_TOKEN = 'access_token'
     DEFAULT_LIMIT = 25
 
@@ -29,6 +29,7 @@ class ThreatExchange(object):
     SAMPLE_TYPE = 'sample_type'
     SHARE_LEVEL = 'share_level'
     SINCE = 'since'
+    SORT_ORDER = 'sort_order'
     STATUS = 'status'
     STRICT_TEXT = 'strict_text'
     TEXT = 'text'
@@ -39,6 +40,9 @@ class ThreatExchange(object):
     DATA = 'data'
     PAGING = 'paging'
     NEXT = 'next'
+
+    ASCENDING = 'ASCENDING'
+    DESCENDING = 'DESCENDING'
 
     METADATA = 'metadata'
 
@@ -314,8 +318,8 @@ class Attack(object):
     EMAIL_SPAM = 'EMAIL_SPAM'
     EXPLICIT_CONTENT = 'EXPLICIT_CONTENT'
     EXPLOIT_KIT = 'EXPLOIT_KIT'
-    FAKE_ACCOUNTS = 'FAKE_ACCOUNTS'
-    FINANCIALS = 'FINANCIALS'
+    FAKE_ACCOUNTS = 'FAKE_ACCOUNT'
+    FINANCIALS = 'FINANCIAL'
     IP_INFRINGEMENT = 'IP_INFRINGEMENT'
     MALICIOUS_APP = 'MALICIOUS_APP'
     MALICIOUS_NAMESERVER = 'MALICIOUS_NAMESERVER'


### PR DESCRIPTION
sort_order has been added to the API so that is now supported. Bumped
vocab to include API version 2.6 as well as additions for sort_order and
the change to Attack Types to keep things singular.

One thing to note is for the singular vocab changes. Historically we have said
if the vocab changes in this way we will keep the class attribute the same and
change the string so code doesn't break. However, we are bumping soon to a
pytx v0.5 release. If we wanted to adjust the class attribute to stay true to the
value, now would be the time to do it. I have left the attribute as-is in this PR 
but if we feel differently and want to adjust the attribute as well I can make a 
quick change and include it here too.