### PR TITLE
python power-search wrapper

### DIFF
--- a/hashing/te-tag-query-python/TE.py
+++ b/hashing/te-tag-query-python/TE.py
@@ -346,7 +346,9 @@ class Net:
                     tags = []
                 else:
                     tags = tags["data"]
-                descriptor["tags"] = [tag["text"] for tag in tags].sort()
+                tags = [tag["text"] for tag in tags]
+                tags.sort()
+                descriptor["tags"] = tags
 
                 if descriptor.get("description") is None:
                     descriptor["description"] = ""

--- a/hashing/te-tag-query-python/TE.py
+++ b/hashing/te-tag-query-python/TE.py
@@ -64,7 +64,7 @@ class Net:
     #   https://graph.facebook.com/v{x}.{y}
     @classmethod
     def setTEBaseURL(self, baseURL):
-        self.DEFAULT_TE_BASE_URL = baseURL
+        self.TE_BASE_URL = baseURL
 
     # ----------------------------------------------------------------
     # Gets the ThreatExchange app token from an environment variable.  Feel

--- a/hashing/te-tag-query-python/TETagQuery.py
+++ b/hashing/te-tag-query-python/TETagQuery.py
@@ -746,7 +746,7 @@ https://developers.facebook.com/docs/threat-exchange/reference/apis/threat-descr
                 )
                 sys.exit(1)
 
-        if urlParams['since'] is None:
+        if urlParams.get('since') is None:
             eprint("%s %s: --since is required" % (self.progName, self.verbName))
             self.usage(1)
         if len(args) > 0:


### PR DESCRIPTION
Still needs doc examples, which should be done on a separate PR since the server-side has a bit of rework to do before this will be ready for prime time.

Testing:

```
$ te-tag-query-python power-search --since 100 --tags-are-anded --tags pwny,testing | jq . | head -n 20
{
  "raw_indicator": "dabbad00f00dfeed5ca1ab1ebeefca11ab1ec0cf",
  "type": "HASH_SHA1",
  "added_on": "2020-07-02T19:56:05+0000",
  "last_updated": "2020-07-27T18:42:17+0000",
  "confidence": 100,
  "owner": {
    "id": "494491891138576",
    "email": "threatexchange@fb.com",
    "name": "Media Hash Sharing RF Test"
  },
  "privacy_type": "HAS_PRIVACY_GROUP",
  "review_status": "REVIEWED_AUTOMATICALLY",
  "status": "NON_MALICIOUS",
  "severity": "INFO",
  "share_level": "AMBER",
  "tags": null,
  "description": "another copy",
  "id": "1791017857689049"
}
```