### PR TITLE
Add invoke-from-anywhere Java wrapper, as for Python/Ruby

### DIFF
--- a/hashing/te-tag-query-java/README.md
+++ b/hashing/te-tag-query-java/README.md
@@ -24,6 +24,10 @@ threatexchange@fb.com
 javac com/facebook/threatexchange/*.java
 ```
 
+# Running the code
+
+The `te-tag-query-java` wrapper script sets the Java classpath and invokes the main Java method in `com/facebook/threatexchange/TETagQuery.java`.
+
 # Setup
 
 * Find your app's access token at https://developers.facebook.com/tools/accesstoken/
@@ -36,18 +40,18 @@ javac com/facebook/threatexchange/*.java
 
 On-line help:
 ```
-java com.facebook.threatexchange.TETagQuery --help
+te-tag-query-java --help
 ```
 
 Querying for all hashes of a given type:
 ```
-java com.facebook.threatexchange.TETagQuery tag-to-details --indicator-type pdq media_type_photo
+te-tag-query-java tag-to-details --indicator-type pdq media_type_photo
 
-java com.facebook.threatexchange.TETagQuery -v tag-to-details --indicator-type pdq media_type_photo
+te-tag-query-java -v tag-to-details --indicator-type pdq media_type_photo
 
-java com.facebook.threatexchange.TETagQuery tag-to-details --indicator-type md5 media_type_video
+te-tag-query-java tag-to-details --indicator-type md5 media_type_video
 
-java com.facebook.threatexchange.TETagQuery tag-to-details \
+te-tag-query-java tag-to-details \
   --page-size 10 \
   --data-dir ./tmk-data-dir \
   --indicator-type tmk \
@@ -56,11 +60,11 @@ java com.facebook.threatexchange.TETagQuery tag-to-details \
 
 Querying for some hashes of a given type:
 ```
-java com.facebook.threatexchange.TETagQuery tag-to-details --indicator-type pdq --tagged-since -1day media_type_photo
+te-tag-query-java tag-to-details --indicator-type pdq --tagged-since -1day media_type_photo
 
-java com.facebook.threatexchange.TETagQuery tag-to-details --indicator-type md5 --tagged-since -1week media_type_video
+te-tag-query-java tag-to-details --indicator-type md5 --tagged-since -1week media_type_video
 
-java com.facebook.threatexchange.TETagQuery tag-to-details \
+te-tag-query-java tag-to-details \
   --page-size 10 \
   --data-dir ./tmk-data-dir \
   --indicator-type tmk \
@@ -73,7 +77,7 @@ java com.facebook.threatexchange.TETagQuery tag-to-details \
 Post a new SHA1 hash:
 
 ```
-java com.facebook.threatexchange.TETagQuery submit \
+te-tag-query-java submit \
   -i dabbad00f00dfeed5ca1ab1ebeefca11ab1ec00e \
   -t HASH_SHA1 \
   -d "testing te-tag-query with post" \
@@ -89,7 +93,7 @@ Suppose that prints `{"success":true,"id":"2964083130339380"}`.
 Update it, using that ID:
 
 ```
-java com.facebook.threatexchange.TETagQuery update \
+te-tag-query-java update \
   -i 2964083130339380 \
   -s UNKNOWN \
   --add-tags testing_java_update
@@ -98,7 +102,7 @@ java com.facebook.threatexchange.TETagQuery update \
 Post another with relation to the first one:
 
 ```
-java com.facebook.threatexchange.TETagQuery submit \
+te-tag-query-java submit \
   -i dabbad00f00dfeed5ca1ab1ebeefca11ab1ec00f \
   -t HASH_SHA1 \
   -d "testing te-tag-query with post" \
@@ -113,7 +117,7 @@ java com.facebook.threatexchange.TETagQuery submit \
 Post a new TMK hash:
 
 ```
-java com.facebook.threatexchange.TETagQuery \
+te-tag-query-java \
   submit \
     -i ../tmk/sample-hashes/chair-22-sd-sepia-bar.tmk \
     -t HASH_TMK \

--- a/hashing/te-tag-query-java/te-tag-query-java
+++ b/hashing/te-tag-query-java/te-tag-query-java
@@ -3,5 +3,4 @@
 ourdir=`dirname $0`
 
 # Set up the Java classpath so this Java program can be invoked from anywhere.
-
 java -cp $ourdir com.facebook.threatexchange.TETagQuery "$@"

--- a/hashing/te-tag-query-java/te-tag-query-java
+++ b/hashing/te-tag-query-java/te-tag-query-java
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+ourdir=`dirname $0`
+
+# Set up the Java classpath so this Java program can be invoked from anywhere.
+
+java -cp $ourdir com.facebook.threatexchange.TETagQuery "$@"


### PR DESCRIPTION
```
$ ./hashing/te-tag-query-python/te-tag-query-python --help
Usage: ./hashing/te-tag-query-python/TETagQuery.py [options] {verb} {verb arguments}
Downloads descriptors in bulk from ThreatExchange, given
either a tag name or a list of IDs one per line on standard input.

Options:
  -h|--help      Show detailed help.
  --list-verbs   Show a list of supported verbs.
  -q|--quiet     Only print IDs/descriptors output with no narrative.
  -v|--verbose   Print IDs/descriptors output along with narrative.
  -s|--show-urls Print URLs used for queries, before executing them.
  -a|--app-token-env-name {...} Name of app-token environment variable.
                 Defaults to "TX_ACCESS_TOKEN".
  -b|--te-base-url {...} Defaults to "https://graph.facebook.com/v6.0"

Verbs:
look-up-tag-id
tag-to-ids
ids-to-details
tag-to-details
paginate
submit
update
copy
```

```
$ ./hashing/te-tag-query-ruby/te-tag-query-ruby --help
Usage: te-tag-query [options] {verb} {verb arguments}
Downloads descriptors in bulk from ThreatExchange, given
either a tag name or a list of IDs one per line on standard input.

Options:
  -h|--help      Show detailed help.
  --list-verbs   Show a list of supported verbs.
  -q|--quiet     Only print IDs/descriptors output with no narrative.
  -v|--verbose   Print IDs/descriptors output along with narrative.
  -s|--show-urls Print URLs used for queries, before executing them.
  -a|--app-token-env-name {...} Name of app-token environment variable.
                 Defaults to "TX_ACCESS_TOKEN".
  -b|--te-base-url {...} Defaults to "https://graph.facebook.com/v6.0"

Verbs:
  look-up-tag-id
  tag-to-ids
  ids-to-details
  tag-to-details
  paginate
  submit
  update
  copy
```

```
$ ./hashing/te-tag-query-java/te-tag-query-java --help
Usage: TETagQuery [options] {verb} {verb arguments}
Downloads descriptors in bulk from ThreatExchange, given
either a tag name or a list of IDs one per line on standard input.
Options:
  -h|--help      Show detailed help.
  -l|--list-verbs   Show a list of supported verbs.
  -q|--quiet     Only print IDs/descriptors output with no narrative.
  -v|--verbose   Print IDs/descriptors output along with narrative.
  -s|--show-urls Print URLs used for queries, before executing them.
  -a|--app-token-env-name {...} Name of app-token environment variable.
                 Defaults to "TX_ACCESS_TOKEN".
  -b|--te-base-url {...} Defaults to "https://graph.facebook.com/v4.0"
Verbs:
  look-up-tag-id
  tag-to-ids
  ids-to-details
  tag-to-details
  incremental
  paginate
  submit
  update
```