### PR TITLE
Fix for not being able to use filehasher in a loop.

### DIFF
--- a/hashing/tmk/cpp/hashing/filehasher.cpp
+++ b/hashing/tmk/cpp/hashing/filehasher.cpp
@@ -178,7 +178,7 @@ bool hashVideoFile(
   //     -s ${output_width}:${output_height} -an -f rawvideo -c:v rawvideo \
   //     -pix_fmt rgb24 -r $output_fps pipe:1
 
-  std::string command = ffmpegPath + " -i " + inputVideoFileName + " -s " +
+  std::string command = ffmpegPath + " -nostdin -i " + inputVideoFileName + " -s " +
       std::to_string(downsampleFrameDimension) + ":" +
       std::to_string(downsampleFrameDimension) +
       " -an -f rawvideo -c:v rawvideo -pix_fmt rgb24 -r " +


### PR DESCRIPTION
There are known [problems](https://unix.stackexchange.com/questions/36310/strange-errors-when-using-ffmpeg-in-a-loop) with using `ffmpeg` in a bash loop. As, `tmk-hash-video` binary uses `ffmpeg`, I couldn't use it in a bash script loop. This PR is a fix for that.