### PR TITLE
Adding github action for Go API Example

### DIFF
--- a/.github/workflows/golang-ci.yaml
+++ b/.github/workflows/golang-ci.yaml
@@ -1,0 +1,31 @@
+name: API Reference Examples CI - Go
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'api-reference-examples/go/**'
+    - '.github/workflows/golang-ci.yaml'
+  pull_request:
+    branches:
+    - master
+    paths:
+    - 'api-reference-examples/go/**'
+    - '.github/workflows/golang-ci.yaml'
+
+defaults:
+  run:
+    working-directory: api-reference-examples/go
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: '^1.15.0'
+    - name: Install testify
+      run: go get github.com/stretchr/testify
+    - name: Run tests
+      run: go test ./...

--- a/api-reference-examples/go/threatexchange/threatexchange.go
+++ b/api-reference-examples/go/threatexchange/threatexchange.go
@@ -218,7 +218,7 @@ func (c *Client) query(apiVersion string, resource string, startTime string, end
 		return "", err
 	}
 	if res.Body == nil {
-		return "", fmt.Errorf("Empty body for query :", u.String())
+		return "", fmt.Errorf("Empty body for query : %s", u.String())
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {


### PR DESCRIPTION
This adds a github action to run go tests on the go example in the api-references-example folder. This actually caught an issue with our existing code that is fixed in this PR also.

Test Plan:

Action should run on this PR and we should see a green checkmark when it is completed in the below status checks.