### PR TITLE
Add --related-ids-for-upload to post request

### DIFF
--- a/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
@@ -35,6 +35,7 @@ class DescriptorPostParameters {
   private String _tagsToSet;
   private String _tagsToAdd;
   private String _tagsToRemove;
+  private String _relatedIDsForUpload;
 
   public DescriptorPostParameters setIndicatorText(String indicatorText) {
     this._indicatorText = indicatorText;
@@ -104,6 +105,10 @@ class DescriptorPostParameters {
     this._tagsToRemove = tagsToRemove;
     return this;
   }
+  public DescriptorPostParameters setRelatedIDsForUpload(String relatedIDsForUpload) {
+    this._relatedIDsForUpload = relatedIDsForUpload;
+    return this;
+  }
 
   public String getIndicatorText() {
     return this._indicatorText;
@@ -155,6 +160,9 @@ class DescriptorPostParameters {
   }
   public String getTagsToRemove() {
     return this._tagsToRemove;
+  }
+  public String getRelatedIDsForUpload() {
+    return this._relatedIDsForUpload;
   }
 
   public boolean validateWithReport(PrintStream o) {
@@ -226,6 +234,9 @@ class DescriptorPostParameters {
     }
     if (this._lastActive != null) {
       sb.append("&last_active=").append(Utils.urlEncodeUTF8(this._tagsToRemove));
+    }
+    if (this._relatedIDsForUpload != null) {
+      sb.append("&related_ids_for_upload=").append(Utils.urlEncodeUTF8(this._relatedIDsForUpload));
     }
     // Put indicator last in case it's long (e.g. TMK) for human readability
     sb.append("&indicator=").append(Utils.urlEncodeUTF8(this._indicatorText));

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -1024,6 +1024,13 @@ public class TETagQuery {
           params.setPrivacyMembers(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
 
+        } else if (option.equals("--related-ids-for-upload")) {
+          if (args.length < 1) {
+            usage(1);
+          }
+          params.setRelatedIDsForUpload(args[0]);
+          args = Arrays.copyOfRange(args, 1, args.length);
+
         } else if (option.equals("--tags")) {
           if (args.length < 1) {
             usage(1);

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -927,6 +927,8 @@ public class TETagQuery {
       o.printf("--tags {...}           Comma-delimited. Overwrites on repost.\n");
       o.printf("--add-tags {...}       Comma-delimited. Adds these on repost.\n");
       o.printf("--remove-tags {...}    Comma-delimited. Removes these on repost.\n");
+      o.printf("--related-ids-for-upload {...} Comma-delimited. IDs of descriptors (which must\n");
+      o.printf("                       already exist) to relate the new descriptor to.\n");
       o.printf("--confidence {...}\n");
       o.printf("-s|--status {...}\n");
       o.printf("-r|--review-status {...}\n");

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -914,8 +914,8 @@ public class TETagQuery {
       o.printf("-t|--type {...}\n");
       o.printf("-d|--description {...}\n");
       o.printf("-l|--share-level {...}\n");
-      o.printf("-s|--status {...}\n");
       o.printf("-p|--privacy-type {...}\n");
+      o.printf("-y|--severity {...}\n");
       o.printf("\n");
       o.printf("Optional:\n");
       o.printf("-h|--help\n");
@@ -928,6 +928,8 @@ public class TETagQuery {
       o.printf("--add-tags {...}       Comma-delimited. Adds these on repost.\n");
       o.printf("--remove-tags {...}    Comma-delimited. Removes these on repost.\n");
       o.printf("--confidence {...}\n");
+      o.printf("-s|--status {...}\n");
+      o.printf("-r|--review-status {...}\n");
       o.printf("--precision {...}\n");
       o.printf("--first-active {...}\n");
       o.printf("--last-active {...}\n");
@@ -989,12 +991,26 @@ public class TETagQuery {
           }
           params.setShareLevel(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
+
         } else if (option.equals("-s") || option.equals("--status")) {
           if (args.length < 1) {
             usage(1);
           }
           params.setStatus(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
+        } else if (option.equals("-r") || option.equals("--review-status")) {
+          if (args.length < 1) {
+            usage(1);
+          }
+          params.setReviewStatus(args[0]);
+          args = Arrays.copyOfRange(args, 1, args.length);
+        } else if (option.equals("-y") || option.equals("--severity")) {
+          if (args.length < 1) {
+            usage(1);
+          }
+          params.setSeverity(args[0]);
+          args = Arrays.copyOfRange(args, 1, args.length);
+
         } else if (option.equals("-p") || option.equals("--privacy-type")) {
           if (args.length < 1) {
             usage(1);


### PR DESCRIPTION
Note this depends on a backend TE API diff which won't land for another hour or two.

Test plan:

```
$ alias jtq
alias jtq='java com.facebook.threatexchange.TETagQuery'

$ jtq -s submit \
  -t HASH_SHA1 \
  -i dabbad00f00dfeed5ca1ab1ebeefca11ab1ec00a \
  -d 'testing te-tag-query submit' \
  -l RED \
  -s UNKNOWN \
  -y INFO \
  -r REVIEWED_MANUALLY \
  -p HAS_WHITELIST \
  -m 1064060413755420,494491891138576 \
  --tags pwny,testing \
  --related-ids-for-upload 3679532438786765,3149337578431046

URL:
https://graph.facebook.com/v4.0/threat_descriptors/?access_token=REDACTED

POST DATA:
type=HASH_SHA1
&description=testing+te-tag-query+submit
&share_level=RED
&status=UNKNOWN
&privacy_type=HAS_WHITELIST
&privacy_members=1064060413755420%2C494491891138576
&tags=pwny%2Ctesting
&review_status=REVIEWED_MANUALLY
&severity=INFO
&related_ids_for_upload=3679532438786765%2C3149337578431046
&indicator=dabbad00f00dfeed5ca1ab1ebeefca11ab1ec00a
```