### PR TITLE
Retry transient 500s on the Python side

### DIFF
--- a/hashing/te-tag-query-ruby/TENet.rb
+++ b/hashing/te-tag-query-ruby/TENet.rb
@@ -325,7 +325,13 @@ def TENet.getInfoForIDs(
   #  }
 
   responseString = Net::HTTP.get(URI(startURL))
+  if responseString.nil?
+    raise protocolErrorString
+  end
   responseObject = JSON.parse(responseString)
+  if responseObject.nil?
+    raise protocolErrorString
+  end
 
   descriptors = []
   responseObject.each do |id, descriptor|


### PR DESCRIPTION
I tried running all of `te-tag-query-ruby tag-to-details media_type_video` and `te-tag-query-python tag-to-details media_type_video` and realized the Python netlib is apparently more brittle with respect to transient 500s than Ruby's or Java's. Mean time to failure is around every 30K/50K descriptors retrieved so this issue only arises on get-all-the-data pulls of bigger datasets.