### PR TITLE
Add READMEs for old hashing locations to redirect viewers to new folders

### DIFF
--- a/hashing/pdq/README.md
+++ b/hashing/pdq/README.md
@@ -1,0 +1,3 @@
+# PDQ reference implementation moved
+
+The reference implementations for PDQ have moved to [the pdq folder at the repo's root](../../pdq).

--- a/hashing/tmk/README.md
+++ b/hashing/tmk/README.md
@@ -1,0 +1,3 @@
+# TMK (for Temporal Match Kernel) reference implementation
+
+The reference implementation for TMK has moved to [the tmk folder at the repo's root](../../tmk).


### PR DESCRIPTION
There are a number of external links that deep linked to both the old
pdq and tmk folders within the hashing folder. These include links in
academic papers and in news articles regarding the initial opensourcing
of PDQ and TMK.

Adding some simple README files should prevent viewers getting GitHub
404 pages when trying to go to those locations within the new directory
structure.