### PR TITLE
Add pickle support to pdq hash indexes

### DIFF
--- a/pytx3/pytx3/hashing/pdq_faiss_matcher.py
+++ b/pytx3/pytx3/hashing/pdq_faiss_matcher.py
@@ -57,6 +57,12 @@ class PDQHashIndex(ABC):
             for i in range(len(query_vectors))
         ]
 
+    def __getstate__(self):
+        return faiss.serialize_index_binary(self.faiss_index)
+
+    def __setstate__(self, data):
+        self.faiss_index = faiss.deserialize_index_binary(data)
+
 
 class PDQFlatHashIndex(PDQHashIndex):
     """

--- a/pytx3/pytx3/hashing/pdq_faiss_matcher.py
+++ b/pytx3/pytx3/hashing/pdq_faiss_matcher.py
@@ -11,12 +11,17 @@ PDQ_HASH_TYPE = t.Union[str, bytes]
 
 class PDQHashIndex(ABC):
     @abstractmethod
-    def __init__(
-        self, faiss_index: faiss.IndexBinary, dataset_hashes: t.Sequence[bytes]
-    ) -> None:
+    def __init__(self, faiss_index: faiss.IndexBinary) -> None:
         self.faiss_index = faiss_index
-        self.dataset_hashes = dataset_hashes
         super().__init__()
+
+    @abstractmethod
+    def hash_at(self, idx: int):
+        """
+        Returns the hash located at the given index. The index order is determined by the initial order of hashes used to
+        create this index.
+        """
+        pass
 
     def search(self, queries: t.Sequence[PDQ_HASH_TYPE], threshhold: int):
         """
@@ -48,10 +53,7 @@ class PDQHashIndex(ABC):
         qs = numpy.array(query_vectors)
         limits, _, I = self.faiss_index.range_search(qs, threshhold + 1)
         return [
-            [
-                binascii.hexlify(self.dataset_hashes[idx]).decode()
-                for idx in I[limits[i] : limits[i + 1]]
-            ]
+            [self.hash_at(idx.item()) for idx in I[limits[i] : limits[i + 1]]]
             for i in range(len(query_vectors))
         ]
 
@@ -64,10 +66,8 @@ class PDQFlatHashIndex(PDQHashIndex):
     performant when using larger thresholds for PDQ similarity.
     """
 
-    def __init__(
-        self, faiss_index: faiss.IndexBinaryFlat, dataset_hashes: t.Sequence[bytes]
-    ):
-        super().__init__(faiss_index, dataset_hashes)
+    def __init__(self, faiss_index: faiss.IndexBinaryFlat):
+        super().__init__(faiss_index)
 
     @staticmethod
     def create(hashes: t.Iterable[PDQ_HASH_TYPE]) -> "PDQFlatHashIndex":
@@ -80,7 +80,11 @@ class PDQFlatHashIndex(PDQHashIndex):
         )
         index = faiss.index_binary_factory(BITS_IN_PDQ, "BFlat")
         index.add(numpy.array(vectors))
-        return PDQFlatHashIndex(index, hash_bytes)
+        return PDQFlatHashIndex(index)
+
+    def hash_at(self, idx: int):
+        vector = self.faiss_index.reconstruct(idx)
+        return binascii.hexlify(vector.tobytes()).decode()
 
 
 class PDQMultiHashIndex(PDQHashIndex):
@@ -91,10 +95,8 @@ class PDQMultiHashIndex(PDQHashIndex):
     IndexBinaryMultiHash binary index.
     """
 
-    def __init__(
-        self, faiss_index: faiss.IndexBinaryMultiHash, dataset_hashes: t.Sequence[bytes]
-    ):
-        super().__init__(faiss_index, dataset_hashes)
+    def __init__(self, faiss_index: faiss.IndexBinaryMultiHash):
+        super().__init__(faiss_index)
 
     @staticmethod
     def create(
@@ -122,8 +124,12 @@ class PDQMultiHashIndex(PDQHashIndex):
         bits_per_hashmap = BITS_IN_PDQ // nhash
         index = faiss.IndexBinaryMultiHash(BITS_IN_PDQ, nhash, bits_per_hashmap)
         index.add(numpy.array(vectors))
-        return PDQMultiHashIndex(index, hash_bytes)
+        return PDQMultiHashIndex(index)
 
     def search(self, queries: t.Sequence[PDQ_HASH_TYPE], threshhold: int):
         self.faiss_index.nflip = threshhold // self.faiss_index.nhash
         return super().search(queries, threshhold)
+
+    def hash_at(self, idx: int):
+        vector = self.faiss_index.storage.reconstruct(idx)
+        return binascii.hexlify(vector.tobytes()).decode()

--- a/pytx3/tests/hashing/test_pdq_faiss_matcher.py
+++ b/pytx3/tests/hashing/test_pdq_faiss_matcher.py
@@ -1,5 +1,6 @@
 import unittest
 import binascii
+import pickle
 
 from pytx3.hashing.pdq_faiss_matcher import PDQFlatHashIndex, PDQMultiHashIndex
 
@@ -81,11 +82,43 @@ class TestPDQFlatHashIndex(MixinTests.PDQHashIndexSearchCommonTests, unittest.Te
         assert self.index.faiss_index.ntotal == len(test_hashes)
 
 
+class TestReserializedPDQFlatHashIndex(
+    MixinTests.PDQHashIndexSearchCommonTests, unittest.TestCase
+):
+    def setUp(self):
+        original_index = PDQFlatHashIndex.create(test_hashes)
+        index_copy = pickle.loads(pickle.dumps(original_index))
+        self.index = index_copy
+
+    def test_create_faiss_index_from_hashes(self):
+        assert type(self.index) is PDQFlatHashIndex
+        hashes_as_bytes = [binascii.unhexlify(h) for h in test_hashes]
+
+        assert self.index.faiss_index is not None
+        assert self.index.faiss_index.ntotal == len(test_hashes)
+
+
 class TestPDQMultiHashIndex(
     MixinTests.PDQHashIndexSearchCommonTests, unittest.TestCase
 ):
     def setUp(self):
         self.index = PDQMultiHashIndex.create(test_hashes)
+
+    def test_create_faiss_index_from_hashes(self):
+        assert type(self.index) is PDQMultiHashIndex
+        hashes_as_bytes = [binascii.unhexlify(h) for h in test_hashes]
+
+        assert self.index.faiss_index is not None
+        assert self.index.faiss_index.ntotal == len(test_hashes)
+
+
+class TestReserializedPDQMultiHashIndex(
+    MixinTests.PDQHashIndexSearchCommonTests, unittest.TestCase
+):
+    def setUp(self):
+        original_index = PDQMultiHashIndex.create(test_hashes)
+        index_copy = pickle.loads(pickle.dumps(original_index))
+        self.index = index_copy
 
     def test_create_faiss_index_from_hashes(self):
         assert type(self.index) is PDQMultiHashIndex

--- a/pytx3/tests/hashing/test_pdq_faiss_matcher.py
+++ b/pytx3/tests/hashing/test_pdq_faiss_matcher.py
@@ -23,6 +23,9 @@ class MixinTests:
             for (r, e) in zip(result, expected):
                 self.assertCountEqual(r, e)
 
+        def test_hash_at(self):
+            assert test_hashes[2] == self.index.hash_at(2)
+
         def test_search_index_for_exact_matches(self):
             query = test_hashes[:1]
             result = self.index.search(query, 0)
@@ -77,9 +80,6 @@ class TestPDQFlatHashIndex(MixinTests.PDQHashIndexSearchCommonTests, unittest.Te
         assert self.index.faiss_index is not None
         assert self.index.faiss_index.ntotal == len(test_hashes)
 
-        assert self.index.dataset_hashes is not None
-        assert self.index.dataset_hashes == hashes_as_bytes
-
 
 class TestPDQMultiHashIndex(
     MixinTests.PDQHashIndexSearchCommonTests, unittest.TestCase
@@ -93,9 +93,6 @@ class TestPDQMultiHashIndex(
 
         assert self.index.faiss_index is not None
         assert self.index.faiss_index.ntotal == len(test_hashes)
-
-        assert self.index.dataset_hashes is not None
-        assert self.index.dataset_hashes == hashes_as_bytes
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
=======

The underlaying faiss indexes for the PDQHashIndex classes do not
natively support pickling (serialization) of the data to bytes.
Adding support for pickling will allow us to easily save and load
these indexes from files or over a network connection (for example
during a map-reduce or batch job).

This work is dependent upon #309. I will rebase off of #309 once that merges.

Test Plan
======

Added additional testing that runs the common PDQHashIndex tests against a reserialized form of the test subject. This is to ensure that functionality remains the same with the index once it was be serialized and then deserialized.