### PR TITLE
Specify dists folder for pypi packages

### DIFF
--- a/.github/workflows/pytx3-release.yaml
+++ b/.github/workflows/pytx3-release.yaml
@@ -33,3 +33,4 @@ jobs:
         with:
           password: ${{ secrets.test_pypi_password }}
           repository_url: https://test.pypi.org/legacy/
+          packages_dir: pytx3/dist


### PR DESCRIPTION
Summary
---------

The pypa/gh-action-pypi-publish action does not respect the working-directory setting, so we need to let it know where the dist folder will be from the repo root.


Test Plan
---------

[Executed action on my local fork](https://github.com/bodnarbm/ThreatExchange/runs/1426584148?check_suite_focus=true) (without the github secret) and verified that it make it through the finding the dist folder phase. Note: action still failed before there is no upload token in my fork.

