### PR TITLE
Add basic ci for testing PDQ cpp code.

### DIFF
--- a/.github/workflows/pdq-ci-cpp.yml
+++ b/.github/workflows/pdq-ci-cpp.yml
@@ -1,0 +1,26 @@
+name: pdq CI - cpp
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "pdq/cpp/**"
+      - ".github/workflows/pdq-ci-cpp.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "pdq/cpp/**"
+      - ".github/workflows/pdq-ci-cpp.yml"
+
+defaults:
+  run:
+    working-directory: pdq/cpp
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: make
+        run: make


### PR DESCRIPTION
Summary
---------

Adds a very simple CI workflow to test the pdq cpp build using the current `make` default target. This will test both building the code and running the regression tests that the cpp PDQ already has.

Test Plan
---------

This PR should pass its status checks, including the new CI job.

