### PR TITLE
Add option to return only the id when searching PDQ hashes

### DIFF
--- a/pytx3/tests/hashing/test_pdq_faiss_matcher.py
+++ b/pytx3/tests/hashing/test_pdq_faiss_matcher.py
@@ -104,6 +104,11 @@ class TestPDQFlatHashIndex(MixinTests.PDQHashIndexCommonTests, unittest.TestCase
     def test_hash_at(self):
         assert test_hashes[2] == self.index.hash_at(2)
 
+    def test_search_index_return_ids(self):
+        query = test_hashes[:2]
+        results = self.index.search(query, 16, return_as_ids=True)
+        self.assertEqualPDQHashSearchResults(results, [[0, 1], [0, 1]])
+
 
 class TestPDQFlatHashIndexWithCustomIds(
     MixinTests.PDQHashIndexCommonTests, unittest.TestCase
@@ -124,6 +129,13 @@ class TestPDQFlatHashIndexWithCustomIds(
     def test_hash_at(self):
         assert test_hashes[2] == self.index.hash_at(self.custom_ids[2])
 
+    def test_search_index_return_ids(self):
+        query = test_hashes[:2]
+        results = self.index.search(query, 16, return_as_ids=True)
+        self.assertEqualPDQHashSearchResults(
+            results, [self.custom_ids[:2], self.custom_ids[:2]]
+        )
+
 
 class TestPDQMultiHashIndex(MixinTests.PDQHashIndexCommonTests, unittest.TestCase):
     def setUp(self):
@@ -138,6 +150,11 @@ class TestPDQMultiHashIndex(MixinTests.PDQHashIndexCommonTests, unittest.TestCas
 
     def test_hash_at(self):
         assert test_hashes[2] == self.index.hash_at(2)
+
+    def test_search_index_return_ids(self):
+        query = test_hashes[:2]
+        results = self.index.search(query, 16, return_as_ids=True)
+        self.assertEqualPDQHashSearchResults(results, [[0, 1], [0, 1]])
 
 
 class TestPDQMultiHashIndexWithCustomIds(
@@ -157,6 +174,13 @@ class TestPDQMultiHashIndexWithCustomIds(
 
     def test_hash_at(self):
         assert test_hashes[2] == self.index.hash_at(self.custom_ids[2])
+
+    def test_search_index_return_ids(self):
+        query = test_hashes[:2]
+        results = self.index.search(query, 16, return_as_ids=True)
+        self.assertEqualPDQHashSearchResults(
+            results, [self.custom_ids[:2], self.custom_ids[:2]]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
---------

Useful especially in the cases where a custom id has been set for the hashes
in the index, allowing the search results to be the id instead of the hash
will help callers that are using that id to lookup the information in another
datastore.

Test Plan
---------

Added tests and ran them with `py.test`
