### PR TITLE
[te-tag-query][py] Add __name__ == '__main__'

### DIFF
--- a/hashing/te-tag-query-python/TETagQuery.py
+++ b/hashing/te-tag-query-python/TETagQuery.py
@@ -1162,4 +1162,5 @@ class CopyHandler(AbstractPostSubcommandHandler):
 
 # Rememmber that sys.argv includes the program name in Python,
 # like C/C++/Go and unlike Java or Ruby.
-MainHandler(sys.argv[0]).handle(sys.argv[1:])
+if __name__ == '__main__':
+  MainHandler(sys.argv[0]).handle(sys.argv[1:])


### PR DESCRIPTION
This PR adds a python convention for files which contains the main, so that they can be loaded without executing the main if loaded by another library. More details can be found here: https://stackoverflow.com/questions/419163/what-does-if-name-main-do

Test plan:
` ./te-tag-query-python --help
Usage: ./TETagQuery.py [options] {verb} {verb arguments}
Downloads descriptors in bulk from ThreatExchange, given
...
`