### PR TITLE
Ruby client fix for assert_params()

### DIFF
--- a/ruby/lib/ThreatExchange/client.rb
+++ b/ruby/lib/ThreatExchange/client.rb
@@ -199,11 +199,11 @@ module ThreatExchange
     end
 
 
-    private def assert_params(params, *args)
-      missing_args = params.keys - args
+    private def assert_params(params, *required_params)
+      missing_params = required_params - params.keys
 
-      if missing_args.size > 0
-        raise ArgumentError.new("Missing required params: #{missing_args.join(',')}")
+      if missing_params.size > 0
+        raise ArgumentError.new("Missing required params: #{missing_params.join(',')}")
       end
     end
   end

--- a/ruby/lib/ThreatExchange/version.rb
+++ b/ruby/lib/ThreatExchange/version.rb
@@ -1,3 +1,3 @@
 module ThreatExchange
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
My last PR added `ThreatExchange::Client#assert_params`, but I mixed up the calculation. This fixes it and gives the args a better name.