### PR TITLE
after-neaten global search-and-replace from prior diff

### DIFF
--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
@@ -239,7 +239,7 @@ class Net {
       System.out.println(url);
     }
 
-    List<ThreatDescriptor> threatDescriptores = new ArrayList<ThreatDescriptor>();
+    List<ThreatDescriptor> threatDescriptors = new ArrayList<ThreatDescriptor>();
     try (InputStream response = new URL(url).openConnection().getInputStream()) {
       // {
       //    "990927953l366387": {
@@ -310,13 +310,13 @@ class Net {
           tagTexts
         );
 
-        threatDescriptores.add(threatDescriptor);
+        threatDescriptors.add(threatDescriptor);
       }
     } catch (Exception e) {
       e.printStackTrace(System.err);
       System.exit(1);
     }
-    return threatDescriptores;
+    return threatDescriptors;
   }
 
   /**
@@ -333,7 +333,7 @@ class Net {
     boolean verbose,
     boolean showURLs
   ) {
-    List<ThreatDescriptor> threatDescriptores = new ArrayList<ThreatDescriptor>();
+    List<ThreatDescriptor> threatDescriptors = new ArrayList<ThreatDescriptor>();
 
     String pageLimit = Integer.toString(pageSize);
     String startURL = TE_BASE_URL
@@ -462,7 +462,7 @@ class Net {
       }
     } while (nextURL != null);
 
-    return threatDescriptores;
+    return threatDescriptors;
   }
 
   /**

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -696,9 +696,9 @@ public class TETagQuery {
 
     // Now look up details for each ID.
     for (List<String> chunk: chunks) {
-      List<ThreatDescriptor> threatDescriptores = Net.getInfoForIDs(chunk, verbose, showURLs,
+      List<ThreatDescriptor> threatDescriptors = Net.getInfoForIDs(chunk, verbose, showURLs,
         printHashString);
-      for (ThreatDescriptor threatDescriptor : threatDescriptores) {
+      for (ThreatDescriptor threatDescriptor : threatDescriptors) {
 
         if (dataDir == null) {
           System.out.println(hashFormatter.format(threatDescriptor, printHashString));
@@ -827,10 +827,10 @@ public class TETagQuery {
 
       String td_indicator_typeForTE = hashFilterer.getTEName();
 
-      List<ThreatDescriptor> threatDescriptores = Net.getIncremental(tagName, td_indicator_typeForTE, since,
+      List<ThreatDescriptor> threatDescriptors = Net.getIncremental(tagName, td_indicator_typeForTE, since,
         pageSize, verbose, showURLs);
 
-      for (ThreatDescriptor threatDescriptor : threatDescriptores) {
+      for (ThreatDescriptor threatDescriptor : threatDescriptors) {
         System.out.println(hashFormatter.format(threatDescriptor, printHashString));
       }
     }


### PR DESCRIPTION
Previous commit's `sharedHash -> threatDescriptor` search-and-replace took `sharedHashes -> threatDescriptores`. Fixing that.