### PR TITLE
[all-in-one] Base implementation for the all-in-one library

### DIFF
--- a/hashing/te-tag-query-python/TETagQuery.py
+++ b/hashing/te-tag-query-python/TETagQuery.py
@@ -1,4 +1,4 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 # ================================================================
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/hashing/te-tag-query-python/all-in-one
+++ b/hashing/te-tag-query-python/all-in-one
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Must be python3
+python3 -m all_in_one_lib.all_in_one "$@"

--- a/hashing/te-tag-query-python/all_in_one_lib/all_in_one.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/all_in_one.py
@@ -1,0 +1,132 @@
+##!/usr/bin/env python
+
+"""
+A wrapper around multi-stage ThreatExchange operations.
+
+Includes simple matching and writing back. Useful for quickly validating new
+sources of ThreatExchange data. A possible template for a native
+implementation in your own architecture.
+
+This helper heavily relies on a config file to provide consistent behavior
+between stages, and a state file to store hashes.
+"""
+
+import argparse
+import os
+import os.path
+import pathlib
+import sys
+import typing as t
+
+import TE
+
+from .collab_config import CollaborationConfig
+from .dataset import Dataset
+from .commands import base, label, match, fetch
+
+
+def get_subcommands() -> t.List[t.Type[base.Command]]:
+    return [label.LabelCommand, match.MatchCommand, fetch.FetchCommand]
+
+
+def get_argparse() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--config",
+        "-c",
+        type=argparse.FileType,
+        help="a ThreatExchange collaboration config",
+    )
+    ap.add_argument(
+        "--app-token",
+        "-a",
+        type=CollaborationConfig.load,
+        metavar="TOKEN",
+        help="the App token for ThreatExchange",
+    )
+    ap.add_argument(
+        "--state-dir",
+        "-s",
+        type=_verify_directory,
+        metavar="DIR",
+        help="the directory with the config state",
+    )
+    subparsers = ap.add_subparsers(title="verbs", help="which action to do")
+    for command in get_subcommands():
+        command.add_command_to_subparser(subparsers)
+
+    return ap
+
+
+def execute_command(namespace) -> None:
+    command_cls = namespace.command_cls
+    try:
+        # Init TE lib
+        init_app_token(namespace.app_token)
+        # Init collab config
+        cfg = init_config_file(namespace.config)
+        # "Init" dataset
+        dataset = Dataset(cfg, namespace.state_dir)
+        command = command_cls.init_from_namespace(namespace)
+        command.execute(dataset)
+    except base.CommandError as ce:
+        print(ce, file=sys.stderr)
+        sys.exit(ce.returncode)
+
+
+def init_app_token(cli_option: str = None) -> None:
+    """Initialize the API key from a variety of fallback sources"""
+
+    file_loc = pathlib.Path("~/.txtoken").expanduser()
+    environment_var = "TX_ACCESS_TOKEN"
+    if cli_option:
+        TE.Net.APP_TOKEN = cli_option
+    elif os.environ.get(environment_var):
+        TE.Net.APP_TOKEN = os.environ[environment_var]
+    elif file_loc.exists() and file_loc.read_text():
+        TE.Net.APP_TOKEN = file_loc.read_text()
+    else:
+        raise base.CommandError(
+            (
+                "Can't find API key - pass as an argument, in the environment as "
+                f"{environment_var} or put it in {file_loc}"
+            ),
+            2,
+        )
+
+
+def init_config_file(cli_provided: t.IO = None) -> CollaborationConfig:
+    """Initialize the collaboration file from a variety of sources"""
+    if cli_provided is not None:
+        return CollaborationConfig.load(cli_provided)
+    path_order = ("te.cfg", "~/te.cfg")
+    for loc in path_order:
+        path = pathlib.Path(loc).expanduser()
+        if path.exists():
+            break
+    else:
+        raise base.CommandError(
+            (
+                "Can't find collaboration config - pass as an argument"
+                f", or in a file named {' or '.join(path_order)}"
+            ),
+            2,
+        )
+    with path.open() as f:
+        return CollaborationConfig.load(f)
+
+
+
+def _verify_directory(raw: str) -> pathlib.Path:
+    ret = pathlib.Path(raw)
+    if ret.exists() and not ret.is_dir():
+        raise argparse.ArgumentTypeError(f"{ret} is a file, not a directory")
+    return ret
+
+
+if __name__ == "__main__":
+    ap = get_argparse()
+    namespace = ap.parse_args()
+    execute_command(namespace)

--- a/hashing/te-tag-query-python/all_in_one_lib/collab_config.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/collab_config.py
@@ -1,10 +1,10 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
 A wrapper around the collaboration config file.
 
 This file controls the behavior of the all-in-one command, and roughly
-corresponds to a single signal sharing usecase.
+corresponds to a single-signal sharing usecase.
 """
 
 import json
@@ -17,6 +17,7 @@ class CollaborationConfig:
     KEY_NAME = "name"
     KEY_PRIVACY_GROUPS = "privacy_groups"
     KEY_LABELS = "labels"
+    KEY_SAMPLE_TAG = "sample_tag"
     KEY_CONTENT_TYPES = "content_types"
 
     def __init__(
@@ -25,11 +26,13 @@ class CollaborationConfig:
         labels: t.Dict[str, t.Any],
         privacy_groups: t.List[int],
         content_types: t.Dict[str, t.Dict[str, t.Any]],
+        sample_tag: t.Optional[str] = None,
     ):
         self.name = name
         self.privacy_groups = privacy_groups
         self.labels = labels
         self.content_types = content_types
+        self.sample_tag = sample_tag
 
     @property
     def default_state_dir_name(self) -> str:
@@ -43,17 +46,30 @@ class CollaborationConfig:
             content[cls.KEY_LABELS],
             content[cls.KEY_PRIVACY_GROUPS],
             content[cls.KEY_CONTENT_TYPES],
+            content.get(cls.KEY_SAMPLE_TAG),
         )
 
     def store(self, filename: str):
         with open(filename, "w") as f:
-            json.dump(
-                {
-                    self.KEY_NAME: self.name,
-                    self.KEY_LABELS: self.labels,
-                    self.KEY_PRIVACY_GROUPS: self.privacy_groups,
-                    self.KEY_CONTENT_TYPES: self.content_types,
-                },
-                f,
-                indent=4,
-            )
+            out = {
+                self.KEY_NAME: self.name,
+                self.KEY_LABELS: self.labels,
+                self.KEY_PRIVACY_GROUPS: self.privacy_groups,
+                self.KEY_CONTENT_TYPES: self.content_types,
+            }
+            if self.sample_tag:
+                out[self.KEY_SAMPLE_TAG] = self.sample_tag
+            json.dump(out, f, indent=4)
+
+    @classmethod
+    def get_example_config(cls) -> "CollabConfig":
+        """
+        Get a config to access the public sample data under media_priority_samples
+        """
+        return cls(
+            name="ThreatExchange Samples",
+            labels={"media_priority_samples": {}},
+            privacy_groups=[],
+            content_types={},
+            sample_tag="media_priority_samples",
+        )

--- a/hashing/te-tag-query-python/all_in_one_lib/collab_config.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/collab_config.py
@@ -1,0 +1,59 @@
+##!/usr/bin/env python
+
+"""
+A wrapper around the collaboration config file.
+
+This file controls the behavior of the all-in-one command, and roughly
+corresponds to a single signal sharing usecase.
+"""
+
+import json
+import re
+import typing as t
+
+
+class CollaborationConfig:
+
+    KEY_NAME = "name"
+    KEY_PRIVACY_GROUPS = "privacy_groups"
+    KEY_LABELS = "labels"
+    KEY_CONTENT_TYPES = "content_types"
+
+    def __init__(
+        self,
+        name: str,
+        labels: t.Dict[str, t.Any],
+        privacy_groups: t.List[int],
+        content_types: t.Dict[str, t.Dict[str, t.Any]],
+    ):
+        self.name = name
+        self.privacy_groups = privacy_groups
+        self.labels = labels
+        self.content_types = content_types
+
+    @property
+    def default_state_dir_name(self) -> str:
+        return re.sub("\W+", "_", self.name.lower())
+
+    @classmethod
+    def load(cls, file: t.IO):
+        content = json.load(file)
+        return cls(
+            content[cls.KEY_NAME],
+            content[cls.KEY_LABELS],
+            content[cls.KEY_PRIVACY_GROUPS],
+            content[cls.KEY_CONTENT_TYPES],
+        )
+
+    def store(self, filename: str):
+        with open(filename, "w") as f:
+            json.dump(
+                {
+                    self.KEY_NAME: self.name,
+                    self.KEY_LABELS: self.labels,
+                    self.KEY_PRIVACY_GROUPS: self.privacy_groups,
+                    self.KEY_CONTENT_TYPES: self.content_types,
+                },
+                f,
+                indent=4,
+            )

--- a/hashing/te-tag-query-python/all_in_one_lib/commands/base.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/commands/base.py
@@ -46,13 +46,13 @@ class Command:
 
     @classmethod
     def init_argparse(cls, argparse: argparse.ArgumentParser) -> None:
-        """Program the command subparser for initFromNamespace"""
-        pass
+        """
+        Program the command subparser for __init__
 
-    @classmethod
-    def init_from_namespace(cls, ns) -> "Command":
-        """Create instance from argparse namespace"""
-        return cls()
+        Your argument names should match the argument names in __init__.
+        Be careful of collisions with the top level arg names from all_in_one.py
+        """
+        pass
 
     @classmethod
     def get_name(cls) -> str:

--- a/hashing/te-tag-query-python/all_in_one_lib/commands/base.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/commands/base.py
@@ -1,0 +1,85 @@
+##!/usr/bin/env python
+
+"""
+Common helpers and libraries for the all-in-one command.
+
+Strongly consider moving classes and functions out of this file if it starts
+to fill up.
+"""
+
+import argparse
+import sys
+import typing as t
+
+from .. import common
+from ..dataset import Dataset
+
+
+class CommandError(Exception):
+    """Wrapper for exceptions which cause return codes"""
+
+    def __init__(self, message: str, returncode: int = 1) -> None:
+        super().__init__(message)
+        self.returncode = returncode
+
+
+class Command:
+    """
+    Simple wrapper around setting up commands for an argparse-based cli.
+    """
+
+    @classmethod
+    def add_command_to_subparser(cls, subparsers) -> None:
+        """
+        Shortcut for adding the command to the parser.
+
+        Propbably don't override.
+        """
+        command_ap = subparsers.add_parser(
+            cls.get_name(),
+            description=cls.get_description(),
+            help=cls.get_help(),
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+        )
+        command_ap.set_defaults(command_cls=cls)
+        cls.init_argparse(command_ap)
+
+    @classmethod
+    def init_argparse(cls, argparse: argparse.ArgumentParser) -> None:
+        """Program the command subparser for initFromNamespace"""
+        pass
+
+    @classmethod
+    def init_from_namespace(cls, ns) -> "Command":
+        """Create instance from argparse namespace"""
+        return cls()
+
+    @classmethod
+    def get_name(cls) -> str:
+        """The display name of the command"""
+        return common.class_name_to_human_name(cls.__name__, "Command").replace(
+            "_", "-"
+        )
+
+    @classmethod
+    def get_description(self) -> str:
+        """The long help of the command"""
+        return self.__doc__
+
+    @classmethod
+    def get_help(cls) -> str:
+        """The short help of the command"""
+        line = cls.get_description().strip().partition("\n")[0]
+        if line[0].isupper():
+            line = line[0].lower() + line[1:]
+        if line[-1] == ".":
+            line = line[:-1]
+        return line
+
+    @staticmethod
+    def stderr(*args, **kwargs) -> None:
+        """Convenience accessor to stderr"""
+        print(*args, file=sys.stderr, **kwargs)
+
+    def execute(self, dataset: Dataset) -> None:
+        raise NotImplementedError

--- a/hashing/te-tag-query-python/all_in_one_lib/commands/fetch.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/commands/fetch.py
@@ -1,0 +1,91 @@
+##!/usr/bin/env python
+
+import argparse
+import collections
+import pathlib
+import typing as t
+import urllib.parse
+
+import TE
+
+from ..collab_config import CollaborationConfig
+from ..content_type import meta
+from ..dataset import Dataset
+from ..descriptor import ThreatDescriptor
+from . import base
+
+
+class FetchCommand(base.Command):
+    """
+    Download content to save time on future matching.
+    """
+
+    @classmethod
+    def init_argparse(cls, ap) -> None:
+        ap.add_argument(
+            "--sample",
+            action="store_true",
+            help="Only fetch a sample of data instead of the whole dataset",
+        )
+
+    @classmethod
+    def init_from_namespace(cls, ns) -> "FetchCommand":
+        return cls(ns.sample)
+
+    def __init__(self, sample: bool) -> None:
+        self.sample = sample
+
+    def execute(self, dataset: Dataset) -> None:
+        signal_types = {clss.get_name(): clss() for clss in meta.get_all_signal_types()}
+
+        counts = collections.Counter()
+
+        for tag_name in dataset.config.labels:
+            tag_id = TE.Net.getTagIDFromName(tag_name)
+            if not tag_id:
+                continue
+            query = _TagQueryFetchCheckpoint(tag_id)
+            while query:
+                descriptors = query.next()
+                for td in descriptors:
+                    descriptor = ThreatDescriptor(
+                        id=int(td["id"]),
+                        raw_indicator=td["raw_indicator"],
+                        indicator_type=td["type"],
+                        owner_id=int(td["owner"]["id"]),
+                        tags=td["tags"] or [],
+                        status=td["status"],
+                        added_on=td["added_on"],
+                    )
+                    for signal_name, signal_type in signal_types.items():
+                        if signal_type.process_descriptor(descriptor):
+                            counts[signal_name] += 1
+                if self.sample:
+                    break
+        if not counts:
+            raise base.CommandError("No items fetched! Something wrong?", returncode=3)
+
+        for signal_name, signal_type in signal_types.items():
+            if signal_name not in counts:
+                continue
+            dataset.store_cache(signal_type)
+            print(f"{signal_name}: {counts[signal_name]}")
+
+
+class _TagQueryFetchCheckpoint:
+    def __init__(self, tag_id: int) -> None:
+        query = urllib.parse.urlencode({"access_token": TE.Net.APP_TOKEN, "limit": 50})
+        self._next_url = f"{TE.Net.TE_BASE_URL}/{tag_id}/tagged_objects/?{query}"
+
+    def __bool__(self) -> bool:
+        return bool(self._next_url)
+
+    def next(self) -> t.Dict[id, t.Any]:
+        response = TE.Net.getJSONFromURL(self._next_url)
+        self._next_url = response.get("paging", {}).get("next")
+        ids = [
+            d["id"] for d in response["data"] if d["type"] == TE.Net.THREAT_DESCRIPTOR
+        ]
+        if not ids:
+            return []
+        return TE.Net.getInfoForIDs(ids)

--- a/hashing/te-tag-query-python/all_in_one_lib/commands/label.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/commands/label.py
@@ -1,0 +1,77 @@
+##!/usr/bin/env python
+
+import typing as t
+
+import TE
+
+from ..collab_config import CollaborationConfig
+from ..content_type import meta, text
+from ..dataset import Dataset
+from . import base
+
+
+class LabelCommand(base.Command):
+    """
+    Apply labels to items in ThreatExchange.
+
+    Examples:
+
+    Label text
+      all-in-one -c te.cfg label violating_label_from_config,other_label text "this is an example bad text"
+
+    Label descriptor
+      all-in-one -c te.cfg label false-positive descriptor 12345
+    """
+
+    FALSE_POSITIVE = "false_positive"
+
+    @classmethod
+    def init_argparse(cls, ap) -> None:
+        ap.add_argument(
+            "labels",
+            type=lambda s: s.strip().split(","),
+            metavar="C  SV",
+            help="labels to apply to item",
+        )
+        ap.add_argument(
+            "content_type", choices=["descriptor"], help="what content type to label"
+        )
+        ap.add_argument("descriptor_id", help="the id of a descriptor to label")
+
+    @classmethod
+    def init_from_namespace(cls, ns) -> "LabelCommand":
+        return cls(ns.descriptor_id, ns.labels)
+
+    def __init__(self, descriptor_id: int, labels: t.List[str]) -> None:
+        self.descriptor_id = descriptor_id
+        self.labels = labels
+        self.false_positive = False
+        # Only use reaction logic if not also adding true positive labels
+        if self.FALSE_POSITIVE in labels:
+            self.labels.remove(self.FALSE_POSITIVE)
+            if not self.labels:
+                self.false_positive = True
+
+    def execute(self, dataset: Dataset) -> None:
+        params = {
+            "descriptor_id": self.descriptor_id,
+            "privacy_type": "HAS_PRIVACY_GROUP",
+            "privacy_members": cfg.privacy_groups,
+        }
+
+        if self.false_positive:
+            params["reactions"] = "DISAGREE_WITH_TAGS"
+        else:
+            params["tags"] = self.labels
+        # TODO: Handle gracefully target doesn't exist
+        # TODO: Handle already labeled (merge don't stomp)
+        err_message, ex, response = TE.Net.copyThreatDescriptor(params, showURLs=True, dryRun=False)
+        if ex:
+            raise ex
+        if err_message:
+            raise base.CommandError(err_message)
+        if not response:
+            raise base.CommandError("Mystery error - empty response")
+
+
+        print(response["descriptor_id"])

--- a/hashing/te-tag-query-python/all_in_one_lib/commands/label.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/commands/label.py
@@ -1,4 +1,8 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
+
+"""
+Label command for uploading opinions (ThreatDescriptors) or reactions.
+"""
 
 import typing as t
 
@@ -15,12 +19,11 @@ class LabelCommand(base.Command):
     Apply labels to items in ThreatExchange.
 
     Examples:
+      # Label text
+      $ all-in-one -c te.cfg label violating_label_from_config,other_label text "this is an example bad text"
 
-    Label text
-      all-in-one -c te.cfg label violating_label_from_config,other_label text "this is an example bad text"
-
-    Label descriptor
-      all-in-one -c te.cfg label false-positive descriptor 12345
+      # Label descriptor
+      $ all-in-one -c te.cfg label false-positive descriptor 12345
     """
 
     FALSE_POSITIVE = "false_positive"
@@ -30,17 +33,10 @@ class LabelCommand(base.Command):
         ap.add_argument(
             "labels",
             type=lambda s: s.strip().split(","),
-            metavar="C  SV",
+            metavar="CSV",
             help="labels to apply to item",
         )
-        ap.add_argument(
-            "content_type", choices=["descriptor"], help="what content type to label"
-        )
         ap.add_argument("descriptor_id", help="the id of a descriptor to label")
-
-    @classmethod
-    def init_from_namespace(cls, ns) -> "LabelCommand":
-        return cls(ns.descriptor_id, ns.labels)
 
     def __init__(self, descriptor_id: int, labels: t.List[str]) -> None:
         self.descriptor_id = descriptor_id
@@ -53,6 +49,8 @@ class LabelCommand(base.Command):
                 self.false_positive = True
 
     def execute(self, dataset: Dataset) -> None:
+        raise NotImplementedError
+        # Everything below is untested and leftover from a previous attempt
         params = {
             "descriptor_id": self.descriptor_id,
             "privacy_type": "HAS_PRIVACY_GROUP",
@@ -60,18 +58,19 @@ class LabelCommand(base.Command):
         }
 
         if self.false_positive:
-            params["reactions"] = "DISAGREE_WITH_TAGS"
+            # TODO reacc
+            raise NotImplementedError
         else:
             params["tags"] = self.labels
         # TODO: Handle gracefully target doesn't exist
         # TODO: Handle already labeled (merge don't stomp)
-        err_message, ex, response = TE.Net.copyThreatDescriptor(params, showURLs=True, dryRun=False)
+        err_message, ex, response = TE.Net.copyThreatDescriptor(
+            params, showURLs=True, dryRun=False
+        )
         if ex:
             raise ex
         if err_message:
             raise base.CommandError(err_message)
         if not response:
             raise base.CommandError("Mystery error - empty response")
-
-
         print(response["descriptor_id"])

--- a/hashing/te-tag-query-python/all_in_one_lib/commands/match.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/commands/match.py
@@ -1,0 +1,139 @@
+##!/usr/bin/env python
+
+import argparse
+import pathlib
+import sys
+import typing as t
+
+from ..content_type import meta
+from ..signal_type.base import FileMatcher, StrMatcher, HashMatcher
+from ..dataset import Dataset
+from . import base, fetch
+
+
+class MatchCommand(base.Command):
+    """
+    Match content to items in ThreatExchange.
+    """
+
+    USE_STDIN = "-"
+
+    @classmethod
+    def init_argparse(cls, ap) -> None:
+
+        ap.add_argument(
+            "content_type",
+            choices=[t.get_name() for t in meta.get_all_content_types()],
+            help="what kind of content to match",
+        )
+
+        ap.add_argument(
+            "--hashes",
+            "-H",
+            action="store_true",
+            help=(
+                "instead of content (i.e. videos), "
+                "input contains intermediate representations (i.e. video MD5s)"
+            ),
+        )
+
+        ap.add_argument(
+            "--as-text",
+            "-T",
+            action="store_true",
+            help="force input to be interpreted as text instead of as filenames",
+        )
+
+        ap.add_argument(
+            "content",
+            nargs="+",
+            help=(
+                "what to match against. Accepts filenames, "
+                "quoted strings, or '-' to read newline-separated stdin"
+            ),
+        )
+
+    @classmethod
+    def init_from_namespace(cls, ns) -> "MatchCommand":
+        return cls(ns.content_type, ns.hashes, ns.as_text, ns.content)
+
+    def __init__(
+        self,
+        content_type: str,
+        input_is_hashes: bool,
+        force_input_to_text: bool,
+        input_: t.List[str],
+    ) -> None:
+        self.content_type = [
+            c for c in meta.get_all_content_types() if c.get_name() == content_type
+        ][0]
+        self.input_generator = self.parse_input(
+            input_, input_is_hashes, force_input_to_text
+        )
+        self.as_hashes = input_is_hashes
+
+    def parse_input(
+        self,
+        input_: t.Iterable[str],
+        input_is_hashes: bool,
+        force_input_to_text: bool,
+        no_stderr=False,
+    ) -> t.Generator[t.Union[str, pathlib.Path], None, None]:
+        def interpret_token(
+            tok: str,
+        ) -> t.Generator[t.Union[str, pathlib.Path], None, None]:
+            if force_input_to_text:
+                return tok
+            path = pathlib.Path(token)
+            if path.exists():
+                return path
+            return tok
+
+        for token in input_:
+            token = token.rstrip()
+            if not no_stderr and token == self.USE_STDIN:
+                yield from self.parse_input(
+                    sys.stdin, input_is_hashes, force_input_to_text, no_stderr=True
+                )
+                continue
+            parsed = interpret_token(token)
+            if input_is_hashes and isinstance(parsed, pathlib.Path):
+                yield from self.parse_input(
+                    parsed.open("r"),
+                    input_is_hashes=True,
+                    force_input_to_text=True,
+                    no_stderr=True,
+                )
+            else:
+                yield parsed
+
+    def execute(self, dataset: Dataset) -> None:
+        if dataset.is_cache_empty:
+            self.stderr("Looks like you are running this for the first time. Fetching some sample data.")
+            fetch.FetchCommand(sample=True).execute(dataset)
+
+        all_signal_types = dataset.load_cache(
+            s() for s in self.content_type.get_signal_types()
+        )
+
+        file_matchers = [s for s in all_signal_types if isinstance(s, FileMatcher)]
+        str_matchers = [s for s in all_signal_types if isinstance(s, StrMatcher)]
+
+        match_str = lambda s, t: s.match(t)
+        if self.as_hashes:
+            match_str = lambda s, t: s.match_hash(t)
+            str_matchers = [s for s in all_signal_types if isinstance(s, HashMatcher)]
+
+        seen = set()
+        for inp in self.input_generator:
+            match_fn = lambda s, t: s.match_file(t)
+            signal_types = file_matchers
+            if isinstance(inp, str):
+                match_fn = match_str
+                signal_types = str_matchers
+
+            for signal_type in signal_types:
+                for match in match_fn(signal_type, inp):
+                    if match.primary_descriptor_id not in seen:
+                        seen.add(match.primary_descriptor_id)
+                        print(match.primary_descriptor_id, signal_type.get_name(), " ".join(match.labels))

--- a/hashing/te-tag-query-python/all_in_one_lib/common.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/common.py
@@ -1,0 +1,27 @@
+##!/usr/bin/env python
+
+"""
+A place to put simple helpers that don't seem like they go anywhere else.
+
+If this file starts getting large, break it up.
+"""
+
+import re
+
+
+def class_name_to_human_name(name: str, suffix: str) -> str:
+    """Helper to make human friendly names using a class name as a template"""
+    if name.endswith(suffix):
+        name = name[:-len(suffix)]
+    return camel_case_to_underscore(name)
+
+
+def camel_case_to_underscore(name: str) -> str:
+    """
+    Convert name in camel-case notation into lowercase+underscore notation.
+
+    For example, AbcXyz will be converted into abc_xyz.
+    TODO: Maybe should live in some kind of common location
+    """
+    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()

--- a/hashing/te-tag-query-python/all_in_one_lib/common.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/common.py
@@ -1,4 +1,4 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
 A place to put simple helpers that don't seem like they go anywhere else.
@@ -10,9 +10,9 @@ import re
 
 
 def class_name_to_human_name(name: str, suffix: str) -> str:
-    """Helper to make human friendly names using a class name as a template"""
+    """Helper to make human-friendly names using a class name as a template"""
     if name.endswith(suffix):
-        name = name[:-len(suffix)]
+        name = name[: -len(suffix)]
     return camel_case_to_underscore(name)
 
 

--- a/hashing/te-tag-query-python/all_in_one_lib/content_type/base.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/content_type/base.py
@@ -1,4 +1,4 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
 Abstraction for different content types.

--- a/hashing/te-tag-query-python/all_in_one_lib/content_type/base.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/content_type/base.py
@@ -1,0 +1,23 @@
+##!/usr/bin/env python
+
+"""
+Abstraction for different content types.
+
+This records all the valid signal types for a piece of content.
+"""
+
+import typing as t
+
+from .. import common
+from ..signal_type import base, raw_text, trend_query, url
+
+
+class ContentType:
+    @classmethod
+    def get_name(cls) -> str:
+        """The human-friendly display name"""
+        return common.class_name_to_human_name(cls.__name__, "Content")
+
+    @classmethod
+    def get_signal_types() -> t.List[t.Type[base.SignalType]]:
+        raise NotImplementedError

--- a/hashing/te-tag-query-python/all_in_one_lib/content_type/meta.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/content_type/meta.py
@@ -1,0 +1,21 @@
+##!/usr/bin/env python
+
+"""
+Stores all the content type implementations for lookup
+"""
+
+import typing as t
+
+from . import base, text, video, photo
+from ..signal_type import base as signal_base
+
+
+def get_all_content_types() -> t.List[t.Type[base.ContentType]]:
+    """Returns all content type implementations for commands"""
+    return [text.TextContent, video.VideoContent, photo.PhotoContent]
+
+
+def get_all_signal_types() -> t.Set[t.Type[signal_base.SignalType]]:
+    """Returns all signal type implementations for commands"""
+    ret = set()
+    return {s for c in get_all_content_types() for s in c.get_signal_types()}

--- a/hashing/te-tag-query-python/all_in_one_lib/content_type/meta.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/content_type/meta.py
@@ -1,4 +1,4 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
 Stores all the content type implementations for lookup
@@ -11,11 +11,11 @@ from ..signal_type import base as signal_base
 
 
 def get_all_content_types() -> t.List[t.Type[base.ContentType]]:
-    """Returns all content type implementations for commands"""
+    """Returns all content_type implementations for commands"""
     return [text.TextContent, video.VideoContent, photo.PhotoContent]
 
 
 def get_all_signal_types() -> t.Set[t.Type[signal_base.SignalType]]:
-    """Returns all signal type implementations for commands"""
+    """Returns all signal_type implementations for commands"""
     ret = set()
     return {s for c in get_all_content_types() for s in c.get_signal_types()}

--- a/hashing/te-tag-query-python/all_in_one_lib/content_type/photo.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/content_type/photo.py
@@ -1,16 +1,27 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
 Wrapper around the video content type.
 """
 import typing as t
 
-from ..signal_type import md5
+from ..signal_type import md5, pdq
 from ..signal_type.base import SignalType
 from .base import ContentType
 
 
 class PhotoContent(ContentType):
+    """
+    Content that contains static visual imagery.
+
+    Examples might be:
+      * jpeg
+      * png
+      * gif (non-animated)
+      * frames from videos
+      * thumbnails of videos
+    """
+
     @classmethod
     def get_signal_types(cls) -> t.List[t.Type[SignalType]]:
-        return [md5.PhotoMD5Signal]
+        return [md5.PhotoMD5Signal, pdq.PdqSignal]

--- a/hashing/te-tag-query-python/all_in_one_lib/content_type/photo.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/content_type/photo.py
@@ -1,0 +1,16 @@
+##!/usr/bin/env python
+
+"""
+Wrapper around the video content type.
+"""
+import typing as t
+
+from ..signal_type import md5
+from ..signal_type.base import SignalType
+from .base import ContentType
+
+
+class PhotoContent(ContentType):
+    @classmethod
+    def get_signal_types(cls) -> t.List[t.Type[SignalType]]:
+        return [md5.PhotoMD5Signal]

--- a/hashing/te-tag-query-python/all_in_one_lib/content_type/text.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/content_type/text.py
@@ -1,4 +1,4 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
 Wrapper around the text content type.
@@ -11,6 +11,16 @@ from .base import ContentType
 
 
 class TextContent(ContentType):
+    """
+    Content that represents static blobs of text.
+
+    Examples might be:
+    * Posts
+    * Profile descriptions
+    * OCR from photos, if the text itself is the dominating element
+      (i.e. a screenshot of a block of text)
+    """
+
     @classmethod
     def get_signal_types(cls) -> t.List[t.Type[SignalType]]:
         return [raw_text.RawTextSignal, trend_query.TrendQuerySignal, url.URLSignal]

--- a/hashing/te-tag-query-python/all_in_one_lib/content_type/text.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/content_type/text.py
@@ -1,0 +1,16 @@
+##!/usr/bin/env python
+
+"""
+Wrapper around the text content type.
+"""
+import typing as t
+
+from ..signal_type import raw_text, trend_query, url
+from ..signal_type.base import SignalType
+from .base import ContentType
+
+
+class TextContent(ContentType):
+    @classmethod
+    def get_signal_types(cls) -> t.List[t.Type[SignalType]]:
+        return [raw_text.RawTextSignal, trend_query.TrendQuerySignal, url.URLSignal]

--- a/hashing/te-tag-query-python/all_in_one_lib/content_type/video.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/content_type/video.py
@@ -1,4 +1,4 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
 Wrapper around the video content type.
@@ -11,6 +11,15 @@ from .base import ContentType
 
 
 class VideoContent(ContentType):
+    """
+    Content representing a sequence of images, giving the illusion of motion.
+
+    Examples might be:
+    * mp4
+    * avi
+    * gif animations
+    """
+
     @classmethod
     def get_signal_types(cls) -> t.List[t.Type[SignalType]]:
         return [md5.VideoMD5Signal, video_tmk_pdqf.VideoTmkPdqfSignal]

--- a/hashing/te-tag-query-python/all_in_one_lib/content_type/video.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/content_type/video.py
@@ -1,0 +1,16 @@
+##!/usr/bin/env python
+
+"""
+Wrapper around the video content type.
+"""
+import typing as t
+
+from ..signal_type import raw_text, trend_query, url, md5, video_tmk_pdqf
+from ..signal_type.base import SignalType
+from .base import ContentType
+
+
+class VideoContent(ContentType):
+    @classmethod
+    def get_signal_types(cls) -> t.List[t.Type[SignalType]]:
+        return [md5.VideoMD5Signal, video_tmk_pdqf.VideoTmkPdqfSignal]

--- a/hashing/te-tag-query-python/all_in_one_lib/dataset.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/dataset.py
@@ -1,4 +1,4 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
 A wrapper around fetching, storing, and recovering the state from TE.
@@ -33,7 +33,7 @@ class Dataset:
     @property
     def is_cache_empty(self) -> bool:
         return not (
-            self.state_dir.exists() and self.state_dir.glob(f"*.{self.EXTENSION}")
+            self.state_dir.exists() and any(self.state_dir.glob(f"*{self.EXTENSION}"))
         )
 
     def clear_cache(self) -> None:

--- a/hashing/te-tag-query-python/all_in_one_lib/dataset.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/dataset.py
@@ -1,0 +1,64 @@
+##!/usr/bin/env python
+
+"""
+A wrapper around fetching, storing, and recovering the state from TE.
+"""
+
+import json
+import pathlib
+import typing as t
+
+import TE
+
+from . import collab_config
+from .content_type import meta
+from .signal_type import base as signal_base
+
+
+class Dataset:
+
+    EXTENSION = ".te"
+
+    def __init__(
+        self,
+        config: collab_config.CollaborationConfig,
+        state_dir: t.Optional[pathlib.Path] = None,
+    ) -> None:
+        self.config = config
+        if state_dir is None:
+            state_dir = pathlib.Path.home() / config.default_state_dir_name
+            assert not state_dir.is_file()
+        self.state_dir = state_dir
+
+    @property
+    def is_cache_empty(self) -> bool:
+        return not (
+            self.state_dir.exists() and self.state_dir.glob(f"*.{self.EXTENSION}")
+        )
+
+    def clear_cache(self) -> None:
+        for p in self.state_dir.iterdir():
+            if p.suffix == self.EXTENSION:
+                p.unlink()
+
+    def _signal_state_file(self, signal_type: signal_base.SignalType) -> pathlib.Path:
+        return self.state_dir / f"{signal_type.get_name()}{self.EXTENSION}"
+
+    def load_cache(
+        self, signal_types: t.Optional[t.Iterable[signal_base.SignalType]] = None
+    ) -> t.List[signal_base.SignalType]:
+        """Load everything in the state directory and initialize signal types"""
+        if signal_types is None:
+            signal_types = [s() for s in meta.get_all_signal_types()]
+        ret = []
+        for signal_type in signal_types:
+            signal_state_file = self._signal_state_file(signal_type)
+            if signal_state_file.exists():
+                signal_type.load(signal_state_file)
+            ret.append(signal_type)
+        return ret
+
+    def store_cache(self, signal_type: signal_base.SignalType) -> None:
+        if not self.state_dir.exists():
+            self.state_dir.mkdir()
+        signal_type.store(self._signal_state_file(signal_type))

--- a/hashing/te-tag-query-python/all_in_one_lib/descriptor.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/descriptor.py
@@ -1,4 +1,8 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
+
+"""
+Wrappers for the json returned by the ThreatExchange API to typed objects.
+"""
 
 import typing as t
 
@@ -71,12 +75,12 @@ class SimpleDescriptorRollup:
         self.labels.union(descriptor.tags)
 
     def as_row(self) -> t.Tuple[int, str, str]:
-        """Simple conversion to csv row"""
+        """Simple conversion to CSV row"""
         return self.first_descriptor_id, self.added_on, " ".join(self.labels)
 
     @classmethod
     def from_row(cls, row: t.Iterable) -> "SimpleDescriptorRollup":
-        """Simple conversion from csv row"""
+        """Simple conversion from CSV row"""
         labels = []
         if row[2]:
             labels = row[2].split(" ")

--- a/hashing/te-tag-query-python/all_in_one_lib/descriptor.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/descriptor.py
@@ -1,0 +1,83 @@
+##!/usr/bin/env python
+
+import typing as t
+
+
+class ThreatDescriptor(t.NamedTuple):
+    """
+    Wrapper around ThreatExchange JSON for a ThreatDescriptor.
+
+    Example:
+    {
+        "id": "3058061737574159"
+        "raw_indicator": "facefacefacefacefacefacefaceface",
+        "type": "HASH_MD5",
+        "owner": {
+            "id": "616912251743987",
+            ...,
+        },
+        "status": "MALICIOUS",
+        "tags": null,
+        "added_on": "2020-07-01T18:31:15+0000"
+        ...
+    }
+    """
+
+    id: int
+    raw_indicator: str
+    indicator_type: str
+    owner_id: int
+    tags: t.List[str]
+    status: str
+    added_on: str
+
+    def to_params(self) -> t.Dict[str, t.Any]:
+        params = dict(self.__dict__)
+        params["type"] = params.pop("indicator_type")
+        if not params["tags"]:
+            del params["tags"]
+        return params
+
+    @property
+    def is_true_positive(self) -> bool:
+        return not self.is_false_positive
+
+    @property
+    def is_false_positive(self) -> bool:
+        return self.status == "NON_MALICIOUS"
+
+
+class SimpleDescriptorRollup:
+    """
+    A simple way to merge opinions on the same indicator.
+
+    This contains all the information needed for simple SignalType state.
+    """
+
+    __slots__ = ["first_descriptor_id", "added_on", "labels"]
+
+    def __init__(
+        self, first_descriptor_id: int, added_on: str, labels: t.Set[str]
+    ) -> None:
+        self.first_descriptor_id = first_descriptor_id
+        self.added_on = added_on  # TODO - convert to int?
+        self.labels = set(labels)
+
+    def merge(self, descriptor: ThreatDescriptor) -> None:
+        self.added_on, self.first_descriptor_id = min(
+            (self.added_on, self.first_descriptor_id),
+            (descriptor.added_on, descriptor.id),
+        )
+        self.labels.union(descriptor.tags)
+
+    def as_row(self) -> t.Tuple[int, str, str]:
+        """Simple conversion to csv row"""
+        return self.first_descriptor_id, self.added_on, " ".join(self.labels)
+
+    @classmethod
+    def from_row(cls, row: t.Iterable) -> "SimpleDescriptorRollup":
+        """Simple conversion from csv row"""
+        labels = []
+        if row[2]:
+            labels = row[2].split(" ")
+        return cls(int(row[0]), row[1], labels)

--- a/hashing/te-tag-query-python/all_in_one_lib/signal_type/base.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/signal_type/base.py
@@ -1,10 +1,7 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
-Abstraction for different signal types.
-
-This helps translates ThreatDescriptors into the correct representation to do
-matching, as well as serialize that representation into a compact form.
+Core abstractions for signal types.
 """
 
 import csv
@@ -29,13 +26,26 @@ class SignalMatch(t.NamedTuple):
 
 
 class SignalType:
+    """
+    Abstraction for different signal types.
+
+    A signal type is an intermediate representation of content that can be used
+    to match against similar or identical content. Sometimes called a "hash"
+    type.
+
+    This class additionally helps translates ThreatDescriptors into the correct
+    representation to do matching, as well as serialize that representation
+    into a compact form.
+    """
+
     @classmethod
     def get_name(cls):
+        """A compact name in lower_with_underscore style (used in filenames)"""
         return common.class_name_to_human_name(cls.__name__, "Signal")
 
     def process_descriptor(self, descriptor: t.Dict[str, t.Any]) -> bool:
         """
-        Add ThreatDescriptor to the state of this type, if it is for this type
+        Add ThreatDescriptor to the state of this type, if it is for this type.
 
         Return true if the true if the descriptor was used.
         """
@@ -145,12 +155,12 @@ class SimpleSignalType(SignalType, HashMatcher):
     def load(self, path: pathlib.Path) -> None:
         self.state.clear()
         csv.field_size_limit(path.stat().st_size)  # dodge field size problems
-        with path.open('r', newline='') as f:
+        with path.open("r", newline="") as f:
             for row in csv.reader(f):
                 self.state[row[0]] = SimpleDescriptorRollup.from_row(row[1:])
 
     def store(self, path: pathlib.Path) -> None:
-        with path.open('w+', newline='') as f:
+        with path.open("w+", newline="") as f:
             writer = csv.writer(f)
             for k, v in self.state.items():
                 writer.writerow((k,) + v.as_row())

--- a/hashing/te-tag-query-python/all_in_one_lib/signal_type/base.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/signal_type/base.py
@@ -1,0 +1,156 @@
+##!/usr/bin/env python
+
+"""
+Abstraction for different signal types.
+
+This helps translates ThreatDescriptors into the correct representation to do
+matching, as well as serialize that representation into a compact form.
+"""
+
+import csv
+import pathlib
+import re
+import typing as t
+
+from .. import common
+from ..descriptor import SimpleDescriptorRollup
+
+
+class SignalMatch(t.NamedTuple):
+    # TODO - Labels probably don't belong here, because we just duplicate storage
+    #        better to have descriptor lookup with the full labels
+    labels: t.Set[str]
+    primary_descriptor_id: int
+    # TODO: Someday, also include the following:
+    # contested: bool
+    # plurality_opinion: t.Tuple(bool, t.Set[str])
+    # highest_action_severity: str
+    # opinions_by_owner: t.Dict[int, MatchOpinion]
+
+
+class SignalType:
+    @classmethod
+    def get_name(cls):
+        return common.class_name_to_human_name(cls.__name__, "Signal")
+
+    def process_descriptor(self, descriptor: t.Dict[str, t.Any]) -> bool:
+        """
+        Add ThreatDescriptor to the state of this type, if it is for this type
+
+        Return true if the true if the descriptor was used.
+        """
+        return False
+
+    def match(self, content: str) -> t.List[SignalMatch]:
+        """
+        Given a string representation of content, return matches.
+
+        You don't need to implement this if it doesn't make sense for your
+        signal type.
+        """
+        raise NotImplementedError
+
+    def match_file(self, file: pathlib.Path) -> t.List[SignalMatch]:
+        """
+        Given a file containing content, return matches.
+        """
+        raise NotImplementedError
+
+    def match_hash(self, hash: str) -> t.List[SignalMatch]:
+        """
+        Given a representation of this SignalType, return matches.
+
+        Example - PDQ distance comparison, or MD5 exact comparison
+        """
+        raise NotImplementedError
+
+    def load(self, path: pathlib.Path) -> None:
+        raise NotImplementedError
+
+    def store(self, path: pathlib.Path) -> None:
+        raise NotImplementedError
+
+
+class HashMatcher:
+    def match_hash(self, hash: str) -> t.List[SignalMatch]:
+        """
+        Given a representation of this SignalType, return matches.
+
+        Example - PDQ distance comparison, or MD5 exact comparison
+        """
+        raise NotImplementedError
+
+
+class FileMatcher:
+    def match_file(self, file: pathlib.Path) -> t.List[SignalMatch]:
+        """
+        Given a file containing content, return matches.
+        """
+        raise NotImplementedError
+
+
+class StrMatcher(FileMatcher):
+    def match(self, content: str) -> t.List[SignalMatch]:
+        """
+        Given a string representation of content, return matches.
+
+        You don't need to implement this if it doesn't make sense for your
+        signal type.
+        """
+        raise NotImplementedError
+
+    def match_file(self, path: pathlib.Path) -> t.List[SignalMatch]:
+        return self.match(path.read_text())
+
+
+class SimpleSignalType(SignalType, HashMatcher):
+    """
+    Dead simple implementation for loading/storing a SignalType.
+
+    Assumes that the signal type can easily merge on a string.
+    """
+
+    INDICATOR_TYPE = ""
+    TYPE_TAG = ""
+
+    def __init__(self) -> None:
+        self.state: t.Dict[str, SimpleDescriptorRollup] = {}
+
+    def process_descriptor(self, descriptor: t.Dict[str, t.Any]) -> bool:
+        """
+        Add ThreatDescriptor to the state of this type, if it is for this type
+
+        Return true if the true if the descriptor was used.
+        """
+        if (
+            descriptor.indicator_type != self.INDICATOR_TYPE
+            or self.TYPE_TAG not in descriptor.tags
+        ):
+            return False
+        old_val = self.state.get(descriptor.raw_indicator)
+        if old_val is None:
+            self.state[descriptor.raw_indicator] = SimpleDescriptorRollup(
+                descriptor.id, descriptor.added_on, descriptor.tags
+            )
+        else:
+            old_val.merge(descriptor)
+        return True
+
+    def match_hash(self, signal_str: str) -> t.List[SignalMatch]:
+        found = self.state.get(signal_str)
+        if found:
+            return [SignalMatch(found.labels, found.first_descriptor_id)]
+        return []
+
+    def load(self, path: pathlib.Path) -> None:
+        self.state.clear()
+        csv.field_size_limit(path.stat().st_size)  # dodge field size problems
+        with path.open('r', newline='') as f:
+            for row in csv.reader(f):
+                self.state[row[0]] = SimpleDescriptorRollup.from_row(row[1:])
+
+    def store(self, path: pathlib.Path) -> None:
+        with path.open('w+', newline='') as f:
+            writer = csv.writer(f)
+            for k, v in self.state.items():
+                writer.writerow((k,) + v.as_row())

--- a/hashing/te-tag-query-python/all_in_one_lib/signal_type/md5.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/signal_type/md5.py
@@ -1,0 +1,34 @@
+##!/usr/bin/env python
+
+"""
+Wrapper around the URL content type.
+"""
+
+import hashlib
+import pathlib
+import typing as t
+
+from ..descriptor import SimpleDescriptorRollup, ThreatDescriptor
+from . import base
+
+
+class VideoMD5Signal(base.SimpleSignalType, base.FileMatcher):
+
+    INDICATOR_TYPE = "HASH_MD5"
+    TYPE_TAG = "media_type_video"
+
+    def match_file(self, file: pathlib.Path) -> t.List[base.SignalMatch]:
+        """Simple MD5 file match."""
+        file_hash = hashlib.md5()
+        blocksize = 8192
+        with file.open('rb') as f:
+            chunk = f.read(blocksize)
+            while chunk:
+                file_hash.update(chunk)
+                chunk = f.read(blocksize)
+        return self.match_hash(file_hash.hexdigest())
+
+
+class PhotoMD5Signal(VideoMD5Signal):
+
+    TYPE_TAG = "media_type_photo"

--- a/hashing/te-tag-query-python/all_in_one_lib/signal_type/md5.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/signal_type/md5.py
@@ -1,7 +1,7 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
-Wrapper around the URL content type.
+Wrapper around the MD5 signal types.
 """
 
 import hashlib
@@ -13,6 +13,16 @@ from . import base
 
 
 class VideoMD5Signal(base.SimpleSignalType, base.FileMatcher):
+    """
+    Simple signal type for Video MD5s.
+
+    Videos are quite expensive to process due to their large size. A simple
+    matching algorithm is to just match against the file MD5, since
+    transcoding is expensive enough that many platforms don't bother doing it.
+
+    Even a single pixel changes will generate a new MD5 - consider formats
+    that are capable of some notion of similarity, such as TMK+PDQF.
+    """
 
     INDICATOR_TYPE = "HASH_MD5"
     TYPE_TAG = "media_type_video"
@@ -21,7 +31,7 @@ class VideoMD5Signal(base.SimpleSignalType, base.FileMatcher):
         """Simple MD5 file match."""
         file_hash = hashlib.md5()
         blocksize = 8192
-        with file.open('rb') as f:
+        with file.open("rb") as f:
             chunk = f.read(blocksize)
             while chunk:
                 file_hash.update(chunk)
@@ -30,5 +40,12 @@ class VideoMD5Signal(base.SimpleSignalType, base.FileMatcher):
 
 
 class PhotoMD5Signal(VideoMD5Signal):
+    """
+    Simple signal type for Photo MD5s.
+
+    Unlike Videos, transcoding of photos is quite common. This should be
+    a format of last resort, as the open source PDQ algorithm will usually
+    have much higher recall without too much loss in precision.
+    """
 
     TYPE_TAG = "media_type_photo"

--- a/hashing/te-tag-query-python/all_in_one_lib/signal_type/pdq.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/signal_type/pdq.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+"""
+Wrapper around the Photo PDQ signal type.
+"""
+
+import typing as t
+
+from ..descriptor import SimpleDescriptorRollup, ThreatDescriptor
+from . import base
+
+
+class PdqSignal(base.SimpleSignalType):
+    """
+    PDQ is an open source photo similarity algorithm.
+
+    Unlike MD5s, which are sensitive to single pixel differences, PDQ has
+    a concept of "distance" and can detect when content is visually similar.
+    This property tends to make it much more effective at finding images that
+    a human would claim are the same, but also opens the door for false
+    positives.
+
+    Which distance to use can differ based on the type of content being
+    searched for. While the PDQ documentation suggests certain thresholds,
+    they can sometimes vary depending on what you are comparing against.
+    """
+
+    INDICATOR_TYPE = "HASH_PDQ"
+    TYPE_TAG = "media_type_photo"
+
+    # TODO at least hash distance functionality

--- a/hashing/te-tag-query-python/all_in_one_lib/signal_type/raw_text.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/signal_type/raw_text.py
@@ -1,0 +1,20 @@
+##!/usr/bin/env python
+
+"""
+Wrapper around the raw text content type.
+"""
+
+import typing as t
+import pathlib
+
+from ..descriptor import SimpleDescriptorRollup, ThreatDescriptor
+from . import base
+
+
+class RawTextSignal(base.SimpleSignalType, base.StrMatcher):
+
+    INDICATOR_TYPE = "DEBUG_STRING"
+    TYPE_TAG = "media_type_text"
+
+    def match(self, content: str) -> t.List[base.SignalMatch]:
+        return self.match_hash(content)

--- a/hashing/te-tag-query-python/all_in_one_lib/signal_type/raw_text.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/signal_type/raw_text.py
@@ -1,7 +1,7 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
-Wrapper around the raw text content type.
+Wrapper around the raw text signal type.
 """
 
 import typing as t
@@ -12,6 +12,13 @@ from . import base
 
 
 class RawTextSignal(base.SimpleSignalType, base.StrMatcher):
+    """
+    Raw text signal is the same as raw text content: the exact text content.
+
+    Unlike other formats like photos or videos, it is difficult to come
+    up with non-reversable hashes of text information which are also effective
+    at detecting similar content.
+    """
 
     INDICATOR_TYPE = "DEBUG_STRING"
     TYPE_TAG = "media_type_text"

--- a/hashing/te-tag-query-python/all_in_one_lib/signal_type/trend_query.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/signal_type/trend_query.py
@@ -1,4 +1,4 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
 Wrapper around the Trend Query (keywords and regexes) content type.
@@ -15,6 +15,9 @@ from . import base
 
 
 class TrendQuery:
+    """
+    A parsed trend query, based on regexes.
+    """
 
     REGEX_PREFIX = "regex-"
 
@@ -44,6 +47,16 @@ class TrendQuery:
 
 
 class TrendQuerySignal(base.SignalType, base.StrMatcher):
+    """
+    Trend Queries are a combination of and/or/not regexes.
+
+    Based off a system effective for grouping content at Facebook, Trend Queries
+    can potentially help you sift though large sets of content to quickly flag
+    ones that might be interesting to you.
+
+    They have high "recall" but potentially low "precision".
+    """
+
     def __init__(self) -> None:
         self.state: t.Dict[str, (TrendQuery, SimpleDescriptorRollup)] = {}
 

--- a/hashing/te-tag-query-python/all_in_one_lib/signal_type/trend_query.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/signal_type/trend_query.py
@@ -1,0 +1,98 @@
+##!/usr/bin/env python
+
+"""
+Wrapper around the Trend Query (keywords and regexes) content type.
+"""
+
+import csv
+import json
+import pathlib
+import re
+import typing as t
+
+from ..descriptor import SimpleDescriptorRollup, ThreatDescriptor
+from . import base
+
+
+class TrendQuery:
+
+    REGEX_PREFIX = "regex-"
+
+    def __init__(self, query_json: t.Dict[str, t.Any]) -> None:
+        self.and_terms: t.List[t.List[re.Pattern]] = [
+            [self._parse_term(t) for t in and_["or"]] for and_ in query_json["and"]
+        ]
+        self.not_terms: t.List[re.Pattern] = [
+            self._parse_term(t) for t in query_json["not"]
+        ]
+
+    def _parse_term(self, t) -> re.Pattern:
+        if t.startswith(self.REGEX_PREFIX):
+            return re.compile(t[len(self.REGEX_PREFIX) + 1 : -1])
+        return re.compile(f"\\b{re.escape(t)}\\b")
+
+    def _match_term(self, t: t.Union[str, re.Pattern], text: str) -> bool:
+        return bool()
+
+    def matches(self, text: str) -> bool:
+        for or_ in self.and_terms:
+            if not any(t.search(text) for t in or_):
+                break
+        else:
+            return not any(t.search(text) for t in self.not_terms)
+        return False
+
+
+class TrendQuerySignal(base.SignalType, base.StrMatcher):
+    def __init__(self) -> None:
+        self.state: t.Dict[str, (TrendQuery, SimpleDescriptorRollup)] = {}
+
+    def process_descriptor(self, descriptor: ThreatDescriptor) -> bool:
+        """
+        Add ThreatDescriptor to the state of this type, if it is for this type
+
+        Return true if the true if the descriptor was used.
+        """
+        if (
+            descriptor.indicator_type != "DEBUG_STRING"
+            or "media_type_trend_query" not in descriptor.tags
+        ):
+            return False
+        old_val = self.state.get(descriptor.raw_indicator)
+        query_json = json.loads(descriptor.raw_indicator)
+
+        if old_val is None:
+            self.state[descriptor.raw_indicator] = (
+                TrendQuery(query_json),
+                SimpleDescriptorRollup(
+                    descriptor.id, descriptor.added_on, descriptor.tags
+                ),
+            )
+        else:
+            old_val[1].merge(descriptor)
+        return True
+
+    def match(self, content: str) -> t.List[base.SignalMatch]:
+        return [
+            base.SignalMatch(rollup.labels, rollup.first_descriptor_id)
+            for query, rollup in self.state.values()
+            if query.matches(content)
+        ]
+
+    def load(self, path: pathlib.Path) -> None:
+        self.state.clear()
+        csv.field_size_limit(path.stat().st_size)  # dodge field size problems
+        with path.open("r", newline="") as f:
+            for row in csv.reader(f, dialect="excel-tab"):
+                raw_indicator = row[0]
+                query_json = json.loads(raw_indicator)
+                self.state[raw_indicator] = (
+                    TrendQuery(query_json),
+                    SimpleDescriptorRollup.from_row(row[1:]),
+                )
+
+    def store(self, path: pathlib.Path) -> None:
+        with path.open("w+", newline="") as f:
+            writer = csv.writer(f, dialect="excel-tab")
+            for k, v in self.state.items():
+                writer.writerow((k,) + v[1].as_row())

--- a/hashing/te-tag-query-python/all_in_one_lib/signal_type/url.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/signal_type/url.py
@@ -1,0 +1,24 @@
+##!/usr/bin/env python
+
+"""
+Wrapper around the URL content type.
+"""
+
+import typing as t
+
+from ..descriptor import SimpleDescriptorRollup, ThreatDescriptor
+from . import base
+
+
+class URLSignal(base.SimpleSignalType, base.StrMatcher):
+
+    INDICATOR_TYPE = "RAW_URI"
+    TYPE_TAG = "media_type_url"
+
+    def match(self, content) -> t.List[base.SignalMatch]:
+        ret = []
+        for word in content.split():
+            found = self.state.get(word)
+            if found:
+                ret.append(base.SignalMatch(found.labels, found.first_descriptor_id))
+        return ret

--- a/hashing/te-tag-query-python/all_in_one_lib/signal_type/url.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/signal_type/url.py
@@ -1,7 +1,7 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
-Wrapper around the URL content type.
+Wrapper around the URL signal type.
 """
 
 import typing as t
@@ -11,7 +11,11 @@ from . import base
 
 
 class URLSignal(base.SimpleSignalType, base.StrMatcher):
+    """
+    Wrapper around URL links, such as https://github.com/
+    """
 
+    # TODO - Also handle URI indicator_type
     INDICATOR_TYPE = "RAW_URI"
     TYPE_TAG = "media_type_url"
 

--- a/hashing/te-tag-query-python/all_in_one_lib/signal_type/video_tmk_pdqf.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/signal_type/video_tmk_pdqf.py
@@ -1,7 +1,7 @@
-##!/usr/bin/env python
+#!/usr/bin/env python
 
 """
-Wrapper around the URL content type.
+Wrapper around the TMK+PDQF signal type.
 """
 
 import typing as t
@@ -11,6 +11,15 @@ from . import base
 
 
 class VideoTmkPdqfSignal(base.SimpleSignalType):
+    """
+    TMK+PDQF is an open-source, constant length hash for videos.
+
+    Video MD5s are a constant length hash, which makes them simple to
+    implement a lookup against an index of hashes, but are sensitive to minor
+    changes in the video content (even a single pixel changed changes the MD5).
+    TMK+PDQF has a notion of "distance" which can be used to tell when content
+    is similar, if not identical.
+    """
 
     INDICATOR_TYPE = "HASH_TMK"
     TYPE_TAG = "media_type_long_hash_video"

--- a/hashing/te-tag-query-python/all_in_one_lib/signal_type/video_tmk_pdqf.py
+++ b/hashing/te-tag-query-python/all_in_one_lib/signal_type/video_tmk_pdqf.py
@@ -1,0 +1,18 @@
+##!/usr/bin/env python
+
+"""
+Wrapper around the URL content type.
+"""
+
+import typing as t
+
+from ..descriptor import SimpleDescriptorRollup, ThreatDescriptor
+from . import base
+
+
+class VideoTmkPdqfSignal(base.SimpleSignalType):
+
+    INDICATOR_TYPE = "HASH_TMK"
+    TYPE_TAG = "media_type_long_hash_video"
+
+    # TODO at least hash distance functionality


### PR DESCRIPTION
Summary:
This is a heroic stab at an attempt to simplify integration to
ThreatExchange collaborations. The primary thesis is that there are
small number of actual decision points to getting the data for a
collaboration and experimenting with it, but that there are enough
nuances (like, anything other than the tag-query API is suspect), that
the cost to actually onboarding is significant.

This commit attempts to remediate that with the following approach:
  1. Encode what encompasses as "collaboration", usually backed by a
     privacy group, into a file that can be distributed instead of
     a bulky pack of documentation with those same conventions.
  2. Provide a fast path for fetching all of the dataset that makes
     up a collaboration.
  3. Provide reference matching implementation in line with the
     conventions commonly used in collaborations.

This allow potentially the following fast path for usage:
```
$ pip install pytx3  # A possible package name I'm considering
$ all-in-one match video --hashes 155976ba876f441fdfa706372a5e21b6
Looks like you are running this for the first time. Fetching some sample
data.
video_tmk_pdqf: 34
trend_query: 50
video_md5: 6
raw_text: 7
2696575617138156 video_md5 media_priority_example
```

This PR is hindered that I have never written anything in open source
python, and though I have experience with py 3.6, I don't have
experience running the various tools (such as those for setting up
testing or typing) outside of Facebook infrastructure context.

Test Plan:
```
$ ./all-in-one -h
usage: all_in_one.py [-h] [--config CONFIG] [--app-token TOKEN]
                     [--state-dir DIR]
                     {label,match,fetch} ...

A wrapper around multi-stage ThreatExchange operations.

Includes simple matching and writing back. Useful for quickly validating new
sources of ThreatExchange data. A possible template for a native
implementation in your own architecture.

This helper heavily relies on a config file to provide consistent behavior
between stages, and a state file to store hashes.

optional arguments:
  -h, --help            show this help message and exit
  --config CONFIG, -c CONFIG
                        a ThreatExchange collaboration config
  --app-token TOKEN, -a TOKEN
                        the App token for ThreatExchange
  --state-dir DIR, -s DIR
                        the directory with the config state

verbs:
  {label,match,fetch}   which action to do
    fetch               download content to save time on future matching
    label               apply labels to items in ThreatExchange
    match               match content to items in ThreatExchange

$ ./all-in-one fetch -h
usage: all_in_one.py fetch [-h] [--sample]

    Download content to save time on future matching.

optional arguments:
  -h, --help  show this help message and exit
  --sample    Only fetch a sample of data instead of the whole dataset

$ ./all-in-one match -h
usage: all_in_one.py match [-h] [--hashes] [--as-text]
                           {text,video,photo} content [content ...]

    Match content to items in ThreatExchange.

positional arguments:
  {text,video,photo}  what kind of content to match
  content             what to match against. Accepts filenames, quoted
                      strings, or '-' to read newline-separated stdin

optional arguments:
  -h, --help          show this help message and exit
  --hashes, -H        instead of content (i.e. videos), input contains
                      intermediate representations (i.e. video MD5s)
  --as-text, -T       force input to be interpreted as text instead of as
                      filenames

$ ./all-in-one label -h
usage: all_in_one.py label [-h] CSV {descriptor} descriptor_id

    Apply labels to items in ThreatExchange.

    Examples:
      # Label text
      $ all-in-one -c te.cfg label
violating_label_from_config,other_label text "this is an example bad
text"

      # Label descriptor
      $ all-in-one -c te.cfg label false-positive descriptor 12345

positional arguments:
  CSV            labels to apply to item
  {descriptor}   what content type to label
  descriptor_id  the id of a descriptor to label

optional arguments:
  -h, --help     show this help message and exit

$ all-in-one match text "bball now? https://developers.facebook.com/docs/threat-exchange/reference/apis/ is a cool api"
Looks like you haven't set up a collaboration config, so using the sample one against public data
Looks like you are running this for the first time. Fetching some sample data.
pdq: 138
trend_query: 1
url: 1
photo_md5: 1
raw_text: 3
video_md5: 2
video_tmk_pdqf: 1
3261912580534814 trend_query media_priority_samples
3697102206986535 url media_priority_samples

$ ./all-in-one fetch --clear
./all-in-one fetch
Looks like you haven't set up a collaboration config, so using the sample one against public data
url: 1
trend_query: 1
video_tmk_pdqf: 1
photo_md5: 1
pdq: 138
raw_text: 3
video_md5: 2

$ all-in-one match video ~/empty_file
Looks like you haven't set up a collaboration config, so using the sample one against public data
3085044528211555 video_md5 media_priority_samples
```