### PR TITLE
[pytx3] Fix merge conflict bug in fetch

### DIFF
--- a/pytx3/pytx3/cli/fetch.py
+++ b/pytx3/pytx3/cli/fetch.py
@@ -281,6 +281,8 @@ class FetchCommand(command_base.Command):
                             dataset.config.labels,
                         )
                     )
+                while pending_futures:
+                    consume_descriptors(pending_futures)
 
         if fetch_type.is_full and not counts:
             raise command_base.CommandError(


### PR DESCRIPTION
Summary: In a previous stack, I had a nasty conflict that I appear to
have fixed incorrectly. This re-adds the code that drains the rest of
the queue at the end of tagging.

Test Plan: pytx3 fetch, gets data instead of erroring.