### PR TITLE
Create initial pytx3 ci with lint check

### DIFF
--- a/.github/workflows/pytx3-ci.yaml
+++ b/.github/workflows/pytx3-ci.yaml
@@ -1,0 +1,34 @@
+name: pytx3 CI
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "pytx3/**"
+      - ".github/workflows/pytx3-ci.yaml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "pytx3/**"
+      - ".github/workflows/pytx3-ci.yaml"
+
+defaults:
+  run:
+    working-directory: pytx3
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install black
+      - name: Check code format
+        run: |
+          black --check .

--- a/pytx3/CONTRIBUTING.md
+++ b/pytx3/CONTRIBUTING.md
@@ -21,6 +21,18 @@ messages and update documentation accordingly (see the next section).
 
 [wf]: https://github.com/erlang/otp/wiki/Writing-good-commit-messages
 
+### Code Style
+pytx3 uses [black](https://pypi.org/project/black/) for consistent formatting across
+the projects python source files. After installing black locally, you can automatically
+format all the pytx3 files by running the following command from the repository root.
+
+```shell
+black ./pytx3/
+```
+
+Additionally, your IDE may have support for automatically re-formatting your source files
+using black through your IDE settings.
+
 ### Running Tests
 pytx3 is a bit short on tests, but you could help fix that.
 To run the tests `make test`


### PR DESCRIPTION
For fast feedback when submitting PRs, we will want to create a full
CI suite to run on changes for pytx3. To get started, this merely
runs the code through the black code formatter's check function.