### PR TITLE
Conditionally import PDQ matchers in `pytx3.hashing`

### DIFF
--- a/pytx3/benchmarks/benchmark_pdq_faiss_matchers.py
+++ b/pytx3/benchmarks/benchmark_pdq_faiss_matchers.py
@@ -9,7 +9,7 @@ import pickle
 import numpy
 import faiss
 
-from pytx3.hashing.pdq_faiss_matcher import (
+from pytx3.hashing import (
     PDQFlatHashIndex,
     PDQMultiHashIndex,
     BITS_IN_PDQ,

--- a/pytx3/pytx3/hashing/__init__.py
+++ b/pytx3/pytx3/hashing/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import warnings
+
+try:
+    from pytx3.hashing.pdq_faiss_matcher import (
+        PDQHashIndex,
+        PDQFlatHashIndex,
+        PDQMultiHashIndex,
+        BITS_IN_PDQ,
+    )
+except:
+    warnings.warn(
+        "pdq matchers require faiss to be installed; install pytx3 with the [faiss] extra to use them",
+        category=ImportWarning,
+    )


### PR DESCRIPTION
Summary
---------

Adding the PDQHashIndex classes to the `pytx3.hashing` package will make it easier for callers to import, and in the future enable us
to provide fall back implementations that don't use faiss for the cases where faiss is not installed. This also adds an import
warning directing users to install the faiss extra if they want to make use of these extras. 

Test Plan
---------

After uninstalling faiss-cpu from my virtual environment using `pip uninstall faiss-cpu`

```
$ python -c 'from pytx3.hashing import PDQFlatHashIndex'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'PDQFlatHashIndex' from 'pytx3.hashing' (/Users/bodnarbm/github/ThreatExchange/pytx3/pytx3/hashing/__init__.py)

$ python -c 'import pytx3.hashing'                      

$ python -W default -c 'from pytx3.hashing import PDQFlatHashIndex'
/Users/bodnarbm/github/ThreatExchange/pytx3/pytx3/hashing/__init__.py:12: ImportWarning: pdq matchers require faiss to be installed; install pytx3 with the [faiss] extra to use them
  warnings.warn(
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'PDQFlatHashIndex' from 'pytx3.hashing' (/Users/bodnarbm/github/ThreatExchange/pytx3/pytx3/hashing/__init__.py)

$ python -W default -c 'import pytx3.hashing'                      
/Users/bodnarbm/github/ThreatExchange/pytx3/pytx3/hashing/__init__.py:12: ImportWarning: pdq matchers require faiss to be installed; install pytx3 with the [faiss] extra to use them
  warnings.warn(
```

After installing faiss-cpu back

```
$ python -c 'from pytx3.hashing import PDQFlatHashIndex'
$ python -c 'import pytx3.hashing'    
$ python -W default -c 'import pytx3.hashing'           
$ python -W default -c 'from pytx3.hashing import PDQFlatHashIndex'
```

