### PR TITLE
Add SSL/TLS support for the RTUListener.

### DIFF
--- a/pytx/docs/quickstart.rst
+++ b/pytx/docs/quickstart.rst
@@ -297,3 +297,20 @@ build up the listener, specifying the host, port, URL suffix we plan on using,
 the custom GET response we configured for our Webhook, and the callback
 function. The custom GET response is necessary so ThreatExchange can validate
 the Webhook with your server. After that we start the listener. That's it!
+
+You can also create your own SSLContext to pass into the RTUListener's
+ssl_context attribute to ensure everything is over HTTPS:
+
+.. code-block :: python
+
+   import ssl
+
+   ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+   ssl_context.load_cert_chain(certfile='<your_cert_file.pem',
+                               keyfile='<your_key_file.key')
+
+You should read the documentation on Webhooks to ensure you are whitelisting the
+IPs associated with Facebook to prevent malicious attacks against your RTU
+Listener:
+
+https://developers.facebook.com/docs/graph-api/webhooks?hc_location=ufi#access

--- a/pytx/pytx/rtu.py
+++ b/pytx/pytx/rtu.py
@@ -23,6 +23,8 @@ class RTUListener(object):
     :type listener_url: str
     :param callback: Custom function you wish to use for POST requests.
     :type callback: class
+    :param ssl_context: Custom ssl.SSLContext for using Flask over TLS.
+    :type ssl_context: :class: `ssl.SSLContext`
     :param debug: Enable Flask debug mode (False by default)
     :type debug: bool
     """
@@ -33,6 +35,7 @@ class RTUListener(object):
                  port=None,
                  listener_url=None,
                  callback=None,
+                 ssl_context=None,
                  debug=False):
 
         self.get_response = get_response
@@ -41,6 +44,7 @@ class RTUListener(object):
         self.debug = debug
         self.listener_url = listener_url
         self.callback = callback
+        self.ssl_context = ssl_context
 
     def listen(self, host=None, port=None, debug=None):
         """
@@ -73,6 +77,7 @@ class RTUListener(object):
             debug=debug,
             host=host,
             port=port,
+            ssl_context=self.ssl_context,
         )
 
 


### PR DESCRIPTION
This adds support for SSL/TLS through Flask using the RTUListener. Developers can create their own custom `SSLContext` with whatever options they deem necessary for their use case and pass it into the RTUListener's `ssl_context` argument.

Also added documentation referencing the Whitelisting of Facebook IPs in the Webhook docs as it pertains to securing your RTU listener.