### PR TITLE
New Malware.rfh() hotness

### DIFF
--- a/pytx/pytx/malware.py
+++ b/pytx/pytx/malware.py
@@ -98,7 +98,7 @@ class Malware(Common):
         return self.zfh.read()
 
     @property
-    def rfh(self):
+    def rfh(self, file_name=None):
         """
         Return a file handle of the base64-decoded and unzipped sample.
         """
@@ -107,7 +107,9 @@ class Malware(Common):
         rfh = io.StringIO()
         with zipfile.ZipFile(zfh, 'r') as zf:
             for entry in zf.infolist():
-                rfh.write(zf.read(entry.filename,
+                if file_name != None:
+                    file_name = entry.filename
+                rfh.write(zf.read(file_name,
                                   self.get(m.PASSWORD)))
                 rfh.seek(0)
         return rfh


### PR DESCRIPTION
Allow you to specify the filename as a param to `Malware.rfh()`