### PR TITLE
[pytx3] Fetch incrementally & partially + 0.07 Release

### DIFF
--- a/pytx3/pytx3/content_type/meta.py
+++ b/pytx3/pytx3/content_type/meta.py
@@ -4,18 +4,26 @@
 Stores all the content type implementations for lookup
 """
 
+import functools
 import typing as t
 
 from . import content_base, text, video, photo
 from ..signal_type import signal_base
 
 
+@functools.lru_cache(1)
 def get_all_content_types() -> t.List[t.Type[content_base.ContentType]]:
     """Returns all content_type implementations for commands"""
     return [text.TextContent, video.VideoContent, photo.PhotoContent]
 
 
+@functools.lru_cache(1)
 def get_all_signal_types() -> t.Set[t.Type[signal_base.SignalType]]:
     """Returns all signal_type implementations for commands"""
     ret = set()
     return {s for c in get_all_content_types() for s in c.get_signal_types()}
+
+
+@functools.lru_cache(1)
+def get_signal_types_by_name() -> t.Dict[str, signal_base.SignalType]:
+    return {s.get_name(): s for s in get_all_signal_types()}

--- a/pytx3/setup.py
+++ b/pytx3/setup.py
@@ -17,7 +17,7 @@ with open(path.join(here, "DESCRIPTION.rst"), encoding="utf-8") as f:
 
 setup(
     name="pytx3",
-    version="0.0.6",
+    version="0.0.7",
     description="Python Library for Facebook ThreatExchange",
     long_description=long_description,
     author="Facebook",


### PR DESCRIPTION
This is a squash of 3 features:

[Incremental Fetch]

Summary:
This diff switches the update model to allow for
incremental updates instead of fully refetching all data,
which it will save network time.

In practice the cost of writing the gigantic PDQF+TMK files
dominates the actual fetch time at this point, so that's the
next diff.

Test Plan:
```
$ time pytx3 -c ~/medium_sized.te.cfg -s /tmp/fetch_speed fetch --until=1589958000 --full
trend_query: 1
video_tmk_pdqf: 131
photo_md5: 8035
pdq: 30
video_md5: 48
raw_text: 120

real    0m15.033s
user    0m6.256s
sys     0m1.673s

$ time pytx3 -c ~/medium_sized.te.cfg -s /tmp/fetch_speed fetch --until=1589968000
Doing an incremental update - this will miss some updates and deletes.
Use --full to force a refetch.
video_tmk_pdqf: 2
video_md5: 1

real    0m2.433s
user    0m1.578s
sys     0m0.124s

$ time pytx3 -c ~/medium_sized.te.cfg -s /tmp/fetch_speed fetch --until=1689968000
Doing an incremental update - this will miss some updates and deletes.
Use --full to force a refetch.
Processed 21862...
Processed 41329...
Processed 60103...
Processed 84822...
Processed 101735...
trend_query: 74
video_tmk_pdqf: 15105
pdq: 55225
video_md5: 8758
raw_text: 31637

real    4m26.464s
user    3m55.061s
sys     0m58.750s

$ time pytx3 -c ~/medium_sized.te.cfg -s /tmp/fetch_speed fetch --until=1689968001
Doing an incremental update - this will miss some updates and deletes.
Use --full to force a refetch.

real    1m2.752s
user    0m57.150s
sys     0m5.097s

$ time pytx3 -c ~/medium_sized.te.cfg -s /tmp/fetch_speed fetch --until=1589968000
Already up-to-date.

real    0m0.239s
user    0m0.215s
sys     0m0.024s

$ pytx3 -c ~/medium_sized.te.cfg -s /tmp/fetch_speed fetch
It's been a long time since a full fetch, forcing one now.
^C

$ pytx3 -c ~/medium_sized.te.cfg -s /tmp/fetch_speed fetch
--until=1689968000
Doing an incremental update - this will miss some updates and deletes.
Use --full to force a refetch.
^C
```

[pytx3] Allow fetching only selecting signals

Summary:
This diff adds the ability to only fetch certain data
types, which specifically allows avoiding TMK, which reading and
writing the state file is now the majority of incremental updates.

Test Plan:
```
$  pytx3 fetch --help
usage: pytx3 fetch [-h] [--sample] [--clear] [--full]
                   [--until-timestamp UNTIL_TIMESTAMP]
                   [--only-signals signal [signal ...]]
                   [--not-signals signal [signal ...]]

    Download content from ThreatExchange to disk.

    Using the CollaborationConfig, identify ThreatDescriptors that
    correspond to a single collaboration, and store them in the state
    directory.

    You can then use the match command to search against this directory for
    the simple content, or you can use the produced files (which by default
    live in your home directory with a name based on the collaboration, but
    can be overridden with the --state-dir argument) to load into your own
    infrastructure to more efficiently match against the downloaded hashes.

    The exact format of each file is determined by the implementation of the
    signal types, but or usually optimized for easy re-use, such as .csv or
    .tsv.

optional arguments:
  -h, --help            show this help message and exit
  --sample              Only fetch a sample of data instead of the whole
                        dataset
  --clear               Don't fetch anything, just clear the dataset
  --full                Force a full refresh of data.
  --until-timestamp UNTIL_TIMESTAMP
                        Instead of fetching all the data, incrementally fetch
                        up to this time
  --only-signals signal [signal ...], -o signal [signal ...]
                        Only download the specified signal types.
  --not-signals signal [signal ...], -n signal [signal ...]
                        Don't fetch the specified signal types.

$ time pytx3 -c ~/medium_sized.te.cfg -s /tmp/fetch_speed fetch -n video_tmk_pdqf
It's been a long time since a full fetch, forcing one now.
Processed 24984...
Processed 41163...
Processed 58739...
Processed 76650...
Processed 91865...
raw_text: 31757
trend_query: 75
photo_md5: 8035
pdq: 55256
video_md5: 8798

real    2m55.366s
user    2m20.908s
sys     1m0.565s

$ time pytx3 -c ~/medium_sized.te.cfg -s /tmp/fetch_speed fetch -n video_tmk_pdqf
Ignoring some signal types will lead to only part of the dataset being fetched until fixed with --full.
Doing an incremental update - this will miss some updates and deletes.
Use --full to force a refetch.
pdq: 2
video_md5: 13

real    0m3.558s
user    0m2.230s
sys     0m0.263s
$ time pytx3 -c ~/medium_sized.te.cfg -s /tmp/fetch_speed fetch -n video_tmk_pdqf
Ignoring some signal types will lead to only part of the dataset being fetched until fixed with --full.
Doing an incremental update - this will miss some updates and deletes.
Use --full to force a refetch.

real    0m2.492s
user    0m1.831s
sys     0m0.183s

```

[pytx3] Release a new package to test repo

Summary:
Release a new package to the test repo (already done).
This bumps us up to 0.0.7

Test Plan:
```
$ make clean
$ make package
$ make push
```