### PR TITLE
Use page size 10 by default in the Java implementation

### DIFF
--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -301,7 +301,7 @@ public class TETagQuery {
       DescriptorFormatter descriptorFormatter
     ) {
       IndicatorTypeFilterer indicatorTypeFilterer = new AllIndicatorTypeFilterer();
-      int pageSize = 1000;
+      int pageSize = 10;
       boolean includeIndicatorInOutput = true;
       String taggedSince = null;
       String taggedUntil = null;


### PR DESCRIPTION
Use page size 10 by default since this is needed for large TMK hashes and a priori we don't know which queries will or won't be fetching TMKs.