### PR TITLE
[pytx3] Fetch 12x faster with 100x threads

### DIFF
--- a/pytx3/pytx3/signal_type/url.py
+++ b/pytx3/pytx3/signal_type/url.py
@@ -24,5 +24,7 @@ class URLSignal(signal_base.SimpleSignalType, signal_base.StrMatcher):
         for word in content.split():
             found = self.state.get(word)
             if found:
-                ret.append(signal_base.SignalMatch(found.labels, found.first_descriptor_id))
+                ret.append(
+                    signal_base.SignalMatch(found.labels, found.first_descriptor_id)
+                )
         return ret


### PR DESCRIPTION
Summary:
This diff tries to improve fetch speeds by making a lot
of asyncronous requests. I structured it to play nicely with some
kind of sequential descriptor-based checkpointing in the future as
well, which would be able to resume from an error/CTRL+C in the middle
of execution as part of some future diff.

Test Plan:
```
$ time time pytx3 -c ~/large_dataset.te.cfg -s /tmp/fetch_speed fetch
...
video_tmk_pdqf: 15201
photo_md5: 8035
video_md5: 8788
trend_query: 75
pdq: 55157
raw_text: 31757

real    54m37.870s
user    4m7.598s
sys     0m38.539s

$ time time pytx3 -c ~/large_dataset.te.cfg -s /tmp/fetch_speed fetch
...
trend_query: 75
video_tmk_pdqf: 15235
photo_md5: 8035
pdq: 55250
video_md5: 8806
raw_text: 31757

real    4m39.773s
user    4m1.313s
sys     1m0.557s
```

Reviewed by: @bodnarbm 