### PR TITLE
Query reactions in Ruby; add/remove reactions in Java and Ruby

### DIFF
--- a/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
@@ -38,6 +38,8 @@ class DescriptorPostParameters {
   private String _tagsToRemove;
   private String _relatedIDsForUpload;
   private String _relatedTriplesForUploadAsJSON;
+  private String _reactionsToAdd;
+  private String _reactionsToRemove;
 
   public DescriptorPostParameters setIndicatorText(String indicatorText) {
     this._indicatorText = indicatorText;
@@ -119,6 +121,14 @@ class DescriptorPostParameters {
     this._relatedTriplesForUploadAsJSON = relatedTriplesForUploadAsJSON;
     return this;
   }
+  public DescriptorPostParameters setReactionsToAdd(String reactionsToAdd) {
+    this._reactionsToAdd = reactionsToAdd;
+    return this;
+  }
+  public DescriptorPostParameters setReactionsToRemove(String reactionsToRemove) {
+    this._reactionsToRemove = reactionsToRemove;
+    return this;
+  }
 
   public String getIndicatorText() {
     return this._indicatorText;
@@ -179,6 +189,12 @@ class DescriptorPostParameters {
   }
   public String getRelatedTriplesForUploadAsJSON() {
     return this._relatedTriplesForUploadAsJSON;
+  }
+  public String getReactionsToAdd() {
+    return this._reactionsToAdd;
+  }
+  public String getReactionsToRemove() {
+    return this._reactionsToRemove;
   }
 
   public boolean validateForSubmitWithReport(PrintStream o) {
@@ -285,7 +301,14 @@ class DescriptorPostParameters {
       sb.append("&related_ids_for_upload=").append(Utils.urlEncodeUTF8(this._relatedIDsForUpload));
     }
     if (this._relatedTriplesForUploadAsJSON != null) {
-      sb.append("&related_triples_for_upload_as_json=").append(Utils.urlEncodeUTF8(this._relatedTriplesForUploadAsJSON));
+      sb.append("&related_triples_for_upload_as_json=")
+        .append(Utils.urlEncodeUTF8(this._relatedTriplesForUploadAsJSON));
+    }
+    if (this._reactionsToAdd != null) {
+      sb.append("&reactions=").append(Utils.urlEncodeUTF8(this._reactionsToAdd));
+    }
+    if (this._reactionsToRemove != null) {
+      sb.append("&reactions_to_remove=").append(Utils.urlEncodeUTF8(this._reactionsToRemove));
     }
     // Put indicator last in case it's long (e.g. TMK) for human readability
     if (this._indicatorText != null) {

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -945,6 +945,8 @@ public class TETagQuery {
       o.printf("                       Here you can uniquely the relate-to descriptors by their\n");
       o.printf("                       owner ID / indicator-type / indicator-text, rather than\n");
       o.printf("                       by their IDs. See README.md for an example.\n");
+      o.printf("--reactions-to-add {...} Example for add/remove: INGESTED,IN_REVIEW\n");
+      o.printf("--reactions-to-remove {...}\n");
       o.printf("-c|--confidence {...}\n");
       o.printf("-s|--status {...}\n");
       o.printf("-r|--review-status {...}\n");
@@ -952,8 +954,10 @@ public class TETagQuery {
       o.printf("--last-active {...}\n");
       o.printf("--expired-on {...}\n");
       o.printf("\n");
-      o.printf("Please see the following for allowed values in all enumerated types:\n");
+      o.printf("Please see the following for allowed values in all enumerated types except reactions:\n");
       o.printf("https://developers.facebook.com/docs/threat-exchange/reference/submitting\n");
+      o.printf("Please see the following for allowed values in all enumerated types in reactions:\n");
+      o.printf("https://developers.facebook.com/docs/threat-exchange/reference/reacting\n");
       System.exit(exitCode);
     }
 
@@ -1051,6 +1055,19 @@ public class TETagQuery {
             usage(1);
           }
           params.setRelatedTriplesForUploadAsJSON(args[0]);
+          args = Arrays.copyOfRange(args, 1, args.length);
+
+        } else if (option.equals("--reactions-to-add")) {
+          if (args.length < 1) {
+            usage(1);
+          }
+          params.setReactionsToAdd(args[0]);
+          args = Arrays.copyOfRange(args, 1, args.length);
+        } else if (option.equals("--reactions-to-remove")) {
+          if (args.length < 1) {
+            usage(1);
+          }
+          params.setReactionsToRemove(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
 
         } else if (option.equals("--tags")) {
@@ -1200,6 +1217,8 @@ public class TETagQuery {
       o.printf("                       Here you can uniquely the relate-to descriptors by their\n");
       o.printf("                       owner ID / indicator-type / indicator-text, rather than\n");
       o.printf("                       by their IDs. See README.md for an example.\n");
+      o.printf("--reactions-to-add {...} Example for add/remove: INGESTED,IN_REVIEW\n");
+      o.printf("--reactions-to-remove {...}\n");
       o.printf("-c|--confidence {...}\n");
       o.printf("-s|--status {...}\n");
       o.printf("-r|--review-status {...}\n");
@@ -1207,8 +1226,10 @@ public class TETagQuery {
       o.printf("--last-active {...}\n");
       o.printf("--expired-on {...}\n");
       o.printf("\n");
-      o.printf("Please see the following for allowed values in all enumerated types:\n");
-      o.printf("https://developers.facebook.com/docs/threat-exchange/reference/editing\n");
+      o.printf("Please see the following for allowed values in all enumerated types except reactions:\n");
+      o.printf("https://developers.facebook.com/docs/threat-exchange/reference/submitting\n");
+      o.printf("Please see the following for allowed values in all enumerated types in reactions:\n");
+      o.printf("https://developers.facebook.com/docs/threat-exchange/reference/reacting\n");
       System.exit(exitCode);
     }
 
@@ -1319,6 +1340,19 @@ public class TETagQuery {
             usage(1);
           }
           params.setTagsToRemove(args[0]);
+          args = Arrays.copyOfRange(args, 1, args.length);
+
+        } else if (option.equals("--reactions-to-add")) {
+          if (args.length < 1) {
+            usage(1);
+          }
+          params.setReactionsToAdd(args[0]);
+          args = Arrays.copyOfRange(args, 1, args.length);
+        } else if (option.equals("--reactions-to-remove")) {
+          if (args.length < 1) {
+            usage(1);
+          }
+          params.setReactionsToRemove(args[0]);
           args = Arrays.copyOfRange(args, 1, args.length);
 
         } else if (option.equals("-c") || option.equals("--confidence")) {

--- a/hashing/te-tag-query-ruby/TENet.rb
+++ b/hashing/te-tag-query-ruby/TENet.rb
@@ -252,7 +252,7 @@ def TENet.getInfoForIDs(
   startURL = @@TE_BASE_URL +
     "/?access_token=" + @@APP_TOKEN +
     "&ids=" + CGI.escape(ids.join(',')) +
-    "&fields=raw_indicator,type,added_on,last_updated,confidence,owner,privacy_type,review_status,status,severity,share_level,tags,description"
+    "&fields=raw_indicator,type,added_on,last_updated,confidence,owner,privacy_type,review_status,status,severity,share_level,tags,description,reactions,my_reactions"
 
   if showURLs
     puts "URL:"

--- a/hashing/te-tag-query-ruby/TENet.rb
+++ b/hashing/te-tag-query-ruby/TENet.rb
@@ -41,6 +41,9 @@ POST_PARAM_NAMES = {
   :last_active                        => "last_active",
   :related_ids_for_upload             => "related_ids_for_upload",
   :related_triples_for_upload_as_json => "related_triples_for_upload_as_json",
+  # Legacy: should have been named reactions_to_add, but isn't. :(
+  :reactions                          => "reactions",
+  :reactions_to_remove                => "reactions_to_remove",
 }
 POST_PARAM_NAMES.default_proc = -> (h, k) { raise KeyError, "POST_PARAM_NAMES[#{k}] is not defined." }
 

--- a/hashing/te-tag-query-ruby/TETagQuery.rb
+++ b/hashing/te-tag-query-ruby/TETagQuery.rb
@@ -585,12 +585,17 @@ Optional:
                        HAS_PRIVACY_GROUP these must be comma-delimited
                        privacy-group IDs.
 --tags {...}           Comma-delimited. Overwrites on repost.
+
 --related-ids-for-upload {...} Comma-delimited. IDs of descriptors (which must
                        already exist) to relate the new descriptor to.
 --related-triples-json-for-upload {...} Alternate to --related-ids-for-upload.
                        Here you can uniquely the relate-to descriptors by their
                        owner ID / indicator-type / indicator-text, rather than
                        by their IDs. See README.md for an example.
+
+--reactions-to-add {...}    Example for add/remove: INGESTED,IN_REVIEW
+--reactions-to-remove {...}
+
 --confidence {...}
 -s|--status {...}
 -r|--review-status {...}
@@ -598,8 +603,13 @@ Optional:
 --last-active {...}
 --expired-on {...}
 
-Please see the following for allowed values in all enumerated types:
+Please see the following for allowed values in all enumerated types except reactions:
 https://developers.facebook.com/docs/threat-exchange/reference/submitting
+
+Please see the following for enumerated types in reactions:
+See also https://developers.facebook.com/docs/threat-exchange/reference/reacting
+
+xxx reactions too
 
 EOF
     stream.puts output
@@ -674,6 +684,13 @@ EOF
       elsif option == '--related-triples-for-upload-as-json'
         self.usage(1) unless args.length >= 1
         postParams[names[:related_triples_for_upload_as_json]] = args.shift;
+
+      elsif option == '--reactions-to-add'
+        self.usage(1) unless args.length >= 1
+        postParams[names[:reactions]] = args.shift;
+      elsif option == '--reactions-to-remove'
+        self.usage(1) unless args.length >= 1
+        postParams[names[:reactions_to_remove]] = args.shift;
 
       elsif option == '--tags'
         self.usage(1) unless args.length >= 1
@@ -810,12 +827,14 @@ Optional:
 --tags {...}           Comma-delimited. Overwrites on repost.
 --add-tags {...}       Comma-delimited. Adds these on repost.
 --remove-tags {...}    Comma-delimited. Removes these on repost.
+
 --related-ids-for-upload {...} Comma-delimited. IDs of descriptors (which must
                        already exist) to relate the new descriptor to.
 --related-triples-json-for-upload {...} Alternate to --related-ids-for-upload.
                        Here you can uniquely the relate-to descriptors by their
                        owner ID / indicator-type / indicator-text, rather than
                        by their IDs. See README.md for an example.
+
 --confidence {...}
 -s|--status {...}
 -r|--review-status {...}
@@ -825,6 +844,9 @@ Optional:
 
 Please see the following for allowed values in all enumerated types:
 https://developers.facebook.com/docs/threat-exchange/reference/editing
+
+Please see the following for enumerated types in reactions:
+See also https://developers.facebook.com/docs/threat-exchange/reference/reacting
 
 EOF
     stream.puts output
@@ -895,6 +917,13 @@ EOF
       elsif option == '--related-triples-for-upload-as-json'
         self.usage(1) unless args.length >= 1
         postParams[names[:related_triples_for_upload_as_json]] = args.shift;
+
+      elsif option == '--reactions-to-add'
+        self.usage(1) unless args.length >= 1
+        postParams[names[:reactions]] = args.shift;
+      elsif option == '--reactions-to-remove'
+        self.usage(1) unless args.length >= 1
+        postParams[names[:reactions_to_remove]] = args.shift;
 
       elsif option == '--tags'
         self.usage(1) unless args.length >= 1


### PR DESCRIPTION
## Test add/remove reactions in Ruby, using Ruby to inspect

Two apps, single threat descriptor, initially no reactions by either of them.

```
$ te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST ids-to-details 2589692907727086 | jq .reactions

null
```

First app reacts

```
$ te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST update --reactions-to-add HELPFUL -i 2589692907727086
{"success":true}

$ te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST ids-to-details 2589692907727086 | jq .reactions
[
  {
    "key": "HELPFUL",
    "value": "1064060413755420"
  }
]
```

Second app reacts

```
$ te-tag-query-ruby -a TX_ACCESS_TOKEN_MHSRFT update --reactions-to-add HELPFUL,INGESTED -i 2589692907727086
{"success":true}

$ te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST ids-to-details 2589692907727086 | jq .reactions
[
  {
    "key": "HELPFUL",
    "value": "494491891138576,1064060413755420"
  },
  {
    "key": "INGESTED",
    "value": "494491891138576"
  }
]
```

First app unreacts once

```
$ te-tag-query-ruby -a TX_ACCESS_TOKEN_MHSRFT update --reactions-to-remove HELPFUL -i 2589692907727086
{"success":true}

$ te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST ids-to-details 2589692907727086 | jq .reactions
[
  {
    "key": "HELPFUL",
    "value": "1064060413755420"
  },
  {
    "key": "INGESTED",
    "value": "494491891138576"
  }
]
```

Second app unreacts

```
$ te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST update --reactions-to-remove HELPFUL -i 2589692907727086
{"success":true}

$ te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST ids-to-details 2589692907727086 | jq .reactions
[
  {
    "key": "INGESTED",
    "value": "494491891138576"
  }
]
```

First app unreacts a second time

```
$ te-tag-query-ruby -a TX_ACCESS_TOKEN_MHSRFT update --reactions-to-remove INGESTED -i 2589692907727086
{"success":true}

$ te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST ids-to-details 2589692907727086 | jq .reactions
null
```

## Test add/remove reactions in Java, using Ruby to inspect

Two apps, single threat descriptor, initially no reactions by either of them.

```
$ ../te-tag-query-ruby/te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST ids-to-details 2589692907727086 | jq .reactions

null
```

```
$ alias jtq='java com.facebook.threatexchange.TETagQuery'
```

First app reacts

```
$ jtq -a TX_ACCESS_TOKEN_MHST update --reactions-to-add HELPFUL -i 2589692907727086
{"success":true}

$ ../te-tag-query-ruby/te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST ids-to-details 2589692907727086 | jq .reactions
[
  {
    "key": "HELPFUL",
    "value": "1064060413755420"
  }
]
```

Second app reacts

```
$ jtq -a TX_ACCESS_TOKEN_MHSRFT update --reactions-to-add HELPFUL,INGESTED -i 2589692907727086
{"success":true}

$ ../te-tag-query-ruby/te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST ids-to-details 2589692907727086 | jq .reactions
[
  {
    "key": "HELPFUL",
    "value": "494491891138576,1064060413755420"
  },
  {
    "key": "INGESTED",
    "value": "494491891138576"
  }
]
```

First app unreacts once

```
$ jtq -a TX_ACCESS_TOKEN_MHSRFT update --reactions-to-remove HELPFUL -i 2589692907727086
{"success":true}

$ ../te-tag-query-ruby/te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST ids-to-details 2589692907727086 | jq .reactions
[
  {
    "key": "HELPFUL",
    "value": "1064060413755420"
  },
  {
    "key": "INGESTED",
    "value": "494491891138576"
  }
]
```

Second app unreacts

```
$ jtq -a TX_ACCESS_TOKEN_MHST update --reactions-to-remove HELPFUL -i 2589692907727086
{"success":true}

$ ../te-tag-query-ruby/te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST ids-to-details 2589692907727086 | jq .reactions
[
  {
    "key": "INGESTED",
    "value": "494491891138576"
  }
]
```

First app unreacts a second time

```
$ jtq -a TX_ACCESS_TOKEN_MHSRFT update --reactions-to-remove INGESTED -i 2589692907727086
{"success":true}

$ ../te-tag-query-ruby/te-tag-query-ruby -a TX_ACCESS_TOKEN_MHST ids-to-details 2589692907727086 | jq .reactions
null
```
