### PR TITLE
Allow command-line override of TE base URL

### DIFF
--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Constants.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Constants.java
@@ -3,7 +3,7 @@ package com.facebook.threatexchange;
 import java.net.URL;
 
 class Constants {
-  public static final String TE_BASE_URL = "https://graph.facebook.com/v4.0";
+  public static final String DEFAULT_TE_BASE_URL = "https://graph.facebook.com/v4.0";
 
   // These are all conventions for hash-sharing over ThreatExchange.
   public static final String HASH_TYPE_PHOTODNA = "HASH_PHOTODNA";

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
@@ -24,6 +24,11 @@ import java.util.stream.Stream;
  */
 class Net {
   private static String APP_TOKEN = null;
+  private static String TE_BASE_URL = Constants.DEFAULT_TE_BASE_URL;
+
+  public static void setTEBaseURL(String TEBaseURL) {
+    TE_BASE_URL = TEBaseURL;
+  }
 
   /**
    * Gets the ThreatExchange app token from an environment variable.
@@ -45,7 +50,7 @@ class Net {
    * Looks up the internal ID for a given tag.
    */
   public static String getTagIDFromName(String tagName, boolean showURLs) {
-    String url = Constants.TE_BASE_URL
+    String url = TE_BASE_URL
       + "/threat_tags"
       + "/?access_token=" + APP_TOKEN
       + "&text=" + URLEncoder.encode(tagName); // since user-supplied string
@@ -102,7 +107,7 @@ class Net {
     IDProcessor idProcessor
   ) {
     String pageLimit = Integer.toString(pageSize);
-    String startURL = Constants.TE_BASE_URL
+    String startURL = TE_BASE_URL
       + "/" + tagID + "/tagged_objects"
       + "/?access_token=" + APP_TOKEN
       + "&limit=" + pageLimit;
@@ -220,7 +225,7 @@ class Net {
       }
     }
 
-    String url = Constants.TE_BASE_URL
+    String url = TE_BASE_URL
       + "/?access_token=" + APP_TOKEN
       + "&ids=%5B" + String.join(",", hashIDs) + "%5D"
       + "&fields=raw_indicator,type,added_on,confidence,owner,review_status,severity,share_level,tags";
@@ -340,7 +345,7 @@ class Net {
     List<SharedHash> sharedHashes = new ArrayList<SharedHash>();
 
     String pageLimit = Integer.toString(pageSize);
-    String startURL = Constants.TE_BASE_URL
+    String startURL = TE_BASE_URL
       + "/threat_descriptors"
       + "/?access_token=" + APP_TOKEN
       + "&fields=raw_indicator,type,added_on,confidence,owner,review_status,severity,share_level,tags"
@@ -484,7 +489,7 @@ class Net {
     boolean dryRun
   ) {
 
-    String urlString = Constants.TE_BASE_URL
+    String urlString = TE_BASE_URL
       + "/threat_descriptors"
       + "/?access_token=" + APP_TOKEN;
 

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -58,6 +58,7 @@ public class TETagQuery {
     o.printf("  -s|--show-urls Print URLs used for queries, before executing them.\n");
     o.printf("  -a|--app-token-env-name {...} Name of app-token environment variable.\n");
     o.printf("                 Defaults to \"%s\".\n", DEFAULT_APP_TOKEN_ENV_NAME);
+    o.printf("  -b|--te-base-url {...} Defaults to \"%s\"\n", Constants.DEFAULT_TE_BASE_URL);
     CommandHandlerFactory.list(o);
     System.exit(exitCode);
   }
@@ -133,6 +134,13 @@ public class TETagQuery {
           usage(1);
         }
         appTokenEnvName = args[0];
+        args = Arrays.copyOfRange(args, 1, args.length);
+
+      } else if (option.equals("-b") || option.equals("--te-base-url")) {
+        if (args.length < 1) {
+          usage(1);
+        }
+        Net.setTEBaseURL(args[0]);
         args = Arrays.copyOfRange(args, 1, args.length);
 
       } else {


### PR DESCRIPTION
```
$ alias jrt='jr com.facebook.threatexchange.TETagQuery'
```

```
$ jrt -h
Usage: TETagQuery [options] {verb} {verb arguments}
Downloads photo/video hashes in bulk from ThreatExchange, given
either a tag name or a list of IDs one per line on standard input.
Options:
  -h|--help      Show detailed help.
  --list-verbs   Show a list of supported verbs.
  --list-tags    Show a list of supported tags.
  -q|--quiet     Only print IDs/hashes output with no narrative.
  -v|--verbose   Print IDs/hashes output along with narrative.
  -s|--show-urls Print URLs used for queries, before executing them.
  -a|--app-token-env-name {...} Name of app-token environment variable.
                 Defaults to "TX_ACCESS_TOKEN".
  -b|--te-base-url {...} Defaults to "https://graph.facebook.com/v4.0"
Verbs:
  look-up-tag-id
  tag-to-ids
  ids-to-details
  tag-to-details
  incremental
  paginate
```

```
$ jrt -b https://graph.facebook.com/v3.1 look-up-tag-id media_priority_test
tag_name=media_priority_test,tag_id=1614401841933057

$ jrt look-up-tag-id media_priority_test
tag_name=media_priority_test,tag_id=1614401841933057
```