### PR TITLE
Add `pdq` labels to PRs affecting pdq code

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,3 +2,6 @@
 
 pytx3:
   - pytx3/**/*
+
+pdq:
+  - pdq/**/*


### PR DESCRIPTION
Summary
---------

Any PR after this that touches the PDQ code directly should have a `pdq` label attached to it automatically.

Test Plan
---------

No yaml linter warnings in my IDE.


