### PR TITLE
Support Python 3.6 and 3.7 in CI tests

### DIFF
--- a/.github/workflows/pytx3-ci.yaml
+++ b/.github/workflows/pytx3-ci.yaml
@@ -34,11 +34,15 @@ jobs:
           black --check .
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Currently our CI tests run only against python 3.8. This adds
support for running CI tests with Python 3.6 and 3.7 also. (Python
3.6 being the lowest we state we support for pytx3).