### PR TITLE
related-triples-for-upload-as-json support

### DIFF
--- a/hashing/te-tag-query-java/README.md
+++ b/hashing/te-tag-query-java/README.md
@@ -70,6 +70,21 @@ java com.facebook.threatexchange.TETagQuery submit \
   --tags testing_java_post
 ```
 
+Post another with relation to the first one:
+
+```
+java com.facebook.threatexchange.TETagQuery submit \
+  -i dabbad00f00dfeed5ca1ab1ebeefca11ab1ec00f \
+  -t HASH_SHA1 \
+  -d "testing te-tag-query with post" \
+  -l AMBER \
+  -s NON_MALICIOUS \
+  -p HAS_WHITELIST \
+  --privacy-members 1064060413755420 \
+  --tags testing_java_post \
+  --related-triples-for-upload-as-json '[{"owner_app_id":494491891138576,"td_indicator_type":"HASH_SHA1","td_raw_indicator":"dabbad00f00dfeed5ca1ab1ebeefca11ab1ec00e"}]'
+```
+
 Post a new TMK hash:
 
 ```

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
@@ -36,6 +36,7 @@ class DescriptorPostParameters {
   private String _tagsToAdd;
   private String _tagsToRemove;
   private String _relatedIDsForUpload;
+  private String _relatedTriplesForUploadAsJSON;
 
   public DescriptorPostParameters setIndicatorText(String indicatorText) {
     this._indicatorText = indicatorText;
@@ -109,6 +110,10 @@ class DescriptorPostParameters {
     this._relatedIDsForUpload = relatedIDsForUpload;
     return this;
   }
+  public DescriptorPostParameters setRelatedTriplesForUploadAsJSON(String relatedTriplesForUploadAsJSON) {
+    this._relatedTriplesForUploadAsJSON = relatedTriplesForUploadAsJSON;
+    return this;
+  }
 
   public String getIndicatorText() {
     return this._indicatorText;
@@ -163,6 +168,9 @@ class DescriptorPostParameters {
   }
   public String getRelatedIDsForUpload() {
     return this._relatedIDsForUpload;
+  }
+  public String getRelatedTriplesForUploadAsJSON() {
+    return this._relatedTriplesForUploadAsJSON;
   }
 
   public boolean validateWithReport(PrintStream o) {
@@ -237,6 +245,9 @@ class DescriptorPostParameters {
     }
     if (this._relatedIDsForUpload != null) {
       sb.append("&related_ids_for_upload=").append(Utils.urlEncodeUTF8(this._relatedIDsForUpload));
+    }
+    if (this._relatedTriplesForUploadAsJSON != null) {
+      sb.append("&related_triples_for_upload_as_json=").append(Utils.urlEncodeUTF8(this._relatedTriplesForUploadAsJSON));
     }
     // Put indicator last in case it's long (e.g. TMK) for human readability
     sb.append("&indicator=").append(Utils.urlEncodeUTF8(this._indicatorText));

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -937,7 +937,10 @@ public class TETagQuery {
       o.printf("--remove-tags {...}    Comma-delimited. Removes these on repost.\n");
       o.printf("--related-ids-for-upload {...} Comma-delimited. IDs of descriptors (which must\n");
       o.printf("                       already exist) to relate the new descriptor to.\n");
-      o.printf("--related-triples-json-for-upload {...} xxx needs doc here\n");
+      o.printf("--related-triples-json-for-upload {...} Alternate to --related-ids-for-upload.\n");
+      o.printf("                       Here you can uniquely the relate-to descriptors by their\n");
+      o.printf("                       owner ID / indicator-type / indicator-text, rather than\n");
+      o.printf("                       by their IDs. See README.md for an example.\n");
       o.printf("--confidence {...}\n");
       o.printf("-s|--status {...}\n");
       o.printf("-r|--review-status {...}\n");

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -937,6 +937,7 @@ public class TETagQuery {
       o.printf("--remove-tags {...}    Comma-delimited. Removes these on repost.\n");
       o.printf("--related-ids-for-upload {...} Comma-delimited. IDs of descriptors (which must\n");
       o.printf("                       already exist) to relate the new descriptor to.\n");
+      o.printf("--related-triples-json-for-upload {...} xxx needs doc here\n");
       o.printf("--confidence {...}\n");
       o.printf("-s|--status {...}\n");
       o.printf("-r|--review-status {...}\n");
@@ -1039,6 +1040,12 @@ public class TETagQuery {
             usage(1);
           }
           params.setRelatedIDsForUpload(args[0]);
+          args = Arrays.copyOfRange(args, 1, args.length);
+        } else if (option.equals("--related-triples-for-upload-as-json")) {
+          if (args.length < 1) {
+            usage(1);
+          }
+          params.setRelatedTriplesForUploadAsJSON(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
 
         } else if (option.equals("--tags")) {


### PR DESCRIPTION
Test plan:

* In the TEUI look for indicator type `HASH_SHA1` and indicator text `dabbad00f00dfeed5ca1ab1ebeefca11ab1ec00a`
* Fan out by related in the TEUI and see 5 descriptors
* Run the code on this diff:

```
$ alias jtq='java com.facebook.threatexchange.TETagQuery'

$ jtq -s submit \
  -t HASH_SHA1 \
  -i dabbad00f00dfeed5ca1ab1ebeefca11ab1ec00a \
  -d 'testing te-tag-query submit' \
  -l RED \
  -s UNKNOWN \
  -y INFO \
  -r REVIEWED_MANUALLY \
  -p HAS_WHITELIST \
  -m 1064060413755420,494491891138576 \
  --tags pwny,testing \
  --related-triples-for-upload-as-json '[{"owner_app_id":494491891138576,"td_indicator_type":"HASH_SHA1","td_raw_indicator":"dabbad00f00dfeed5ca1ab1ebeefca11ab1ec00b"}]'
```

* Again fan out by related in the TEUI and see there are now 6, with the new one being the one just posted