### PR TITLE
Initial implementation for threat tags.

### DIFF
--- a/pytx/docs/index.rst
+++ b/pytx/docs/index.rst
@@ -26,6 +26,7 @@ Contents:
    pytx.threat_exchange_member
    pytx.threat_indicator
    pytx.threat_privacy_group
+   pytx.threat_tag
    pytx.utils
    pytx.vocabulary
 

--- a/pytx/docs/pytx.threat_tag.rst
+++ b/pytx/docs/pytx.threat_tag.rst
@@ -1,0 +1,10 @@
+pytx.threat_tag package
+====================
+
+Module contents
+---------------
+
+.. automodule:: pytx.threat_tag
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/pytx/pytx/__init__.py
+++ b/pytx/pytx/__init__.py
@@ -11,6 +11,7 @@ from .threat_exchange_member import ThreatExchangeMember
 from .threat_descriptor import ThreatDescriptor
 from .threat_indicator import ThreatIndicator
 from .threat_privacy_group import ThreatPrivacyGroup
+from .threat_tag import ThreatTag
 
 __all__ = [
     'access_token',
@@ -25,5 +26,6 @@ __all__ = [
     'ThreatDescriptor',
     'ThreatIndicator',
     'ThreatPrivacyGroup',
+    'ThreatTag',
     'utils',
 ]

--- a/pytx/pytx/malware.py
+++ b/pytx/pytx/malware.py
@@ -31,6 +31,7 @@ class Malware(Common):
         m.SHARE_LEVEL,
         m.SSDEEP,
         m.STATUS,
+        m.TAGS,
         m.VICTIM_COUNT,
         m.XPI,
     ]
@@ -51,6 +52,7 @@ class Malware(Common):
         m.SHARE_LEVEL,
         m.SSDEEP,
         m.STATUS,
+        m.TAGS,
         m.VICTIM_COUNT,
         m.XPI,
     ]

--- a/pytx/pytx/threat_descriptor.py
+++ b/pytx/pytx/threat_descriptor.py
@@ -29,6 +29,7 @@ class ThreatDescriptor(Common):
         td.SHARE_LEVEL,
         td.SOURCE_URI,
         td.STATUS,
+        td.TAGS,
         td.THREAT_TYPE,
         td.TYPE,
     ]
@@ -53,6 +54,7 @@ class ThreatDescriptor(Common):
         td.SHARE_LEVEL,
         td.SOURCE_URI,
         td.STATUS,
+        td.TAGS,
         td.THREAT_TYPE,
         td.TYPE,
     ]

--- a/pytx/pytx/threat_tag.py
+++ b/pytx/pytx/threat_tag.py
@@ -1,0 +1,25 @@
+from .common import Common
+from .vocabulary import ThreatTag as tt
+from .vocabulary import ThreatExchange as t
+
+
+class ThreatTag(Common):
+
+    _URL = t.URL + t.VERSION + t.THREAT_TAGS
+    _DETAILS = t.URL + t.VERSION
+    _RELATED = t.URL + t.VERSION
+
+    _fields = [
+        tt.ID,
+        tt.TAGGED_OBJECTS,
+        tt.TEXT,
+    ]
+
+    _default_fields = [
+        tt.ID,
+        tt.TAGGED_OBJECTS,
+        tt.TEXT,
+    ]
+
+    _unique = [
+    ]

--- a/pytx/pytx/vocabulary.py
+++ b/pytx/pytx/vocabulary.py
@@ -18,6 +18,7 @@ class ThreatExchange(object):
     THREAT_PRIVACY_GROUPS = 'threat_privacy_groups/'
     THREAT_PRIVACY_GROUPS_MEMBER = 'threat_privacy_groups_member/'
     THREAT_PRIVACY_GROUPS_OWNER = 'threat_privacy_groups_owner/'
+    THREAT_TAGS = 'threat_tags/'
 
     FIELDS = 'fields'
     INCLUDE_EXPIRED = 'include_expired'
@@ -132,6 +133,7 @@ class Malware(object):
     SHARE_LEVEL = Common.SHARE_LEVEL
     SSDEEP = 'ssdeep'
     STATUS = Common.STATUS
+    TAGS = 'tags'
     VICTIM_COUNT = Common.VICTIM_COUNT
     XPI = 'xpi'
 
@@ -293,8 +295,21 @@ class ThreatDescriptor(object):
     SHARE_LEVEL = Common.SHARE_LEVEL
     SOURCE_URI = 'source_uri'
     STATUS = Common.STATUS
+    TAGS = 'tags'
     THREAT_TYPE = 'threat_type'
     TYPE = 'type'
+
+
+class ThreatTag(object):
+
+    """
+    Vocabulary specific to searching for, adding, or modifying a Threat
+    Tag object.
+    """
+
+    ID = Common.ID
+    TAGGED_OBJECTS = 'tagged_objects'
+    TEXT = 'text'
 
 
 class Attack(object):


### PR DESCRIPTION
Threat Tags are independent objects with an 'id' and 'text' field. They
have an edge to 'tagged_objects' so if you include that in your fields
list (which is not there by default when querying the graph) it will
show you the related malware and threat descriptors. Also if you include
'tags' in the fields list when querying for Malware Analyses or Threat
Descriptors, the tags will be available to you.

I cannot test this since tags aren't out yet, but it will at least allow for
the conversation to start if any adjustments need to be made for this :)