### PR TITLE
API examples

### DIFF
--- a/hashing/te-tag-query-java/APIExamples.java
+++ b/hashing/te-tag-query-java/APIExamples.java
@@ -96,7 +96,7 @@ public class APIExamples {
     // Note: in the TEAPI at present we can't read the privacy-members of a
     // copy-from descriptor unless we already own it, so this needs to be
     // specified explicitly here.
-    postParams.setPrivacyMembers("781588512307315");
+    postParams.setPrivacyMembers("781588512307315"); // Comma-delimited if there are multiples
     postParams.setPrivacyType("HAS_PRIVACY_GROUP");
 
     postParams.setTagsToAdd("testing-copy");

--- a/hashing/te-tag-query-java/APIExamples.java
+++ b/hashing/te-tag-query-java/APIExamples.java
@@ -1,0 +1,98 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+// ================================================================
+// The main reference tooling is com/facebook/threatexchange/TETagQuery.java,
+// which is likely most useful. However, this file is a more clear-cut example
+// of incorporating the API into your own framework.
+//
+// Compile with
+//
+//   javac com/facebook/threatexchange/*.java APIExamples.java
+//
+// and run with
+//
+//   java APIExamples
+// ================================================================
+
+import com.facebook.threatexchange.Net;
+import com.facebook.threatexchange.DescriptorPostParameters;
+
+import java.io.IOException;
+
+public class APIExamples {
+  // ----------------------------------------------------------------
+  public static void main(String[] args) throws IOException {
+    Net.setAppToken("TX_ACCESS_TOKEN");
+    submitExample();
+    updateExample();
+    copyExample();
+  }
+
+  // ----------------------------------------------------------------
+  private static void submitExample() {
+    boolean showURLs = false;
+    boolean dryRun = false;
+    DescriptorPostParameters postParams = new DescriptorPostParameters();
+
+    postParams.setIndicatorText("dabbad00f00dfeed5ca1ab1ebeefca11ab1ec00e");
+    postParams.setIndicatorType("HASH_SHA1");
+    postParams.setDescription("testing API-example post");
+    postParams.setShareLevel("AMBER");
+    postParams.setStatus("NON_MALICIOUS");
+    postParams.setPrivacyType("HAS_WHITELIST");
+    postParams.setPrivacyMembers("1064060413755420");
+    postParams.setTagsToSet("testing_java_post");
+
+    Net.PostResult postResult = Net.submitThreatDescriptor(postParams, showURLs, dryRun);
+    if (!postResult.ok) {
+      System.err.println(postResult.errorMessage);
+      System.exit(1);
+    } else {
+      System.out.println(postResult.responseMessage);
+    }
+  }
+
+  // ----------------------------------------------------------------
+  private static void updateExample() {
+    boolean showURLs = false;
+    boolean dryRun = false;
+    DescriptorPostParameters postParams = new DescriptorPostParameters();
+
+    postParams.setDescriptorID("2964083130339380");
+    postParams.setStatus("UNKNOWN");
+    postParams.setTagsToAdd("testing_java_update");
+
+    Net.PostResult postResult = Net.updateThreatDescriptor(postParams, showURLs, dryRun);
+    if (!postResult.ok) {
+      System.err.println(postResult.errorMessage);
+      System.exit(1);
+    } else {
+      System.out.println(postResult.responseMessage);
+    }
+  }
+
+  // ----------------------------------------------------------------
+  private static void copyExample() {
+    boolean verbose = false;
+    boolean showURLs = false;
+    boolean dryRun = false;
+    DescriptorPostParameters postParams = new DescriptorPostParameters();
+
+    postParams.setDescriptorID("2964083130339380");
+    postParams.setDescription("our copies");
+    postParams.setIndicatorText("dabbad00f00dfeed5ca1ab1ebeefca11ab1ec0ce");
+    postParams.setIndicatorType("HASH_SHA1");
+    postParams.setPrivacyType("HAS_PRIVACY_GROUP");
+    postParams.setPrivacyMembers("781588512307315");
+    postParams.setTagsToAdd("testing-copy");
+
+    Net.PostResult postResult = Net.copyThreatDescriptor(postParams, verbose, showURLs, dryRun);
+    if (!postResult.ok) {
+      System.err.println(postResult.errorMessage);
+      System.exit(1);
+    } else {
+      System.out.println(postResult.responseMessage);
+    }
+  }
+
+}

--- a/hashing/te-tag-query-java/APIExamples.java
+++ b/hashing/te-tag-query-java/APIExamples.java
@@ -40,7 +40,7 @@ public class APIExamples {
     postParams.setShareLevel("AMBER");
     postParams.setStatus("NON_MALICIOUS");
     postParams.setPrivacyType("HAS_WHITELIST");
-    postParams.setPrivacyMembers("1064060413755420");
+    postParams.setPrivacyMembers("1064060413755420"); // This is the app ID of another test app
     postParams.setTagsToSet("testing_java_post");
 
     Net.PostResult postResult = Net.submitThreatDescriptor(postParams, showURLs, dryRun);
@@ -58,9 +58,9 @@ public class APIExamples {
     boolean dryRun = false;
     DescriptorPostParameters postParams = new DescriptorPostParameters();
 
-    postParams.setDescriptorID("2964083130339380");
-    postParams.setStatus("UNKNOWN");
-    postParams.setTagsToAdd("testing_java_update");
+    postParams.setDescriptorID("2964083130339380"); // ID of the descriptor to be updated
+
+    postParams.setReactionsToAdd("INGESTED,IN_REVIEW");
 
     Net.PostResult postResult = Net.updateThreatDescriptor(postParams, showURLs, dryRun);
     if (!postResult.ok) {
@@ -78,12 +78,27 @@ public class APIExamples {
     boolean dryRun = false;
     DescriptorPostParameters postParams = new DescriptorPostParameters();
 
+    // ID of descriptor to make a copy of. All remaining fields are overrides
+    // to that copy-from template.
     postParams.setDescriptorID("2964083130339380");
+
+    // Modifications to the copy-from template are as follows.
+
     postParams.setDescription("our copies");
     postParams.setIndicatorText("dabbad00f00dfeed5ca1ab1ebeefca11ab1ec0ce");
     postParams.setIndicatorType("HASH_SHA1");
-    postParams.setPrivacyType("HAS_PRIVACY_GROUP");
+
+    // This is the ID of a privacy group which includes two test apps.
+    //
+    // See also
+    // https://developers.facebook.com/apps/your-app-id-goes-here/threat-exchange/privacy_groups
+    //
+    // Note: in the TEAPI at present we can't read the privacy-members of a
+    // copy-from descriptor unless we already own it, so this needs to be
+    // specified explicitly here.
     postParams.setPrivacyMembers("781588512307315");
+    postParams.setPrivacyType("HAS_PRIVACY_GROUP");
+
     postParams.setTagsToAdd("testing-copy");
 
     Net.PostResult postResult = Net.copyThreatDescriptor(postParams, verbose, showURLs, dryRun);

--- a/hashing/te-tag-query-java/README.md
+++ b/hashing/te-tag-query-java/README.md
@@ -181,6 +181,10 @@ te-tag-query-java \
     --tags testing_java_post
 ```
 
+# Examples of using the API wrappers
+
+The above examples use the `te-tag-query-java` script. However, if you'd like more easily copyable examples of using the API, you can look at `APIExamples.java` in the current directory.
+
 # Bare-curl notes
 
 As noted at the top of this document, the `TETagQuery` program is intended to be a reference design -- for you to use as-is, or to help you write tooling in other languages.

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
@@ -330,60 +330,58 @@ public class DescriptorPostParameters {
     return this._reactionsToRemove;
   }
 
-  public boolean validateForSubmitWithReport(PrintStream o) {
+  // Returns null if no errors, non-null for error.
+  public String validateForSubmitWithReport() {
     if (this._descriptorID != null) {
-      o.println("Descriptor ID must not be specified for submit.\n");
-      return false;
+      return "Descriptor ID must not be specified for submit.";
     }
     if (this._indicatorText == null) {
-      o.println("Indicator text is missing.\n");
-      return false;
+      return "Indicator text is missing.";
     }
     if (this._indicatorType == null) {
-      o.println("Indicator type is missing.\n");
-      return false;
+      return "Indicator type is missing.";
     }
     if (this._description == null) {
-      o.println("Description is missing.\n");
-      return false;
+      return "Description is missing.";
     }
     if (this._shareLevel == null) {
-      o.println("Share level is missing.\n");
-      return false;
+      return "Share level is missing.\n";
     }
     if (this._status == null) {
-      o.println("Status is missing.\n");
-      return false;
+      return "Status is missing.\n";
     }
     if (this._privacyType == null) {
-      o.println("Privacy type is missing.\n");
-      return false;
+      return "Privacy type is missing.\n";
     }
-    return true;
+    return null;
   }
 
-  public boolean validateForUpdateWithReport(PrintStream o) {
+  // Returns null if no errors, non-null for error.
+  public String validateForUpdateWithReport() {
     if (this._descriptorID == null) {
-      o.println("Descriptor ID must be specified for update.\n");
-      return false;
+      return "Descriptor ID must be specified for update.";
     }
     if (this._indicatorText != null) {
-      o.println("Indicator text must not be specified for update.\n");
-      return false;
+      return "Indicator text must not be specified for update.";
     }
     if (this._indicatorType != null) {
-      o.println("Indicator type must not be specified for update.\n");
-      return false;
+      return "Indicator type must not be specified for update.";
     }
-    return true;
+    return null;
   }
 
-  public boolean validateForCopyWithReport(PrintStream o) {
+  // Returns null if no errors, non-null for error.
+  public String validateForCopyWithReport() {
     if (this._descriptorID == null) {
-      o.println("Descriptor ID must be specified for copy.\n");
-      return false;
+      return "Descriptor ID must be specified for copy.";
     }
-    return true;
+    if (this._privacyMembers == null) {
+      return "Privacy members is missing.";
+    }
+    if (this._privacyType == null) {
+      return "Privacy type is missing.";
+    }
+    return null;
   }
 
   // URL-encode since data is user-provided.

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 /**
  * Helper container class for posting threat descriptors to ThreatExchange.
  */
-class DescriptorPostParameters {
+public class DescriptorPostParameters {
   private String _indicatorText; // Required for submit
   private String _indicatorType; // Required for submit
   private String _descriptorID;  // Required for update

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/DescriptorPostParameters.java
@@ -336,22 +336,22 @@ public class DescriptorPostParameters {
       return "Descriptor ID must not be specified for submit.";
     }
     if (this._indicatorText == null) {
-      return "Indicator text is missing.";
+      return "Indicator text must be specified for submit.";
     }
     if (this._indicatorType == null) {
-      return "Indicator type is missing.";
+      return "Indicator type must be specified for submit.";
     }
     if (this._description == null) {
-      return "Description is missing.";
+      return "Description must be specified for submit.";
     }
     if (this._shareLevel == null) {
-      return "Share level is missing.\n";
+      return "Share level must be specified for submit.\n";
     }
     if (this._status == null) {
-      return "Status is missing.\n";
+      return "Status must be specified for submit.\n";
     }
     if (this._privacyType == null) {
-      return "Privacy type is missing.\n";
+      return "Privacy type must be specified for submit.\n";
     }
     return null;
   }
@@ -376,10 +376,10 @@ public class DescriptorPostParameters {
       return "Descriptor ID must be specified for copy.";
     }
     if (this._privacyMembers == null) {
-      return "Privacy members is missing.";
+      return "Privacy members must be specified for copy.";
     }
     if (this._privacyType == null) {
-      return "Privacy type is missing.";
+      return "Privacy type must be specified for copy.";
     }
     return null;
   }

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
@@ -677,7 +677,7 @@ public class Net {
     try {
       connection = (HttpURLConnection) url.openConnection();
     } catch (IOException e) {
-      return new PostResult(false, null, "A malformed URL was constructed: " + urlString);
+      return new PostResult(false, null, "The connection could not be opened: " + urlString);
     }
     connection.setDoOutput(true); // since there is a POST body
 

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
  * HTTP-wrapper methods
  * See also https://developers.facebook.com/docs/threat-exchange
  */
-class Net {
+public class Net {
   private static String APP_TOKEN = null;
   private static String TE_BASE_URL = Constants.DEFAULT_TE_BASE_URL;
 

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
@@ -717,6 +717,12 @@ public class Net {
       JSONObject object = (JSONObject) new JSONParser().parse(new InputStreamReader(response));
       return new PostResult(true, object.toString(), null);
     } catch (Exception e) {
+      // There is perhaps some value in e.getMessage() and
+      // e.printStackTrace(System.err).  However, in practice we find that the
+      // connection.getErrorStream() JSON has the necessary information for
+      // diagnosing issues. As well, that's what's passed back to the caller in
+      // the Python and Ruby impls, so we stick with just that, for
+      // consistency.
       try {
         InputStream response = connection.getErrorStream();
         JSONObject object = (JSONObject) new JSONParser().parse(new InputStreamReader(response));

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/Net.java
@@ -520,16 +520,32 @@ public class Net {
   }
 
   /**
+   * In Python/Ruby/etc you can return tuples. For Java we define a simple
+   * class containing the results of a POST.
+   */
+  public static class PostResult {
+    public final boolean ok;
+    public final String responseMessage;
+    public final String errorMessage;
+    public PostResult(boolean ok_, String responseMessage_, String errorMessage_) {
+      this.ok = ok_;
+      this.responseMessage = responseMessage_;
+      this.errorMessage = errorMessage_;
+    }
+  }
+
+  /**
    * Does a single POST to the threat_descriptors endpoint.  See also
    * https://developers.facebook.com/docs/threat-exchange/reference/submitting
    */
-  public static boolean submitThreatDescriptor(
+  public static PostResult submitThreatDescriptor(
     DescriptorPostParameters postParams,
     boolean showURLs,
     boolean dryRun
   ) {
-    if (!postParams.validateForSubmitWithReport(System.err)) {
-      return false;
+    String validationErrorMessage = postParams.validateForSubmitWithReport();
+    if (validationErrorMessage != null) {
+      return new PostResult(false, null, validationErrorMessage);
     }
 
     String urlString = TE_BASE_URL
@@ -543,13 +559,14 @@ public class Net {
    * Does a single POST to the threat_descriptor ID endpoint.  See also
    * https://developers.facebook.com/docs/threat-exchange/reference/editing
    */
-  public static boolean updateThreatDescriptor(
+  public static PostResult updateThreatDescriptor(
     DescriptorPostParameters postParams,
     boolean showURLs,
     boolean dryRun
   ) {
-    if (!postParams.validateForUpdateWithReport(System.err)) {
-      return false;
+    String validationErrorMessage = postParams.validateForUpdateWithReport();
+    if (validationErrorMessage != null) {
+      return new PostResult(false, null, validationErrorMessage);
     }
 
     String urlString = TE_BASE_URL
@@ -564,22 +581,22 @@ public class Net {
    * See also
    * https://developers.facebook.com/docs/threat-exchange/reference/editing
    */
-  public static boolean copyThreatDescriptor(
+  public static PostResult copyThreatDescriptor(
     DescriptorPostParameters overrideParams,
     boolean verbose,
     boolean showURLs,
     boolean dryRun
   ) {
-    if (!overrideParams.validateForCopyWithReport(System.err)) {
-      return false;
+    String validationErrorMessage = overrideParams.validateForCopyWithReport();
+    if (validationErrorMessage != null) {
+      return new PostResult(false, null, validationErrorMessage);
     }
 
     // Get source descriptor
     String sourceID = overrideParams.getDescriptorID();
     ThreatDescriptor sourceDescriptor = getInfoForID(sourceID, verbose, showURLs, false);
     if (sourceDescriptor == null) {
-      System.err.printf("Could not load copy-from descriptor with ID \"%s\".\n", sourceID);
-      return false;
+      return new PostResult(false, null, "Could not load copy-from descriptor with ID \"" + sourceID + "\".");
     }
 
     // Take the source-descriptor values and overwrite any post-params fields
@@ -637,7 +654,7 @@ public class Net {
   /**
    * Code-reuse method for submit and update.
    */
-  private static boolean postThreatDescriptor(
+  private static PostResult postThreatDescriptor(
     String urlString,
     DescriptorPostParameters postParams,
     boolean showURLs,
@@ -653,18 +670,14 @@ public class Net {
     try {
       url = new URL(urlString);
     } catch (MalformedURLException e) {
-      System.err.println("A malformed URL was constructed:");
-      System.err.println(urlString);
-      return false;
+      return new PostResult(false, null, "A malformed URL was constructed: " + urlString);
     }
 
     HttpURLConnection connection = null;
     try {
       connection = (HttpURLConnection) url.openConnection();
     } catch (IOException e) {
-      System.err.println("A malformed URL was constructed:");
-      System.err.println(urlString);
-      return false;
+      return new PostResult(false, null, "A malformed URL was constructed: " + urlString);
     }
     connection.setDoOutput(true); // since there is a POST body
 
@@ -672,9 +685,7 @@ public class Net {
     try {
       connection.setRequestMethod("POST");
     } catch (ProtocolException e) {
-      System.err.println("Unable to set request method to POST.");
-      System.err.println(urlString);
-      return false;
+      return new PostResult(false, null, "Unable to set request method to POST: " + urlString);
     }
     connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
     connection.setRequestProperty("charset", "utf-8");
@@ -690,48 +701,32 @@ public class Net {
     connection.setRequestProperty("Content-Length", Integer.toString(postDataBytes.length));
 
     if (dryRun) {
-      System.out.println("Not doing POST since --dry-run.");
-    } else {
+      return new PostResult(false, null, "Not doing POST since --dry-run.");
+    }
+
+    try {
+      connection.getOutputStream().write(postDataBytes);
+    } catch (IOException e) {
+      System.err.println();
+      e.printStackTrace(System.err);
+      System.err.println();
+      return new PostResult(false, null, "POST failure");
+    }
+
+    try (InputStream response = connection.getInputStream()) {
+      JSONObject object = (JSONObject) new JSONParser().parse(new InputStreamReader(response));
+      return new PostResult(true, object.toString(), null);
+    } catch (Exception e) {
       try {
-        connection.getOutputStream().write(postDataBytes);
-      } catch (IOException e) {
-        System.err.println();
-        System.err.printf("POST failure.\n");
-        System.err.printf("\n");
-        e.printStackTrace(System.err);
-        return false;
-      }
-
-      try (InputStream response = connection.getInputStream()) {
-
+        InputStream response = connection.getErrorStream();
         JSONObject object = (JSONObject) new JSONParser().parse(new InputStreamReader(response));
-        System.out.println(object);
-      } catch (Exception e) {
-        try {
-          InputStream response = connection.getErrorStream();
-          JSONObject object = (JSONObject) new JSONParser().parse(new InputStreamReader(response));
-
-          System.err.println();
-          System.out.println("ERROR STREAM:");
-          System.out.println(object);
-        } catch (IOException e2) {
-          System.err.println("IOException trying to print the error stream :(");
-        } catch (org.json.simple.parser.ParseException e2) {
-          System.err.println("ParseException trying to print the error stream :(");
-        }
-
-        System.err.println();
-        System.err.println("EXCEPTION MESSAGE:");
-        System.err.println(e.getMessage());
-
-        System.err.println();
-        System.err.println("EXCEPTION STACK TRACE:");
-        e.printStackTrace(System.err);
-
-        return false;
+        return new PostResult(false, null, object.toString());
+      } catch (IOException e2) {
+        return new PostResult(false, null, "IOException trying to print the error stream :(");
+      } catch (org.json.simple.parser.ParseException e2) {
+        return new PostResult(false, null, "ParseException trying to print the error stream :(");
       }
     }
-    return true;
   }
 
 } // Net

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -1267,10 +1267,12 @@ public class TETagQuery {
         postParams.setIndicatorText(contents);
       }
 
-      boolean ok = Net.submitThreatDescriptor(postParams, showURLs, dryRun);
-      if (!ok) {
-        // Error message already printed out
+      Net.PostResult postResult = Net.submitThreatDescriptor(postParams, showURLs, dryRun);
+      if (!postResult.ok) {
+        System.err.println(postResult.errorMessage);
         System.exit(1);
+      } else {
+        System.out.println(postResult.responseMessage);
       }
     }
 
@@ -1425,10 +1427,12 @@ public class TETagQuery {
       boolean showURLs,
       boolean dryRun
     ) {
-      boolean ok = Net.updateThreatDescriptor(postParams, showURLs, dryRun);
-      if (!ok) {
-        // Error message already printed out
+      Net.PostResult postResult = Net.updateThreatDescriptor(postParams, showURLs, dryRun);
+      if (!postResult.ok) {
+        System.err.println(postResult.errorMessage);
         System.exit(1);
+      } else {
+        System.out.println(postResult.responseMessage);
       }
     }
 
@@ -1579,10 +1583,12 @@ public class TETagQuery {
       boolean showURLs,
       boolean dryRun
     ) {
-      boolean ok = Net.copyThreatDescriptor(postParams, verbose, showURLs, dryRun);
-      if (!ok) {
-        // Error message already printed out
+      Net.PostResult postResult = Net.copyThreatDescriptor(postParams, verbose, showURLs, dryRun);
+      if (!postResult.ok) {
+        System.err.println(postResult.errorMessage);
         System.exit(1);
+      } else {
+        System.out.println(postResult.responseMessage);
       }
     }
 

--- a/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
+++ b/hashing/te-tag-query-java/com/facebook/threatexchange/TETagQuery.java
@@ -1557,7 +1557,7 @@ public class TETagQuery {
             lno++;
             // In Java, line-terminators already stripped for us
             postParams.setDescriptorID(line);
-            CopySingle(postParams, verbose, showURLs, dryRun);
+            copySingle(postParams, verbose, showURLs, dryRun);
           }
         } catch (IOException e) {
           System.err.printf("Couldn't read line %d of standard input.\n", lno);
@@ -1569,11 +1569,11 @@ public class TETagQuery {
             PROGNAME, _verb);
           System.exit(1);
         }
-        CopySingle(postParams, verbose, showURLs, dryRun);
+        copySingle(postParams, verbose, showURLs, dryRun);
       }
     }
 
-    private void CopySingle(
+    private void copySingle(
       DescriptorPostParameters postParams,
       boolean verbose,
       boolean showURLs,

--- a/hashing/te-tag-query-python/README.md
+++ b/hashing/te-tag-query-python/README.md
@@ -180,6 +180,16 @@ $ te-tag-query-python ids-to-details 3046896738736542 | jq .
 }
 ```
 
+# Examples of using the API wrappers
+
+The above examples use the `te-tag-query-python` script. However, if you'd like more easily copyable examples of using the API, you can do
+
+```
+python api-example-submit.py
+python api-example-update.py
+python api-example-copy.py
+```
+
 # Bare-curl notes
 
 As noted at the top of this document, the `TETagQuery` program is intended to be a reference design -- for you to use as-is, or to help you write tooling in other languages.

--- a/hashing/te-tag-query-python/TE.py
+++ b/hashing/te-tag-query-python/TE.py
@@ -374,6 +374,7 @@ class Net:
 
     # Get source descriptor
     sourceID = postParams['descriptor_id']
+    # Not valid for posting a new descriptor
     del postParams['descriptor_id']
     sourceDescriptor = self.getInfoForIDs([sourceID], showURLs=showURLs)
     sourceDescriptor = sourceDescriptor[0]
@@ -385,6 +386,11 @@ class Net:
     if 'tags' in newDescriptor and newDescriptor['tags'] is None:
       del newDescriptor['tags']
 
+    # The shape is different between the copy-from data (mapping app IDs to
+    # reactions) and the post data (just a comma-delimited string of owner-app
+    # reactions).
+    if 'reactions' in newDescriptor:
+      del newDescriptor['reactions']
 
     # Take the source-descriptor values and overwrite any post-params fields
     # supplied by the caller. Note: Python's dict-update method keeps the old

--- a/hashing/te-tag-query-python/TE.py
+++ b/hashing/te-tag-query-python/TE.py
@@ -331,7 +331,11 @@ class Net:
   @classmethod
   def validatePostPararmsForCopy(self, postParams):
     if postParams.get(self.POST_PARAM_NAMES['descriptor_id']) == None:
-      return "Source-descriptor ID must be specified for update."
+      return "Source-descriptor ID must be specified for copy."
+    if postParams.get(self.POST_PARAM_NAMES['privacy_type']) == None:
+      return "Privacy type must be specified for copy."
+    if postParams.get(self.POST_PARAM_NAMES['privacy_members']) == None:
+      return "Privacy members must be specified for copy."
     return None
 
 

--- a/hashing/te-tag-query-python/TETagQuery.py
+++ b/hashing/te-tag-query-python/TETagQuery.py
@@ -914,7 +914,7 @@ class SubmitHandler(AbstractPostSubcommandHandler):
 
     if serverSideError != None:
       eprint(str(serverSideError))
-      print(json.dumps(responseBody))
+      eprint(json.dumps(responseBody))
       sys.exit(1)
 
     print(json.dumps(responseBody))
@@ -1032,7 +1032,7 @@ class UpdateHandler(AbstractPostSubcommandHandler):
 
     if serverSideError != None:
       eprint(str(serverSideError))
-      print(json.dumps(responseBody))
+      eprint(json.dumps(responseBody))
       sys.exit(1)
 
     print(json.dumps(responseBody))
@@ -1151,7 +1151,7 @@ class CopyHandler(AbstractPostSubcommandHandler):
 
     if serverSideError != None:
       eprint(str(serverSideError))
-      print(json.dumps(responseBody))
+      eprint(json.dumps(responseBody))
       sys.exit(1)
 
     print(json.dumps(responseBody))

--- a/hashing/te-tag-query-python/api-example-copy.py
+++ b/hashing/te-tag-query-python/api-example-copy.py
@@ -11,8 +11,20 @@ import TE
 TE.Net.setAppTokenFromEnvName('TX_ACCESS_TOKEN')
 
 postParams = {
+  # ID of descriptor to make a copy of. All remaining fields are overrides to
+  # that copy-from template.
   'descriptor_id': '4036655176350945',
+
   'indicator': 'dabbad00f00dfeed5ca1ab1ebeefca11ab1ec21b',
+
+  # This is the ID of a privacy group which includes two test apps.
+  #
+  # See also
+  # https://developers.facebook.com/apps/your-app-id-goes-here/threat-exchange/privacy_groups
+  #
+  # Note: in the TEAPI at present we can't read the privacy-members of a
+  # copy-from descriptor unless we already own it, so this needs to be
+  # specified explicitly here.
   'privacy_type': 'HAS_PRIVACY_GROUP',
   'privacy_members': '781588512307315',
 }

--- a/hashing/te-tag-query-python/api-example-copy.py
+++ b/hashing/te-tag-query-python/api-example-copy.py
@@ -1,0 +1,34 @@
+##!/usr/bin/env python
+
+# ================================================================
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# ================================================================
+
+import sys
+import json
+import TE
+
+TE.Net.setAppTokenFromEnvName('TX_ACCESS_TOKEN')
+
+postParams = {
+  'descriptor_id': '4036655176350945',
+  'indicator': 'dabbad00f00dfeed5ca1ab1ebeefca11ab1ec21b',
+  'privacy_type': 'HAS_PRIVACY_GROUP',
+  'privacy_members': '781588512307315',
+}
+
+showURLs = True
+dryRun = False
+validationErrorMessage, serverSideError, responseBody = TE.Net.copyThreatDescriptor(
+  postParams, showURLs, dryRun)
+
+if validationErrorMessage != None:
+  sys.stderr.write(validationErrorMessage + "\n")
+  sys.exit(1)
+
+if serverSideError != None:
+  sys.stderr.write(str(serverSideError) + "\n")
+  sys.stderr.write(json.dumps(responseBody) + "\n")
+  sys.exit(1)
+
+print(json.dumps(responseBody))

--- a/hashing/te-tag-query-python/api-example-copy.py
+++ b/hashing/te-tag-query-python/api-example-copy.py
@@ -26,7 +26,7 @@ postParams = {
   # copy-from descriptor unless we already own it, so this needs to be
   # specified explicitly here.
   'privacy_type': 'HAS_PRIVACY_GROUP',
-  'privacy_members': '781588512307315',
+  'privacy_members': '781588512307315', # Comma-delimited if there are multiples
 }
 
 showURLs = True

--- a/hashing/te-tag-query-python/api-example-copy.py
+++ b/hashing/te-tag-query-python/api-example-copy.py
@@ -1,4 +1,4 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 # ================================================================
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/hashing/te-tag-query-python/api-example-submit.py
+++ b/hashing/te-tag-query-python/api-example-submit.py
@@ -1,0 +1,38 @@
+##!/usr/bin/env python
+
+# ================================================================
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# ================================================================
+
+import sys
+import json
+import TE
+
+TE.Net.setAppTokenFromEnvName('TX_ACCESS_TOKEN')
+
+postParams = {
+  'indicator': 'dabbad00f00dfeed5ca1ab1ebeefca11ab1ec20f',
+  'type': 'HASH_SHA1',
+  'description': 'testing API-example post',
+  'share_level': 'AMBER',
+  'status': 'NON_MALICIOUS',
+  'privacy_type': 'HAS_WHITELIST',
+  'privacy_members': '1064060413755420',
+  'tags': 'testing_python_post'
+}
+
+showURLs = False
+dryRun = False
+validationErrorMessage, serverSideError, responseBody = TE.Net.submitThreatDescriptor(
+  postParams, showURLs, dryRun)
+
+if validationErrorMessage != None:
+  sys.stderr.write(validationErrorMessage + "\n")
+  sys.exit(1)
+
+if serverSideError != None:
+  sys.stderr.write(str(serverSideError) + "\n")
+  sys.stderr.write(json.dumps(responseBody) + "\n")
+  sys.exit(1)
+
+print(json.dumps(responseBody))

--- a/hashing/te-tag-query-python/api-example-submit.py
+++ b/hashing/te-tag-query-python/api-example-submit.py
@@ -17,7 +17,7 @@ postParams = {
   'share_level': 'AMBER',
   'status': 'NON_MALICIOUS',
   'privacy_type': 'HAS_WHITELIST',
-  'privacy_members': '1064060413755420',
+  'privacy_members': '1064060413755420', # This is the ID of another test app
   'tags': 'testing_python_post'
 }
 

--- a/hashing/te-tag-query-python/api-example-submit.py
+++ b/hashing/te-tag-query-python/api-example-submit.py
@@ -1,4 +1,4 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 # ================================================================
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/hashing/te-tag-query-python/api-example-update.py
+++ b/hashing/te-tag-query-python/api-example-update.py
@@ -1,0 +1,32 @@
+##!/usr/bin/env python
+
+# ================================================================
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# ================================================================
+
+import sys
+import json
+import TE
+
+TE.Net.setAppTokenFromEnvName('TX_ACCESS_TOKEN')
+
+postParams = {
+  'descriptor_id': '4036655176350945',
+  'reactions': 'INGESTED,IN_REVIEW'
+}
+
+showURLs = False
+dryRun = False
+validationErrorMessage, serverSideError, responseBody = TE.Net.updateThreatDescriptor(
+  postParams, showURLs, dryRun)
+
+if validationErrorMessage != None:
+  sys.stderr.write(validationErrorMessage + "\n")
+  sys.exit(1)
+
+if serverSideError != None:
+  sys.stderr.write(str(serverSideError) + "\n")
+  sys.stderr.write(json.dumps(responseBody) + "\n")
+  sys.exit(1)
+
+print(json.dumps(responseBody))

--- a/hashing/te-tag-query-python/api-example-update.py
+++ b/hashing/te-tag-query-python/api-example-update.py
@@ -1,4 +1,4 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 # ================================================================
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/hashing/te-tag-query-python/api-example-update.py
+++ b/hashing/te-tag-query-python/api-example-update.py
@@ -11,7 +11,7 @@ import TE
 TE.Net.setAppTokenFromEnvName('TX_ACCESS_TOKEN')
 
 postParams = {
-  'descriptor_id': '4036655176350945',
+  'descriptor_id': '4036655176350945', # ID of the descriptor to be updated
   'reactions': 'INGESTED,IN_REVIEW'
 }
 

--- a/hashing/te-tag-query-ruby/README.md
+++ b/hashing/te-tag-query-ruby/README.md
@@ -179,6 +179,16 @@ $ te-tag-query-ruby ids-to-details 3046896738736542 | jq .
 }
 ```
 
+# Examples of using the API wrappers
+
+The above examples use the `te-tag-query-ruby` script. However, if you'd like more easily copyable examples of using the API, you can do
+
+```
+ruby api-example-submit.rb
+ruby api-example-update.rb
+ruby api-example-copy.rb
+```
+
 # Bare-curl notes
 
 As noted at the top of this document, the `TETagQuery` program is intended to be a reference design -- for you to use as-is, or to help you write tooling in other languages.

--- a/hashing/te-tag-query-ruby/TENet.rb
+++ b/hashing/te-tag-query-ruby/TENet.rb
@@ -422,6 +422,12 @@ def TENet.validatePostPararmsForCopy(postParams)
   if postParams[POST_PARAM_NAMES[:descriptor_id]].nil?
     return "Source-descriptor ID must be specified for copy."
   end
+  if postParams[POST_PARAM_NAMES[:privacy_type]].nil?
+    return "Privacy type must be specified for copy."
+  end
+  if postParams[POST_PARAM_NAMES[:privacy_members]].nil?
+    return "Privacy type must be specified for copy."
+  end
   return nil
 end
 

--- a/hashing/te-tag-query-ruby/TENet.rb
+++ b/hashing/te-tag-query-ruby/TENet.rb
@@ -500,6 +500,13 @@ def TENet.copyThreatDescriptor(
     newDescriptor.delete('tags')
   end
 
+  # The shape is different between the copy-from data (mapping app IDs to
+  # reactions) and the post data (just a comma-delimited string of owner-app
+  # reactions).
+  if newDescriptor['reactions'] != nil
+    newDescriptor.delete('reactions')
+  end
+
   # Take the source-descriptor values and overwrite any post-params fields
   # supplied by the caller. Note: Ruby's hash-merge method keeps the old
   # value for a given field name when both old and new are present so we

--- a/hashing/te-tag-query-ruby/TETagQuery.rb
+++ b/hashing/te-tag-query-ruby/TETagQuery.rb
@@ -925,7 +925,7 @@ class SubmitHandler < AbstractPostSubcommandHandler
       dryRun: dryRun)
 
     unless validationErrorMessage.nil?
-      $stderr.puts errorMessage
+      $stderr.puts validationErrorMessage
       exit 1
     end
 

--- a/hashing/te-tag-query-ruby/api-example-copy.rb
+++ b/hashing/te-tag-query-ruby/api-example-copy.rb
@@ -1,4 +1,4 @@
-##!/usr/bin/env ruby
+#!/usr/bin/env ruby
 
 # ================================================================
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/hashing/te-tag-query-ruby/api-example-copy.rb
+++ b/hashing/te-tag-query-ruby/api-example-copy.rb
@@ -23,7 +23,7 @@ postParams = {
   # specified explicitly here.
   'indicator' => 'dabbad00f00dfeed5ca1ab1ebeefca11ab1ec21b',
   'privacy_type' => 'HAS_PRIVACY_GROUP',
-  'privacy_members' => '781588512307315',
+  'privacy_members' => '781588512307315', # Comma-delimited if there are multiples
 }
 
 showURLs = false

--- a/hashing/te-tag-query-ruby/api-example-copy.rb
+++ b/hashing/te-tag-query-ruby/api-example-copy.rb
@@ -9,7 +9,18 @@ require './TENet.rb'
 ThreatExchange::TENet::setAppTokenFromEnvName('TX_ACCESS_TOKEN')
 
 postParams = {
+  # ID of descriptor to make a copy of. All remaining fields are overrides to
+  # that copy-from template.
   'descriptor_id' => '4036655176350945',
+
+  # This is the ID of a privacy group which includes two test apps.
+  #
+  # See also
+  # https://developers.facebook.com/apps/your-app-id-goes-here/threat-exchange/privacy_groups
+  #
+  # Note: in the TEAPI at present we can't read the privacy-members of a
+  # copy-from descriptor unless we already own it, so this needs to be
+  # specified explicitly here.
   'indicator' => 'dabbad00f00dfeed5ca1ab1ebeefca11ab1ec21b',
   'privacy_type' => 'HAS_PRIVACY_GROUP',
   'privacy_members' => '781588512307315',

--- a/hashing/te-tag-query-ruby/api-example-copy.rb
+++ b/hashing/te-tag-query-ruby/api-example-copy.rb
@@ -1,0 +1,34 @@
+##!/usr/bin/env ruby
+
+# ================================================================
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# ================================================================
+
+require './TENet.rb'
+
+ThreatExchange::TENet::setAppTokenFromEnvName('TX_ACCESS_TOKEN')
+
+postParams = {
+  'descriptor_id' => '4036655176350945',
+  'indicator' => 'dabbad00f00dfeed5ca1ab1ebeefca11ab1ec21b',
+  'privacy_type' => 'HAS_PRIVACY_GROUP',
+  'privacy_members' => '781588512307315',
+}
+
+showURLs = false
+dryRun = false
+validationErrorMessage, response_body, response_code = ThreatExchange::TENet::copyThreatDescriptor(
+  postParams,
+  showURLs: showURLs,
+  dryRun: dryRun)
+
+unless validationErrorMessage.nil?
+  $stderr.puts validationErrorMessage
+  exit 1
+end
+
+puts response_body
+
+if response_code != 200
+  exit 1
+end

--- a/hashing/te-tag-query-ruby/api-example-submit.rb
+++ b/hashing/te-tag-query-ruby/api-example-submit.rb
@@ -1,0 +1,38 @@
+##!/usr/bin/env ruby
+
+# ================================================================
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# ================================================================
+
+require './TENet.rb'
+
+ThreatExchange::TENet::setAppTokenFromEnvName('TX_ACCESS_TOKEN')
+
+postParams = {
+  'indicator' => 'dabbad00f00dfeed5ca1ab1ebeefca11ab1ec10e',
+  'type' => 'HASH_SHA1',
+  'description' => 'testing te-tag-query with post',
+  'share_level' => 'AMBER',
+  'status' => 'NON_MALICIOUS',
+  'privacy_type' => 'HAS_WHITELIST',
+  'privacy_members' => '1064060413755420',
+  'tags' => 'testing_ruby_post',
+}
+
+showURLs = false
+dryRun = false
+validationErrorMessage, response_body, response_code = ThreatExchange::TENet::submitThreatDescriptor(
+  postParams,
+  showURLs: showURLs,
+  dryRun: dryRun)
+
+unless validationErrorMessage.nil?
+  $stderr.puts validationErrorMessage
+  exit 1
+end
+
+puts response_body
+
+if response_code != 200
+  exit 1
+end

--- a/hashing/te-tag-query-ruby/api-example-submit.rb
+++ b/hashing/te-tag-query-ruby/api-example-submit.rb
@@ -1,4 +1,4 @@
-##!/usr/bin/env ruby
+#!/usr/bin/env ruby
 
 # ================================================================
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/hashing/te-tag-query-ruby/api-example-submit.rb
+++ b/hashing/te-tag-query-ruby/api-example-submit.rb
@@ -15,7 +15,7 @@ postParams = {
   'share_level' => 'AMBER',
   'status' => 'NON_MALICIOUS',
   'privacy_type' => 'HAS_WHITELIST',
-  'privacy_members' => '1064060413755420',
+  'privacy_members' => '1064060413755420', # This is the ID of another test app
   'tags' => 'testing_ruby_post',
 }
 

--- a/hashing/te-tag-query-ruby/api-example-update.rb
+++ b/hashing/te-tag-query-ruby/api-example-update.rb
@@ -1,4 +1,4 @@
-##!/usr/bin/env ruby
+#!/usr/bin/env ruby
 
 # ================================================================
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/hashing/te-tag-query-ruby/api-example-update.rb
+++ b/hashing/te-tag-query-ruby/api-example-update.rb
@@ -1,0 +1,32 @@
+##!/usr/bin/env ruby
+
+# ================================================================
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# ================================================================
+
+require './TENet.rb'
+
+ThreatExchange::TENet::setAppTokenFromEnvName('TX_ACCESS_TOKEN')
+postParams = {
+  'descriptor_id' => '3546989395318416',
+  'status' => 'UNKNOWN',
+  'add_tags' => 'testing_ruby_update',
+}
+
+showURLs = false
+dryRun = false
+validationErrorMessage, response_body, response_code = ThreatExchange::TENet::updateThreatDescriptor(
+  postParams,
+  showURLs: showURLs,
+  dryRun: dryRun)
+
+unless validationErrorMessage.nil?
+  $stderr.puts validationErrorMessage
+  exit 1
+end
+
+puts response_body
+
+if response_code != 200
+  exit 1
+end

--- a/hashing/te-tag-query-ruby/api-example-update.rb
+++ b/hashing/te-tag-query-ruby/api-example-update.rb
@@ -8,9 +8,8 @@ require './TENet.rb'
 
 ThreatExchange::TENet::setAppTokenFromEnvName('TX_ACCESS_TOKEN')
 postParams = {
-  'descriptor_id' => '3546989395318416',
-  'status' => 'UNKNOWN',
-  'add_tags' => 'testing_ruby_update',
+  'descriptor_id' => '3546989395318416', # ID of the descriptor to be updated
+  'reactions': 'INGESTED,IN_REVIEW'
 }
 
 showURLs = false


### PR DESCRIPTION
The main commit https://github.com/facebook/ThreatExchange/pull/259/commits/33db3614eebebcde3f85f16d36f9eec70479500d demonstrates how to use the API (as currently articulated), pulled out from the main `TETagQuery` programs. The commits below are supporting neatens/enables.

Regression testing: run all the commands in all the `hashing/te-tag-query-*/README.md` files

Testing for the new API examples:

```
cd ../te-tag-query-python
python api-example-submit.py
python api-example-copy.py
python api-example-update.py

cd ../te-tag-query-ruby/
ruby api-example-submit.rb
ruby api-example-update.rb
ruby api-example-copy.rb

cd ../te-tag-query-java/
javac com/facebook/threatexchange/*.java APIExamples.java
java APIExamples
```