### PR TITLE
[pytx3] Fix bug with fetch --sample labels

### DIFF
--- a/pytx3/pytx3/commands/fetch.py
+++ b/pytx3/pytx3/commands/fetch.py
@@ -73,7 +73,7 @@ class FetchCommand(base.Command):
             else:
                 only_first_fetch = True
 
-        for tag_name in dataset.config.labels:
+        for tag_name in tags_to_fetch:
             tag_id = TE.Net.getTagIDFromName(tag_name)
             if not tag_id:
                 continue


### PR DESCRIPTION
Summary:
Sample is supposed to prefer a sample label if provided.
If no label is provided, it only fetches the first 20 items.

I missed a variable :'(

Test Plan:
Used a large dataset from one of our collabs, added a sample tag, then added
enough print()'s to confirm only the sample was being fetched.

Reviewed by: @bodnarbm 