### PR TITLE
Python/Ruby created-at filters

### DIFF
--- a/hashing/te-tag-query-python/TETagQuery.py
+++ b/hashing/te-tag-query-python/TETagQuery.py
@@ -507,7 +507,7 @@ Options:
         eprint("%s %s: Please specify at most one of --tagged-until and --created-until." %
           (self.progName, self.verbName))
         sys.exit(1)
-      options['taggedUntil'] = None
+      # keep options['taggedUntil'] = None
       options['createdUntilEpochSeconds'] = TE.Net.parseTimeStringToEpochSeconds(options['createdUntil'])
 
     # Step 1: tag text to ID

--- a/hashing/te-tag-query-ruby/TENet.rb
+++ b/hashing/te-tag-query-ruby/TENet.rb
@@ -7,6 +7,7 @@ require 'CGI' # for URL-encoding
 require 'net/http'
 require 'uri'
 require 'json'
+require 'date'
 
 # ================================================================
 # HTTP-wrapper methods
@@ -170,10 +171,10 @@ def TENet.processDescriptorIDsByTagID(
     "/?access_token=" + @@APP_TOKEN +
     "&limit=" + pageSize.to_s
   unless taggedSince.nil?
-    startURL += "&tagged_since=" + taggedSince
+    startURL += "&tagged_since=" + CGI.escape(taggedSince)
   end
   unless taggedUntil.nil?
-    startURL += "&tagged_until=" + taggedUntil
+    startURL += "&tagged_until=" + CGI.escape(taggedUntil)
   end
 
   nextURL = startURL
@@ -185,7 +186,7 @@ def TENet.processDescriptorIDsByTagID(
       puts nextURL
     end
 
-    protocolErrorString = "ThreatExchange::TENet::getDescriptorIDsByTagID: protocol error finding \"#{tagID}\""
+    protocolErrorString = "ThreatExchange::TENet::getDescriptorIDsByTagID: protocol error finding descriptors for tag ID \"#{tagID}\""
 
     # Format we're parsing:
     # {
@@ -211,6 +212,7 @@ def TENet.processDescriptorIDsByTagID(
 
     dataObject = responseObject['data']
     if dataObject.nil?
+      $stderr.puts(responseString)
       raise protocolErrorString
     end
     pagingObject = responseObject['paging']
@@ -565,5 +567,144 @@ def TENet._postThreatDescriptor(
 
 end # TENet.submitThreatDescriptor
 
+# ----------------------------------------------------------------
+# This is for client-side creation-time filtering. We accept the same
+# command-line values as for tagged-time filtering which is done server-side
+# using PHP\strtotime which takes various epoch-seconds timestamps, various
+# format strings, and time-deltas like "-3hours" and "-1week".  Here we
+# re-invent some of PHP\strtotime.
+def TENet.parseTimeStringToEpochSeconds(mixedString)
+  retval = TENet._parseIntStringToEpochSeconds(mixedString)
+  return retval unless retval.nil?
+
+  retval = TENet._parseDateTimeStringToEpochSeconds(mixedString)
+  return retval unless retval.nil?
+
+  retval = TENet._parseRelativeStringToEpochSeconds(mixedString)
+  return retval unless retval.nil?
+  return nil
+end # TENet.parseTimeStringToEpochSeconds
+
+# Helper for parseTimeStringToEpochSeconds to try epoch-seconds timestamps
+def TENet._parseIntStringToEpochSeconds(mixedString)
+  begin
+    return Integer(mixedString)
+  rescue ArgumentError
+    return nil
+  end
+end
+
+DATETIME_FORMATS = [
+  '%Y-%m-%dT%H:%M:%S%z', # TE server-side date format -- try first
+  '%Y-%m-%d %H:%M:%S',
+  '%Y/%m/%d %H:%M:%S',
+  '%Y-%m-%dT%H:%M:%S',
+  '%Y-%m-%dT%H:%M:%SZ',
+]
+
+# Helper for parseTimeStringToEpochSeconds to try various format-string
+# timestamps
+def TENet._parseDateTimeStringToEpochSeconds(mixedString)
+  DATETIME_FORMATS.each do |formatString|
+    begin
+      return DateTime.strptime(mixedString, formatString).to_time.to_i
+    rescue ArgumentError
+      return nil
+    end
+  end
+   return nil
+ end
+
+# Helper for parseTimeStringToEpochSeconds to try various relative-time
+# indications.
+def TENet._parseRelativeStringToEpochSeconds(mixedString)
+  retval = TENet._parseRelativeStringMinute(mixedString)
+  return retval unless retval.nil?
+  retval = TENet._parseRelativeStringHour(mixedString)
+  return retval unless retval.nil?
+  retval = TENet._parseRelativeStringDay(mixedString)
+  return retval unless retval.nil?
+  retval = TENet._parseRelativeStringWeek(mixedString)
+  return retval unless retval.nil?
+  return nil
+end
+
+# Helper for parseTimeStringToEpochSeconds to try particular relative-time
+# indications.
+def TENet._parseRelativeStringMinute(mixedString)
+  output = mixedString.match("^-([0-9]+)minutes?$")
+  if output != nil
+    count = Integer(output[1])
+    return DateTime.now.to_time.to_i - count * 60 # timezone-unsafe
+  else
+    return nil
+  end
+end
+
+# Helper for parseTimeStringToEpochSeconds to try particular relative-time
+# indications.
+def TENet._parseRelativeStringHour(mixedString)
+  output = mixedString.match("^-([0-9]+)hours?$")
+  if output != nil
+    count = Integer(output[1])
+    return DateTime.now.to_time.to_i - count * 60 * 60 # timezone-unsafe
+  else
+    return nil
+  end
+end
+
+# Helper for parseTimeStringToEpochSeconds to try particular relative-time
+# indications.
+def TENet._parseRelativeStringDay(mixedString)
+  output = mixedString.match("^-([0-9]+)days?$")
+  if output != nil
+    count = Integer(output[1])
+    return DateTime.now.to_time.to_i - count * 24 * 60 * 60 # timezone-unsafe
+  else
+    return nil
+  end
+end
+
+# Helper for parseTimeStringToEpochSeconds to try particular relative-time
+# indications.
+def TENet._parseRelativeStringWeek(mixedString)
+  output = mixedString.match("^-([0-9]+)weeks?$")
+  if output != nil
+    count = Integer(output[1])
+    return DateTime.now.to_time.to_i - count * 7 * 24 * 60 * 60 # timezone-unsafe
+  else
+    return nil
+  end
+end
+
 end # module TENet
 end # module ThreatExchange
+
+# ================================================================
+# Validator for client-side creation-time datetime parsing. Not written as unit
+# tests per se since "-1week" et al. are dynamic things. Invoke via "ruby TENet.rb".
+if __FILE__ == $0
+  def showParseTimeStringToEpochSeconds(mixedString)
+    retval = ThreatExchange::TENet::parseTimeStringToEpochSeconds(mixedString)
+    readable = 'nil'
+    if retval != nil
+      readable = Time.at(retval).to_datetime.strftime('%Y-%m-%dT%H:%M:%S%z')
+    end
+    puts("#{mixedString.ljust(30)} #{retval.to_s.ljust(30)} #{readable}")
+  end
+
+  showParseTimeStringToEpochSeconds("1591626448")
+  showParseTimeStringToEpochSeconds("2020-06-08T14:27:53Z")
+  showParseTimeStringToEpochSeconds("2020-06-08T14:27:53+0400")
+  showParseTimeStringToEpochSeconds("2020-06-08T14:27:53-0400")
+  showParseTimeStringToEpochSeconds("2020-05-01T07:02:25+0000")
+  showParseTimeStringToEpochSeconds("-1minute")
+  showParseTimeStringToEpochSeconds("-3minutes")
+  showParseTimeStringToEpochSeconds("-1hour")
+  showParseTimeStringToEpochSeconds("-3hours")
+  showParseTimeStringToEpochSeconds("-1day")
+  showParseTimeStringToEpochSeconds("-3day")
+  showParseTimeStringToEpochSeconds("-1week")
+  showParseTimeStringToEpochSeconds("-3weeks")
+  showParseTimeStringToEpochSeconds("nonesuch")
+end

--- a/hashing/te-tag-query-ruby/TETagQuery.rb
+++ b/hashing/te-tag-query-ruby/TETagQuery.rb
@@ -414,6 +414,16 @@ Usage: #{$0} #{@verbName} [options] {tag name}
 Options:
 --tagged-since {x}
 --tagged-until {x}
+--created-since {x}
+--created-until {x}
+
+  Timestamp options for all four are epoch seconds, various datetime formats
+  including "2020-12-34T56:07:08+0900", and time-deltas like "-5minutes",
+  "-3hours", "-1week".
+
+  At most one of --tagged-since and --created-since can be specified; likewise
+  --tagged-until and --created-until.
+
 --page-size {x}
 --no-print-indicator -- Don't print the indicator to the terminal
 The \"tagged-since\" or \"tagged-until\" parameter is any supported by ThreatExchange,
@@ -444,6 +454,13 @@ EOF
         self.usage(1) unless args.length >= 1
         options['taggedUntil'] = args.shift;
 
+      elsif option == '--created-since'
+        self.usage(1) unless args.length >= 1
+        options['createdSince'] = args.shift;
+      elsif option == '--created-until'
+        self.usage(1) unless args.length >= 1
+        options['createdUntil'] = args.shift;
+
       elsif option == '--page-size'
         self.usage(1) unless args.length >= 1
         options['pageSize'] = args.shift;
@@ -455,6 +472,37 @@ EOF
         $stderr.puts "#{$0} #{@verbName}: unrecognized  option #{option}"
         exit 1
       end
+    end
+
+    # Tagged-at filtering is done server-side -- the TE /tagged_objects
+    # endpoint filters by tagged-at timestamps on the graph edges from tag to
+    # descriptor ID. An implementation detail of /tagged_objects is that it
+    # only yields abstract IDs; descriptor IDs to details are a separate pass
+    # in this design.
+    #
+    # This means that if the user wants to filter on created-at:
+    # * We have the invariants that created-at <= tagged-at, and tagged-at <= now.
+    # * If they ask for created-since t, we query the server for tagged-since t
+    #   (which overfetches) and then we filter client-side.
+    # * If they as for created-until t, we query the server for tagged-until now
+    #   (which overfetches) and then we filter client-side.
+    options['createdSinceEpochSeconds'] = nil
+    options['createdUntilEpochSeconds'] = nil
+    if options['createdSince'] != nil
+      if options['taggedSince'] != nil
+        $stderr.puts "#{$0} #{@verbName}: Please specify at most one of --tagged-since and --created-since."
+        exit 1
+      end
+      options['taggedSince'] = options['createdSince']
+      options['createdSinceEpochSeconds'] = ThreatExchange::TENet::parseTimeStringToEpochSeconds(options['createdSince'])
+    end
+    if options['createdUntil'] != nil
+      if options['taggedUntil'] != nil
+        $stderr.puts "#{$0} #{@verbName}: Please specify at most one of --tagged-until and --created-until."
+        exit 1
+      end
+      options['taggedUntil'] = nil
+      options['createdUntilEpochSeconds'] = ThreatExchange::TENet::parseTimeStringToEpochSeconds(options['createdUntil'])
     end
 
     if args.length != 1
@@ -477,7 +525,29 @@ EOF
         verbose: options['verbose'],
         showURLs: options['showURLs'],
         includeIndicatorInOutput: options['includeIndicatorInOutput'])
+
+      createdSinceEpochSeconds = options['createdSinceEpochSeconds']
+      createdUntilEpochSeconds = options['createdUntilEpochSeconds']
+
       descriptors.each do |descriptor|
+        added_on = descriptor['added_on']
+        if added_on.nil?
+          puts("WTFA")
+          puts(descriptor)
+          puts("WTFB")
+        end
+        descriptorCreatedAtEpochSeconds = ThreatExchange::TENet::parseTimeStringToEpochSeconds(added_on)
+        if createdSinceEpochSeconds != nil
+          if descriptorCreatedAtEpochSeconds < createdSinceEpochSeconds
+            next
+          end
+        end
+        if createdUntilEpochSeconds != nil
+          if descriptorCreatedAtEpochSeconds > createdUntilEpochSeconds
+            next
+          end
+        end
+
         # Stub processing -- one would perhaps integrate with one's own system
         puts descriptor.to_json
       end

--- a/hashing/te-tag-query-ruby/TETagQuery.rb
+++ b/hashing/te-tag-query-ruby/TETagQuery.rb
@@ -501,7 +501,7 @@ EOF
         $stderr.puts "#{$0} #{@verbName}: Please specify at most one of --tagged-until and --created-until."
         exit 1
       end
-      options['taggedUntil'] = nil
+      # keep options['taggedUntil'] = nil
       options['createdUntilEpochSeconds'] = ThreatExchange::TENet::parseTimeStringToEpochSeconds(options['createdUntil'])
     end
 


### PR DESCRIPTION
Details/rationale in comments.

Tested via

```
te-tag-query-python tag-to-details \
  --created-since 2020-06-01T00:00:00Z \
  --created-until 2020-06-03T00:00:00Z \
  tag-name-goes-here \
| jq .added_on

te-tag-query-python tag-to-details \
  --created-since -2weeks \
  --created-until -1week \
  tag-name-goes-here \
| jq .added_on
```

and checking timestamps are in the desired range.