### PR TITLE
Fix newsroom link

### DIFF
--- a/hashing/README.md
+++ b/hashing/README.md
@@ -1,6 +1,6 @@
 Please see:
 
-* [Facebook Newsroom post on the open-source release of TMK+PDQF and PDQ](https://newsroom.fb.com/news/2019/08/open-source-photo-video-matching])
+* [Facebook Newsroom post on the open-source release of TMK+PDQF and PDQ](https://newsroom.fb.com/news/2019/08/open-source-photo-video-matching)
 * [Detailed information on algorithm sketch, details, and evaluation](https://github.com/facebook/ThreatExchange/blob/master/hashing/hashing.pdf)
 * [Implementation and setup information about TMK+PDQF](https://github.com/facebook/ThreatExchange/blob/master/hashing/tmk/README.md)
 * [Implementation and setup information about PDQ](https://github.com/facebook/ThreatExchange/blob/master/hashing/pdq/README.md)


### PR DESCRIPTION
Removed “]” accidentally put in link text. 