### PR TITLE
Fix Python 3 compatability

### DIFF
--- a/pytx/.gitignore
+++ b/pytx/.gitignore
@@ -1,0 +1,2 @@
+# Pycharm project settings
+.idea/

--- a/pytx/pytx/__init__.py
+++ b/pytx/pytx/__init__.py
@@ -16,10 +16,10 @@ from .rtu import RTUListener
 
 
 __title__ = 'pytx'
-__version__ = '0.5.5'
+__version__ = '0.5.6'
 __author__ = 'Mike Goffin'
 __license__ = 'BSD'
-__copyright__ = 'Copyright 2016 Mike Goffin'
+__copyright__ = 'Copyright 2017 Mike Goffin'
 
 __all__ = [
     'access_token',

--- a/pytx/pytx/common.py
+++ b/pytx/pytx/common.py
@@ -1,3 +1,5 @@
+from sys import version_info
+
 from .request import Broker
 
 from .vocabulary import Common as c
@@ -10,6 +12,11 @@ from .errors import (
     pytxAttributeError,
     pytxValueError
 )
+
+
+#  Python 3 comparability hack
+if version_info[0] >= 3:
+    basestring = str
 
 
 class class_or_instance_method(object):

--- a/pytx/pytx/utils.py
+++ b/pytx/pytx/utils.py
@@ -1,5 +1,10 @@
+from sys import version_info
 import dateutil.parser
 import datetime
+
+#  Python 3 comparability hack
+if version_info[0] >= 3:
+    basestring = str
 
 
 def convert_to_header(field):


### PR DESCRIPTION
The ``basestring`` builtin type was removed in Python 3.