### PR TITLE
Use page size 10 by default

### DIFF
--- a/hashing/te-tag-query-curl/README.md
+++ b/hashing/te-tag-query-curl/README.md
@@ -42,7 +42,7 @@ HTTP query:
 ```
 curl -s 'https://graph.facebook.com/v4.0/threat_tags/'\
 "?access_token=$TX_ACCESS_TOKEN"\
-'&text=pwny'
+'&text=pwny&limit=10'
 ```
 
 JSON response:


### PR DESCRIPTION
Use page size 10 by default since this is needed for large TMK hashes and a priori we don't know which queries will or won't be fetching TMKs.