### PR TITLE
Add a new script for dumping out a malware family from ThreatExchange

### DIFF
--- a/pytx/scripts/malware_family_grabber.py
+++ b/pytx/scripts/malware_family_grabber.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+import argparse
+import base64
+import cStringIO
+import csv
+import os
+import zipfile
+
+from pytx import Malware, MalwareFamily
+from pytx.vocabulary import Connection as c
+from pytx.vocabulary import Malware as m
+from pytx.vocabulary import MalwareFamily as mf
+
+VARIANT_HASH_FIELDS = [
+    m.ID,
+    m.CRX,
+    m.IMPHASH,
+    m.MD5,
+    m.PE_RICH_HEADER,
+    m.SHA1,
+    m.SHA256,
+    m.SSDEEP,
+    m.XPI
+]
+
+VARIANT_SAMPLE_FIELDS = [
+    m.ID,
+    m.PASSWORD,
+    m.SAMPLE,
+    m.SHA1
+]
+
+def run(families, output_dir, include_samples):
+    print('Fetching variants from %d families' % len(families))
+    for family_id in families:
+        results = MalwareFamily.connections(
+            id=family_id,
+            connection=c.VARIANTS)
+        writer = None
+        for result in results:
+            malware_dict = result.to_dict()
+            if writer == None:
+                writer = csv_writer(output_dir, family_id)
+            writer.writerow({key: malware_dict[key] for key in VARIANT_HASH_FIELDS})
+            if include_samples:
+                save_sample(malware_dict[m.ID], os.path.join(output_dir, str(family_id)))
+
+def csv_writer(output_dir, family_id):
+    file_name = os.path.join(output_dir, str(family_id) + '.csv')
+    f = open(file_name, 'wb')
+    writer = csv.DictWriter(f, fieldnames=VARIANT_HASH_FIELDS)
+    writer.writeheader()
+    return writer
+
+def save_sample(malware_id, output_dir):
+    sample = Malware.details(id=malware_id, fields=VARIANT_SAMPLE_FIELDS)
+    if sample.get(m.SAMPLE) == '':
+        print 'No sample available for %s, skipping' % sample.get(m.ID)
+    try:
+        zipfilehandle = cStringIO.StringIO()
+        zipfilehandle.write(base64.b64decode(sample.get(m.SAMPLE)))
+        with zipfile.ZipFile(zipfilehandle, 'r') as zf:
+            for entry in zf.infolist():
+                if not os.path.exists(output_dir):
+                    os.makedirs(output_dir)
+                with open(os.path.join(output_dir, sample.get(m.SHA1)), 'wb') as f:
+                    print('Writing to %s' % sample.get(m.SHA1))
+                    f.write(zf.read(entry.filename, sample.get(m.PASSWORD)))
+    except Exception, e:
+        print 'Error saving to file: %s' % str(e)
+
+def get_args():
+    parser = argparse.ArgumentParser(description='Download malware family members from ThreatExchange')
+    parser.add_argument('-i', '--ids', default=[], action='append', nargs='?',
+                        help='Malware family ID to lookup. May be specified more than once.')
+    parser.add_argument('-f', '--ids-file', default='ids.txt', nargs='?',
+                        help='File path for a file with one family ID per line')
+    parser.add_argument('-o', '--output-dir', default='.', nargs='?',
+                        help='Directory for storing output.')
+    parser.add_argument('--no-samples', dest='samples', action='store_false',
+                        help='Only download a list of hashes (default).')
+    parser.add_argument('--samples', dest='samples', action='store_true',
+                        help='Download the variant samples, as well as a list of hashes.')
+    parser.set_defaults(samples=False)
+    return parser.parse_args()
+
+def main():
+    args = get_args()
+
+    # If the file doesn't exist, no big deal
+    if os.path.exists(args.ids_file):
+        with open(args.ids_file) as fp:
+            for line in fp.readlines():
+                args.ids.append(line.strip())
+    elif args.ids == []:
+        print('The specified file "%s" was not found!' % args.ids_file)
+
+    run(args.ids, args.output_dir, args.samples)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This adds a new script for quickly dumping out the members of a malware
family in ThreatExchange: as CSV of the variant hashes or the variants
themselves.