### PR TITLE
Support custom ids for PDQ hash indexes

### DIFF
--- a/pytx3/benchmarks/benchmark_pdq_faiss_matchers.py
+++ b/pytx3/benchmarks/benchmark_pdq_faiss_matchers.py
@@ -48,6 +48,13 @@ parser.add_argument(
     help="PDQ similarity threshold values to benchmark with",
 )
 parser.add_argument("--seed", type=int, help="seed for random number generator")
+parser.add_argument(
+    "--use-custom-ids",
+    dest="use_custom_ids",
+    action="store_true",
+    help="whether to use custom ids in the index",
+)
+parser.set_defaults(use_custom_ids=False)
 
 args = parser.parse_args()
 
@@ -114,13 +121,18 @@ def generate_random_hash_with_hamming_distance(original_hash, desired_hamming_di
 
 dataset = [generate_random_hash() for _ in range(args.dataset_size)]
 
+if args.use_custom_ids:
+    custom_ids = [i + 100_000_000_000_000 for i in range(args.dataset_size)]
+else:
+    custom_ids = None
+
 start_build_flat_hash_index = time.time()
-flat_index = PDQFlatHashIndex.create(dataset)
+flat_index = PDQFlatHashIndex.create(dataset, custom_ids=custom_ids)
 serialized_flat_index = pickle.dumps(flat_index)
 end_build_flat_hash_index = time.time()
 
 start_build_multi_hash_index = time.time()
-multi_index = PDQMultiHashIndex.create(dataset)
+multi_index = PDQMultiHashIndex.create(dataset, custom_ids=custom_ids)
 serialized_multi_index = pickle.dumps(multi_index)
 end_build_multi_hash_index = time.time()
 


### PR DESCRIPTION
Summary
---------

Later PRs will enable tying PDQ Hashes to ThreatExchange IDs to enable reacting to the PDQ hash with a
`SAW_THIS_TOO` tag. This PR lies the foundation for supporting custom ids within the indexes themselves
using the faiss indexes support for custom ids. 

There are some existing issues within faiss for supporting reconstructing hashes from an custom id for 
the MultiHash binary indexes, but this PR contains a workaround until that can be fixed upstream. I will
create the issue in the faiss repo and make PRs there to have those resolved. Until then, the workaround
just adds some additional memory cost but doubling up on the reverse lookup map that is already present
in the faiss data structure.

Test Plan
---------

Added unit test cases for custom ids and tested with `py.test`.

Also added support to the benchmark code for running with custom ids.

```
(threatexchange) ➜  pytx3 git:(support-custom-ids) python benchmarks/benchmark_pdq_faiss_matchers.py --seed  1605188176723381000 --use-custom-ids                       
Benchmark: PDQ Faiss Matcher Comparison

Options:
         faiss_threads :  1
         dataset_size :  250000
         num_queries :  1000
         thresholds :  [0, 15, 31, 47]
         seed :  1605188176723381000
         use_custom_ids :  True

Building Stats:
        PDQFlatHashIndex: time to build (s):  0.7206830978393555
        PDQFlatHashIndex: approximate size: 9,765KB
        PDQMultiHashIndex: time to build (s):  2.870143175125122
        PDQMultiHashIndex: approximate size: 22,811KB

Benchmarks for threshold:  0
        PDQFlatHashIndex - Total Time to search  (s):  0.6360461711883545
        PDQMultiHashIndex - Total Time to search  (s):  0.03747916221618652
        PDQFlatHashIndex - Precent of targets found:  100.0
        PDQMultiHashIndex - Precent of targets found:  100.0

Benchmarks for threshold:  15
        PDQFlatHashIndex - Total Time to search  (s):  0.6084301471710205
        PDQMultiHashIndex - Total Time to search  (s):  0.028983116149902344
        PDQFlatHashIndex - Precent of targets found:  100.0
        PDQMultiHashIndex - Precent of targets found:  100.0

Benchmarks for threshold:  31
        PDQFlatHashIndex - Total Time to search  (s):  0.584428071975708
        PDQMultiHashIndex - Total Time to search  (s):  0.3369121551513672
        PDQFlatHashIndex - Precent of targets found:  100.0
        PDQMultiHashIndex - Precent of targets found:  100.0

Benchmarks for threshold:  47
        PDQFlatHashIndex - Total Time to search  (s):  0.5721471309661865
        PDQMultiHashIndex - Total Time to search  (s):  2.5447847843170166
        PDQFlatHashIndex - Precent of targets found:  100.0
        PDQMultiHashIndex - Precent of targets found:  100.0

```

