### PR TITLE
Add memory information to faiss index benchmarks

### DIFF
--- a/pytx3/benchmarks/benchmark_pdq_faiss_matchers.py
+++ b/pytx3/benchmarks/benchmark_pdq_faiss_matchers.py
@@ -4,7 +4,7 @@ import argparse
 import binascii
 import os
 import time
-import warnings
+import pickle
 
 import numpy
 import faiss
@@ -116,10 +116,12 @@ dataset = [generate_random_hash() for _ in range(args.dataset_size)]
 
 start_build_flat_hash_index = time.time()
 flat_index = PDQFlatHashIndex.create(dataset)
+serialized_flat_index = pickle.dumps(flat_index)
 end_build_flat_hash_index = time.time()
 
 start_build_multi_hash_index = time.time()
 multi_index = PDQMultiHashIndex.create(dataset)
+serialized_multi_index = pickle.dumps(multi_index)
 end_build_multi_hash_index = time.time()
 
 print("Building Stats:")
@@ -129,8 +131,14 @@ print(
     end_build_flat_hash_index - start_build_flat_hash_index,
 )
 print(
+    f"\tPDQFlatHashIndex: approximate size: {len(serialized_flat_index) // 1024:,d}KB"
+)
+print(
     "\tPDQMultiHashIndex: time to build (s): ",
     end_build_multi_hash_index - start_build_multi_hash_index,
+)
+print(
+    f"\tPDQMultiHashIndex: approximate size: {len(serialized_multi_index) // 1024:,d}KB"
 )
 print("")
 


### PR DESCRIPTION
Summary
=========

To help understand index selection choice on memory requirements,
adding some benchmark output for how approximately how much storage
is needed for the serialized form for the indexes.

Test Plan
========

Ran the benchmark locally and noted the below output

```
(threatexchange) ➜  pytx3 git:(add-memory-benchmark-for-faiss-indexes) python benchmarks/benchmark_pdq_faiss_matchers.py                   
Benchmark: PDQ Faiss Matcher Comparison

Options:
         faiss_threads :  1
         dataset_size :  250000
         num_queries :  1000
         thresholds :  [0, 15, 31, 47]
         seed :  None

using random seed of  1604086833819350000
use --seed  1604086833819350000  to rerun with same random values

Building Stats:
        PDQFlatHashIndex: time to build (s):  0.3096351623535156
        PDQFlatHashIndex: approximate size: 7,812KB
        PDQMultiHashIndex: time to build (s):  2.423464298248291
        PDQMultiHashIndex: approximate size: 20,858KB

Benchmarks for threshold:  0
        PDQFlatHashIndex - Total Time to search  (s):  0.7060251235961914
        PDQMultiHashIndex - Total Time to search  (s):  0.029154062271118164
        PDQFlatHashIndex - Precent of targets found:  100.0
        PDQMultiHashIndex - Precent of targets found:  100.0

Benchmarks for threshold:  15
        PDQFlatHashIndex - Total Time to search  (s):  0.6720812320709229
        PDQMultiHashIndex - Total Time to search  (s):  0.022841930389404297
        PDQFlatHashIndex - Precent of targets found:  100.0
        PDQMultiHashIndex - Precent of targets found:  100.0

Benchmarks for threshold:  31
        PDQFlatHashIndex - Total Time to search  (s):  0.6760938167572021
        PDQMultiHashIndex - Total Time to search  (s):  0.35967183113098145
        PDQFlatHashIndex - Precent of targets found:  100.0
        PDQMultiHashIndex - Precent of targets found:  100.0

Benchmarks for threshold:  47
        PDQFlatHashIndex - Total Time to search  (s):  0.6572327613830566
        PDQMultiHashIndex - Total Time to search  (s):  2.8741109371185303
        PDQFlatHashIndex - Precent of targets found:  100.0
        PDQMultiHashIndex - Precent of targets found:  100.0
```