### PR TITLE
replace media_type/media_priority single-valued requirement with more flexible tags-list logic

### DIFF
--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Constants.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Constants.java
@@ -16,19 +16,4 @@ class Constants {
   public static final String HASH_TYPE_TMK = "HASH_TMK";
 
   public static final String THREAT_DESCRIPTOR = "THREAT_DESCRIPTOR";
-
-  public static final String TAG_PREFIX_MEDIA_TYPE = "media_type_";
-  public static final String TAG_MEDIA_TYPE_PHOTO = "media_type_photo";
-  public static final String TAG_MEDIA_TYPE_VIDEO = "media_type_video";
-  public static final String TAG_MEDIA_TYPE_LONG_HASH_VIDEO = "media_type_long_hash_video";
-
-  public static final String TAG_PREFIX_MEDIA_PRIORITY = "media_priority_";
-  public static final String TAG_MEDIA_PRIORITY_S0 = "media_priority_s0";
-  public static final String TAG_MEDIA_PRIORITY_S1 = "media_priority_s1";
-  public static final String TAG_MEDIA_PRIORITY_S2 = "media_priority_s2";
-  public static final String TAG_MEDIA_PRIORITY_S3 = "media_priority_s3";
-  public static final String TAG_MEDIA_PRIORITY_T0 = "media_priority_t0";
-  public static final String TAG_MEDIA_PRIORITY_T1 = "media_priority_t1";
-  public static final String TAG_MEDIA_PRIORITY_T2 = "media_priority_t2";
-  public static final String TAG_MEDIA_PRIORITY_T3 = "media_priority_t3";
 }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/HashFormatters.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/HashFormatters.java
@@ -25,8 +25,7 @@ class JSONHashFormatter implements HashFormatter {
     w.add("owner_id", sharedHash.ownerID);
     w.add("owner_email", sharedHash.ownerEmail);
     w.add("owner_name", sharedHash.ownerName);
-    w.add("media_type", sharedHash.mediaType);
-    w.add("media_priority", sharedHash.mediaPriority);
+    w.add("tags", String.join(",", sharedHash.tags));
     return w.format();
   }
 }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
@@ -18,6 +18,7 @@ import java.net.ProtocolException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
@@ -285,31 +286,13 @@ class Net {
         JSONObject tags = (JSONObject)item.get("tags");
         JSONArray tag_data = (JSONArray)tags.get("data");
         int n = tag_data.size();
-        String mediaType = "not_found";
-        String mediaPriority = "not_found";
-        int numMediaType = 0;
-        int numMediaPriority = 0;
+        List<String> tagTexts = new ArrayList<String>();
         for (int j = 0; j < n; j++) {
           JSONObject tag = (JSONObject) tag_data.get(j);
-          String tag_text = (String)tag.get("text");
-          if (tag_text.startsWith(Constants.TAG_PREFIX_MEDIA_TYPE)) {
-            mediaType = tag_text.replace(Constants.TAG_PREFIX_MEDIA_TYPE, "").toUpperCase();
-            numMediaType++;
-          } else if (tag_text.startsWith(Constants.TAG_PREFIX_MEDIA_PRIORITY)) {
-            mediaPriority = tag_text.replace(Constants.TAG_PREFIX_MEDIA_PRIORITY, "").toUpperCase();
-            numMediaPriority++;
-          }
+          String tagText = (String)tag.get("text");
+          tagTexts.add(tagText);
         }
-
-        if (verbose) {
-          if (numMediaType != 1 || numMediaPriority != 1) {
-            SimpleJSONWriter w = new SimpleJSONWriter();
-            w.add("hash_id", (String)item.get("id"));
-            w.add("num_media_type", numMediaType);
-            w.add("num_media_priority", numMediaPriority);
-            System.out.println(w.format());
-          }
-        }
+        Collections.sort(tagTexts); // canonicalize
 
         SharedHash sharedHash = new SharedHash(
           (String)item.get("id"),
@@ -320,8 +303,8 @@ class Net {
           (String)owner.get("id"),
           (String)owner.get("email"),
           (String)owner.get("name"),
-          mediaType,
-          mediaPriority);
+          tagTexts
+        );
 
         sharedHashes.add(sharedHash);
       }
@@ -444,21 +427,13 @@ class Net {
           JSONObject tags = (JSONObject)item.get("tags");
           JSONArray tag_data = (JSONArray)tags.get("data");
           int n = tag_data.size();
-          String mediaType = "not_found";
-          String mediaPriority = "not_found";
-          int numMediaType = 0;
-          int numMediaPriority = 0;
+          List<String> tagTexts = new ArrayList<String>();
           for (int j = 0; j < n; j++) {
             JSONObject tag = (JSONObject) tag_data.get(j);
-            String tag_text = (String)tag.get("text");
-            if (tag_text.startsWith(Constants.TAG_PREFIX_MEDIA_TYPE)) {
-              mediaType = tag_text.replace(Constants.TAG_PREFIX_MEDIA_TYPE, "").toUpperCase();
-              numMediaType++;
-            } else if (tag_text.startsWith(Constants.TAG_PREFIX_MEDIA_PRIORITY)) {
-              mediaPriority = tag_text.replace(Constants.TAG_PREFIX_MEDIA_PRIORITY, "").toUpperCase();
-              numMediaPriority++;
-            }
+            String tagText = (String)tag.get("text");
+            tagTexts.add(tagText);
           }
+          Collections.sort(tagTexts); // canonicalize
 
           SharedHash sharedHash = new SharedHash(
             itemID,
@@ -469,9 +444,8 @@ class Net {
             (String)owner.get("id"),
             (String)owner.get("email"),
             (String)owner.get("name"),
-            mediaType,
-            mediaPriority);
-
+            tagTexts
+          );
         }
         pageIndex++;
       } catch (Exception e) {

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/SharedHash.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/SharedHash.java
@@ -3,6 +3,8 @@
 // ================================================================
 
 package com.facebook.threatexchange;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Helper container class for parsed results back from ThreatExchange.
@@ -16,8 +18,7 @@ public class SharedHash {
   public final String ownerID;
   public final String ownerEmail;
   public final String ownerName;
-  public final String mediaType;
-  public final String mediaPriority;
+  public final List<String> tags;
 
   public SharedHash(
     String hashID_,
@@ -28,8 +29,7 @@ public class SharedHash {
     String ownerID_,
     String ownerEmail_,
     String ownerName_,
-    String mediaType_,
-    String mediaPriority_
+    List<String> tags_
   ) {
     hashID = hashID_;
     hashValue = hashValue_;
@@ -39,7 +39,6 @@ public class SharedHash {
     ownerID = ownerID_;
     ownerEmail = ownerEmail_;
     ownerName = ownerName_;
-    mediaType = mediaType_;
-    mediaPriority = mediaPriority_;
+    tags = new ArrayList(tags_);
   }
 }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -52,7 +52,6 @@ public class TETagQuery {
     o.printf("Options:\n");
     o.printf("  -h|--help      Show detailed help.\n");
     o.printf("  --list-verbs   Show a list of supported verbs.\n", PROGNAME);
-    o.printf("  --list-tags    Show a list of supported tags.\n", PROGNAME);
     o.printf("  -q|--quiet     Only print IDs/hashes output with no narrative.\n");
     o.printf("  -v|--verbose   Print IDs/hashes output along with narrative.\n");
     o.printf("  -s|--show-urls Print URLs used for queries, before executing them.\n");
@@ -94,20 +93,6 @@ public class TETagQuery {
 
       } else if (option.equals("--list-verbs")) {
         CommandHandlerFactory.list(System.out);
-        System.exit(0);
-
-      } else if (option.equals("--list-tags")) {
-        System.out.println(Constants.TAG_MEDIA_TYPE_PHOTO);
-        System.out.println(Constants.TAG_MEDIA_TYPE_VIDEO);
-        System.out.println(Constants.TAG_MEDIA_TYPE_LONG_HASH_VIDEO);
-        System.out.println(Constants.TAG_MEDIA_PRIORITY_S0);
-        System.out.println(Constants.TAG_MEDIA_PRIORITY_S1);
-        System.out.println(Constants.TAG_MEDIA_PRIORITY_S2);
-        System.out.println(Constants.TAG_MEDIA_PRIORITY_S3);
-        System.out.println(Constants.TAG_MEDIA_PRIORITY_T0);
-        System.out.println(Constants.TAG_MEDIA_PRIORITY_T1);
-        System.out.println(Constants.TAG_MEDIA_PRIORITY_T2);
-        System.out.println(Constants.TAG_MEDIA_PRIORITY_T3);
         System.exit(0);
 
       } else if (option.equals("--ids-per-query")) {


### PR DESCRIPTION
```
alias jtq='java com.facebook.threatexchange.TETagQuery'
```

```
$ jtq tag-to-details pwny | jq .
...
{
  "hash_id": "2683772931706491",
  "hash_value": "https://evilevillabs.com/evil.php",
  "hash_type": "URI",
  "added_on": "2020-01-06T14:58:34+0000",
  "confidence": "50",
  "owner_id": "1064060413755420",
  "owner_email": "threatexchange@support.facebook.com",
  "owner_name": "Media Hash Sharing Test",
  "tags": "pwny,testing,testing-bulk-edit,testing-bulk-edit-for-doc"
}
{
  "hash_id": "2265118903591404",
  "hash_value": "e8b19da37825a3056e84c522f05eb0a2",
  "hash_type": "HASH_MD5",
  "added_on": "2020-03-28T17:00:48+0000",
  "confidence": "100",
  "owner_id": "494491891138576",
  "owner_email": "kerl@fb.com",
  "owner_name": "Media Hash Sharing RF Test",
  "tags": "pwny,testing"
}
...
```