### PR TITLE
Initial benchmark script for comparing run times for faiss pdq matchers

### DIFF
--- a/pytx3/benchmarks/benchmark_pdq_faiss_matchers.py
+++ b/pytx3/benchmarks/benchmark_pdq_faiss_matchers.py
@@ -1,3 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
 import argparse
 import binascii
 import os

--- a/pytx3/benchmarks/benchmark_pdq_faiss_matchers.py
+++ b/pytx3/benchmarks/benchmark_pdq_faiss_matchers.py
@@ -1,0 +1,200 @@
+import argparse
+import binascii
+import os
+import time
+import warnings
+
+import numpy
+import faiss
+
+from pytx3.hashing.pdq_faiss_matcher import (
+    PDQFlatHashIndex,
+    PDQMultiHashIndex,
+    BITS_IN_PDQ,
+)
+
+parser = argparse.ArgumentParser(
+    description="Run basic benchmarks comparing PDQHashIndex implementations using faiss",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+
+parser.add_argument(
+    "--faiss-threads",
+    type=int,
+    default=1,
+    help="number of threads for faiss to use while searching",
+)
+parser.add_argument(
+    "--dataset-size",
+    type=int,
+    default=250000,
+    help="number of hashes to generate for the dataset to search against",
+)
+parser.add_argument(
+    "--num-queries",
+    type=int,
+    default=1000,
+    help="number of queries to generate for each search",
+)
+parser.add_argument(
+    "--thresholds",
+    type=int,
+    default=[0, 15, 31, 47],
+    choices=range(256),
+    nargs="+",
+    metavar="THRESHOLDS",
+    help="PDQ similarity threshold values to benchmark with",
+)
+parser.add_argument("--seed", type=int, help="seed for random number generator")
+
+args = parser.parse_args()
+
+######
+# Print Benchmark Settings
+######
+
+print("Benchmark: PDQ Faiss Matcher Comparison")
+print("")
+print("Options:")
+for arg in vars(args):
+    print("\t", arg, ": ", getattr(args, arg))
+print("")
+
+######
+# Set up environment and helpers
+######
+
+faiss.omp_set_num_threads(args.faiss_threads)
+seed = args.seed if args.seed else time.time_ns()
+rng = numpy.random.default_rng(seed)
+if args.seed is None:
+    print("using random seed of ", seed)
+    print("use --seed ", seed, " to rerun with same random values")
+    print("")
+
+
+def generate_random_hash():
+    """
+    returns a random 256 bit PDQ hash as a hexstring of 64 characters
+    """
+    hash_bytes = rng.bytes(BITS_IN_PDQ // 8)
+    return binascii.hexlify(hash_bytes).decode()
+
+
+def generate_random_distance_mask(hamming_distance):
+    """
+    returns a random numpy array of uint8s that can be used as bitwise mask
+    to generate a hash with the given hamming distance
+    """
+    ones = numpy.ones(hamming_distance, dtype=numpy.uint8)
+    bitmask = numpy.pad(
+        ones, (0, BITS_IN_PDQ - hamming_distance), "constant", constant_values=0
+    )
+    return numpy.packbits(rng.permutation(bitmask))
+
+
+def generate_random_hash_with_hamming_distance(original_hash, desired_hamming_distance):
+    """
+    returns a random 256 bit PDQ hash as a hexstring of 64 characters that is the given
+    hamming distance from the provided original hash
+    """
+    original_hash_bytes = numpy.frombuffer(
+        binascii.unhexlify(original_hash), dtype=numpy.uint8
+    )
+    mask = generate_random_distance_mask(desired_hamming_distance)
+    new_hash_bytes = numpy.bitwise_xor(original_hash_bytes, mask).tobytes()
+    return binascii.hexlify(new_hash_bytes).decode()
+
+
+######
+# Generate Random Dataset and Build Indexes
+######
+
+dataset = [generate_random_hash() for _ in range(args.dataset_size)]
+
+start_build_flat_hash_index = time.time()
+flat_index = PDQFlatHashIndex.create(dataset)
+end_build_flat_hash_index = time.time()
+
+start_build_multi_hash_index = time.time()
+multi_index = PDQMultiHashIndex.create(dataset)
+end_build_multi_hash_index = time.time()
+
+print("Building Stats:")
+
+print(
+    "\tPDQFlatHashIndex: time to build (s): ",
+    end_build_flat_hash_index - start_build_flat_hash_index,
+)
+print(
+    "\tPDQMultiHashIndex: time to build (s): ",
+    end_build_multi_hash_index - start_build_multi_hash_index,
+)
+print("")
+
+######
+# Run benchmarks for each requested search threshold
+######
+for threshold in args.thresholds:
+    print("Benchmarks for threshold: ", threshold)
+
+    # Create queries with hamming distance of threshold compared to their search targets
+    search_targets = rng.choice(dataset, size=args.num_queries)
+    queries = [
+        generate_random_hash_with_hamming_distance(target, threshold)
+        for target in search_targets
+    ]
+
+    # Benchmark Searching Indexes
+    start_flat_search = time.time()
+    flat_results = flat_index.search(queries, threshold)
+    end_flat_search = time.time()
+
+    start_multi_search = time.time()
+    multi_results = multi_index.search(queries, threshold)
+    end_multi_search = time.time()
+
+    def count_targets_found(targets, queries, results):
+        """
+        Checks that each element of the provided search results list contains
+        the associated target for that query, warning if it does not.
+
+        Returns the number of targets that were found in their corresponding
+        results
+        """
+        found_targets = 0
+        for target, query, result in zip(targets, queries, results):
+            if target not in result:
+                print(
+                    "Query missed target in result: query=",
+                    query,
+                    "target=",
+                    target,
+                    "result=",
+                    result,
+                )
+            else:
+                found_targets += 1
+        return found_targets
+
+    flat_found_targets = count_targets_found(search_targets, queries, flat_results)
+    multi_found_targets = count_targets_found(search_targets, queries, multi_results)
+
+    print(
+        "\tPDQFlatHashIndex - Total Time to search  (s): ",
+        end_flat_search - start_flat_search,
+    )
+    print(
+        "\tPDQMultiHashIndex - Total Time to search  (s): ",
+        end_multi_search - start_multi_search,
+    )
+    print(
+        "\tPDQFlatHashIndex - Precent of targets found: ",
+        flat_found_targets / len(queries) * 100,
+    )
+    print(
+        "\tPDQMultiHashIndex - Precent of targets found: ",
+        multi_found_targets / len(queries) * 100,
+    )
+
+    print("")


### PR DESCRIPTION
Summary
=======

An initial simple benchmark for comparing the runtimes of the flat and
multi-index hashing versions of the faiss pdq matchers.

Test Plan
=========

From within the pytx3 folder, and with all dependencies installed (including the 'faiss' extra)

```shell
> python3 benchmarks/benchmark_pdq_faiss_matchers.py
Benchmark: PDQ Faiss Matcher Comparison

Options:
	 faiss_threads :  1
	 dataset_size :  250000
	 num_queries :  1000
	 thresholds :  [0, 15, 31, 47]
	 seed :  None

using random seed of  1603988652838031000
use --seed  1603988652838031000  to rerun with same random values

Building Stats:
	PDQFlatHashIndex: time to build (s):  0.28624796867370605
	PDQMultiHashIndex: time to build (s):  2.1199889183044434

Benchmarks for threshold:  0
	PDQFlatHashIndex - Total Time to search  (s):  0.6399660110473633
	PDQMultiHashIndex - Total Time to search  (s):  0.034684181213378906
	PDQFlatHashIndex - Precent of targets found:  100.0
	PDQMultiHashIndex - Precent of targets found:  100.0

Benchmarks for threshold:  15
	PDQFlatHashIndex - Total Time to search  (s):  0.6072051525115967
	PDQMultiHashIndex - Total Time to search  (s):  0.018383026123046875
	PDQFlatHashIndex - Precent of targets found:  100.0
	PDQMultiHashIndex - Precent of targets found:  100.0

Benchmarks for threshold:  31
	PDQFlatHashIndex - Total Time to search  (s):  0.5946729183197021
	PDQMultiHashIndex - Total Time to search  (s):  0.5259621143341064
	PDQFlatHashIndex - Precent of targets found:  100.0
	PDQMultiHashIndex - Precent of targets found:  100.0

Benchmarks for threshold:  47
	PDQFlatHashIndex - Total Time to search  (s):  0.5699150562286377
	PDQMultiHashIndex - Total Time to search  (s):  2.919827938079834
	PDQFlatHashIndex - Precent of targets found:  100.0
	PDQMultiHashIndex - Precent of targets found:  100.0
```
