### PR TITLE
[go] fix json unmarshalling for expired_on for ThreatDescriptor

### DIFF
--- a/api-reference-examples/go/threatexchange/threatexchange.go
+++ b/api-reference-examples/go/threatexchange/threatexchange.go
@@ -95,7 +95,7 @@ type ThreatDescriptor struct {
 	ShareLevel   string          `json:"share_level,omitempty"`
 	AddedOn      string          `json:"added_on,omitempty"`
 	Confidence   int             `json:"confidence,omitempty"`
-	ExpiredOn    int             `json:"expired_on,omitempty"`
+	ExpiredOn    string          `json:"expired_on,omitempty"`
 	LastUpdated  string          `json:"last_updated,omitempty"`
 	SourceUri    string          `json:"source_uri,omitempty"`
 }

--- a/api-reference-examples/go/threatexchange/threatexchange_test.go
+++ b/api-reference-examples/go/threatexchange/threatexchange_test.go
@@ -3,12 +3,13 @@ package threatexchange
 
 import (
 	"github.com/stretchr/testify/assert"
+	"os"
 	"testing"
 )
 
-const (
-	appId     = "" // Fill this to make tests run
-	appSecret = "" // Fill this to make tests run
+var (
+	appId     = os.Getenv("TX_APP_ID")     // Set this for integration tests
+	appSecret = os.Getenv("TX_APP_SECRET") // Set this for integration tests
 )
 
 func TestQueryThreatDescriptorsOfIpsProxy(t *testing.T) {


### PR DESCRIPTION
Facebook graph returns date by default in a string representation
using the ISO-8601 format. For now, we can fix unmarshalling the json
by using a string instead of an int.

Fixes #196

Test Plan:

Tested this locally by setting the environment variables TX_APP_ID and TX_APP_SECRET for a test application and then executed the following in the go implementation folder

```
$ go test -v -run TestQueryThreatDescriptorsOfIpsProxy
=== RUN   TestQueryThreatDescriptorsOfIpsProxy
--- PASS: TestQueryThreatDescriptorsOfIpsProxy (0.77s)
=== RUN   TestQueryThreatDescriptorsOfIpsProxyByFBAdminOwner
--- PASS: TestQueryThreatDescriptorsOfIpsProxyByFBAdminOwner (1.19s)
PASS
ok      _/Users/bodnarbm/github/ThreatExchange/api-reference-examples/go/threatexchange 2.116s
```

