### PR TITLE
Mark and close stale issues

### DIFF
--- a/.github/workflows/repo-stale-issues.yml
+++ b/.github/workflows/repo-stale-issues.yml
@@ -1,0 +1,24 @@
+name: Close stale issues
+on:
+  schedule:
+    - cron: "0 17 * * *" # Every day at 5pm UTC
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 90
+          days-before-close: 14
+          stale-issue-message: |
+            This issue is being marked as stale because it has no recent activity. It will be closed automatically in 14 days
+            unless it becomes active before then. To prevent closing, please comment on the issue before that time. If the 
+            issue is no longer relevant, please feel free to close it prior to that time.
+
+            Cleaning up stale issues helps redirect focus to the issues top of mind of the community. Thank you for your help
+            with this.
+          close-issue-message: |
+            This issue has been closed due to no recent activity. If you need this issue reopened, please let us know.
+            Thanks!


### PR DESCRIPTION
Summary
---------

Add GitHub action to mark and comment on stale issues, and later close them if there is no activity.

Set the current timeframes to 90 days with no activity before marking an issue as stale, and 2 weeks graceperiod before closing.

Test Plan
---------

Unfortuately, this is difficult to test as the action needs to run in a cron job. Mostly just compared the settings with the examples at https://github.com/actions/stale and ensured that my IDE yaml linter did not identify any errors.
