### PR TITLE
add some initial tests for ruby client

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,37 +1,53 @@
 PATH
   remote: .
   specs:
-    ThreatExchange (1.0.0)
+    ThreatExchange (1.0.1)
       json
       rest-client
 
 GEM
   remote: https://rubygems.org/
   specs:
-    domain_name (0.5.24)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    http-cookie (1.0.2)
+    hashdiff (1.0.0)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
-    json (2.0.1)
-    mime-types (2.4.3)
-    netrc (0.10.3)
-    rake (10.4.2)
-    rest-client (1.8.0)
+    json (2.2.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.0331)
+    minitest (5.11.3)
+    netrc (0.11.0)
+    public_suffix (3.1.1)
+    rake (12.3.3)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    safe_yaml (1.0.5)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.6)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   ThreatExchange!
-  bundler (~> 1.6)
+  bundler (~> 2.0)
+  minitest (~> 5.0)
   rake
   rest-client
+  webmock (~> 2.1)
 
 BUNDLED WITH
-   1.12.5
+   2.0.2

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -41,7 +41,10 @@ result = TE.threat_indicators(query)
 The result will return either a string, a singular hash or an array of hashes and then from there you can manipulate the data as you like.
 If you would like to see examples of each type of query take a look at the script in the example directory.
 
+## Testing
+  To run tests just invoke rake. 
 
+    rake
 
 ## Contributing
 

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,2 +1,10 @@
 require "bundler/gem_tasks"
+require 'rake/testtask'
 
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+task :default => :test

--- a/ruby/ThreatExchange.gemspec
+++ b/ruby/ThreatExchange.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "webmock", "~> 2.1"
   spec.add_development_dependency "rake"
   spec.add_dependency "rest-client"
   spec.add_dependency "json"

--- a/ruby/test/client_test.rb
+++ b/ruby/test/client_test.rb
@@ -1,0 +1,74 @@
+require 'test_helper'
+
+describe "client" do
+  before(:all) do
+  end
+
+  describe ".new" do
+    it "sets app_id" do
+      client = ThreatExchange::Client.new(1, 'secret')
+      value(client.app_id).must_equal 1
+    end
+  end
+
+  describe "#malware_analyses" do
+    it "gets paged data" do
+      response = {
+        "data": [
+          {
+            "added_on": "2014-02-08T10:45:08+0000",
+            "md5": "f5c3281ed489772c840a137011c76b58",
+            "sha1": "2517620f427f0019e2eee3b36e206567b6e7a74a",
+            "sha256": "cb57e263ab51f8e9b40d6f292bb17512cec0aa701bde14df33dfc06c815be54c",
+            "status": "UNKNOWN",
+            "victim_count": 0,
+            "id": "760220740669930"
+          },
+        ],
+        "paging": {
+          "cursors": {
+          },
+          "next": "https://graph.facebook.com/v2.8/malware_analyses?access_token=5555|1234&pretty=0&since=1391813489&until=1391856689&limit=25&after=MjQZD"
+        },
+      }.to_json
+
+      stub_request(:get, /malware_analyses/).
+        to_return(:status => 200, :body => response)
+
+      client = ThreatExchange::Client.new(1, 'secret')
+      data = client.malware_analyses
+
+      value(data).must_equal([{"added_on"=>"2014-02-08T10:45:08+0000",
+                               "md5"=>"f5c3281ed489772c840a137011c76b58",
+                               "sha1"=>"2517620f427f0019e2eee3b36e206567b6e7a74a",
+                               "sha256"=>"cb57e263ab51f8e9b40d6f292bb17512cec0aa701bde14df33dfc06c815be54c",
+                               "status"=>"UNKNOWN",
+                               "victim_count"=>0,
+                               "id"=>"760220740669930"}])
+    end
+  end
+
+  describe "#members" do
+    it "gets data" do
+      response = {
+        "data": [
+          {
+            "id": "820763734618599",
+            "email": "threatexchange@support.facebook.com",
+            "name": "Facebook ThreatExchange"
+          } ] }.to_json
+
+          stub_request(:get, /threat_exchange_members/).
+            to_return(:status => 200, :body => response)
+
+          client = ThreatExchange::Client.new(1, 'secret')
+          data = client.members
+
+          value(data).must_equal({"data"=>[
+            {"id"=>"820763734618599",
+             "email"=>"threatexchange@support.facebook.com",
+             "name"=>"Facebook ThreatExchange"}]})
+    end
+  end
+end
+

--- a/ruby/test/test_helper.rb
+++ b/ruby/test/test_helper.rb
@@ -1,0 +1,5 @@
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+
+require 'ThreatExchange'
+require 'minitest/autorun'
+require 'webmock/minitest'


### PR DESCRIPTION
Whaaaat? No tests for the ruby client?

* updated rest-client to recent version
* add minitest
* add webmock
* add basic tests for `#members` and `#malware_analyses`
* add to README

I really just wanted a starting point to get some basic test coverage. There are some things I'd like to clean up in client, but not without coverage first.

The updated Gemfile shows 1.0.0 => 1.0.1 It was and is 1.0.1 The last update didn't check in the updated Gemfile.