### PR TITLE
Remove threat type and attack type from pytx

### DIFF
--- a/pytx/README.rst
+++ b/pytx/README.rst
@@ -44,7 +44,7 @@ Quick Example
    access_token('<app-id>', '<app-secret>')
    results = ThreatDescriptor.objects(text='www.facebook.com')
    for result in results:
-       print result.get(td.THREAT_TYPE)
+       print result.get(td.CONFIDENCE)
 
    # type is type_ because type is a reserved word.
    results = ThreatDescriptor.objects(type_='IP_ADDRESS',

--- a/pytx/docs/quickstart.rst
+++ b/pytx/docs/quickstart.rst
@@ -126,7 +126,7 @@ classes like so:
 
    results = ThreatDescriptor.objects(text='www.facebook.com')
    for result in results:
-       print result.get(td.THREAT_TYPES)
+       print result.get(td.CONFIDENCE)
 
    # type is type_ because type is a reserved word.
    results = ThreatDescriptor.objects(type_=t.IP_ADDRESS,

--- a/pytx/pytx/common.py
+++ b/pytx/pytx/common.py
@@ -140,7 +140,6 @@ class Common(object):
                 text=None,
                 strict_text=False,
                 type_=None,
-                threat_type=None,
                 sample_type=None,
                 fields=None,
                 limit=None,
@@ -172,8 +171,6 @@ class Common(object):
         :type strict_text: bool, str, int
         :param type_: The Indicator type to limit to.
         :type type_: str
-        :param threat_type: The Threat type to limit to.
-        :type threat_type: str
         :param sample_type: The Sample type to limit to.
         :type sample_type: str
         :param fields: Select specific fields to pull
@@ -235,7 +232,6 @@ class Common(object):
                 text=text,
                 strict_text=strict_text,
                 type_=type_,
-                threat_type=threat_type,
                 sample_type=sample_type,
                 fields=fields,
                 limit=limit,

--- a/pytx/pytx/request.py
+++ b/pytx/pytx/request.py
@@ -159,7 +159,6 @@ class Broker(object):
                              text=None,
                              strict_text=None,
                              type_=None,
-                             threat_type=None,
                              sample_type=None,
                              fields=None,
                              limit=None,
@@ -183,8 +182,6 @@ class Broker(object):
         :type strict_text: bool, str, int
         :param type_: The Indicator type to limit to.
         :type type_: str
-        :param threat_type: The Threat type to limit to.
-        :type threat_type: str
         :param sample_type: The Sample type to limit to.
         :type sample_type: str
         :param fields: Select specific fields to pull
@@ -227,8 +224,6 @@ class Broker(object):
             params[t.STRICT_TEXT] = strict
         if type_:
             params[t.TYPE] = type_
-        if threat_type:
-            params[t.THREAT_TYPE] = threat_type
         if fields:
             params[t.FIELDS] = ','.join(fields) if isinstance(fields, list) else fields
         if limit:

--- a/pytx/pytx/threat_descriptor.py
+++ b/pytx/pytx/threat_descriptor.py
@@ -11,7 +11,6 @@ class ThreatDescriptor(Common):
 
     _fields = [
         td.ADDED_ON,
-        td.ATTACK_TYPE,
         td.CONFIDENCE,
         td.DESCRIPTION,
         td.EXPIRED_ON,
@@ -31,13 +30,11 @@ class ThreatDescriptor(Common):
         td.SOURCE_URI,
         td.STATUS,
         td.TAGS,
-        td.THREAT_TYPE,
         td.TYPE,
     ]
 
     _default_fields = [
         td.ADDED_ON,
-        td.ATTACK_TYPE,
         td.CONFIDENCE,
         td.DESCRIPTION,
         td.EXPIRED_ON,
@@ -57,7 +54,6 @@ class ThreatDescriptor(Common):
         td.SOURCE_URI,
         td.STATUS,
         td.TAGS,
-        td.THREAT_TYPE,
         td.TYPE,
     ]
 

--- a/pytx/pytx/vocabulary.py
+++ b/pytx/pytx/vocabulary.py
@@ -35,7 +35,6 @@ class ThreatExchange(object):
     STATUS = 'status'
     STRICT_TEXT = 'strict_text'
     TEXT = 'text'
-    THREAT_TYPE = 'threat_type'
     TYPE = 'type'
     UNTIL = 'until'
 
@@ -304,7 +303,6 @@ class ThreatDescriptor(object):
     """
 
     ADDED_ON = 'added_on'
-    ATTACK_TYPE = 'attack_type'
     CONFIDENCE = 'confidence'
     DESCRIPTION = 'description'
     EXPIRED_ON = 'expired_on'
@@ -324,7 +322,6 @@ class ThreatDescriptor(object):
     SOURCE_URI = 'source_uri'
     STATUS = Common.STATUS
     TAGS = 'tags'
-    THREAT_TYPE = 'threat_type'
     TYPE = 'type'
 
 
@@ -340,47 +337,6 @@ class ThreatTag(object):
     TAGGED_OBJECTS = 'tagged_objects'
     TEXT = 'text'
     TYPE = 'type'
-
-
-class Attack(object):
-
-    """
-    Vocabulary for the Threat Indicator Attack type.
-    """
-
-    ACCESS_TOKEN_THEFT = 'ACCESS_TOKEN_THEFT'
-    BOGON = 'BOGON'
-    BOT = 'BOT'
-    BRUTE_FORCE = 'BRUTE_FORCE'
-    CLICKJACKING = 'CLICKJACKING'
-    COMPROMISED = 'COMPROMISED'
-    CREEPER = 'CREEPER'
-    DRUGS = 'DRUGS'
-    EMAIL_SPAM = 'EMAIL_SPAM'
-    EXPLICIT_CONTENT = 'EXPLICIT_CONTENT'
-    EXPLOIT_KIT = 'EXPLOIT_KIT'
-    FAKE_ACCOUNTS = 'FAKE_ACCOUNT'
-    FINANCIALS = 'FINANCIAL'
-    IP_INFRINGEMENT = 'IP_INFRINGEMENT'
-    MALICIOUS_APP = 'MALICIOUS_APP'
-    MALICIOUS_NAMESERVER = 'MALICIOUS_NAMESERVER'
-    MALICIOUS_WEBSERVER = 'MALICIOUS_WEBSERVER'
-    MALVERTISING = 'MALVERTISING'
-    MALWARE = 'MALWARE'
-    PASSIVE_DNS = 'PASSIVE_DNS'
-    PHISHING = 'PHISHING'
-    PIRACY = 'PIRACY'
-    PROXY = 'PROXY'
-    SCAM = 'SCAM'
-    SCANNING = 'SCANNING'
-    SCRAPING = 'SCRAPING'
-    SELF_XSS = 'SELF_XSS'
-    SHARE_BAITING = 'SHARE_BAITING'
-    TARGETED = 'TARGETED'
-    TERRORISM = 'TERRORISM'
-    WEAPONS = 'WEAPONS'
-    WEB_APP = 'WEB_APP'
-    UNKNOWN = 'UNKNOWN'
 
 
 class MalwareFamily(object):
@@ -515,42 +471,6 @@ class Status(object):
     NON_MALICIOUS = 'NON_MALICIOUS'
     SUSPICIOUS = 'SUSPICIOUS'
     UNKNOWN = 'UNKNOWN'
-
-
-class ThreatType(object):
-
-    """
-    Vocabulary for the available Threat Types for a Threat Indicator.
-    """
-
-    BAD_ACTOR = 'BAD_ACTOR'
-    COMPROMISED_CREDENTIAL = 'COMPROMISED_CREDENTIAL'
-    COMMAND_EXEC = 'COMMAND_EXEC'
-    HT_VICTIM = 'HT_VICTIM'
-    MALICIOUS_AD = 'MALICIOUS_AD'
-    MALICIOUS_API_KEY = 'MALICIOUS_API_KEY'
-    MALICIOUS_CONTENT = 'MALICIOUS_CONTENT'
-    MALICIOUS_DOMAIN = 'MALICIOUS_DOMAIN'
-    MALICIOUS_INJECT = 'MALICIOUS_INJECT'
-    MALICIOUS_IP = 'MALICIOUS_IP'
-    MALICIOUS_SSL_CERT = 'MALICIOUS_SSL_CERT'
-    MALICIOUS_SUBNET = 'MALICIOUS_SUBNET'
-    MALICIOUS_URL = 'MALICIOUS_URL'
-    MALICIOUS_URL_CHUNK = 'MALICIOUS_URL_CHUNK'
-    MALWARE_ARTIFACTS = 'MALWARE_ARTIFACTS'
-    MALWARE_SAMPLE = 'MALWARE_SAMPLE'
-    MALWARE_SIGNATURE = 'MALWARE_SIGNATURE'
-    MALWARE_VICTIM = 'MALWARE_VICTIM'
-    PROXY_IP = 'PROXY_IP'
-    SIGNATURE = 'SIGNATURE'
-    SINKHOLE_EVENT = 'SINKHOLE_EVENT'
-    SMS_SPAM = 'SMS_SPAM'
-    UNKNOWN = 'UNKNOWN'
-    VICTIM_IP_USAGE = 'VICTIM_IP_USAGE'
-    WEB_REQUEST = 'WEB_REQUEST'
-    WHITELIST_DOMAIN = 'WHITELIST_DOMAIN'
-    WHITELIST_IP = 'WHITELIST_IP'
-    WHITELIST_URL = 'WHITELIST_URL'
 
 
 class Types(object):

--- a/pytx/scripts/get_compromised_credentials.py
+++ b/pytx/scripts/get_compromised_credentials.py
@@ -17,7 +17,7 @@ def get_results(options):
     if options.since is None or options.until is None:
         raise Exception('You must specify both "since" and "until" values')
 
-    results = ThreatIndicator.objects(threat_type=tt.COMPROMISED_CREDENTIAL, type_=t.EMAIL_ADDRESS, limit=options.limit,
+    results = ThreatIndicator.objects(type_=t.EMAIL_ADDRESS, limit=options.limit,
                                       fields=['indicator', 'passwords'], since=options.since, until=options.until)
     return results
 


### PR DESCRIPTION
As noted in https://www.facebook.com/groups/threatex/permalink/573588456165790/, we have removed threat type and attack type from ThreatExchange. These options are no longer supported and attempting to use them results in an error. As such, this PR removes them from pytx.