### PR TITLE
Create PDQ Hash Index using Multi-Index Hashing

### DIFF
--- a/pytx3/tests/hashing/test_pdq_faiss_matcher.py
+++ b/pytx3/tests/hashing/test_pdq_faiss_matcher.py
@@ -1,6 +1,5 @@
 import unittest
 import binascii
-import faiss
 
 from pytx3.hashing.pdq_faiss_matcher import PDQFlatHashIndex, PDQMultiHashIndex
 

--- a/pytx3/tests/hashing/test_pdq_faiss_matcher.py
+++ b/pytx3/tests/hashing/test_pdq_faiss_matcher.py
@@ -1,69 +1,102 @@
 import unittest
 import binascii
+import faiss
 
-import pytx3.hashing.pdq_faiss_matcher
+from pytx3.hashing.pdq_faiss_matcher import PDQFlatHashIndex, PDQMultiHashIndex
+
+test_hashes = [
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "000000000000000000000000000000000000000000000000000000000000ffff",
+    "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f",
+    "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
+    "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+]
 
 
-class TestPDQFlatHashIndex(unittest.TestCase):
+class MixinTests:
+    class PDQHashIndexSearchCommonTests(unittest.TestCase):
+        index = None
 
-    test_hashes = [
-        "0000000000000000000000000000000000000000000000000000000000000000",
-        "000000000000000000000000000000000000000000000000000000000000ffff",
-        "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f",
-        "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
-        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-    ]
+        def assertEqualPDQHashSearchResults(self, result, expected):
+            self.assertEqual(
+                len(result), len(expected), "search results not of expected length"
+            )
+            for (r, e) in zip(result, expected):
+                self.assertCountEqual(r, e)
 
+        def test_search_index_for_exact_matches(self):
+            query = test_hashes[:1]
+            result = self.index.search(query, 0)
+            self.assertEqualPDQHashSearchResults(result, [[q] for q in query])
+
+        def test_search_index_for_near_matches(self):
+            query = test_hashes[:1]
+            result = self.index.search(query, 16)
+            self.assertEqualPDQHashSearchResults(result, [test_hashes[:2]])
+
+        def test_search_index_for_far_match(self):
+            query = test_hashes[:1]
+            result = self.index.search(query, 128)
+            self.assertEqualPDQHashSearchResults(result, [test_hashes[:-1]])
+
+        def test_search_index_multiple_queries(self):
+            query = test_hashes
+            result = self.index.search(query, 0)
+            self.assertEqualPDQHashSearchResults(result, [[h] for h in test_hashes])
+
+        def test_search_index_with_no_match(self):
+            query = ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+            result = self.index.search(query, 0)
+            self.assertEqualPDQHashSearchResults(result, [[]])
+
+        def test_search_index_with_multiple_no_matches(self):
+            query = [
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            ]
+            result = self.index.search(query, 0)
+            self.assertEqualPDQHashSearchResults(result, [[], []])
+
+        def test_search_index_with_multiple_mixed_results(self):
+            query = [
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                test_hashes[-1],
+            ]
+            result = self.index.search(query, 0)
+            self.assertEqualPDQHashSearchResults(result, [[], [], [test_hashes[-1]]])
+
+
+class TestPDQFlatHashIndex(MixinTests.PDQHashIndexSearchCommonTests, unittest.TestCase):
     def setUp(self):
-        self.index = pytx3.hashing.pdq_faiss_matcher.PDQFlatHashIndex.create(
-            self.test_hashes
-        )
+        self.index = PDQFlatHashIndex.create(test_hashes)
 
     def test_create_faiss_index_from_hashes(self):
-        hashes_as_bytes = [binascii.unhexlify(h) for h in self.test_hashes]
+        assert type(self.index) is PDQFlatHashIndex
+        hashes_as_bytes = [binascii.unhexlify(h) for h in test_hashes]
 
         assert self.index.faiss_index is not None
-        assert self.index.faiss_index.ntotal == len(self.test_hashes)
+        assert self.index.faiss_index.ntotal == len(test_hashes)
 
         assert self.index.dataset_hashes is not None
         assert self.index.dataset_hashes == hashes_as_bytes
 
-    def test_search_index_for_exact_matches(self):
-        query = self.test_hashes[:1]
-        result = self.index.search(query, 0)
-        assert result == [[q] for q in query]
 
-    def test_search_index_for_near_matches(self):
-        query = self.test_hashes[:1]
-        result = self.index.search(query, 16)
-        assert result == [self.test_hashes[:2]]
+class TestPDQMultiHashIndex(
+    MixinTests.PDQHashIndexSearchCommonTests, unittest.TestCase
+):
+    def setUp(self):
+        self.index = PDQMultiHashIndex.create(test_hashes)
 
-    def test_search_index_multiple_queries(self):
-        query = self.test_hashes
-        result = self.index.search(query, 0)
-        assert result == [[h] for h in self.test_hashes]
+    def test_create_faiss_index_from_hashes(self):
+        assert type(self.index) is PDQMultiHashIndex
+        hashes_as_bytes = [binascii.unhexlify(h) for h in test_hashes]
 
-    def test_search_index_with_no_match(self):
-        query = ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
-        result = self.index.search(query, 0)
-        assert result == [[]]
+        assert self.index.faiss_index is not None
+        assert self.index.faiss_index.ntotal == len(test_hashes)
 
-    def test_search_index_with_multiple_no_matches(self):
-        query = [
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        ]
-        result = self.index.search(query, 0)
-        assert result == [[], []]
-
-    def test_search_index_with_multiple_mixed_results(self):
-        query = [
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            self.test_hashes[-1],
-        ]
-        result = self.index.search(query, 0)
-        assert result == [[], [], [self.test_hashes[-1]]]
+        assert self.index.dataset_hashes is not None
+        assert self.index.dataset_hashes == hashes_as_bytes
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
========

Creates a PDQMultiHashIndex that uses the faiss IndexBinaryMultiHash
class. This will use Multi-Index Hashing for searches on hashes, which
should provide for optimistically sub-linear hash lookups.

Test Plan
=========

Create additional unit tests to cover this new class, and run locally with

```shell
$ py.test
```
