### PR TITLE
Ignore python build artifacts in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 *.pyc
 pytx/build
 pytx/dist
-pytx/pytx.egg-info
 pytx/docs/_build
+pytx3/build/
+pytx3/dist/
+*.egg-info/
 .DS_Store
 .tox/
 .coverage


### PR DESCRIPTION
Summary:

Python build process generates artifacts in the `build/`,
`dist/` and `pytx3.egg-info/` folders that should not be
committed in git.

Test Plan:

```
$ pip install setuptools wheel
$ python setup.py sdist bdist_wheel
$ git status
```

Confirm build artifacts are not being enumerated by git

Reviewers: @Dcallies

Subscribers:

Tasks:

Tags: