### PR TITLE
Python port; bulk-copy feature

### DIFF
--- a/hashing/te-tag-query-python/README.md
+++ b/hashing/te-tag-query-python/README.md
@@ -1,0 +1,118 @@
+Example technique for retrieving hashes with a given tag from ThreatExchange, as well as uploading.
+
+# Purpose of this code
+
+You can use this for downloading/uploading hashes from/to ThreatExchange, found by tag. You can use the Python code as-is, or use it to illuminate tooling in other languages. Note that `te-tag-query-python -s ...` will print the URLs this tool constructs for you, to help make clear how to access ThreatExchange via URLs.
+
+# Query mechanism
+
+* We use the `tagged_objects` endpoint to fetch IDs of all hashes. This
+endpoint doesn't return all desired metadata fields, so we use it as a quick
+map from tag ID to list of hash IDs. This is relatively quick.
+
+* Then for each resulting hash ID we do a query for all fields associated with
+that ID. This is relatively slow, but batching multiple IDs per query helps a
+lot.
+
+# Contact
+
+threatexchange@fb.com
+
+# Files
+
+There are three.
+
+1. The `te-tag-query-python` wrapper script sets the Python path and invokes the main Python method in `TETagQuery.py`.
+
+```
+#!/bin/bash
+ourdir=`dirname $0`
+# Set up the Python path so this Python program can be invoked from anywhere.
+# Must be python3
+python3 $ourdir/TETagQuery.py "$@"
+```
+
+2. `TETagQuery.py` contains command-line parsing and invokes the library methods in `TE.py`.
+
+3. `TE.py` contains the library methods.
+
+# Setup
+
+* Find your app's access token at https://developers.facebook.com/tools/accesstoken/
+
+* Put this into `~/.txtoken` and `chmod 600 ~/.txtoken`
+
+* `export TX_ACCESS_TOKEN=$(cat ~/.txtoken)` in your shell's init file
+
+# Examples of using the code for queries
+
+On-line help:
+```
+te-tag-query-python --help
+```
+
+Querying for all hashes of a given type:
+```
+te-tag-query-python tag-to-details media_type_photo
+
+te-tag-query-python -v tag-to-details media_type_photo
+
+te-tag-query-python tag-to-details media_type_video
+```
+
+Querying for some hashes of a given type:
+```
+te-tag-query-python tag-to-details --tagged-since -1day media_type_photo
+
+te-tag-query-python tag-to-details --tagged-since -1week media_type_video
+```
+
+# Examples of using the code for posts
+
+Post a new SHA1 hash:
+
+```
+te-tag-query-python submit \
+  -i dabbad00f00dfeed5ca1ab1ebeefca11ab1ec20e \
+  -t HASH_SHA1 \
+  -d "testing te-tag-query-python post" \
+  -l AMBER \
+  -s NON_MALICIOUS \
+  -p HAS_WHITELIST \
+  --privacy-members 1064060413755420 \
+  --tags testing_python_post
+```
+
+{"success": true, "id": "2920637101389201"}
+
+Update it, using that ID:
+
+```
+te-tag-query-python update \
+  -i 3546989395318416 \
+  -s UNKNOWN \
+  --add-tags testing_python_update
+```
+
+Post another with relation to the first one:
+
+```
+te-tag-query-python submit \
+  -i dabbad00f00dfeed5ca1ab1ebeefca11ab1ec20f \
+  -t HASH_SHA1 \
+  -d "testing te-tag-query-python post" \
+  -l AMBER \
+  -s NON_MALICIOUS \
+  -p HAS_WHITELIST \
+  --privacy-members 1064060413755420 \
+  --tags testing_python_post \
+  --related-triples-for-upload-as-json '[{"owner_app_id":494491891138576,"td_indicator_type":"HASH_SHA1","td_raw_indicator":"dabbad00f00dfeed5ca1ab1ebeefca11ab1ec20e"}]'
+```
+
+# Bare-curl notes
+
+As noted at the top of this document, the `TETagQuery` program is intended to be a reference design -- for you to use as-is, or to help you write tooling in other languages.
+
+For reference, we show what those bare-curl commands look like if you're not using the Python code:
+
+https://github.com/facebook/ThreatExchange/blob/master/hashing/te-tag-query-curl/README.md

--- a/hashing/te-tag-query-python/README.md
+++ b/hashing/te-tag-query-python/README.md
@@ -109,6 +109,66 @@ te-tag-query-python submit \
   --related-triples-for-upload-as-json '[{"owner_app_id":494491891138576,"td_indicator_type":"HASH_SHA1","td_raw_indicator":"dabbad00f00dfeed5ca1ab1ebeefca11ab1ec20e"}]'
 ```
 
+Make copies of a set of descriptors, e.g. from a data-sharing partner:
+
+```
+$ jq '.id | tonumber' partner-data.json
+1548810399019426
+1638880316185816
+1934838869863501
+1508037889310099
+1560856918869301
+1590064801887298
+1661005877388540
+1670668732978808
+1788683904488807
+1811154288888224
+```
+
+Here you copy all descriptor data from the query output, only modifying your own values.
+Note, however, that for the present you must explicitly set `--privacy-members`.
+
+```
+$ jq '.id | tonumber' partner-data.json \
+| te-tag-query-python copy -N \
+  --description 'our copies' \
+  --privacy-type HAS_PRIVACY_GROUP --privacy-members 781588512307315
+{"success":true,"id":"3216884688390703"}
+{"success":true,"id":"3039118856170891"}
+{"success":true,"id":"3049939888083721"}
+{"success":true,"id":"3180176808832725"}
+{"success":true,"id":"3280047872888160"}
+{"success":true,"id":"3415103841888795"}
+{"success":true,"id":"2912237555558894"}
+{"success":true,"id":"4163069720400887"}
+{"success":true,"id":"3080705925329880"}
+{"success":true,"id":"3046896738736542"}
+```
+
+```
+$ te-tag-query-python ids-to-details 3046896738736542 | jq .
+{
+  "raw_indicator": "c7dfd847207cbd54a8bb292525fc111d",
+  "type": "HASH_MD5",
+  "added_on": "2020-06-03T01:38:01+0000",
+  "last_updated": "2020-06-03T01:38:02+0000",
+  "confidence": 100,
+  "owner": {
+    "id": "494491891138576",
+    "email": "threatexchange@fb.com",
+    "name": "Media Hash Sharing RF Test"
+  },
+  "privacy_type": "HAS_PRIVACY_GROUP",
+  "review_status": "REVIEWED_AUTOMATICALLY",
+  "status": "MALICIOUS",
+  "severity": "WARNING",
+  "share_level": "AMBER",
+  "description": "our copies",
+  "id": "3046896738736542",
+  "tags": null
+}
+```
+
 # Bare-curl notes
 
 As noted at the top of this document, the `TETagQuery` program is intended to be a reference design -- for you to use as-is, or to help you write tooling in other languages.

--- a/hashing/te-tag-query-python/TE.py
+++ b/hashing/te-tag-query-python/TE.py
@@ -1,0 +1,382 @@
+# ================================================================
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# ================================================================
+
+# General Python dependencies
+import os
+import urllib
+import urllib.parse
+import urllib.request
+import urllib.error
+import json
+
+# ================================================================
+# HTTP-wrapper methods
+# See also https://developers.facebook.com/docs/threat-exchange
+
+# This is a class with all static methods -- no need to instantiate it.  I
+# meant it to be just a module but ran into an implementation detail with
+# updating module-private variables in Python; ended up just making it a class.
+
+class Net:
+  THREAT_DESCRIPTOR = "THREAT_DESCRIPTOR";
+  DEFAULT_TE_BASE_URL = "https://graph.facebook.com/v6.0"
+  TE_BASE_URL = DEFAULT_TE_BASE_URL
+  APP_TOKEN = None
+
+  # This is just a keystroke-saver / error-avoider for passing around
+  # post-parameter field names.
+
+  POST_PARAM_NAMES = {
+    'indicator'                          : 'indicator',     # For submit
+    'type'                               : 'type',          # For submit
+    'descriptor_id'                      : 'descriptor_id', # For update
+  
+    'description'                        : 'description',
+    'share_level'                        : 'share_level',
+    'status'                             : 'status',
+    'privacy_type'                       : 'privacy_type',
+    'privacy_members'                    : 'privacy_members',
+    'tags'                               : 'tags',
+    'add_tags'                           : 'add_tags',
+    'remove_tags'                        : 'remove_tags',
+    'confidence'                         : 'confidence',
+    'precision'                          : 'precision',
+    'review_status'                      : 'review_status',
+    'severity'                           : 'severity',
+    'expired_on'                         : 'expired_on',
+    'first_active'                       : 'first_active',
+    'last_active'                        : 'last_active',
+    'related_ids_for_upload'             : 'related_ids_for_upload',
+    'related_triples_for_upload_as_json' : 'related_triples_for_upload_as_json',
+    # Legacy : should have been named reactions_to_add, but isn't. :(
+    'reactions'                          : 'reactions',
+    'reactions_to_remove'                : 'reactions_to_remove',
+  }
+
+  # ----------------------------------------------------------------
+  # E.g. for overridiing
+  #   https://graph.facebook.com/v{i}.{j}
+  # to
+  #   https://graph.facebook.com/v{x}.{y}
+  @classmethod
+  def setTEBaseURL(self, baseURL):
+    self.DEFAULT_TE_BASE_URL = baseURL
+
+  # ----------------------------------------------------------------
+  # Gets the ThreatExchange app token from an environment variable.  Feel
+  # free to replace the app-token discovery method here with whatever is
+  # most convenient for your project. However, be aware that app tokens
+  # are like passwords and shouldn't be stored in the open.
+
+  # I like to put export TX_ACCESS_TOKEN=$(cat ~/.txtoken) in my .bashrc where
+  # ~/.txtoken is a mode-600 file.
+  @classmethod
+  def setAppTokenFromEnvName(self, appTokenEnvName):
+    if appTokenEnvName in os.environ:
+      self.APP_TOKEN = os.environ[appTokenEnvName]
+    else:
+      raise Exception("$%s not found in environment." % appTokenEnvName)
+
+  # ----------------------------------------------------------------
+  # Helper method for issuing a GET and returning the JSON payload.
+  @classmethod
+  def getJSONFromURL(self, url):
+    # The timeout is a heuristic
+    response = urllib.request.urlopen(url, None, 60)
+    # This is a Python 'bytes'
+    response = response.read()
+    # Now make it a string
+    response = response.decode("utf-8")
+    return json.loads(response)
+
+  # ----------------------------------------------------------------
+  # Looks up the "objective tag" ID for a given tag. This is suitable input for the /threat_tags endpoint.
+
+  @classmethod
+  def getTagIDFromName(self, tagName, showURLs = False):
+    url = self.TE_BASE_URL + \
+      "/threat_tags" + \
+      "/?access_token=" + self.APP_TOKEN + \
+      "&text=" + urllib.parse.quote(tagName)
+    if showURLs:
+      print("URL:")
+      print(url)
+
+    response = self.getJSONFromURL(url)
+
+    # The lookup will get everything that has this as a prefix.
+    # So we need to filter the results. This loop also handles the
+    # case when the results array is empty.
+    #
+    # Example: when querying for "media_type_video", we want the 2nd one:
+    # { "data": [
+    #   { "id": "9999338563303771", "text": "media_type_video_long_hash" },
+    #   { "id": "9999474908560728", "text": "media_type_video" },
+    #   { "id": "9889872714202918", "text": "media_type_video_hash_long" }
+    #   ], ...
+    # }
+    data = response['data']
+    desired = list(filter(lambda o: o['text'] == tagName, data))
+    if len(desired) < 1:
+      return None
+    else:
+      return desired[0]['id']
+
+
+  # ----------------------------------------------------------------
+  # Looks up all descriptors with a given tag. Invokes a specified callback on
+  # each page of IDs.
+
+  @classmethod
+  def processDescriptorIDsByTagID(self, tagID, idProcessorCallback, **kwargs):
+    verbose = kwargs.get('verbose', False)
+    showURLs = kwargs.get('showURLs', False)
+    includeIndicatorInOutput = kwargs.get('includeIndicatorInOutput', True)
+    pageSize = kwargs.get('pageSize', 10)
+    taggedSince = kwargs.get('taggedSince', None)
+    taggedUntil = kwargs.get('taggedUntil', None)
+
+    startURL = self.TE_BASE_URL + \
+      "/" + tagID + "/tagged_objects" + \
+      "/?access_token=" + self.APP_TOKEN + \
+      "&limit=" + str(pageSize)
+
+    if taggedSince != None:
+      startURL += "&tagged_since=" + taggedSince
+    if taggedUntil != None:
+      startURL += "&tagged_until=" + taggedUntil
+
+    nextURL = startURL
+    pageIndex = 0;
+
+    while nextURL != None:
+      if showURLs:
+        print("URL:")
+        print(nextURL)
+
+      # Format we're parsing:
+      # {
+      #   "data": [
+      #     {
+      #       "id": "9915337796604770",
+      #       "type": "THREAT_DESCRIPTOR",
+      #       "name": "7ef5...aa97"
+      #     }
+      #     ...
+      #   ],
+      #   "paging": {
+      #     "cursors": {
+      #       "before": "XYZIU...NjQ0h3Unh3",
+      #       "after": "XYZIUk...FXNzVNd1Jn"
+      #     },
+      #     "next": "https://graph.facebook.com/v3.1/9999338387644295/tagged_objects?access_token=..."
+      #   }
+      # }
+
+      response = self.getJSONFromURL(nextURL)
+
+      data = response['data']
+
+      nextURL = None
+      if 'paging' in response:
+        paging = response['paging']
+        if 'next' in paging:
+          nextURL = paging['next']
+      ids = []
+      for item in data:
+        itemID = item['id']
+        itemType = item['type']
+        if includeIndicatorInOutput:
+          itemName = item['name']
+        else:
+          del item['name']
+        if itemType != self.THREAT_DESCRIPTOR:
+          continue
+        if verbose:
+          print(json.dumps(item))
+        ids.append(itemID)
+      if verbose:
+        info = {}
+        info['page_index'] = pageIndex
+        info['num_items_pre_filter'] = len(data)
+        info['num_items_post_filter'] = len(ids)
+        print(json.dumps(info))
+
+      idProcessorCallback(ids)
+
+      pageIndex += 1
+
+
+  # ----------------------------------------------------------------
+  # Looks up all metadata for given IDs.
+  @classmethod
+  def getInfoForIDs(self, ids, **kwargs):
+    verbose = kwargs.get('verbose', False)
+    showURLs = kwargs.get('showURLs', False)
+    includeIndicatorInOutput = kwargs.get('includeIndicatorInOutput', True)
+
+    # Check well-formattedness of descriptor IDs (which may have come from
+    # arbitrary data on stdin).
+    for id in ids:
+      try:
+        _ = int(id)
+      except ValueError:
+        raise Exception("Malformed descriptor ID \"%s\"" % id)
+
+    # See also
+    # https://developers.facebook.com/docs/threat-exchange/reference/apis/threat-descriptor/v6.0
+    # for available fields
+
+    url = self.TE_BASE_URL + \
+      "/?access_token=" + self.APP_TOKEN + \
+      "&ids=" + ','.join(ids) + \
+      "&fields=raw_indicator,type,added_on,last_updated,confidence,owner,privacy_type,review_status,status,severity,share_level,tags,description,reactions,my_reactions"
+
+    if showURLs:
+      print("URL:")
+      print(url)
+
+    response = self.getJSONFromURL(url)
+
+    descriptors = []
+    for id, descriptor in response.items():
+      if includeIndicatorInOutput == False:
+        del descriptor['raw_indicator']
+      if verbose:
+        print(json.dumps(descriptor))
+
+      tags = descriptor['tags']
+      if tags is None:
+        tags = []
+      else:
+        tags = tags['data']
+
+      # Canonicalize the tag ordering and simplify the
+      # structure to simply an array of tag-texts
+      descriptor['tags'] = [tag['text'] for tag in tags].sort()
+
+      if descriptor.get('description') is None:
+        descriptor['description'] = ''
+
+      descriptors.append(descriptor)
+
+    return descriptors
+
+  # ----------------------------------------------------------------
+  # Returns error message or None.
+  # This simply checks to see (client-side) if required fields aren't provided.
+  @classmethod
+  def validatePostPararmsForSubmit(self, postParams):
+    if postParams.get(self.POST_PARAM_NAMES['descriptor_id']) != None:
+      return "descriptor_id must not be specified for submit."
+
+    requiredFields = [
+      self.POST_PARAM_NAMES['indicator'],
+      self.POST_PARAM_NAMES['type'],
+      self.POST_PARAM_NAMES['description'],
+      self.POST_PARAM_NAMES['share_level'],
+      self.POST_PARAM_NAMES['status'],
+      self.POST_PARAM_NAMES['privacy_type'],
+    ]
+
+    missingFields = [
+      fieldName if postParams.get(fieldName) == None  else None
+      for fieldName in requiredFields
+    ]
+    missingFields = [fieldName for fieldName in missingFields if fieldName != None]
+
+    if len(missingFields) == 0:
+      return None
+    elif len(missingFields) == 1:
+      return "Missing field %s" % missingFields[0]
+    else:
+      return "Missing fields %s" % ','.join(missingFields)
+
+
+  # ----------------------------------------------------------------
+  # Returns error message or None.
+  # This simply checks to see (client-side) if required fields aren't provided.
+  @classmethod
+  def validatePostPararmsForUpdate(self, postParams):
+    if postParams.get(self.POST_PARAM_NAMES['descriptor_id']) == None:
+      return "Descriptor ID must be specified for update."
+    if postParams.get(self.POST_PARAM_NAMES['indicator']) != None:
+      return "Indicator must not be specified for update."
+    if postParams.get(self.POST_PARAM_NAMES['type']) != None:
+      return "Type must not be specified for update."
+    return None
+
+
+  # ----------------------------------------------------------------
+  # Does a single POST to the threat_descriptors endpoint.  See also
+  # https://developers.facebook.com/docs/threat-exchange/reference/submitting
+  @classmethod
+  def submitThreatDescriptor(self, postParams, showURLs, dryRun):
+    errorMessage = self.validatePostPararmsForSubmit(postParams)
+    if errorMessage != None:
+      return [errorMessage, None, None]
+
+    url = self.TE_BASE_URL + \
+      "/threat_descriptors" + \
+      "/?access_token=" + self.APP_TOKEN
+
+    return self._postThreatDescriptor(url, postParams, showURLs, dryRun)
+
+  # ----------------------------------------------------------------
+  # Does a single POST to the threat_descriptor ID endpoint.  See also
+  # https://developers.facebook.com/docs/threat-exchange/reference/editing
+  @classmethod
+  def updateThreatDescriptor(self, postParams, showURLs, dryRun):
+    errorMessage = self.validatePostPararmsForUpdate(postParams)
+    if errorMessage != None:
+      return [errorMessage, None, None]
+
+    url = self.TE_BASE_URL + \
+      "/" + postParams[self.POST_PARAM_NAMES['descriptor_id']] + \
+      "/?access_token=" + self.APP_TOKEN
+
+    return self._postThreatDescriptor(url, postParams, showURLs, dryRun)
+
+
+  # ----------------------------------------------------------------
+  # Code-reuse for submit and update
+  @classmethod
+  def _postThreatDescriptor(self, url, postParams, showURLs, dryRun):
+    for key, value in postParams.items():
+      url += ("&%s=%s" % (key, urllib.parse.quote(value)))
+    if showURLs:
+      print()
+      print("URL:")
+      print(url)
+    if (dryRun):
+      print("Not doing POST since --dry-run.")
+      return [None, None, '']
+
+    # Encode the inputs to the POST
+    header = {
+      'Content-Type':  'text/json',
+      'charset': 'utf-8',
+    }
+    # This is a string
+    data = urllib.parse.urlencode(postParams)
+    # Turn it into a Python bytes object
+    data = data.encode('ascii')
+
+    # Do the POST
+    try:
+      response = urllib.request.urlopen(url, data)
+
+      # Decode the outputs from the POST
+      # This is a Python 'bytes'
+      response = response.read()
+      # Now make it a string
+      response = response.decode("utf-8")
+      responseBody = json.loads(response)
+      responseCode = None
+
+      return [None, None, responseBody]
+
+
+    except urllib.error.HTTPError as e:
+      return [None, e, None]

--- a/hashing/te-tag-query-python/TE.py
+++ b/hashing/te-tag-query-python/TE.py
@@ -349,7 +349,6 @@ class Net:
     return self._postThreatDescriptor(url, postParams, showURLs, dryRun)
 
   # ----------------------------------------------------------------
-  # xxx
   @classmethod
   def copyThreatDescriptor(self, postParams, showURLs, dryRun):
     errorMessage = self.validatePostPararmsForCopy(postParams)
@@ -361,10 +360,8 @@ class Net:
     del postParams['descriptor_id']
     sourceDescriptor = self.getInfoForIDs([sourceID], showURLs=showURLs)
     sourceDescriptor = sourceDescriptor[0]
-    # xxx check for non-null/whatever ... try/catch maybe ...
 
     # Mutate necessary fields
-    # xxx transmogrify -- raw_indicator -> indicator -- what else?
     newDescriptor = copy.deepcopy(sourceDescriptor)
     newDescriptor['indicator'] = sourceDescriptor['raw_indicator']
     del newDescriptor['raw_indicator']
@@ -393,7 +390,6 @@ class Net:
       if self.POST_PARAM_NAMES.get(key) != None:
         postParams[key] = value
 
-    # xxx privacy_members -- underdiff
 
     return self.submitThreatDescriptor(postParams, showURLs, dryRun)
 
@@ -436,7 +432,6 @@ class Net:
 
       return [None, None, responseBody]
 
-    # xxx code ...
     except urllib.error.HTTPError as e:
       responseBody = json.loads(e.read().decode("utf-8"))
       return [None, e, responseBody]

--- a/hashing/te-tag-query-python/TETagQuery.py
+++ b/hashing/te-tag-query-python/TETagQuery.py
@@ -1,0 +1,1032 @@
+##!/usr/bin/env python
+
+# ================================================================
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# ================================================================
+# Example technique for retrieving all descriptors with a given tag from
+# ThreatExchange.
+#
+# Notes:
+#
+# * We use the tagged_objects endpoint to fetch IDs of all descriptors. This
+#   endpoint doesn't return all desired metadata fields, so we use it as a
+#   quick map from tag ID to list of descriptor IDs. This is relatively quick.
+#
+# * Then for each resulting descriptor ID we do a query for all fields
+#   associated with that ID. This is relatively slow, but batching multiple
+#   IDs per query helps a lot.
+#
+# Please see README.md for example usages.
+# ================================================================
+
+import sys
+import json
+
+# ThreatExchange dependencies
+import TE
+
+def eprint(string):
+  sys.stderr.write(string)
+  sys.stderr.write("\n")
+
+# ================================================================
+# MAIN COMMAND-LINE ENTRY POINT
+class MainHandler:
+  def __init__(self, progName):
+    self.progName = progName
+
+  # ----------------------------------------------------------------
+  # General rule about exit-codes and output streams:
+  # * When help was asked for: print to stdout and exit 0.
+  # * When unacceptable command-line syntax was provided: print to stderr and exit 1.
+  def usage(self, exitCode):
+    stream =  sys.stdout if exitCode == 0 else sys.stderr
+    output = """Usage: %s [options] {verb} {verb arguments}
+Downloads descriptors in bulk from ThreatExchange, given
+either a tag name or a list of IDs one per line on standard input.
+
+Options:
+  -h|--help      Show detailed help.
+  --list-verbs   Show a list of supported verbs.
+  -q|--quiet     Only print IDs/descriptors output with no narrative.
+  -v|--verbose   Print IDs/descriptors output along with narrative.
+  -s|--show-urls Print URLs used for queries, before executing them.
+  -a|--app-token-env-name {...} Name of app-token environment variable.
+                 Defaults to "TX_ACCESS_TOKEN".
+  -b|--te-base-url {...} Defaults to "%s"
+
+""" % (self.progName, TE.Net.DEFAULT_TE_BASE_URL)
+
+    stream.write(output + "\n")
+    SubcommandHandlerFactory.listVerbs()
+    sys.exit(exitCode)
+
+
+  # ----------------------------------------------------------------
+  # We don't use getopt, intentionally so. It doesn't know about our subcommand
+  # structure.
+  #
+  # * python TETagQuery.py -h
+  #   We want the -h handled by main().
+  # * python TETagQuery.py submit -h
+  #   We want the -h handled by submit().
+  # * python TETagQuery.py -s submit -i ... -t ...
+  #   We want the -s handled by main(), and -i/-t/etc handled by submit().
+
+  def handle(self, args):
+    options = self.getDefaultOptions()
+    subcommandHandlerFactory = SubcommandHandlerFactory()
+
+    while True:
+      if len(args) == 0:
+        break
+      if args[0][0] != '-':
+        break
+      option = args[0]
+      args = args[1:]
+
+      if option == '-h':
+        self.usage(0)
+      elif option == '--help':
+        self.usage(0)
+      elif option == '-l' or option == '--list-verbs':
+        SubcommandHandlerFactory.listVerbs()
+        sys.exit(0)
+
+      elif option == '-v' or option == '--verbose':
+        options['verbose'] = True
+      elif option == '-q' or option == '--quiet':
+        options['verbose'] = False
+      elif option == '-s' or option == '--show-urls':
+        options['showURLs'] = True
+      elif option == '-a' or option == '--app-token-env-name':
+        if len(args) < 1:
+          self.usage(1)
+        options['accessTokenEnvName'] = args[0]
+        args = args[1:]
+      elif option == '-b' or option == '--base-te-url':
+        if len(args) < 1:
+          self.usage(1)
+        options['baseTEURL'] = args[0]
+        args = args[1:]
+      else:
+        eprint('%s: unrecognized  option %s' % (self.progName, option))
+        sys.exit(1)
+
+    if len(args) < 1:
+      self.usage(1)
+
+    verbName = args[0]
+    args = args[1:]
+
+    # Endpoint setup common to all verbs
+    # ThreatExchange::TENet::setAppTokenFromEnvName(options['accessTokenEnvName'])
+    baseTEURL = options['baseTEURL']
+    if baseTEURL != None:
+      TE.Net.setTEBaseURL(baseTEURL)
+    if options['accessTokenEnvName'] != None:
+      TE.Net.setAppTokenFromEnvName(options['accessTokenEnvName'])
+
+    subcommandHandler = subcommandHandlerFactory.create(self.progName, verbName)
+    if subcommandHandler is None:
+      eprint("%s: unrecognized verb %s" % (self.progName, verbName))
+      sys.exit(1)
+    subcommandHandler.handle(args, options)
+
+
+  # ----------------------------------------------------------------
+  def getDefaultOptions(self):
+    return {
+      'verbose'            : False,
+      'showURLs'           : False,
+      'pageSize'           : 10,
+
+      'accessTokenEnvName' : 'TX_ACCESS_TOKEN',
+      'baseTEURL'          : None,
+    }
+
+
+
+# ================================================================
+# This is just a subcommand looker-upper. We use n subcommands within one
+# script, instead of shipping n scripts.
+class SubcommandHandlerFactory:
+  VERB_NAMES = {
+    'look-up-tag-id' : 'look-up-tag-id',
+    'tag-to-ids'     : 'tag-to-ids',
+    'ids-to-details' : 'ids-to-details',
+    'tag-to-details' : 'tag-to-details',
+    'paginate'       : 'paginate',
+    'submit'         : 'submit',
+    'update'         : 'update',
+  }
+
+  # Static method
+  @classmethod
+  def listVerbs(self):
+    print("Verbs:")
+    for keyValuePair in self.VERB_NAMES.items():
+      key = keyValuePair[0]
+      print(key)
+
+  def create(self, progName, verbName):
+    if verbName == self.VERB_NAMES['look-up-tag-id']:
+      return LookUpTagIDHandler(progName, verbName)
+    elif verbName == self.VERB_NAMES['tag-to-ids']:
+      return TagToIDsHandler(progName, verbName)
+    elif verbName == self.VERB_NAMES['ids-to-details']:
+      return IDsToDetailsHandler(progName, verbName)
+    elif verbName == self.VERB_NAMES['tag-to-details']:
+      return TagToDetailsHandler(progName, verbName)
+    elif verbName == self.VERB_NAMES['paginate']:
+      return PaginateHandler(progName, verbName)
+    elif verbName == self.VERB_NAMES['submit']:
+      return SubmitHandler(progName, verbName)
+    elif verbName == self.VERB_NAMES['update']:
+      return UpdateHandler(progName, verbName)
+    else:
+      return None
+
+
+# ================================================================
+# Code-reuse for all subcommand handlers.
+class SubcommandHandler:
+  def __init__(self, progName, verbName):
+    self.progName = progName
+    self.verbName = verbName
+
+
+## ================================================================
+class LookUpTagIDHandler(SubcommandHandler):
+  def __init__(self, progName, verbName):
+    super(__class__, self).__init__(progName, verbName)
+
+  def usage(self, exitCode):
+    stream =  sys.stdout if exitCode == 0 else sys.stderr
+    output = "Usage: %s %s {one or more tag names}" % (self.progName, self.verbName)
+    stream.write(output + "\n")
+    sys.exit(exitCode)
+
+  def handle(self, args, options):
+    pass
+    if len(args) >= 1:
+      if args[0] == '-h' or args[0] == '--help':
+        self.usage(0)
+
+    if len(args) != 1:
+      self.usage(1)
+
+    tagName = args[0]
+    tag_id = TE.Net.getTagIDFromName(tagName, options['showURLs'])
+    if tag_id is None:
+      eprint("Tag \"%s\" not found." % tagName)
+      sys.exit(1)
+    else:
+      print(tag_id)
+
+
+# ================================================================
+class TagToIDsHandler(SubcommandHandler):
+  def __init__(self, progName, verbName):
+    super(__class__, self).__init__(progName, verbName)
+
+  def usage(self, exitCode):
+    stream =  sys.stdout if exitCode == 0 else sys.stderr
+    output = """Usage: %s %s [options] {tag name}
+Options:
+--tagged-since {x}
+--tagged-until {x}
+--page-size {x}
+The \"tagged-since\" or \"tagged-until\" parameter is any supported by ThreatExchange,
+e.g. seconds since the epoch, or "-1hour", or "-1day", etc.
+""" % (self.progName, self.verbName)
+    stream.write(output + "\n")
+    sys.exit(exitCode)
+
+  def handle(self, args, options):
+
+    options['includeIndicatorInOutput'] = True
+    options['pageSize'] = 10
+
+    while True:
+      if len(args) == 0:
+        break
+      if args[0][0] != '-':
+        break
+      option = args[0]
+      args = args[1:]
+
+      if option == '-h':
+        self.usage(0)
+      elif option == '--help':
+        self.usage(0)
+
+      elif option == '--tagged-since':
+        if len(args) < 1:
+          self.usage(1)
+        options['taggedSince'] = args[0]
+        args = args[1:]
+      elif option == '--tagged-until':
+        if len(args) < 1:
+          self.usage(1)
+        options['taggedUntil'] = args[0]
+        args = args[1:]
+
+      elif option == '--page-size':
+        if len(args) < 1:
+          self.usage(1)
+        options['pageSize'] = args[0]
+        args = args[1:]
+
+      else:
+        eprint("%s %s: unrecognized  option %s" % (self.progName, self.verbName, option))
+        sys.exit(1)
+
+    if len(args) != 1:
+      self.usage(1)
+    tagName = args[0]
+
+    tag_id = TE.Net.getTagIDFromName(tagName, options['showURLs'])
+    if tag_id is None:
+      eprint("Tag \"%s\" not found." % tagName)
+      sys.exit(1)
+
+    # Step 1: tag text to ID
+    # Step 2: tag ID to descriptor IDs, paginated
+    # Step 3: descriptor IDs to descriptor details, paginated
+    idProcessor = lambda idBatch : self.IDProcessor(idBatch)
+
+    TE.Net.processDescriptorIDsByTagID(tag_id, idProcessor,
+      verbose=options['verbose'],
+      showURLs=options['showURLs'],
+      taggedSince=options.get('taggedSince', None),
+      taggedUnti=options.get('taggedUntil', None),
+      pageSize=options['pageSize'])
+
+
+  @classmethod
+  def IDProcessor(self, idBatch):
+    for id in idBatch:
+      print(id)
+
+
+# ================================================================
+class IDsToDetailsHandler(SubcommandHandler):
+  def __init__(self, progName, verbName):
+    super(__class__, self).__init__(progName, verbName)
+
+  def usage(self, exitCode):
+    stream =  sys.stdout if exitCode == 0 else sys.stderr
+    output = """Usage: %s %s [options] [IDs]
+Options:
+--no-print-indicator -- Don't print the indicator to the terminal
+Please supply IDs either one line at a time on standard input, or on the command line
+after the options.
+""" % (self.progName, self.verbName)
+    stream.write(output + "\n")
+    sys.exit(exitCode)
+
+  def handle(self, args, options):
+    options['includeIndicatorInOutput'] = True
+    options['pageSize'] = 10
+
+    while True:
+      if len(args) == 0:
+        break
+      if args[0][0] != '-':
+        break
+      option = args[0]
+      args = args[1:]
+
+      if option == '-h':
+        self.usage(0)
+      elif option == '--help':
+        self.usage(0)
+
+      elif option == '--tagged-since':
+        if len(args) < 1:
+          self.usage(1)
+        options['taggedSince'] = args[0]
+        args = args[1:]
+      elif option == '--tagged-until':
+        if len(args) < 1:
+          self.usage(1)
+        options['taggedUntil'] = args[0]
+        args = args[1:]
+
+      elif option == '--page-size':
+        if len(args) < 1:
+          self.usage(1)
+        options['pageSize'] = args[0]
+        args = args[1:]
+      elif option == '--no-print-indicator':
+        if len(args) < 1:
+          self.usage(1)
+        options['includeIndicatorInOutput'] = False
+
+      else:
+        eprint("%s %s: unrecognized  option %s" % (self.progName, self.verbName, option))
+        sys.exit(1)
+
+    ids = []
+    if len(args) > 0:
+      ids = args
+    else:
+      while True:
+        # Python line-reader returns the trailing newlines so
+        # we need to right-strip the lines
+        line = sys.stdin.readline()
+        if line == '':
+          break
+        ids.append(line.rstrip())
+
+    for id in ids:
+      idBatch = [id]
+
+      descriptors = TE.Net.getInfoForIDs(idBatch,
+        verbose=options['verbose'],
+        showURLs=options['showURLs'],
+        includeIndicatorInOutput=options['includeIndicatorInOutput'])
+      for descriptor in descriptors:
+        print(json.dumps(descriptor))
+
+
+# ================================================================
+class TagToDetailsHandler(SubcommandHandler):
+  def __init__(self, progName, verbName):
+    super(__class__, self).__init__(progName, verbName)
+
+  def usage(self, exitCode):
+    stream =  sys.stdout if exitCode == 0 else sys.stderr
+    output = """Usage: %s %s [options] {tag name}
+Options:
+--tagged-since {x}
+--tagged-until {x}
+--page-size {x}
+--no-print-indicator -- Don't print the indicator to the terminal
+The \"tagged-since\" or \"tagged-until\" parameter is any supported by ThreatExchange,
+e.g. seconds since the epoch, or "-1hour", or "-1day", etc.
+""" % (self.progName, self.verbName)
+    stream.write(output + "\n")
+    sys.exit(exitCode)
+
+  def handle(self, args, options):
+    options['includeIndicatorInOutput'] = True
+    options['pageSize'] = 10
+
+    while True:
+      if len(args) == 0:
+        break
+      if args[0][0] != '-':
+        break
+      option = args[0]
+      args = args[1:]
+
+      if option == '-h':
+        self.usage(0)
+      elif option == '--help':
+        self.usage(0)
+
+      elif option == '--tagged-since':
+        if len(args) < 1:
+          self.usage(1)
+        options['taggedSince'] = args[0]
+        args = args[1:]
+      elif option == '--tagged-until':
+        if len(args) < 1:
+          self.usage(1)
+        options['taggedUntil'] = args[0]
+        args = args[1:]
+
+      elif option == '--page-size':
+        if len(args) < 1:
+          self.usage(1)
+        options['pageSize'] = args[0]
+        args = args[1:]
+      elif option == '--no-print-indicator':
+        if len(args) < 1:
+          self.usage(1)
+        options['includeIndicatorInOutput'] = False
+
+      else:
+        eprint("%s %s: unrecognized  option %s" % (self.progName, self.verbName, option))
+        sys.exit(1)
+
+    if len(args) != 1:
+      self.usage(1)
+    tagName = args[0]
+
+    # Step 1: tag text to ID
+    # Step 2: tag ID to descriptor IDs, paginated
+    # Step 3: descriptor IDs to descriptor details, paginated
+
+    tag_id = TE.Net.getTagIDFromName(tagName, options['showURLs'])
+    if tag_id is None:
+      eprint("Tag \"%s\" not found." % tagName)
+      sys.exit(1)
+
+    # Step 1: tag text to ID
+    # Step 2: tag ID to descriptor IDs, paginated
+    # Step 3: descriptor IDs to descriptor details, paginated
+    idProcessor = lambda idBatch : self.IDProcessor(idBatch, options)
+
+    TE.Net.processDescriptorIDsByTagID(tag_id, idProcessor,
+      verbose=options['verbose'],
+      showURLs=options['showURLs'],
+      taggedSince=options.get('taggedSince', None),
+      taggedUnti=options.get('taggedUntil', None),
+      pageSize=options['pageSize'])
+
+
+  @classmethod
+  def IDProcessor(self, idBatch, options):
+    descriptors = TE.Net.getInfoForIDs(idBatch,
+      verbose=options['verbose'],
+      showURLs=options['showURLs'],
+      includeIndicatorInOutput=options['includeIndicatorInOutput'])
+    for descriptor in descriptors:
+      # Stub processing -- one would perhaps integrate with one's own system
+      print(json.dumps(descriptor))
+
+
+# ================================================================
+class PaginateHandler(SubcommandHandler):
+  def __init__(self, progName, verbName):
+    super(__class__, self).__init__(progName, verbName)
+
+  def usage(self, exitCode):
+    stream =  sys.stdout if exitCode == 0 else sys.stderr
+    output = """Usage: %s %s {URL}
+Curls the URL, JSON-dumps the return value's data blob, then curls
+the next-page URL and repeats until there are no more pages.
+""" % (self.progName, self.verbName)
+    stream.write(output + "\n")
+    sys.exit(exitCode)
+
+  def handle(self, args, options):
+    if len(args) >= 1:
+      if args[0] == '-h' or args[0] == '--help':
+        self.usage(0)
+    if len(args) != 1:
+      self.usage(1)
+
+    startURL = args[0]
+    nextURL = startURL
+
+    while nextURL != None:
+      if (options['showURLs']):
+        print("URL:")
+        print(nextURL)
+      response = TE.Net.getJSONFromURL(nextURL)
+      data = response.get('data', None)
+      paging = response.get('paging', None)
+      if data is None:
+        eprint("No data field found in response JSON.")
+        break
+      if paging is None:
+        nextURL = None
+      else:
+        nextURL = paging.get('next', None)
+
+      print(json.dumps(data))
+
+
+# ================================================================
+# NOTE: SubmitHandler and UpdateHandler have a lot of the same code but also
+# several differences. I found it simpler (albeit more verbose) to duplicate
+# rather than do an abstract-and-override refactor.
+
+class SubmitHandler(SubcommandHandler):
+  def __init__(self, progName, verbName):
+    super(__class__, self).__init__(progName, verbName)
+
+  def usage(self, exitCode):
+    stream =  sys.stdout if exitCode == 0 else sys.stderr
+    output = """Usage: %s %s [options]
+Uploads a threat descriptor with the specified values.
+On repost (with same indicator text/type and app ID), updates changed fields.
+
+Required:
+-i|--indicator {...}   If indicator type is HASH_TMK this must be the
+                       path to a .tmk file, else the indicator text.
+-I                     Take indicator text from standard input, one per line.
+Exactly one of -i or -I is required.
+-t|--type {...}
+-d|--description {...}
+-l|--share-level {...}
+-p|--privacy-type {...}
+-y|--severity {...}
+
+Optional:
+-h|--help
+--dry-run
+-m|--privacy-members {...} If privacy-type is HAS_WHITELIST these must be
+                       comma-delimited app IDs. If privacy-type is
+                       HAS_PRIVACY_GROUP these must be comma-delimited
+                       privacy-group IDs.
+--tags {...}           Comma-delimited. Overwrites on repost.
+
+--related-ids-for-upload {...} Comma-delimited. IDs of descriptors (which must
+                       already exist) to relate the new descriptor to.
+--related-triples-json-for-upload {...} Alternate to --related-ids-for-upload.
+                       Here you can uniquely the relate-to descriptors by their
+                       owner ID / indicator-type / indicator-text, rather than
+                       by their IDs. See README.md for an example.
+
+--reactions-to-add {...}    Example for add/remove: INGESTED,IN_REVIEW
+--reactions-to-remove {...}
+
+--confidence {...}
+-s|--status {...}
+-r|--review-status {...}
+--first-active {...}
+--last-active {...}
+--expired-on {...}
+
+Please see the following for allowed values in all enumerated types except reactions:
+https://developers.facebook.com/docs/threat-exchange/reference/submitting
+
+Please see the following for enumerated types in reactions:
+See also https://developers.facebook.com/docs/threat-exchange/reference/reacting
+
+""" % (self.progName, self.verbName)
+    stream.write(output + "\n")
+    sys.exit(exitCode)
+
+
+  def handle(self, args, options):
+    options['dryRun'] = False;
+    options['indicatorTextFromStdin'] = False;
+
+    postParams = {}
+    # Local keystroke-saver for this enum
+    names = TE.Net.POST_PARAM_NAMES
+
+    while True:
+      if len(args) == 0:
+        break
+      if args[0][0] != '-':
+        break
+      option = args[0]
+      args = args[1:]
+
+      if option == '-h':
+        self.usage(0)
+      elif option == '--help':
+        self.usage(0)
+
+      elif option == '--dry-run':
+        options['dryRun'] = True
+
+      elif option == '-I':
+        options['indicatorTextFromStdin'] = True;
+      elif option == '-i' or option == '--indicator':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['indicator']] = args[0]
+        args = args[1:]
+
+      elif option == '-t' or option == '--type':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['type']] = args[0]
+        args = args[1:]
+
+      elif option == '-d' or option == '--description':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['description']] = args[0]
+        args = args[1:]
+
+      elif option == '-l' or option == '--share-level':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['share_level']] = args[0]
+        args = args[1:]
+      elif option == '-p' or option == '--privacy-type':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['privacy_type']] = args[0]
+        args = args[1:]
+      elif option == '-m' or option == '--privacy-members':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['privacy_members']] = args[0]
+        args = args[1:]
+
+      elif option == '-s' or option == '--status':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['status']] = args[0]
+        args = args[1:]
+      elif option == '-r' or option == '--review-status':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['review_status']] = args[0]
+        args = args[1:]
+      elif option == '-y' or option == '--severity':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['severity']] = args[0]
+        args = args[1:]
+      elif option == '-c' or option == '--confidence':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['confidence']] = args[0]
+        args = args[1:]
+
+      elif option == '--related-ids-for-upload':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['related_ids_for_upload']] = args[0]
+        args = args[1:]
+      elif option == '--related-triples-for-upload-as-json':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['related_triples_for_upload_as_json']] = args[0]
+        args = args[1:]
+
+      elif option == '--reactions-to-add':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['reactions']] = args[0]
+        args = args[1:]
+      elif option == '--reactions-to-remove':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['reactions_to_remove']] = args[0]
+        args = args[1:]
+
+      elif option == '--tags':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['tags']] = args[0]
+        args = args[1:]
+
+      elif option == '--first-active':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['first_active']] = args[0]
+        args = args[1:]
+      elif option == '--last-active':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['last']] = args[0]
+        args = args[1:]
+      elif option == '--expired-on':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['expired_on']] = args[0]
+        args = args[1:]
+
+      else:
+        eprint("%s %s: unrecognized  option %s" % (self.progName, self.verbName, option))
+        sys.exit(1)
+
+    if len(args) > 0:
+      eprint("%s %s: extraneous argument(s) \"%s\"" %
+        (self.progName, self.verbName, ' '.join(args)))
+      sys.exit(1)
+
+    if options['indicatorTextFromStdin']:
+      if postParams.get(names['indicator'], None) != None:
+        eprint("%s %s: only one of -I and -i must be supplied." %
+          (self.progName, self.verbName))
+        sys.exit(1)
+      while True:
+        # Python line-reader returns the trailing newlines so
+        # we need to right-strip the lines
+        line = sys.stdin.readline()
+        if line == '':
+          break
+        postParams[names['indicator']] = line.rstrip()
+        self.submitSingle(
+          postParams,
+          options['verbose'],
+          options['showURLs'],
+          options['dryRun'],
+        )
+    else:
+      if postParams.get(names['indicator'], None) == None:
+        eprint("%s %s: only one of -I and -i must be supplied." %
+          (self.progName, self.verbName))
+        sys.exit(1)
+      self.submitSingle(
+        postParams,
+        options['verbose'],
+        options['showURLs'],
+        options['dryRun'],
+      )
+
+
+  # ----------------------------------------------------------------
+  def submitSingle(self, postParams, verbose, showURLs, dryRun):
+    validationErrorMessage, serverSideError, responseBody = TE.Net.submitThreatDescriptor(
+      postParams, showURLs, dryRun)
+
+    if validationErrorMessage != None:
+      eprint(validationErrorMessage)
+      sys.exit(1)
+
+    if serverSideError != None:
+      eprint(str(serverSideError))
+      sys.exit(1)
+
+    print(json.dumps(responseBody))
+
+# ================================================================
+# NOTE: SubmitHandler and UpdateHandler have a lot of the same code but also
+# several differences. I found it simpler (albeit more verbose) to duplicate
+# rather than do an abstract-and-override refactor.
+
+class UpdateHandler(SubcommandHandler):
+  def __init__(self, progName, verbName):
+    super(__class__, self).__init__(progName, verbName)
+
+
+  # ----------------------------------------------------------------
+  def usage(self, exitCode):
+    stream =  sys.stdout if exitCode == 0 else sys.stderr
+    output = """Usage: %s %s [options]
+Updates specified attributes on an existing threat descriptor.
+
+Required:
+-i {...}               ID of descriptor to be edited. Must already exist.
+-I                     Take descriptor IDs from standard input, one per line.
+Exactly one of -i or -I is required.
+-d|--description {...}
+-l|--share-level {...}
+-p|--privacy-type {...}
+-y|--severity {...}
+
+Optional:
+-h|--help
+--dry-run
+-m|--privacy-members {...} If privacy-type is HAS_WHITELIST these must be
+                       comma-delimited app IDs. If privacy-type is
+                       HAS_PRIVACY_GROUP these must be comma-delimited
+                       privacy-group IDs.
+--tags {...}           Comma-delimited. Overwrites on repost.
+--add-tags {...}       Comma-delimited. Adds these on repost.
+--remove-tags {...}    Comma-delimited. Removes these on repost.
+
+--related-ids-for-upload {...} Comma-delimited. IDs of descriptors (which must
+                       already exist) to relate the new descriptor to.
+--related-triples-json-for-upload {...} Alternate to --related-ids-for-upload.
+                       Here you can uniquely the relate-to descriptors by their
+                       owner ID / indicator-type / indicator-text, rather than
+                       by their IDs. See README.md for an example.
+
+--confidence {...}
+-s|--status {...}
+-r|--review-status {...}
+--first-active {...}
+--last-active {...}
+--expired-on {...}
+
+Please see the following for allowed values in all enumerated types:
+https://developers.facebook.com/docs/threat-exchange/reference/editing
+
+Please see the following for enumerated types in reactions:
+See also https://developers.facebook.com/docs/threat-exchange/reference/reacting
+""" % (self.progName, self.verbName)
+    stream.write(output + "\n")
+    sys.exit(exitCode)
+
+
+  # ----------------------------------------------------------------
+  def handle(self, args, options):
+
+    options['dryRun'] = False;
+    options['descriptorIDsFromStdin'] = False;
+
+    postParams = {}
+
+    # Local keystroke-saver for this enum
+    names = TE.Net.POST_PARAM_NAMES
+
+    while True:
+      if len(args) == 0:
+        break
+      if args[0][0] != '-':
+        break
+      option = args[0]
+      args = args[1:]
+
+      if option == '-h':
+        self.usage(0)
+      elif option == '--help':
+        self.usage(0)
+
+      elif option == '--dry-run':
+        options['dryRun'] = True
+
+      elif option == '-I':
+        options['descriptorIDsFromStdin'] = True;
+      elif option == '-i':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['descriptor_id']] = args[0]
+        args = args[1:]
+
+      elif option == '-d' or option == '--description':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['description']] = args[0]
+        args = args[1:]
+
+      elif option == '-l' or option == '--share-level':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['share_level']] = args[0]
+        args = args[1:]
+      elif option == '-p' or option == '--privacy-type':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['privacy_type']] = args[0]
+        args = args[1:]
+      elif option == '-m' or option == '--privacy-members':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['privacy_members']] = args[0]
+        args = args[1:]
+
+      elif option == '-s' or option == '--status':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['status']] = args[0]
+        args = args[1:]
+      elif option == '-r' or option == '--review-status':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['review_status']] = args[0]
+        args = args[1:]
+      elif option == '-y' or option == '--severity':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['severity']] = args[0]
+        args = args[1:]
+      elif option == '-c' or option == '--confidence':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['confidence']] = args[0]
+        args = args[1:]
+
+      elif option == '--related-ids-for-upload':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['related_ids_for_upload']] = args[0]
+        args = args[1:]
+      elif option == '--related-triples-for-upload-as-json':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['related_triples_for_upload_as_json']] = args[0]
+        args = args[1:]
+
+      elif option == '--reactions-to-add':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['reactions']] = args[0]
+        args = args[1:]
+      elif option == '--reactions-to-remove':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['reactions_to_remove']] = args[0]
+        args = args[1:]
+
+      elif option == '--tags':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['tags']] = args[0]
+        args = args[1:]
+
+      elif option == '--add-tags':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['add_tags']] = args[0]
+        args = args[1:]
+      elif option == '--remove-tags':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['remove_tags']] = args[0]
+        args = args[1:]
+
+      elif option == '--first-active':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['first_active']] = args[0]
+        args = args[1:]
+      elif option == '--last-active':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['last']] = args[0]
+        args = args[1:]
+      elif option == '--expired-on':
+        if len(args) < 1:
+          self.usage(1)
+        postParams[names['expired_on']] = args[0]
+        args = args[1:]
+
+      else:
+        eprint("%s %s: unrecognized  option %s" %
+          (self.progName, self.verbName, option))
+        sys.exit(1)
+
+    if len(args) > 0:
+      eprint("%s %s: extraneous argument(s) \"%s\"" %
+        (self.progName, self.verbName, ' '.join(args)))
+      sys.exit(1)
+
+    if options['descriptorIDsFromStdin']:
+      if postParams.get(names['descriptor_id'], None) != None:
+        eprint("%s %s: only one of -I and -i must be supplied." %
+          (self.progName, self.verbName))
+        sys.exit(1)
+      while True:
+        # Python line-reader returns the trailing newlines so
+        # we need to right-strip the lines
+        line = sys.stdin.readline()
+        if line == '':
+          break
+        postParams[names['descriptor_id']] = line.rstrip()
+        self.updateSingle(
+          postParams,
+          options['verbose'],
+          options['showURLs'],
+          options['dryRun'],
+        )
+    else:
+      if postParams.get(names['descriptor_id'], None) == None:
+        eprint("%s %s: only one of -I and -i must be supplied." %
+          (self.progName, self.verbName))
+        sys.exit(1)
+      self.updateSingle(
+        postParams,
+        options['verbose'],
+        options['showURLs'],
+        options['dryRun'],
+      )
+
+  # ----------------------------------------------------------------
+  def updateSingle(self, postParams, verbose, showURLs, dryRun):
+    validationErrorMessage, serverSideError, responseBody = TE.Net.updateThreatDescriptor(
+      postParams, showURLs, dryRun)
+
+    if validationErrorMessage != None:
+      eprint(validationErrorMessage)
+      sys.exit(1)
+
+    if serverSideError != None:
+      eprint(str(serverSideError))
+      sys.exit(1)
+
+    print(json.dumps(responseBody))
+
+
+# ----------------------------------------------------------------
+# Top-down programming style, please :)
+
+# Rememmber that sys.argv includes the program name in Python,
+# like C/C++/Go and unlike Java or Ruby.
+MainHandler(sys.argv[0]).handle(sys.argv[1:])

--- a/hashing/te-tag-query-python/te-tag-query-python
+++ b/hashing/te-tag-query-python/te-tag-query-python
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+ourdir=`dirname $0`
+
+# Set up the Python path so this Python program can be invoked from anywhere.
+
+# Must be python3
+#xxx python -I $ourdir $ourdir/TETagQuery.py "$@"
+python3 $ourdir/TETagQuery.py "$@"

--- a/hashing/te-tag-query-python/te-tag-query-python
+++ b/hashing/te-tag-query-python/te-tag-query-python
@@ -5,5 +5,4 @@ ourdir=`dirname $0`
 # Set up the Python path so this Python program can be invoked from anywhere.
 
 # Must be python3
-#xxx python -I $ourdir $ourdir/TETagQuery.py "$@"
 python3 $ourdir/TETagQuery.py "$@"

--- a/hashing/te-tag-query-ruby/README.md
+++ b/hashing/te-tag-query-ruby/README.md
@@ -108,6 +108,66 @@ te-tag-query-ruby submit \
   --related-triples-for-upload-as-json '[{"owner_app_id":494491891138576,"td_indicator_type":"HASH_SHA1","td_raw_indicator":"dabbad00f00dfeed5ca1ab1ebeefca11ab1ec10e"}]'
 ```
 
+Make copies of a set of descriptors, e.g. from a data-sharing partner:
+
+```
+$ jq '.id | tonumber' partner-data.json
+1548810399019426
+1638880316185816
+1934838869863501
+1508037889310099
+1560856918869301
+1590064801887298
+1661005877388540
+1670668732978808
+1788683904488807
+1811154288888224
+```
+
+Here you copy all descriptor data from the query output, only modifying your own values.
+Note, however, that for the present you must explicitly set `--privacy-members`.
+
+```
+$ jq '.id | tonumber' partner-data.json \
+| te-tag-query-ruby copy -N \
+  --description 'our copies' \
+  --privacy-type HAS_PRIVACY_GROUP --privacy-members 781588512307315
+{"success":true,"id":"3216884688390703"}
+{"success":true,"id":"3039118856170891"}
+{"success":true,"id":"3049939888083721"}
+{"success":true,"id":"3180176808832725"}
+{"success":true,"id":"3280047872888160"}
+{"success":true,"id":"3415103841888795"}
+{"success":true,"id":"2912237555558894"}
+{"success":true,"id":"4163069720400887"}
+{"success":true,"id":"3080705925329880"}
+{"success":true,"id":"3046896738736542"}
+```
+
+```
+$ te-tag-query-ruby ids-to-details 3046896738736542 | jq .
+{
+  "raw_indicator": "c7dfd847207cbd54a8bb292525fc111d",
+  "type": "HASH_MD5",
+  "added_on": "2020-06-03T01:38:01+0000",
+  "last_updated": "2020-06-03T01:38:02+0000",
+  "confidence": 100,
+  "owner": {
+    "id": "494491891138576",
+    "email": "threatexchange@fb.com",
+    "name": "Media Hash Sharing RF Test"
+  },
+  "privacy_type": "HAS_PRIVACY_GROUP",
+  "review_status": "REVIEWED_AUTOMATICALLY",
+  "status": "MALICIOUS",
+  "severity": "WARNING",
+  "share_level": "AMBER",
+  "description": "our copies",
+  "id": "3046896738736542",
+  "tags": []
+}
+```
+
 # Bare-curl notes
 
 As noted at the top of this document, the `TETagQuery` program is intended to be a reference design -- for you to use as-is, or to help you write tooling in other languages.

--- a/hashing/te-tag-query-ruby/TENet.rb
+++ b/hashing/te-tag-query-ruby/TENet.rb
@@ -47,8 +47,7 @@ POST_PARAM_NAMES = {
 }
 POST_PARAM_NAMES.default_proc = -> (h, k) { raise KeyError, "POST_PARAM_NAMES[#{k}] is not defined." }
 
-# xxx comment
-FOO_POST_PARAM_NAMES = {
+STRING_POST_PARAM_NAMES = {
   'indicator'                         => "indicator",    # For submit
   'type'                              => "type",         # For submit
   'descriptor_id'                     => "descriptor_id", # For update
@@ -469,7 +468,6 @@ def TENet.updateThreatDescriptor(
 end
 
 # ----------------------------------------------------------------
-# xxx comment
 def TENet.copyThreatDescriptor(
   postParams:,
   showURLs: false, # boolean,
@@ -485,10 +483,8 @@ def TENet.copyThreatDescriptor(
   postParams.delete(POST_PARAM_NAMES[:descriptor_id])
   sourceDescriptor = TENet.getInfoForIDs(ids: [sourceID], showURLs:showURLs)
   sourceDescriptor = sourceDescriptor[0]
-  # xxx check for non-null/whatever ... try/catch maybe ...
 
   # Mutate necessary fields
-  # xxx transmogrify -- raw_indicator -> indicator -- what else?
   newDescriptor = Marshal.load(Marshal.dump(sourceDescriptor)) # deepcopy
   newDescriptor['indicator'] = sourceDescriptor['raw_indicator']
   newDescriptor.delete('raw_indicator')
@@ -514,11 +510,10 @@ def TENet.copyThreatDescriptor(
   # aren't valid for post
   postParams = {}
   newDescriptor.each do |key, value|
-    if FOO_POST_PARAM_NAMES[key] != nil
+    if STRING_POST_PARAM_NAMES[key] != nil
       postParams[key] = value
     end
   end
-  # xxx privacy_members -- underdiff
 
   return self.submitThreatDescriptor(postParams:postParams, showURLs:showURLs, dryRun:dryRun)
 end

--- a/hashing/te-tag-query-ruby/TENet.rb
+++ b/hashing/te-tag-query-ruby/TENet.rb
@@ -451,7 +451,7 @@ def TENet._postThreatDescriptor(
 
   if (dryRun)
     puts "Not doing POST since --dry-run."
-    return ['', 0]
+    return [nil, '', nil]
   else
     header = {
       'Content-Type':  'text/json',

--- a/hashing/te-tag-query-ruby/TETagQuery.rb
+++ b/hashing/te-tag-query-ruby/TETagQuery.rb
@@ -548,30 +548,61 @@ EOF
 end
 
 # ================================================================
-# NOTE: SubmitHandler and UpdateHandler have a lot of the same code but also
-# several differences. I found it simpler (albeit more verbose) to duplicate
-# rather than do an abstract-and-override refactor.
+# Some code-reuse for all subcommand handlers that do POSTs.
+class AbstractPostSubcommandHandler < SubcommandHandler
+  # These allow us to customize the mostly-overlapping usage() method
+  POSTER_NAME_SUBMIT = 'submit'
+  POSTER_NAME_UPDATE = 'update'
+  POSTER_NAME_COPY   = 'copy'
+  attr_accessor :POSTER_NAME_SUBMIT, :POSTER_NAME_UPDATE, :POSTER_NAME_COPY
 
-class SubmitHandler < SubcommandHandler
   # ----------------------------------------------------------------
   def initialize(verbName)
     super(verbName)
   end
 
   # ----------------------------------------------------------------
-  def usage(exitCode)
+  protected
+  def commonPosterUsage(exitCode, posterName)
+    if posterName.nil?
+      raise "#{$0}: internal coding error in commonPosterUsage"
+    end
+
     stream =  exitCode == 0 ? $stdout : $stderr
-  output = <<-EOF
+    output1 = <<-EOF1
 Usage: #{$0} #{@verbName} [options]
+EOF1
+
+    output2 = nil
+    output3 = nil
+    output4 = nil
+    output5 = nil
+
+    output2 = nil
+    if posterName == POSTER_NAME_SUBMIT
+      output2 = <<-EOF2s
 Uploads a threat descriptor with the specified values.
 On repost (with same indicator text/type and app ID), updates changed fields.
 
 Required:
--i|--indicator {...}   If indicator type is HASH_TMK this must be the
-                       path to a .tmk file, else the indicator text.
+-i|--indicator {...}   The indicator text: hash/URL/etc.
 -I                     Take indicator text from standard input, one per line.
 Exactly one of -i or -I is required.
 -t|--type {...}
+EOF2s
+    end
+    if posterName == POSTER_NAME_UPDATE
+      output2 = <<-EOF2u
+Updates specified attributes on an existing threat descriptor.
+
+Required:
+-i {...}               ID of descriptor to be edited. Must already exist.
+-I                     Take descriptor IDs from standard input, one per line.
+Exactly one of -i or -I is required.
+EOF2u
+    end
+
+    output3 = <<-EOF3
 -d|--description {...}
 -l|--share-level {...}
 -p|--privacy-type {...}
@@ -585,7 +616,17 @@ Optional:
                        HAS_PRIVACY_GROUP these must be comma-delimited
                        privacy-group IDs.
 --tags {...}           Comma-delimited. Overwrites on repost.
+EOF3
 
+    output4=nil
+    if posterName == POSTER_NAME_UPDATE
+      output3 = <<-EOF4u
+--add-tags {...}       Comma-delimited. Adds these on repost.
+--remove-tags {...}    Comma-delimited. Removes these on repost.
+EOF4u
+    end
+
+    output5 = <<-EOF5
 --related-ids-for-upload {...} Comma-delimited. IDs of descriptors (which must
                        already exist) to relate the new descriptor to.
 --related-triples-json-for-upload {...} Alternate to --related-ids-for-upload.
@@ -606,12 +647,113 @@ Optional:
 Please see the following for allowed values in all enumerated types except reactions:
 https://developers.facebook.com/docs/threat-exchange/reference/submitting
 
+Please also see:
+https://developers.facebook.com/docs/threat-exchange/reference/editing
+
 Please see the following for enumerated types in reactions:
 See also https://developers.facebook.com/docs/threat-exchange/reference/reacting
-EOF
-    stream.puts output
+EOF5
+
+    stream.puts(output1)
+    stream.puts(output2) unless output2.nil?
+    stream.puts(output3)
+    stream.puts(output4) unless output4.nil?
+    stream.puts(output5)
 
     exit(exitCode)
+  end
+
+
+  # ----------------------------------------------------------------
+  # For CLI-parsing
+  #
+  # Input:
+  # * option such as '-d'
+  # * remaining args as string-list
+  # * postParams dict
+  #
+  # Output:
+  # * boolean whether the option was recognized
+  # * args may be shifted if the option was recognized and successfully handled
+  #
+  # Modified by reference:
+  # * postParams dict modified by reference if the option was recognized and
+  #   successfully handled
+  def commonPosterOptionCheck(option, args, postParams)
+    # Local keystroke-saver for this enum
+    names = ThreatExchange::TENet::POST_PARAM_NAMES
+
+    handled = true
+
+    if option == '-d' || option == '--description'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:description]] = args.shift;
+
+    elsif option == '-l' || option == '--share-level'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:share_level]] = args.shift;
+    elsif option == '-p' || option == '--privacy-type'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:privacy_type]] = args.shift;
+    elsif option == '-m' || option == '--privacy-members'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:privacy_members]] = args.shift;
+
+    elsif option == '-s' || option == '--status'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:status]] = args.shift;
+    elsif option == '-r' || option == '--review-status'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:review_status]] = args.shift;
+    elsif option == '-y' || option == '--severity'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:severity]] = args.shift;
+    elsif option == '-c' || option == '--confidence'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:confidence]] = args.shift;
+
+    elsif option == '--related-ids-for-upload'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:related_ids_for_upload]] = args.shift;
+    elsif option == '--related-triples-for-upload-as-json'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:related_triples_for_upload_as_json]] = args.shift;
+
+    elsif option == '--reactions-to-add'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:reactions]] = args.shift;
+    elsif option == '--reactions-to-remove'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:reactions_to_remove]] = args.shift;
+
+    elsif option == '--first-active'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:first_active]] = args.shift;
+    elsif option == '--last-active'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:last]] = args.shift;
+    elsif option == '--expired-on'
+      self.usage(1) unless args.length >= 1
+      postParams[names[:expired_on]] = args.shift;
+
+    else
+      handled = false
+    end
+
+    return [handled, args]
+  end
+end
+
+# ================================================================
+class SubmitHandler < AbstractPostSubcommandHandler
+  # ----------------------------------------------------------------
+  def initialize(verbName)
+    super(verbName)
+  end
+
+  # ----------------------------------------------------------------
+  def usage(exitCode)
+    self.commonPosterUsage(exitCode, POSTER_NAME_SUBMIT)
   end
 
   # ----------------------------------------------------------------
@@ -648,64 +790,16 @@ EOF
         self.usage(1) unless args.length >= 1
         postParams[names[:type]] = args.shift;
 
-      elsif option == '-d' || option == '--description'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:description]] = args.shift;
-
-      elsif option == '-l' || option == '--share-level'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:share_level]] = args.shift;
-      elsif option == '-p' || option == '--privacy-type'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:privacy_type]] = args.shift;
-      elsif option == '-m' || option == '--privacy-members'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:privacy_members]] = args.shift;
-
-      elsif option == '-s' || option == '--status'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:status]] = args.shift;
-      elsif option == '-r' || option == '--review-status'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:review_status]] = args.shift;
-      elsif option == '-y' || option == '--severity'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:severity]] = args.shift;
-      elsif option == '-c' || option == '--confidence'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:confidence]] = args.shift;
-
-      elsif option == '--related-ids-for-upload'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:related_ids_for_upload]] = args.shift;
-      elsif option == '--related-triples-for-upload-as-json'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:related_triples_for_upload_as_json]] = args.shift;
-
-      elsif option == '--reactions-to-add'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:reactions]] = args.shift;
-      elsif option == '--reactions-to-remove'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:reactions_to_remove]] = args.shift;
-
       elsif option == '--tags'
         self.usage(1) unless args.length >= 1
         postParams[names[:tags]] = args.shift;
 
-      elsif option == '--first-active'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:first_active]] = args.shift;
-      elsif option == '--last-active'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:last]] = args.shift;
-      elsif option == '--expired-on'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:expired_on]] = args.shift;
-
       else
-        $stderr.puts "#{$0} #{@verbName}: unrecognized  option #{option}"
-        exit 1
+        handled, args = self.commonPosterOptionCheck(option, args, postParams)
+        if not handled
+          $stderr.puts "#{$0} #{@verbName}: unrecognized  option #{option}"
+          exit 1
+        end
       end
     end
 
@@ -751,24 +845,6 @@ EOF
     showURLs: false,
     dryRun: false)
 
-    # TO DO: port this over from Java, pending demand for people posting TMK hashes.
-
-    # if (postParams.getIndicatorType().equals(Constants.INDICATOR_TYPE_TMK)) {
-    #   String filename = postParams.getIndicatorText();
-    #   String contents = null;
-    #   try {
-    #     contents = Utils.readTMKHashFromFile(filename, verbose);
-    #   } catch (FileNotFoundException e) {
-    #     System.err.printf("%s %s: cannot find \"%s\".\n",
-    #       PROGNAME, _verb, filename);
-    #   } catch (IOException e) {
-    #     System.err.printf("%s %s: cannot load \"%s\".\n",
-    #       PROGNAME, _verb, filename);
-    #     e.printStackTrace(System.err);
-    #   }
-    #   postParams.setIndicatorText(contents);
-    # }
-
     validationErrorMessage, response_body, response_code = ThreatExchange::TENet::submitThreatDescriptor(
       postParams: postParams,
       showURLs: showURLs,
@@ -792,7 +868,7 @@ end # class SubmitHandler
 # several differences. I found it simpler (albeit more verbose) to duplicate
 # rather than do an abstract-and-override refactor.
 
-class UpdateHandler < SubcommandHandler
+class UpdateHandler < AbstractPostSubcommandHandler
   # ----------------------------------------------------------------
   def initialize(verbName)
     super(verbName)
@@ -800,55 +876,7 @@ class UpdateHandler < SubcommandHandler
 
   # ----------------------------------------------------------------
   def usage(exitCode)
-    stream =  exitCode == 0 ? $stdout : $stderr
-  output = <<-EOF
-Usage: #{$0} #{@verbName} [options]
-Updates specified attributes on an existing threat descriptor.
-
-Required:
--i {...}               ID of descriptor to be edited. Must already exist.
--I                     Take descriptor IDs from standard input, one per line.
-Exactly one of -i or -I is required.
--d|--description {...}
--l|--share-level {...}
--p|--privacy-type {...}
--y|--severity {...}
-
-Optional:
--h|--help
---dry-run
--m|--privacy-members {...} If privacy-type is HAS_WHITELIST these must be
-                       comma-delimited app IDs. If privacy-type is
-                       HAS_PRIVACY_GROUP these must be comma-delimited
-                       privacy-group IDs.
---tags {...}           Comma-delimited. Overwrites on repost.
---add-tags {...}       Comma-delimited. Adds these on repost.
---remove-tags {...}    Comma-delimited. Removes these on repost.
-
---related-ids-for-upload {...} Comma-delimited. IDs of descriptors (which must
-                       already exist) to relate the new descriptor to.
---related-triples-json-for-upload {...} Alternate to --related-ids-for-upload.
-                       Here you can uniquely the relate-to descriptors by their
-                       owner ID / indicator-type / indicator-text, rather than
-                       by their IDs. See README.md for an example.
-
---confidence {...}
--s|--status {...}
--r|--review-status {...}
---first-active {...}
---last-active {...}
---expired-on {...}
-
-Please see the following for allowed values in all enumerated types:
-https://developers.facebook.com/docs/threat-exchange/reference/editing
-
-Please see the following for enumerated types in reactions:
-See also https://developers.facebook.com/docs/threat-exchange/reference/reacting
-
-EOF
-    stream.puts output
-
-    exit(exitCode)
+    self.commonPosterUsage(exitCode, POSTER_NAME_UPDATE)
   end
 
   # ----------------------------------------------------------------
@@ -881,51 +909,9 @@ EOF
         self.usage(1) unless args.length >= 1
         postParams[names[:descriptor_id]] = args.shift;
 
-      elsif option == '-d' || option == '--description'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:description]] = args.shift;
-
-      elsif option == '-l' || option == '--share-level'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:share_level]] = args.shift;
-      elsif option == '-p' || option == '--privacy-type'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:privacy_type]] = args.shift;
-      elsif option == '-m' || option == '--privacy-members'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:privacy_members]] = args.shift;
-
-      elsif option == '-s' || option == '--status'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:status]] = args.shift;
-      elsif option == '-r' || option == '--review-status'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:review_status]] = args.shift;
-      elsif option == '-y' || option == '--severity'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:severity]] = args.shift;
-      elsif option == '-c' || option == '--confidence'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:confidence]] = args.shift;
-
-      elsif option == '--related-ids-for-upload'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:related_ids_for_upload]] = args.shift;
-      elsif option == '--related-triples-for-upload-as-json'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:related_triples_for_upload_as_json]] = args.shift;
-
-      elsif option == '--reactions-to-add'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:reactions]] = args.shift;
-      elsif option == '--reactions-to-remove'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:reactions_to_remove]] = args.shift;
-
       elsif option == '--tags'
         self.usage(1) unless args.length >= 1
         postParams[names[:tags]] = args.shift;
-
       elsif option == '--add-tags'
         self.usage(1) unless args.length >= 1
         postParams[names[:add_tags]] = args.shift;
@@ -933,19 +919,12 @@ EOF
         self.usage(1) unless args.length >= 1
         postParams[names[:remove_tags]] = args.shift;
 
-      elsif option == '--first-active'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:first_active]] = args.shift;
-      elsif option == '--last-active'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:last]] = args.shift;
-      elsif option == '--expired-on'
-        self.usage(1) unless args.length >= 1
-        postParams[names[:expired_on]] = args.shift;
-
       else
-        $stderr.puts "#{$0} #{@verbName}: unrecognized  option #{option}"
-        exit 1
+        handled, args = self.commonPosterOptionCheck(option, args, postParams)
+        if not handled
+          $stderr.puts "#{$0} #{@verbName}: unrecognized  option #{option}"
+          exit 1
+        end
       end
     end
 
@@ -989,24 +968,6 @@ EOF
     verbose: false,
     showURLs: false,
     dryRun: false)
-
-    # TO DO: port this over from Java, pending demand for people posting TMK hashes.
-
-    # if (postParams.getIndicatorType().equals(Constants.INDICATOR_TYPE_TMK)) {
-    #   String filename = postParams.getIndicatorText();
-    #   String contents = null;
-    #   try {
-    #     contents = Utils.readTMKHashFromFile(filename, verbose);
-    #   } catch (FileNotFoundException e) {
-    #     System.err.printf("%s %s: cannot find \"%s\".\n",
-    #       PROGNAME, _verb, filename);
-    #   } catch (IOException e) {
-    #     System.err.printf("%s %s: cannot load \"%s\".\n",
-    #       PROGNAME, _verb, filename);
-    #     e.printStackTrace(System.err);
-    #   }
-    #   postParams.setIndicatorText(contents);
-    # }
 
     validationErrorMessage, response_body, response_code = ThreatExchange::TENet::updateThreatDescriptor(
       postParams: postParams,


### PR DESCRIPTION
First commit: Python port.
Second commit: creation of `AbstractPostSubcommandHandler` for improved code-reuse between `submit` and `update`, as the third commit will introduce a `copy` alongside them.
Third commit: the `copy` functionality.
Fourth commit: some comment-neatens.

Testing: run all the commands in `README.md` for Ruby as well as Python.