### PR TITLE
Setup CI workflow to automate pytx3 releases

### DIFF
--- a/.github/workflows/pytx3-release.yaml
+++ b/.github/workflows/pytx3-release.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+name: Publish pytx3
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "pytx3/version.txt"
+
+defaults:
+  run:
+    working-directory: pytx3
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.6"
+      - name: Install packaging dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[package]"
+      - name: Package pytx3
+        run: |
+          python ./setup.py sdist bdist_wheel
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.test_pypi_password }}
+          repository_url: https://test.pypi.org/legacy/

--- a/pytx3/setup.py
+++ b/pytx3/setup.py
@@ -16,12 +16,13 @@ with open(path.join(here, "DESCRIPTION.rst"), encoding="utf-8") as f:
     description = f.read()
 
 with open(path.join(here, "version.txt"), encoding="utf-8") as f:
-    version = f.read()
+    version = f.read().strip()
 
 extras_require = {"faiss": ["faiss-cpu>=1.6.3", "numpy"]}
 
 all_extras = set(sum(extras_require.values(), []))
 extras_require["test"] = sorted({"pytest"} | all_extras)
+extras_require["package"] = ["wheel"]
 extras_require["lint"] = ["black"]
 extras_require["all"] = sorted(set(sum(extras_require.values(), [])))
 
@@ -42,7 +43,7 @@ setup(
     ],
     keywords="facebook threatexchange",
     url="https://www.github.com/facebook/ThreatExchange",
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(exclude=["tests*"]),
     install_requires=[
         "python-Levenshtein",
     ],


### PR DESCRIPTION
Summary
---------

To make releasing easy and encourge frequent releases, we can automate the packaging of new versions of pytx3. This workflow will automatically create the pytx3 release and upload it to the Test PyPI repowheneve a commit lands in master that alters the pytx3 version file.

- [ ] Have test pypi secret token added to repo secrets.

Test Plan
---------

Simple yaml testing for now. After this lands, we will cut a release of pytx3 to test the workflow properly using the test pypi index. Once that is successful, we will followup with another PR that adds uploading to the production pypi index.

