### PR TITLE
Check if no command is given to python-threatexchange and print help if so

### DIFF
--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -67,6 +67,9 @@ def get_argparse() -> argparse.ArgumentParser:
 
 
 def execute_command(namespace) -> None:
+    if not hasattr(namespace, "command_cls"):
+        get_argparse().print_help()
+        return
     command_cls = namespace.command_cls
     try:
         # Init TE lib


### PR DESCRIPTION
Summary
---------

See title

Test Plan
---------

Before:
```
$ threatexchange 
Traceback (most recent call last):
  File "/Users/barrett/homebrew/bin/threatexchange", line 33, in <module>
    sys.exit(load_entry_point('threatexchange', 'console_scripts', 'threatexchange')())
  File "/Users/barrett/dev/github/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 149, in main
    execute_command(namespace)
  File "/Users/barrett/dev/github/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 70, in execute_command
    if namespace.command_cls is None:
AttributeError: 'Namespace' object has no attribute 'command_cls'
```
After:
```
$ threatexchange 
usage: threatexchange [-h] [--config CONFIG] [--app-token TOKEN] [--state-dir DIR] {fetch,experimental-fetch,match,label} ...

A wrapper around multi-stage ThreatExchange operations.

Includes simple matching and writing back. Useful for quickly validating new
sources of ThreatExchange data. A possible template for a native
implementation in your own architecture.

This helper heavily relies on a config file to provide consistent behavior
between stages, and a state file to store hashes.

optional arguments:
  -h, --help            show this help message and exit
  --config CONFIG, -c CONFIG
                        a ThreatExchange collaboration config
  --app-token TOKEN, -a TOKEN
                        the App token for ThreatExchange
  --state-dir DIR, -s DIR
                        the directory with the config state

verbs:
  {fetch,experimental-fetch,match,label}
                        which action to do
    fetch               download content from ThreatExchange to disk
    experimental-fetch  wARNING: This is experimental, you probably want to use "Fetch" instead
    match               match content to items in ThreatExchange
    label               apply labels to items in ThreatExchange
```
