### PR TITLE
attribute-renames to adhere more closely to the rest of TE

### DIFF
--- a/hashing/te-tag-query-java/README.md
+++ b/hashing/te-tag-query-java/README.md
@@ -29,29 +29,29 @@ java com.facebook.threatexchange.TETagQuery --help
 
 Querying for all hashes of a given type:
 ```
-java com.facebook.threatexchange.TETagQuery tag-to-details --hash-type pdq media_type_photo
+java com.facebook.threatexchange.TETagQuery tag-to-details --indicator-type pdq media_type_photo
 
-java com.facebook.threatexchange.TETagQuery -v tag-to-details --hash-type pdq media_type_photo
+java com.facebook.threatexchange.TETagQuery -v tag-to-details --indicator-type pdq media_type_photo
 
-java com.facebook.threatexchange.TETagQuery tag-to-details --hash-type md5 media_type_video
+java com.facebook.threatexchange.TETagQuery tag-to-details --indicator-type md5 media_type_video
 
 java com.facebook.threatexchange.TETagQuery tag-to-details \
   --page-size 10 \
-  --hash-dir ./tmk-hash-dir \
-  --hash-type tmk \
+  --data-dir ./tmk-hash-dir \
+  --indicator-type tmk \
   media_type_long_hash_video
 ```
 
 Querying for some hashes of a given type:
 ```
-java com.facebook.threatexchange.TETagQuery tag-to-details --hash-type pdq --since -1day media_type_photo
+java com.facebook.threatexchange.TETagQuery tag-to-details --indicator-type pdq --since -1day media_type_photo
 
-java com.facebook.threatexchange.TETagQuery tag-to-details --hash-type md5 --since -1week media_type_video
+java com.facebook.threatexchange.TETagQuery tag-to-details --indicator-type md5 --since -1week media_type_video
 
 java com.facebook.threatexchange.TETagQuery tag-to-details \
   --page-size 10 \
-  --hash-dir ./tmk-hash-dir \
-  --hash-type tmk \
+  --data-dir ./tmk-hash-dir \
+  --indicator-type tmk \
   --since -1week \
   media_type_long_hash_video
 ```

--- a/hashing/te-tag-query-java/README.md
+++ b/hashing/te-tag-query-java/README.md
@@ -37,7 +37,7 @@ java com.facebook.threatexchange.TETagQuery tag-to-details --indicator-type md5 
 
 java com.facebook.threatexchange.TETagQuery tag-to-details \
   --page-size 10 \
-  --data-dir ./tmk-hash-dir \
+  --data-dir ./tmk-data-dir \
   --indicator-type tmk \
   media_type_long_hash_video
 ```
@@ -50,7 +50,7 @@ java com.facebook.threatexchange.TETagQuery tag-to-details --indicator-type md5 
 
 java com.facebook.threatexchange.TETagQuery tag-to-details \
   --page-size 10 \
-  --data-dir ./tmk-hash-dir \
+  --data-dir ./tmk-data-dir \
   --indicator-type tmk \
   --since -1week \
   media_type_long_hash_video

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Constants.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Constants.java
@@ -10,10 +10,10 @@ class Constants {
   public static final String DEFAULT_TE_BASE_URL = "https://graph.facebook.com/v4.0";
 
   // These are all conventions for hash-sharing over ThreatExchange.
-  public static final String HASH_TYPE_PHOTODNA = "HASH_PHOTODNA";
-  public static final String HASH_TYPE_PDQ = "HASH_PDQ";
-  public static final String HASH_TYPE_MD5 = "HASH_MD5";
-  public static final String HASH_TYPE_TMK = "HASH_TMK";
+  public static final String INDICATOR_TYPE_PHOTODNA = "HASH_PHOTODNA";
+  public static final String INDICATOR_TYPE_PDQ = "HASH_PDQ";
+  public static final String INDICATOR_TYPE_MD5 = "HASH_MD5";
+  public static final String INDICATOR_TYPE_TMK = "HASH_TMK";
 
   public static final String THREAT_DESCRIPTOR = "THREAT_DESCRIPTOR";
 }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/HashFormatters.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/HashFormatters.java
@@ -8,28 +8,28 @@ package com.facebook.threatexchange;
  * Hash output-formatter
  */
 interface HashFormatter {
-  public String format(SharedHash sharedHash, boolean printHashString);
+  public String format(ThreatDescriptor threatDescriptor, boolean printHashString);
 }
 
 class JSONHashFormatter implements HashFormatter {
   @Override
-  public String format(SharedHash sharedHash, boolean printHashString) {
+  public String format(ThreatDescriptor threatDescriptor, boolean printHashString) {
     SimpleJSONWriter w = new SimpleJSONWriter();
-    w.add("id", sharedHash.id);
+    w.add("id", threatDescriptor.id);
     if (printHashString) {
-      w.add("td_raw_indicator", sharedHash.td_raw_indicator);
+      w.add("td_raw_indicator", threatDescriptor.td_raw_indicator);
     }
-    w.add("td_indicator_type", sharedHash.td_indicator_type);
-    w.add("added_on", sharedHash.added_on);
-    w.add("td_confidence", sharedHash.td_confidence);
-    w.add("td_owner_id", sharedHash.td_owner_id);
-    w.add("td_owner_email", sharedHash.td_owner_email);
-    w.add("td_owner_name", sharedHash.td_owner_name);
-    w.add("td_visibility", sharedHash.td_visibility);
-    w.add("td_status", sharedHash.td_status);
-    w.add("td_severity", sharedHash.td_severity);
-    w.add("td_share_level", sharedHash.td_share_level);
-    w.add("td_subjective_tags", String.join(",", sharedHash.td_subjective_tags));
+    w.add("td_indicator_type", threatDescriptor.td_indicator_type);
+    w.add("added_on", threatDescriptor.added_on);
+    w.add("td_confidence", threatDescriptor.td_confidence);
+    w.add("td_owner_id", threatDescriptor.td_owner_id);
+    w.add("td_owner_email", threatDescriptor.td_owner_email);
+    w.add("td_owner_name", threatDescriptor.td_owner_name);
+    w.add("td_visibility", threatDescriptor.td_visibility);
+    w.add("td_status", threatDescriptor.td_status);
+    w.add("td_severity", threatDescriptor.td_severity);
+    w.add("td_share_level", threatDescriptor.td_share_level);
+    w.add("td_subjective_tags", String.join(",", threatDescriptor.td_subjective_tags));
     return w.format();
   }
 }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/HashFormatters.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/HashFormatters.java
@@ -15,17 +15,21 @@ class JSONHashFormatter implements HashFormatter {
   @Override
   public String format(SharedHash sharedHash, boolean printHashString) {
     SimpleJSONWriter w = new SimpleJSONWriter();
-    w.add("hash_id", sharedHash.hashID);
+    w.add("id", sharedHash.id);
     if (printHashString) {
-      w.add("hash_value", sharedHash.hashValue);
+      w.add("td_raw_indicator", sharedHash.td_raw_indicator);
     }
-    w.add("hash_type", sharedHash.hashType);
-    w.add("added_on", sharedHash.addedOn);
-    w.add("confidence", sharedHash.confidence);
-    w.add("owner_id", sharedHash.ownerID);
-    w.add("owner_email", sharedHash.ownerEmail);
-    w.add("owner_name", sharedHash.ownerName);
-    w.add("tags", String.join(",", sharedHash.tags));
+    w.add("td_indicator_type", sharedHash.td_indicator_type);
+    w.add("added_on", sharedHash.added_on);
+    w.add("td_confidence", sharedHash.td_confidence);
+    w.add("td_owner_id", sharedHash.td_owner_id);
+    w.add("td_owner_email", sharedHash.td_owner_email);
+    w.add("td_owner_name", sharedHash.td_owner_name);
+    w.add("td_visibility", sharedHash.td_visibility);
+    w.add("td_status", sharedHash.td_status);
+    w.add("td_severity", sharedHash.td_severity);
+    w.add("td_share_level", sharedHash.td_share_level);
+    w.add("td_subjective_tags", String.join(",", sharedHash.td_subjective_tags));
     return w.format();
   }
 }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/IDProcessor.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/IDProcessor.java
@@ -11,5 +11,5 @@ import java.util.List;
  * page of threat-descriptor-ID results.
  */
 interface IDProcessor {
-  public void processIDs(List<String> hashIDs);
+  public void processIDs(List<String> ids);
 }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
@@ -213,7 +213,7 @@ class Net {
   /**
    * Looks up all metadata for given ID.
    */
-  public static List<SharedHash> getInfoForIDs(
+  public static List<ThreatDescriptor> getInfoForIDs(
     List<String> ids,
     boolean verbose,
     boolean showURLs,
@@ -239,7 +239,7 @@ class Net {
       System.out.println(url);
     }
 
-    List<SharedHash> sharedHashes = new ArrayList<SharedHash>();
+    List<ThreatDescriptor> threatDescriptores = new ArrayList<ThreatDescriptor>();
     try (InputStream response = new URL(url).openConnection().getInputStream()) {
       // {
       //    "990927953l366387": {
@@ -294,7 +294,7 @@ class Net {
         }
         Collections.sort(tagTexts); // canonicalize
 
-        SharedHash sharedHash = new SharedHash(
+        ThreatDescriptor threatDescriptor = new ThreatDescriptor(
           (String)item.get("id"),
           (String)item.get("raw_indicator"),
           (String)item.get("type"),
@@ -310,13 +310,13 @@ class Net {
           tagTexts
         );
 
-        sharedHashes.add(sharedHash);
+        threatDescriptores.add(threatDescriptor);
       }
     } catch (Exception e) {
       e.printStackTrace(System.err);
       System.exit(1);
     }
-    return sharedHashes;
+    return threatDescriptores;
   }
 
   /**
@@ -325,7 +325,7 @@ class Net {
    * There are many queries for which the 'next' paging parameter will remain
    * non-null on every next-page request.
    */
-  public static List<SharedHash> getIncremental(
+  public static List<ThreatDescriptor> getIncremental(
     String tagName,
     String td_indicator_type,
     String since,
@@ -333,7 +333,7 @@ class Net {
     boolean verbose,
     boolean showURLs
   ) {
-    List<SharedHash> sharedHashes = new ArrayList<SharedHash>();
+    List<ThreatDescriptor> threatDescriptores = new ArrayList<ThreatDescriptor>();
 
     String pageLimit = Integer.toString(pageSize);
     String startURL = TE_BASE_URL
@@ -439,7 +439,7 @@ class Net {
           }
           Collections.sort(tagTexts); // canonicalize
 
-          SharedHash sharedHash = new SharedHash(
+          ThreatDescriptor threatDescriptor = new ThreatDescriptor(
             itemID,
             itemText,
             itemType,
@@ -462,7 +462,7 @@ class Net {
       }
     } while (nextURL != null);
 
-    return sharedHashes;
+    return threatDescriptores;
   }
 
   /**

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
@@ -163,7 +163,7 @@ class Net {
 
         int numItems = data.size();
 
-        List<String> hashIDs = new ArrayList<String>();
+        List<String> ids = new ArrayList<String>();
         for (int i = 0; i < numItems; i++) {
           JSONObject item = (JSONObject) data.get(i);
 
@@ -188,19 +188,19 @@ class Net {
             System.out.println(w.format());
             System.out.flush();
           }
-          hashIDs.add(itemID);
+          ids.add(itemID);
         }
 
         if (verbose) {
           SimpleJSONWriter w = new SimpleJSONWriter();
           w.add("page_index", pageIndex);
           w.add("num_items_pre_filter", numItems);
-          w.add("num_items_post_filter", hashIDs.size());
+          w.add("num_items_post_filter", ids.size());
           System.out.println(w.format());
           System.out.flush();
         }
 
-        idProcessor.processIDs(hashIDs);
+        idProcessor.processIDs(ids);
 
         pageIndex++;
       } catch (Exception e) {
@@ -214,26 +214,26 @@ class Net {
    * Looks up all metadata for given ID.
    */
   public static List<SharedHash> getInfoForIDs(
-    List<String> hashIDs,
+    List<String> ids,
     boolean verbose,
     boolean showURLs,
     boolean printHashString
   ) {
     // Check well-formattedness of hash IDs (which may have come from
     // arbitrary data on stdin).
-    for(String hashID : hashIDs) {
+    for(String id : ids) {
       try {
-        Long.valueOf(hashID);
+        Long.valueOf(id);
       } catch (NumberFormatException e) {
-        System.err.printf("Malformed hash ID \"%s\"\n", hashID);
+        System.err.printf("Malformed hash ID \"%s\"\n", id);
         System.exit(1);
       }
     }
 
     String url = TE_BASE_URL
       + "/?access_token=" + APP_TOKEN
-      + "&ids=%5B" + String.join(",", hashIDs) + "%5D"
-      + "&fields=raw_indicator,type,added_on,confidence,owner,review_status,severity,share_level,tags";
+      + "&ids=%5B" + String.join(",", ids) + "%5D"
+      + "&fields=raw_indicator,type,added_on,confidence,owner,review_status,privacy_type,status,severity,share_level,tags";
     if (showURLs) {
       System.out.println("URL:");
       System.out.println(url);
@@ -283,8 +283,8 @@ class Net {
         }
 
         JSONObject owner = (JSONObject)item.get("owner");
-        JSONObject tags = (JSONObject)item.get("tags");
-        JSONArray tag_data = (JSONArray)tags.get("data");
+        JSONObject td_subjective_tags = (JSONObject)item.get("tags");
+        JSONArray tag_data = (JSONArray)td_subjective_tags.get("data");
         int n = tag_data.size();
         List<String> tagTexts = new ArrayList<String>();
         for (int j = 0; j < n; j++) {
@@ -303,6 +303,10 @@ class Net {
           (String)owner.get("id"),
           (String)owner.get("email"),
           (String)owner.get("name"),
+          (String)item.get("privacy_type"),
+          (String)item.get("status"),
+          (String)item.get("severity"),
+          (String)item.get("share_level"),
           tagTexts
         );
 
@@ -323,7 +327,7 @@ class Net {
    */
   public static List<SharedHash> getIncremental(
     String tagName,
-    String hashType,
+    String td_indicator_type,
     String since,
     int pageSize,
     boolean verbose,
@@ -335,12 +339,12 @@ class Net {
     String startURL = TE_BASE_URL
       + "/threat_descriptors"
       + "/?access_token=" + APP_TOKEN
-      + "&fields=raw_indicator,type,added_on,confidence,owner,review_status,severity,share_level,tags"
+      + "&fields=raw_indicator,type,added_on,confidence,owner,review_status,privacy_type,status,severity,share_level,tags"
       + "&limit=" + pageLimit
       + "&tags=" + tagName
       + "&since=" + since;
-    if (hashType != null) {
-      startURL = startURL + "&type=" + hashType;
+    if (td_indicator_type != null) {
+      startURL = startURL + "&type=" + td_indicator_type;
     }
 
     String nextURL = startURL;
@@ -424,8 +428,8 @@ class Net {
 
           JSONObject owner = (JSONObject)item.get("owner");
 
-          JSONObject tags = (JSONObject)item.get("tags");
-          JSONArray tag_data = (JSONArray)tags.get("data");
+          JSONObject td_subjective_tags = (JSONObject)item.get("tags");
+          JSONArray tag_data = (JSONArray)td_subjective_tags.get("data");
           int n = tag_data.size();
           List<String> tagTexts = new ArrayList<String>();
           for (int j = 0; j < n; j++) {
@@ -444,6 +448,10 @@ class Net {
             (String)owner.get("id"),
             (String)owner.get("email"),
             (String)owner.get("name"),
+            (String)item.get("privacy_type"),
+            (String)item.get("status"),
+            (String)item.get("severity"),
+            (String)item.get("share_level"),
             tagTexts
           );
         }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/SharedHash.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/SharedHash.java
@@ -6,39 +6,103 @@ package com.facebook.threatexchange;
 import java.util.ArrayList;
 import java.util.List;
 
+// TEUI CSV-download column names:
+// $ mlr --c2x head -n 1 pwny.csv
+// td_description          Testing bulk upload
+// td_status               NON_MALICIOUS
+// td_severity             INFO
+// td_share_level          AMBER
+// td_review_status        REVIEWED_AUTOMATICALLY
+// td_raw_indicator        e8b19da37825a3056e84c522f05eb001
+// td_indicator            [object Object]
+// td_visibility           HAS_WHITELIST
+// td_reactions_by_app
+// td_source_uri
+// td_reaction_count       0
+// td_same_indicator_count 2
+// td_related_count        4
+// td_creation_time        2019-12-04T15:05:28-05:00
+// td_update_time          2019-12-04T15:05:28-05:00
+// td_expire_time
+// td_first_active
+// td_last_active
+// td_owner_id             2061458520576715
+// td_owner_name           ISE TE Non-MSH Test App
+// td_subjective_tags      testing;pwny
+// td_whitelist_apps       2061458520576715:ISE TE Non-MSH Test App;494491891138576:Media Hash Sharing RF Test
+// td_privacy_groups
+
+// AVAILABLE WITHIN THE GRAPH API, BEING USED:
+// * id
+// * added_on
+// * confidence
+// * owner
+// * raw_indicator
+// * type
+// * severity
+// * share_level
+// * privacy_type
+// * status
+
+// AVAILABLE WITHIN THE GRAPH API, TO BE USED:
+// * description -- be sure to escape embedded double-quotes for the JSON ...
+// * review_status
+
+// AVAILABLE WITHIN THE GRAPH API, MAYBE USE:
+// ? indicator (to get the id ...) -- only useful for relation-edge-following
+// ? expired_on
+// ? first_active
+// ? last_active
+// ? last_updated
+// ? my_reactions
+// ? reactions
+
 /**
  * Helper container class for parsed results back from ThreatExchange.
  */
 public class SharedHash {
-  public final String hashID;
-  public final String hashValue;
-  public final String hashType;
-  public final String addedOn;
-  public final String confidence;
-  public final String ownerID;
-  public final String ownerEmail;
-  public final String ownerName;
-  public final List<String> tags;
+  public final String id;
+  public final String td_raw_indicator;
+  public final String td_indicator_type;
+  public final String added_on;
+  public final String td_confidence;
+  public final String td_owner_id;
+  public final String td_owner_email;
+  public final String td_owner_name;
+  public final String td_visibility;
+  public final String td_status;
+  public final String td_severity;
+  public final String td_share_level;
+  public final List<String> td_subjective_tags;
 
   public SharedHash(
-    String hashID_,
-    String hashValue_,
-    String hashType_,
-    String addedOn_,
-    String confidence_,
-    String ownerID_,
-    String ownerEmail_,
-    String ownerName_,
-    List<String> tags_
+    String id_,
+    String td_raw_indicator_,
+    String td_indicator_type_,
+    String added_on_,
+    String td_confidence_,
+    String td_owner_id_,
+    String td_owner_email_,
+    String td_owner_name_,
+    String td_visibility_,
+    String td_status_,
+    String td_severity_,
+    String td_share_level_,
+    List<String> td_subjective_tags_
   ) {
-    hashID = hashID_;
-    hashValue = hashValue_;
-    hashType = hashType_;
-    addedOn = addedOn_;
-    confidence = confidence_;
-    ownerID = ownerID_;
-    ownerEmail = ownerEmail_;
-    ownerName = ownerName_;
-    tags = new ArrayList(tags_);
+    id = id_;
+    td_raw_indicator = td_raw_indicator_;
+    td_indicator_type = td_indicator_type_;
+    added_on = added_on_;
+    td_confidence = td_confidence_;
+    td_owner_id = td_owner_id_;
+    td_owner_email = td_owner_email_;
+    td_owner_name = td_owner_name_;
+    td_visibility = td_visibility_;
+    td_status = td_status_;
+    td_severity = td_severity_;
+    td_share_level = td_share_level_;
+
+    td_subjective_tags = new ArrayList(td_subjective_tags_);
   }
 }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -696,17 +696,17 @@ public class TETagQuery {
 
     // Now look up details for each ID.
     for (List<String> chunk: chunks) {
-      List<SharedHash> sharedHashes = Net.getInfoForIDs(chunk, verbose, showURLs,
+      List<ThreatDescriptor> threatDescriptores = Net.getInfoForIDs(chunk, verbose, showURLs,
         printHashString);
-      for (SharedHash sharedHash : sharedHashes) {
+      for (ThreatDescriptor threatDescriptor : threatDescriptores) {
 
         if (dataDir == null) {
-          System.out.println(hashFormatter.format(sharedHash, printHashString));
+          System.out.println(hashFormatter.format(threatDescriptor, printHashString));
         } else {
           String path = dataDir
             + File.separator
-            + sharedHash.id
-            + Utils.td_indicator_typeToFileSuffix(sharedHash.td_indicator_type);
+            + threatDescriptor.id
+            + Utils.td_indicator_typeToFileSuffix(threatDescriptor.td_indicator_type);
 
           SimpleJSONWriter w = new SimpleJSONWriter();
           w.add("path", path);
@@ -714,7 +714,7 @@ public class TETagQuery {
           System.out.flush();
 
           try {
-            Utils.outputHashToFile(sharedHash, path, verbose);
+            Utils.outputHashToFile(threatDescriptor, path, verbose);
           } catch (FileNotFoundException e) {
             System.err.printf("FileNotFoundException: \"%s\".\n", path);
           } catch (IOException e) {
@@ -827,11 +827,11 @@ public class TETagQuery {
 
       String td_indicator_typeForTE = hashFilterer.getTEName();
 
-      List<SharedHash> sharedHashes = Net.getIncremental(tagName, td_indicator_typeForTE, since,
+      List<ThreatDescriptor> threatDescriptores = Net.getIncremental(tagName, td_indicator_typeForTE, since,
         pageSize, verbose, showURLs);
 
-      for (SharedHash sharedHash : sharedHashes) {
-        System.out.println(hashFormatter.format(sharedHash, printHashString));
+      for (ThreatDescriptor threatDescriptor : threatDescriptores) {
+        System.out.println(hashFormatter.format(threatDescriptor, printHashString));
       }
     }
   }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -921,9 +921,9 @@ public class TETagQuery {
       o.printf("                       comma-delimited app IDs. If privacy-type is\n");
       o.printf("                       HAS_PRIVACY_GROUP these must be comma-delimited\n");
       o.printf("                       privacy-group IDs.\n");
-      o.printf("--td_subjective_tags {...}           Comma-delimited. Overwrites on repost.\n");
-      o.printf("--add-td_subjective_tags {...}       Comma-delimited. Adds these on repost.\n");
-      o.printf("--remove-td_subjective_tags {...}    Comma-delimited. Removes these on repost.\n");
+      o.printf("--tags {...}           Comma-delimited. Overwrites on repost.\n");
+      o.printf("--add-tags {...}       Comma-delimited. Adds these on repost.\n");
+      o.printf("--remove-tags {...}    Comma-delimited. Removes these on repost.\n");
       o.printf("--confidence {...}\n");
       o.printf("--precision {...}\n");
       o.printf("--first-active {...}\n");
@@ -1005,19 +1005,19 @@ public class TETagQuery {
           params.setPrivacyMembers(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
 
-        } else if (option.equals("--td_subjective_tags")) {
+        } else if (option.equals("--tags")) {
           if (args.length < 1) {
             usage(1);
           }
           params.setTagsToSet(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
-        } else if (option.equals("--add-td_subjective_tags")) {
+        } else if (option.equals("--add-tags")) {
           if (args.length < 1) {
             usage(1);
           }
           params.setTagsToAdd(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
-        } else if (option.equals("--remove-td_subjective_tags")) {
+        } else if (option.equals("--remove-tags")) {
           if (args.length < 1) {
             usage(1);
           }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -390,25 +390,25 @@ public class TETagQuery {
       _verbose = verbose;
     }
 
-    public void processIDs(List<String> hashIDs) {
+    public void processIDs(List<String> ids) {
       if (_verbose) {
         SimpleJSONWriter w = new SimpleJSONWriter();
-        w.add("hash_count", hashIDs.size());
+        w.add("hash_count", ids.size());
         System.out.println(w.format());
         System.out.flush();
 
         int i = 0;
-        for (String hashID : hashIDs) {
+        for (String id : ids) {
           w = new SimpleJSONWriter();
           w.add("i", i);
-          w.add("hash_id", hashID);
+          w.add("hash_id", id);
           System.out.println(w.format());
           System.out.flush();
           i++;
         }
       } else {
-        for (String hashID: hashIDs) {
-          System.out.println(hashID);
+        for (String id: ids) {
+          System.out.println(id);
           System.out.flush();
         }
       }
@@ -484,7 +484,7 @@ public class TETagQuery {
         }
       }
 
-      List<String> hashIDs = new ArrayList<String>();
+      List<String> ids = new ArrayList<String>();
 
       BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
       String line;
@@ -493,14 +493,14 @@ public class TETagQuery {
         while ((line = reader.readLine()) != null) {
           lno++;
           // In Java, line-terminators already stripped for us
-          hashIDs.add(line);
+          ids.add(line);
         }
       } catch (IOException e) {
         System.err.printf("Couldn't read line %d of standard input.\n", lno);
         System.exit(1);
       }
 
-      outputDetails(hashIDs, numIDsPerQuery, verbose, showURLs, printHashString,
+      outputDetails(ids, numIDsPerQuery, verbose, showURLs, printHashString,
         hashDir, hashFormatter);
     }
   }
@@ -673,8 +673,8 @@ public class TETagQuery {
       _hashFormatter = hashFormatter;
     }
 
-    public void processIDs(List<String> hashIDs) {
-      outputDetails(hashIDs, _numIDsPerQuery, _verbose, _showURLs, _printHashString,
+    public void processIDs(List<String> ids) {
+      outputDetails(ids, _numIDsPerQuery, _verbose, _showURLs, _printHashString,
         _hashDir, _hashFormatter);
     }
   }
@@ -684,7 +684,7 @@ public class TETagQuery {
    * and IDs-to-details handlers.
    */
   public static void outputDetails(
-    List<String> hashIDs,
+    List<String> ids,
     int numIDsPerQuery,
     boolean verbose,
     boolean showURLs,
@@ -692,7 +692,7 @@ public class TETagQuery {
     String hashDir,
     HashFormatter hashFormatter)
   {
-    List<List<String>> chunks = Utils.chunkify(hashIDs, numIDsPerQuery);
+    List<List<String>> chunks = Utils.chunkify(ids, numIDsPerQuery);
 
     // Now look up details for each ID.
     for (List<String> chunk: chunks) {
@@ -703,7 +703,7 @@ public class TETagQuery {
         if (hashDir == null) {
           System.out.println(hashFormatter.format(sharedHash, printHashString));
         } else {
-          String path = hashDir + File.separator + sharedHash.hashID + Utils.hashTypeToFileSuffix(sharedHash.hashType);
+          String path = hashDir + File.separator + sharedHash.id + Utils.td_indicator_typeToFileSuffix(sharedHash.td_indicator_type);
 
           SimpleJSONWriter w = new SimpleJSONWriter();
           w.add("path", path);
@@ -822,9 +822,9 @@ public class TETagQuery {
       }
       String tagName = args[0];
 
-      String hashTypeForTE = hashFilterer.getTEName();
+      String td_indicator_typeForTE = hashFilterer.getTEName();
 
-      List<SharedHash> sharedHashes = Net.getIncremental(tagName, hashTypeForTE, since,
+      List<SharedHash> sharedHashes = Net.getIncremental(tagName, td_indicator_typeForTE, since,
         pageSize, verbose, showURLs);
 
       for (SharedHash sharedHash : sharedHashes) {
@@ -921,9 +921,9 @@ public class TETagQuery {
       o.printf("                       comma-delimited app IDs. If privacy-type is\n");
       o.printf("                       HAS_PRIVACY_GROUP these must be comma-delimited\n");
       o.printf("                       privacy-group IDs.\n");
-      o.printf("--tags {...}           Comma-delimited. Overwrites on repost.\n");
-      o.printf("--add-tags {...}       Comma-delimited. Adds these on repost.\n");
-      o.printf("--remove-tags {...}    Comma-delimited. Removes these on repost.\n");
+      o.printf("--td_subjective_tags {...}           Comma-delimited. Overwrites on repost.\n");
+      o.printf("--add-td_subjective_tags {...}       Comma-delimited. Adds these on repost.\n");
+      o.printf("--remove-td_subjective_tags {...}    Comma-delimited. Removes these on repost.\n");
       o.printf("--confidence {...}\n");
       o.printf("--precision {...}\n");
       o.printf("--first-active {...}\n");
@@ -1005,19 +1005,19 @@ public class TETagQuery {
           params.setPrivacyMembers(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
 
-        } else if (option.equals("--tags")) {
+        } else if (option.equals("--td_subjective_tags")) {
           if (args.length < 1) {
             usage(1);
           }
           params.setTagsToSet(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
-        } else if (option.equals("--add-tags")) {
+        } else if (option.equals("--add-td_subjective_tags")) {
           if (args.length < 1) {
             usage(1);
           }
           params.setTagsToAdd(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
-        } else if (option.equals("--remove-tags")) {
+        } else if (option.equals("--remove-td_subjective_tags")) {
           if (args.length < 1) {
             usage(1);
           }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -274,7 +274,7 @@ public class TETagQuery {
       o.printf("--since {x}\n");
       o.printf("--until {x}\n");
       o.printf("--page-size {x}\n");
-      o.printf("--hash-type {x}\n");
+      o.printf("--indicator-type {x}\n");
       o.printf("--no-print-hash -- Don't print the hash to the terminal\n");
       o.printf("The \"since\" or \"until\" parameter is any supported by ThreatExchange,\n");
       o.printf("e.g. seconds since the epoch.\n");
@@ -325,7 +325,7 @@ public class TETagQuery {
           pageSize = Integer.valueOf(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
 
-        } else if (option.equals("--hash-type")) {
+        } else if (option.equals("--indicator-type")) {
           if (args.length < 1) {
             usage(1);
           }
@@ -428,7 +428,7 @@ public class TETagQuery {
         PROGNAME, _verb);
       o.printf("Options:\n");
       o.printf("--no-print-hash -- Don't print the hash to the terminal\n");
-      o.printf("--hash-dir {d} -- Write hashes as {ID}.{extension} files in directory named {d}\n");
+      o.printf("--data-dir {d} -- Write hashes as {ID}.{extension} files in directory named {d}\n");
       o.printf("Please supply IDs one line at a time on standard input.\n");
       System.exit(exitCode);
     }
@@ -442,7 +442,7 @@ public class TETagQuery {
       HashFormatter hashFormatter
     ) {
       boolean printHashString = true;
-      String hashDir = null;
+      String dataDir = null;
 
       while (args.length > 0 && args[0].startsWith("-")) {
         String option = args[0];
@@ -451,11 +451,11 @@ public class TETagQuery {
         if (option.equals("-h") || option.equals("--help")) {
           usage(0);
 
-        } else if (option.equals("--hash-dir")) {
+        } else if (option.equals("--data-dir")) {
           if (args.length < 1) {
             usage(1);
           }
-          hashDir = args[0];
+          dataDir = args[0];
           args = Arrays.copyOfRange(args, 1, args.length);
 
         } else if (option.equals("--no-print-hash")) {
@@ -474,12 +474,12 @@ public class TETagQuery {
         usage(1);
       }
 
-      if (hashDir != null) {
-        File handle = new File(hashDir);
+      if (dataDir != null) {
+        File handle = new File(dataDir);
         boolean ok = handle.exists() || handle.mkdirs();
         if (!ok) {
           System.err.printf("%s: could not create output directory \"%s\"\n",
-            PROGNAME, hashDir);
+            PROGNAME, dataDir);
           System.exit(1);
         }
       }
@@ -501,7 +501,7 @@ public class TETagQuery {
       }
 
       outputDetails(ids, numIDsPerQuery, verbose, showURLs, printHashString,
-        hashDir, hashFormatter);
+        dataDir, hashFormatter);
     }
   }
 
@@ -520,9 +520,9 @@ public class TETagQuery {
       o.printf("--since {x}\n");
       o.printf("--until {x}\n");
       o.printf("--page-size {x}\n");
-      o.printf("--hash-type {x}\n");
+      o.printf("--indicator-type {x}\n");
       o.printf("--no-print-hash -- Don't print the hash\n");
-      o.printf("--hash-dir {d} -- Write hashes as {ID}.{extension} files in directory named {d}\n");
+      o.printf("--data-dir {d} -- Write hashes as {ID}.{extension} files in directory named {d}\n");
       o.printf("The \"since\" or \"until\" parameter is any supported by ThreatExchange,\n");
       o.printf("e.g. seconds since the epoch.\n");
       o.printf("Hash types:\n");
@@ -543,7 +543,7 @@ public class TETagQuery {
       String since = null;
       String until = null;
       boolean printHashString = true;
-      String hashDir = null;
+      String dataDir = null;
 
       while (args.length > 0 && args[0].startsWith("-")) {
         String option = args[0];
@@ -552,11 +552,11 @@ public class TETagQuery {
         if (option.equals("-h") || option.equals("--help")) {
           usage(0);
 
-        } else if (option.equals("--hash-dir")) {
+        } else if (option.equals("--data-dir")) {
           if (args.length < 1) {
             usage(1);
           }
-          hashDir = args[0];
+          dataDir = args[0];
           args = Arrays.copyOfRange(args, 1, args.length);
 
         } else if (option.equals("--since")) {
@@ -580,7 +580,7 @@ public class TETagQuery {
           pageSize = Integer.valueOf(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
 
-        } else if (option.equals("--hash-type")) {
+        } else if (option.equals("--indicator-type")) {
           if (args.length < 1) {
             usage(1);
           }
@@ -609,12 +609,12 @@ public class TETagQuery {
       }
       String tagName = args[0];
 
-      if (hashDir != null) {
-        File handle = new File(hashDir);
+      if (dataDir != null) {
+        File handle = new File(dataDir);
         boolean ok = handle.exists() || handle.mkdirs();
         if (!ok) {
           System.err.printf("%s: could not create output directory \"%s\"\n",
-            PROGNAME, hashDir);
+            PROGNAME, dataDir);
           System.exit(1);
         }
       }
@@ -638,7 +638,7 @@ public class TETagQuery {
       // "THREAT_DESCRIPTOR". From this we can dive in on each item, though, and
       // query for its details one ID at a time.
       IDProcessor processor = new IDDetailsProcessor(numIDsPerQuery, verbose,
-        showURLs, printHashString, hashDir, hashFormatter);
+        showURLs, printHashString, dataDir, hashFormatter);
       Net.getHashIDsByTagID(tagID, verbose, showURLs,
         hashFilterer, since, until, pageSize, printHashString, processor);
     }
@@ -662,14 +662,14 @@ public class TETagQuery {
       boolean verbose,
       boolean showURLs,
       boolean printHashString,
-      String hashDir,
+      String dataDir,
       HashFormatter hashFormatter
     ) {
       _numIDsPerQuery = numIDsPerQuery;
       _verbose = verbose;
       _showURLs = showURLs;
       _printHashString = printHashString;
-      _hashDir = hashDir;
+      _hashDir = dataDir;
       _hashFormatter = hashFormatter;
     }
 
@@ -689,7 +689,7 @@ public class TETagQuery {
     boolean verbose,
     boolean showURLs,
     boolean printHashString,
-    String hashDir,
+    String dataDir,
     HashFormatter hashFormatter)
   {
     List<List<String>> chunks = Utils.chunkify(ids, numIDsPerQuery);
@@ -700,10 +700,13 @@ public class TETagQuery {
         printHashString);
       for (SharedHash sharedHash : sharedHashes) {
 
-        if (hashDir == null) {
+        if (dataDir == null) {
           System.out.println(hashFormatter.format(sharedHash, printHashString));
         } else {
-          String path = hashDir + File.separator + sharedHash.id + Utils.td_indicator_typeToFileSuffix(sharedHash.td_indicator_type);
+          String path = dataDir
+            + File.separator
+            + sharedHash.id
+            + Utils.td_indicator_typeToFileSuffix(sharedHash.td_indicator_type);
 
           SimpleJSONWriter w = new SimpleJSONWriter();
           w.add("path", path);
@@ -737,7 +740,7 @@ public class TETagQuery {
         PROGNAME, _verb);
       o.printf("Options:\n");
       o.printf("--since {x}\n");
-      o.printf("--hash-type {x}\n");
+      o.printf("--indicator-type {x}\n");
       o.printf("--page-size {x}\n");
       o.printf("The \"since\" parameter is any supported by ThreatExchange,\n");
       o.printf("e.g. seconds since the epoch.\n");
@@ -788,7 +791,7 @@ public class TETagQuery {
           pageSize = Integer.valueOf(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
 
-        } else if (option.equals("--hash-type")) {
+        } else if (option.equals("--indicator-type")) {
           if (args.length < 1) {
             usage(1);
           }
@@ -1107,7 +1110,7 @@ public class TETagQuery {
         usage(1);
       }
 
-      if (params.getIndicatorType().equals(Constants.HASH_TYPE_TMK)) {
+      if (params.getIndicatorType().equals(Constants.INDICATOR_TYPE_TMK)) {
         String filename = params.getIndicatorText();
         String contents = null;
         try {

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/ThreatDescriptor.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/ThreatDescriptor.java
@@ -60,7 +60,7 @@ import java.util.List;
 /**
  * Helper container class for parsed results back from ThreatExchange.
  */
-public class SharedHash {
+public class ThreatDescriptor {
   public final String id;
   public final String td_raw_indicator;
   public final String td_indicator_type;
@@ -75,7 +75,7 @@ public class SharedHash {
   public final String td_share_level;
   public final List<String> td_subjective_tags;
 
-  public SharedHash(
+  public ThreatDescriptor(
     String id_,
     String td_raw_indicator_,
     String td_indicator_type_,

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Utils.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Utils.java
@@ -103,15 +103,15 @@ class Utils {
   }
 
   public static void outputHashToFile(
-    SharedHash sharedHash,
+    ThreatDescriptor threatDescriptor,
     String path,
     boolean verbose)
       throws FileNotFoundException, IOException
   {
-    if (sharedHash.td_indicator_type.equals(Constants.INDICATOR_TYPE_TMK)) {
-      outputTMKHashToFile(sharedHash, path, verbose);
+    if (threatDescriptor.td_indicator_type.equals(Constants.INDICATOR_TYPE_TMK)) {
+      outputTMKHashToFile(threatDescriptor, path, verbose);
     } else {
-      outputNonTMKHashToFile(sharedHash, path, verbose);
+      outputNonTMKHashToFile(threatDescriptor, path, verbose);
     }
   }
 
@@ -122,15 +122,15 @@ class Utils {
   // such, followed by a pipe delimiter, then the rest of the binary file
   // base64-encdoed. Here we undo that encoding.
   public static void outputTMKHashToFile(
-    SharedHash sharedHash,
+    ThreatDescriptor threatDescriptor,
     String path,
     boolean verbose)
       throws FileNotFoundException, IOException
   {
     FileOutputStream fos = new FileOutputStream(path);
-    int hlen = sharedHash.td_raw_indicator.length();
+    int hlen = threatDescriptor.td_raw_indicator.length();
 
-    String base64EncodedHash = sharedHash.td_raw_indicator;
+    String base64EncodedHash = threatDescriptor.td_raw_indicator;
 
     byte[] bytes = base64EncodedHash.getBytes();
     byte[] first = Arrays.copyOfRange(bytes, 0, 12);
@@ -140,8 +140,8 @@ class Utils {
     if (verbose) {
       SimpleJSONWriter w = new SimpleJSONWriter();
       w.add("path", path);
-      w.add("td_indicator_type", sharedHash.td_indicator_type);
-      w.add("encoded_length", sharedHash.td_raw_indicator.length());
+      w.add("td_indicator_type", threatDescriptor.td_indicator_type);
+      w.add("encoded_length", threatDescriptor.td_raw_indicator.length());
       w.add("binary_length", first.length + rest.length);
       System.out.println(w.format());
       System.out.flush();
@@ -151,20 +151,20 @@ class Utils {
 
   // Just write PhotoDNA, PDQ, MD5, etc. hash-data to the file contents.
   public static void outputNonTMKHashToFile(
-    SharedHash sharedHash,
+    ThreatDescriptor threatDescriptor,
     String path,
     boolean verbose)
       throws FileNotFoundException, IOException
   {
     FileOutputStream fos = new FileOutputStream(path);
 
-    byte[] bytes = sharedHash.td_raw_indicator.getBytes();
+    byte[] bytes = threatDescriptor.td_raw_indicator.getBytes();
     fos.write(bytes);
     if (verbose) {
       SimpleJSONWriter w = new SimpleJSONWriter();
       w.add("path", path);
-      w.add("td_indicator", sharedHash.td_indicator_type);
-      w.add("indicator_length", sharedHash.td_raw_indicator.length());
+      w.add("td_indicator", threatDescriptor.td_indicator_type);
+      w.add("indicator_length", threatDescriptor.td_raw_indicator.length());
       System.out.println(w.format());
       System.out.flush();
     }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Utils.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Utils.java
@@ -83,9 +83,9 @@ class Utils {
     return retval;
   }
 
-  public static String hashTypeToFileSuffix(String hashType) {
+  public static String td_indicator_typeToFileSuffix(String td_indicator_type) {
     String suffix = ".hsh";
-    switch (hashType) {
+    switch (td_indicator_type) {
     case Constants.HASH_TYPE_PHOTODNA:
       suffix = ".pdna";
       break;
@@ -108,7 +108,7 @@ class Utils {
     boolean verbose)
       throws FileNotFoundException, IOException
   {
-    if (sharedHash.hashType.equals(Constants.HASH_TYPE_TMK)) {
+    if (sharedHash.td_indicator_type.equals(Constants.HASH_TYPE_TMK)) {
       outputTMKHashToFile(sharedHash, path, verbose);
     } else {
       outputNonTMKHashToFile(sharedHash, path, verbose);
@@ -117,7 +117,7 @@ class Utils {
 
   // TMK hashes are binary data with data strucure in the TMK package's
   // tmktypes.h. The string attributes are not 8-bit clean in the
-  // ThreatExchange API so the hashValue attribute is stored as base64-encoded,
+  // ThreatExchange API so the td_raw_indicator attribute is stored as base64-encoded,
   // with one caveat: the first 12 bytes (which are ASCII) are stored as
   // such, followed by a pipe delimiter, then the rest of the binary file
   // base64-encdoed. Here we undo that encoding.
@@ -128,9 +128,9 @@ class Utils {
       throws FileNotFoundException, IOException
   {
     FileOutputStream fos = new FileOutputStream(path);
-    int hlen = sharedHash.hashValue.length();
+    int hlen = sharedHash.td_raw_indicator.length();
 
-    String base64EncodedHash = sharedHash.hashValue;
+    String base64EncodedHash = sharedHash.td_raw_indicator;
 
     byte[] bytes = base64EncodedHash.getBytes();
     byte[] first = Arrays.copyOfRange(bytes, 0, 12);
@@ -140,8 +140,8 @@ class Utils {
     if (verbose) {
       SimpleJSONWriter w = new SimpleJSONWriter();
       w.add("path", path);
-      w.add("hash_type", sharedHash.hashType);
-      w.add("encoded_length", sharedHash.hashValue.length());
+      w.add("hash_type", sharedHash.td_indicator_type);
+      w.add("encoded_length", sharedHash.td_raw_indicator.length());
       w.add("binary_length", first.length + rest.length);
       System.out.println(w.format());
       System.out.flush();
@@ -158,13 +158,13 @@ class Utils {
   {
     FileOutputStream fos = new FileOutputStream(path);
 
-    byte[] bytes = sharedHash.hashValue.getBytes();
+    byte[] bytes = sharedHash.td_raw_indicator.getBytes();
     fos.write(bytes);
     if (verbose) {
       SimpleJSONWriter w = new SimpleJSONWriter();
       w.add("path", path);
-      w.add("hash_type", sharedHash.hashType);
-      w.add("hash_length", sharedHash.hashValue.length());
+      w.add("hash_type", sharedHash.td_indicator_type);
+      w.add("hash_length", sharedHash.td_raw_indicator.length());
       System.out.println(w.format());
       System.out.flush();
     }
@@ -174,7 +174,7 @@ class Utils {
 
   // TMK hashes are binary data with data strucure in the TMK package's
   // tmktypes.h. The string attributes are not 8-bit clean in the
-  // ThreatExchange API so the hashValue attribute is stored as base64-encoded,
+  // ThreatExchange API so the td_raw_indicator attribute is stored as base64-encoded,
   // with one caveat: the first 12 bytes (which are ASCII) are stored as
   // such, followed by a pipe delimiter, then the rest of the binary file
   // base64-encdoed. Here we undo that encoding.

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Utils.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Utils.java
@@ -86,16 +86,16 @@ class Utils {
   public static String td_indicator_typeToFileSuffix(String td_indicator_type) {
     String suffix = ".hsh";
     switch (td_indicator_type) {
-    case Constants.HASH_TYPE_PHOTODNA:
+    case Constants.INDICATOR_TYPE_PHOTODNA:
       suffix = ".pdna";
       break;
-    case Constants.HASH_TYPE_PDQ:
+    case Constants.INDICATOR_TYPE_PDQ:
       suffix = ".pdq";
       break;
-    case Constants.HASH_TYPE_MD5:
+    case Constants.INDICATOR_TYPE_MD5:
       suffix = ".md5";
       break;
-    case Constants.HASH_TYPE_TMK:
+    case Constants.INDICATOR_TYPE_TMK:
       suffix = ".tmk";
       break;
     }
@@ -108,7 +108,7 @@ class Utils {
     boolean verbose)
       throws FileNotFoundException, IOException
   {
-    if (sharedHash.td_indicator_type.equals(Constants.HASH_TYPE_TMK)) {
+    if (sharedHash.td_indicator_type.equals(Constants.INDICATOR_TYPE_TMK)) {
       outputTMKHashToFile(sharedHash, path, verbose);
     } else {
       outputNonTMKHashToFile(sharedHash, path, verbose);
@@ -140,7 +140,7 @@ class Utils {
     if (verbose) {
       SimpleJSONWriter w = new SimpleJSONWriter();
       w.add("path", path);
-      w.add("hash_type", sharedHash.td_indicator_type);
+      w.add("td_indicator_type", sharedHash.td_indicator_type);
       w.add("encoded_length", sharedHash.td_raw_indicator.length());
       w.add("binary_length", first.length + rest.length);
       System.out.println(w.format());
@@ -163,8 +163,8 @@ class Utils {
     if (verbose) {
       SimpleJSONWriter w = new SimpleJSONWriter();
       w.add("path", path);
-      w.add("hash_type", sharedHash.td_indicator_type);
-      w.add("hash_length", sharedHash.td_raw_indicator.length());
+      w.add("td_indicator", sharedHash.td_indicator_type);
+      w.add("indicator_length", sharedHash.td_raw_indicator.length());
       System.out.println(w.format());
       System.out.flush();
     }


### PR DESCRIPTION
Long ago I was trying to make this a semi-opaque layer atop the TE API. But given the consistency across the [API](https://developers.facebook.com/docs/threat-exchange/reference/apis/threat-descriptors) and [UI download](https://developers.facebook.com/docs/threat-exchange/reference/ui/descriptors#downloading) / [UI upload](https://developers.facebook.com/docs/threat-exchange/reference/submitting#uploading) it no longer makes sense to have different column names for things.

Also this exposes a few more columns, such as `status`.

Testing: re-run all commands at https://github.com/facebook/ThreatExchange/blob/master/hashing/te-tag-query-java/README.md

Also:

```
$ java com.facebook.threatexchange.TETagQuery tag-to-details pwny | jq .
...
{
  "id": "2944704542215377",
  "td_raw_indicator": "https://evilevillabs.com/evil2.php",
  "td_indicator_type": "URI",
  "added_on": "2020-01-09T03:09:03+0000",
  "td_confidence": "75",
  "td_owner_id": "1064060413755420",
  "td_owner_email": "threatexchange@support.facebook.com",
  "td_owner_name": "Media Hash Sharing Test",
  "td_visibility": "HAS_WHITELIST",
  "td_status": "UNKNOWN",
  "td_severity": "INFO",
  "td_share_level": "AMBER",
  "td_subjective_tags": "pwny,testing,testing-bulk-edit,testing-bulk-edit-for-doc"
}
...
```