### PR TITLE
Add testing to pytx3 ci

### DIFF
--- a/.github/workflows/pytx3-ci.yaml
+++ b/.github/workflows/pytx3-ci.yaml
@@ -32,3 +32,17 @@ jobs:
       - name: Check code format
         run: |
           black --check .
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+      - name: Test with pytest
+        run: |
+          py.test

--- a/pytx3/.gitignore
+++ b/pytx3/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 build/
 dist/
 pytx3.egg-info/
+.eggs/

--- a/pytx3/Makefile
+++ b/pytx3/Makefile
@@ -5,7 +5,10 @@ package:
 	python3 ./setup.py sdist bdist_wheel
 
 local_install:
-	python3 -m pip install -e .
+	python3 -m pip install -e .[all]
+
+test:
+	python3 -m pytest
 
 push:
 	python3 -m twine upload --repository testpypi dist/*
@@ -17,4 +20,4 @@ clean:
 	find . -name '__pycache__' -delete
 
 
-.PHONY: all clean package local_install push clean
+.PHONY: all clean package local_install test push clean

--- a/pytx3/setup.py
+++ b/pytx3/setup.py
@@ -15,6 +15,12 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 with open(path.join(here, "DESCRIPTION.rst"), encoding="utf-8") as f:
     description = f.read()
 
+extras_require = {}
+
+extras_require["test"] = ["pytest"]
+extras_require["lint"] = ["black"]
+extras_require["all"] = sorted(set(sum(extras_require.values(), [])))
+
 setup(
     name="pytx3",
     version="0.0.8",
@@ -36,5 +42,6 @@ setup(
     install_requires=[
         "python-Levenshtein",
     ],
+    extras_require=extras_require,
     entry_points={"console_scripts": ["pytx3 = pytx3.cli.main:main"]},
 )

--- a/pytx3/tests/test_common.py
+++ b/pytx3/tests/test_common.py
@@ -1,0 +1,8 @@
+import unittest
+
+import pytx3.common
+
+
+class TestCommon(unittest.TestCase):
+    def test_camel_case_to_underscore(self):
+        assert pytx3.common.camel_case_to_underscore("AbcXyz") == "abc_xyz"


### PR DESCRIPTION
Adds basic test running using pytest to the pr ci builds for pytx3.
Additionally adds a very basic test to give the ci something to run as a starting point.