### PR TITLE
mimic https://github.com/facebook/ThreatExchange/pull/252 for Ruby

### DIFF
--- a/hashing/te-tag-query-ruby/TETagQuery.rb
+++ b/hashing/te-tag-query-ruby/TETagQuery.rb
@@ -1186,9 +1186,11 @@ end # class CopyHandler
 # ----------------------------------------------------------------
 # Top-down programming style, please :)
 
-begin
-  MainHandler.new.handle(ARGV)
-  exit 0
-rescue Interrupt => e # Control-C handling
-  exit 1
+if __FILE__ == $0
+  begin
+    MainHandler.new.handle(ARGV)
+    exit 0
+  rescue Interrupt => e # Control-C handling
+    exit 1
+  end
 end


### PR DESCRIPTION
Testing:

```
$ ruby -I . TETagQuery.rb
Usage: te-tag-query [options] {verb} {verb arguments}
Downloads descriptors in bulk from ThreatExchange, given
either a tag name or a list of IDs one per line on standard input.

Options:
  -h|--help      Show detailed help.
  --list-verbs   Show a list of supported verbs.
  -q|--quiet     Only print IDs/descriptors output with no narrative.
  -v|--verbose   Print IDs/descriptors output along with narrative.
  -s|--show-urls Print URLs used for queries, before executing them.
  -a|--app-token-env-name {...} Name of app-token environment variable.
                 Defaults to "TX_ACCESS_TOKEN".
  -b|--te-base-url {...} Defaults to "https://graph.facebook.com/v6.0"

Verbs:
  look-up-tag-id
  tag-to-ids
  ids-to-details
  tag-to-details
  paginate
  submit
  update
  copy
```

and

```
$ te-tag-query-ruby
Usage: te-tag-query [options] {verb} {verb arguments}
Downloads descriptors in bulk from ThreatExchange, given
either a tag name or a list of IDs one per line on standard input.

Options:
  -h|--help      Show detailed help.
  --list-verbs   Show a list of supported verbs.
  -q|--quiet     Only print IDs/descriptors output with no narrative.
  -v|--verbose   Print IDs/descriptors output along with narrative.
  -s|--show-urls Print URLs used for queries, before executing them.
  -a|--app-token-env-name {...} Name of app-token environment variable.
                 Defaults to "TX_ACCESS_TOKEN".
  -b|--te-base-url {...} Defaults to "https://graph.facebook.com/v6.0"

Verbs:
  look-up-tag-id
  tag-to-ids
  ids-to-details
  tag-to-details
  paginate
  submit
  update
  copy
```