### PR TITLE
Switch to pagewise-streaming model for bulk download

### DIFF
--- a/hashing/te-tag-query-java/README.md
+++ b/hashing/te-tag-query-java/README.md
@@ -37,7 +37,7 @@ java com.facebook.threatexchange.TETagQuery tag-to-details \
   --page-size 10 \
   --hash-dir ./tmk-hash-dir \
   --hash-type tmk \
-  media_priority_test
+  media_type_long_hash_video
 ```
 
 # Contact

--- a/hashing/te-tag-query-java/README.md
+++ b/hashing/te-tag-query-java/README.md
@@ -27,10 +27,17 @@ Examples:
 ```
 java com.facebook.threatexchange.TETagQuery --help
 
-java com.facebook.threatexchange.TETagQuery    tag-to-details --hash-type pdq media_type_photo
-java com.facebook.threatexchange.TETagQuery -q tag-to-details --hash-type pdq media_type_photo
-java com.facebook.threatexchange.TETagQuery    tag-to-details --hash-type md5 media_type_video
-java com.facebook.threatexchange.TETagQuery    tag-to-details --page-size 10 --hash-dir ./tmk-hash-dir --hash-type tmk media_priority_test
+java com.facebook.threatexchange.TETagQuery tag-to-details --hash-type pdq media_type_photo
+
+java com.facebook.threatexchange.TETagQuery -v tag-to-details --hash-type pdq media_type_photo
+
+java com.facebook.threatexchange.TETagQuery tag-to-details --hash-type md5 media_type_video
+
+java com.facebook.threatexchange.TETagQuery tag-to-details \
+  --page-size 10 \
+  --hash-dir ./tmk-hash-dir \
+  --hash-type tmk \
+  media_priority_test
 ```
 
 # Contact

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
@@ -7,10 +7,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-// ================================================================
-// CONTAINER CLASS FOR DESCRIPTOR-POST
-// ================================================================
-
 /**
  * Helper container class for posting threat descriptors to ThreatExchange.
  */

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/HashFilterers.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/HashFilterers.java
@@ -3,12 +3,11 @@ package com.facebook.threatexchange;
 import java.io.PrintStream;
 import java.util.stream.Stream;
 
-// ================================================================
-// Hash-filterer, using hash-text rather than ThreatExchange 'type'
-// field, since it's far more performant to filter on the former
-// than the latter.
-// ================================================================
-
+/**
+ * Hash-filterer, using hash-text rather than ThreatExchange 'type'
+ * field, since it's far more performant to filter on the former
+ * than the latter.
+ */
 class HashFiltererFactory {
   private static final String OPTION_PHOTODNA = "photodna";
   private static final String OPTION_PDQ      = "pdq";

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/HashFormatters.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/HashFormatters.java
@@ -1,9 +1,8 @@
 package com.facebook.threatexchange;
 
-// ================================================================
-// HASH OUTPUT-FORMATTER
-// ================================================================
-
+/**
+ * Hash output-formatter
+ */
 interface HashFormatter {
   public String format(SharedHash sharedHash, boolean printHashString);
 }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/IDProcessor.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/IDProcessor.java
@@ -1,0 +1,11 @@
+package com.facebook.threatexchange;
+
+import java.util.List;
+
+/**
+ * Callback interface for callsites to define what they want to do with each
+ * page of threat-descriptor-ID results.
+ */
+interface IDProcessor {
+  public void processIDs(List<String> hashIDs);
+}

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
@@ -18,10 +18,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
-// ================================================================
-// HTTP-wrapper methods
-// ================================================================
-
+/**
+ * HTTP-wrapper methods
+ * See also https://developers.facebook.com/docs/threat-exchange
+ */
 class Net {
   private static String APP_TOKEN = null;
 

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/SharedHash.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/SharedHash.java
@@ -1,9 +1,5 @@
 package com.facebook.threatexchange;
 
-// ================================================================
-// CONTAINER CLASS FOR HASHES AND METADATA
-// ================================================================
-
 /**
  * Helper container class for parsed results back from ThreatExchange.
  */

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/SimpleJSONWriter.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/SimpleJSONWriter.java
@@ -4,9 +4,9 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-// ================================================================
-// SIMPLE JSON OUTPUT
-// ================================================================
+/**
+ * Simple JSON output
+ */
 public class SimpleJSONWriter {
   LinkedHashMap<String,String> _pairs;
 

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -69,7 +69,7 @@ public class TETagQuery {
 
     // Set defaults
     String appTokenEnvName = DEFAULT_APP_TOKEN_ENV_NAME;
-    boolean verbose = true;
+    boolean verbose = false;
     boolean showURLs = false;
     int numIDsPerQuery = MAX_IDS_PER_QUERY;
     HashFormatter hashFormatter = new JSONHashFormatter();
@@ -279,7 +279,7 @@ public class TETagQuery {
       o.printf("--until {x}\n");
       o.printf("--page-size {x}\n");
       o.printf("--hash-type {x}\n");
-      o.printf("--no-hash -- Don't print the hash to the terminal\n");
+      o.printf("--no-print-hash -- Don't print the hash to the terminal\n");
       o.printf("The \"since\" or \"until\" parameter is any supported by ThreatExchange,\n");
       o.printf("e.g. seconds since the epoch.\n");
       o.printf("Hash types:\n");
@@ -343,7 +343,7 @@ public class TETagQuery {
 
           args = Arrays.copyOfRange(args, 1, args.length);
 
-        } else if (option.equals("--no-hash")) {
+        } else if (option.equals("--no-print-hash")) {
           printHashString = false;
 
         } else {
@@ -377,10 +377,25 @@ public class TETagQuery {
       // gives back only ID code, hash text, and the uninformative label
       // "THREAT_DESCRIPTOR". From this we can dive in on each item, though, and
       // query for its details one ID at a time.
-      List<String> hashIDs = Net.getHashIDsByTagID(tagID, verbose, showURLs,
-        hashFilterer, since, until, pageSize, printHashString);
+      Net.getHashIDsByTagID(tagID, verbose, showURLs,
+        hashFilterer, since, until, pageSize, printHashString,
+        new IDPrinterProcessor(verbose));
+    }
+  }
 
-      if (verbose) {
+  /**
+   * Callback for TagToIDsHandler: what we want done with every batch of
+   * threat-descriptor IDs.
+   */
+  private static class IDPrinterProcessor implements IDProcessor {
+    private final boolean _verbose;
+
+    public IDPrinterProcessor(boolean verbose) {
+      _verbose = verbose;
+    }
+
+    public void processIDs(List<String> hashIDs) {
+      if (_verbose) {
         SimpleJSONWriter w = new SimpleJSONWriter();
         w.add("hash_count", hashIDs.size());
         System.out.println(w.format());
@@ -396,7 +411,7 @@ public class TETagQuery {
           i++;
         }
       } else {
-        for (String hashID : hashIDs) {
+        for (String hashID: hashIDs) {
           System.out.println(hashID);
           System.out.flush();
         }
@@ -416,7 +431,7 @@ public class TETagQuery {
       o.printf("Usage: %s %s [options]\n",
         PROGNAME, _verb);
       o.printf("Options:\n");
-      o.printf("--no-hash -- Don't print the hash to the terminal\n");
+      o.printf("--no-print-hash -- Don't print the hash to the terminal\n");
       o.printf("--hash-dir {d} -- Write hashes as {ID}.{extension} files in directory named {d}\n");
       o.printf("Please supply IDs one line at a time on standard input.\n");
       System.exit(exitCode);
@@ -447,7 +462,7 @@ public class TETagQuery {
           hashDir = args[0];
           args = Arrays.copyOfRange(args, 1, args.length);
 
-        } else if (option.equals("--no-hash")) {
+        } else if (option.equals("--no-print-hash")) {
           printHashString = false;
 
         } else {
@@ -504,7 +519,7 @@ public class TETagQuery {
       o.printf("--until {x}\n");
       o.printf("--page-size {x}\n");
       o.printf("--hash-type {x}\n");
-      o.printf("--no-hash -- Don't print the hash\n");
+      o.printf("--no-print-hash -- Don't print the hash\n");
       o.printf("--hash-dir {d} -- Write hashes as {ID}.{extension} files in directory named {d}\n");
       o.printf("The \"since\" or \"until\" parameter is any supported by ThreatExchange,\n");
       o.printf("e.g. seconds since the epoch.\n");
@@ -577,7 +592,7 @@ public class TETagQuery {
 
           args = Arrays.copyOfRange(args, 1, args.length);
 
-        } else if (option.equals("--no-hash")) {
+        } else if (option.equals("--no-print-hash")) {
           printHashString = false;
 
         } else {
@@ -620,11 +635,45 @@ public class TETagQuery {
       // gives back only ID code, hash text, and the uninformative label
       // "THREAT_DESCRIPTOR". From this we can dive in on each item, though, and
       // query for its details one ID at a time.
-      List<String> hashIDs = Net.getHashIDsByTagID(tagID, verbose, showURLs,
-        hashFilterer, since, until, pageSize, printHashString);
+      IDProcessor processor = new IDDetailsProcessor(numIDsPerQuery, verbose,
+        showURLs, printHashString, hashDir, hashFormatter);
+      Net.getHashIDsByTagID(tagID, verbose, showURLs,
+        hashFilterer, since, until, pageSize, printHashString, processor);
+    }
+  }
 
-      outputDetails(hashIDs, numIDsPerQuery, verbose, showURLs, printHashString,
-        hashDir, hashFormatter);
+  /**
+   * Callback for TagToDetailsHandler: what we want done with every batch of
+   * threat-descriptor IDs.
+   */
+
+  private static class IDDetailsProcessor implements IDProcessor {
+    private final int _numIDsPerQuery;
+    private final boolean _verbose;
+    private final boolean _showURLs;
+    private final boolean _printHashString;
+    private final String _hashDir;
+    private final HashFormatter _hashFormatter;
+
+    public IDDetailsProcessor(
+      int numIDsPerQuery,
+      boolean verbose,
+      boolean showURLs,
+      boolean printHashString,
+      String hashDir,
+      HashFormatter hashFormatter
+    ) {
+      _numIDsPerQuery = numIDsPerQuery;
+      _verbose = verbose;
+      _showURLs = showURLs;
+      _printHashString = printHashString;
+      _hashDir = hashDir;
+      _hashFormatter = hashFormatter;
+    }
+
+    public void processIDs(List<String> hashIDs) {
+      outputDetails(hashIDs, _numIDsPerQuery, _verbose, _showURLs, _printHashString,
+        _hashDir, _hashFormatter);
     }
   }
 
@@ -649,10 +698,15 @@ public class TETagQuery {
         printHashString);
       for (SharedHash sharedHash : sharedHashes) {
 
-        System.out.println(hashFormatter.format(sharedHash, printHashString));
-
-        if (hashDir != null) {
+        if (hashDir == null) {
+          System.out.println(hashFormatter.format(sharedHash, printHashString));
+        } else {
           String path = hashDir + File.separator + sharedHash.hashID + Utils.hashTypeToFileSuffix(sharedHash.hashType);
+
+          SimpleJSONWriter w = new SimpleJSONWriter();
+          w.add("path", path);
+          System.out.println(w.format());
+          System.out.flush();
 
           try {
             Utils.outputHashToFile(sharedHash, path, verbose);
@@ -746,7 +800,7 @@ public class TETagQuery {
 
           args = Arrays.copyOfRange(args, 1, args.length);
 
-        } else if (option.equals("--no-hash")) {
+        } else if (option.equals("--no-print-hash")) {
           printHashString = false;
 
         } else {

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -472,6 +472,12 @@ public class TETagQuery {
         }
       }
 
+      if (args.length > 0) {
+        System.err.printf("%s %s: extraneous arguments.\n", PROGNAME, _verb);
+        System.err.printf("IDs must be provided on standard input, one per line.\n");
+        usage(1);
+      }
+
       if (hashDir != null) {
         File handle = new File(hashDir);
         boolean ok = handle.exists() || handle.mkdirs();

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Utils.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Utils.java
@@ -15,10 +15,9 @@ import java.util.Base64;
 import java.util.List;
 import java.util.stream.Stream;
 
-// ================================================================
-// UTILITY METHODS
-// ================================================================
-
+/**
+ * Utility methods
+ */
 class Utils {
 
   /**


### PR DESCRIPTION
Previously a query would get the list of all queried-for descriptor IDs, then go back through and pull details for each. This was a simple coding model but it had the expense of high latency from start of query to arrival of first detail. Switching to a callback model makes the code a bit less obvious but means that we start retrieving details almost immediately.

Test scenario involves running the commands in `hashing/te-tag-query-java/README.md`.