### PR TITLE
Add simple pdq matcher

### DIFF
--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -18,7 +18,13 @@ with open(path.join(here, "DESCRIPTION.rst"), encoding="utf-8") as f:
 with open(path.join(here, "version.txt"), encoding="utf-8") as f:
     version = f.read().strip()
 
-extras_require = {"faiss": ["faiss-cpu>=1.6.3", "numpy"]}
+extras_require = {
+    "faiss": ["faiss-cpu>=1.6.3", "numpy"],
+    "pdq_hasher": [
+        "pdqhash>=0.2.2",
+        "Pillow",
+    ],
+}
 
 all_extras = set(sum(extras_require.values(), []))
 extras_require["test"] = sorted({"pytest"} | all_extras)

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -21,6 +21,7 @@ with open(path.join(here, "version.txt"), encoding="utf-8") as f:
 extras_require = {
     "faiss": ["faiss-cpu>=1.6.3", "numpy"],
     "pdq_hasher": [
+        "numpy",
         "pdqhash>=0.2.2",
         "Pillow",
     ],

--- a/python-threatexchange/tests/hashing/test_pdq_utils.py
+++ b/python-threatexchange/tests/hashing/test_pdq_utils.py
@@ -1,0 +1,60 @@
+import unittest
+import binascii
+
+from threatexchange.hashing.pdq_utils import *
+
+test_hashes = [
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f",
+    "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
+    "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+]
+
+
+class TestPDQUtils(unittest.TestCase):
+    def test_hex_to_binary(self):
+        for test_hash in test_hashes:
+            bin_hash = hex_to_binary_str(test_hash)
+            self.assertEqual(len(bin_hash), BITS_IN_PDQ)
+        self.assertEqual(hex_to_binary_str(test_hashes[0]), "0" * BITS_IN_PDQ)
+        self.assertEqual(hex_to_binary_str(test_hashes[-1]), "1" * BITS_IN_PDQ)
+        self.assertEqual(
+            hex_to_binary_str(test_hashes[1]), "00001111" * (BITS_IN_PDQ // 8)
+        )
+
+    def test_distance_binary(self):
+        self.assertEqual(
+            simple_distance_binary("0" * BITS_IN_PDQ, "1" * BITS_IN_PDQ), BITS_IN_PDQ
+        )
+        self.assertEqual(
+            simple_distance_binary("0" * BITS_IN_PDQ, "0" * BITS_IN_PDQ), 0
+        )
+        self.assertEqual(
+            simple_distance_binary(
+                "0" * BITS_IN_PDQ, hex_to_binary_str(test_hashes[1])
+            ),
+            BITS_IN_PDQ // 2,
+        )
+
+    def test_distance(self):
+        self.assertEqual(simple_distance(test_hashes[1], test_hashes[1]), 0)
+        self.assertEqual(simple_distance(test_hashes[1], test_hashes[2]), BITS_IN_PDQ)
+        self.assertEqual(
+            simple_distance(test_hashes[1], test_hashes[3]), BITS_IN_PDQ // 2
+        )
+
+    def test_match_threshold(self):
+        self.assertFalse(pdq_match(test_hashes[0], test_hashes[1], threshold=31))
+        self.assertTrue(
+            pdq_match(test_hashes[0], test_hashes[1], threshold=BITS_IN_PDQ)
+        )
+        self.assertTrue(pdq_match(test_hashes[0], test_hashes[0], threshold=0))
+        self.assertFalse(pdq_match(test_hashes[0], test_hashes[1], threshold=0))
+        self.assertTrue(pdq_match(test_hashes[1], test_hashes[3], BITS_IN_PDQ // 2))
+        self.assertFalse(
+            pdq_match(test_hashes[1], test_hashes[3], BITS_IN_PDQ // 2 - 1)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python-threatexchange/threatexchange/hashing/__init__.py
+++ b/python-threatexchange/threatexchange/hashing/__init__.py
@@ -1,12 +1,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import warnings
 
+from threatexchange.hashing.pdq_utils import BITS_IN_PDQ
+
 try:
     from threatexchange.hashing.pdq_faiss_matcher import (
         PDQHashIndex,
         PDQFlatHashIndex,
         PDQMultiHashIndex,
-        BITS_IN_PDQ,
     )
 except:
     warnings.warn(

--- a/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
+++ b/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
@@ -6,7 +6,7 @@ import binascii
 import numpy  # type: ignore
 from abc import ABC, abstractmethod
 
-BITS_IN_PDQ = 256
+from .pdq_utils import BITS_IN_PDQ
 
 PDQ_HASH_TYPE = t.Union[str, bytes]
 

--- a/python-threatexchange/threatexchange/hashing/pdq_hasher.py
+++ b/python-threatexchange/threatexchange/hashing/pdq_hasher.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import pdqhash
+import pathlib
+import numpy as np
+from PIL import Image, ImageOps
+
+
+def pdq_from_file(path: pathlib.Path):
+    """
+    Given a path to a file return the PDQ Hash string in hex
+    Current Supported file types: jpg
+    """
+    img_pil = Image.open(path)
+    image = np.asarray(img_pil)
+    hash_vector, quality = pdqhash.compute(image)
+
+    bin_str = "".join([str(x) for x in hash_vector])
+    hex_str = "%0*X" % ((len(bin_str) + 3) // 4, int(bin_str, 2))
+    hex_str = hex_str.lower()
+
+    return hex_str, quality

--- a/python-threatexchange/threatexchange/hashing/pdq_hasher.py
+++ b/python-threatexchange/threatexchange/hashing/pdq_hasher.py
@@ -17,6 +17,10 @@ def pdq_from_file(path: pathlib.Path):
     hash_vector, quality = pdqhash.compute(image)
 
     bin_str = "".join([str(x) for x in hash_vector])
+
+    # binary to hex using format string
+    # '%0*' is for padding up to ceil(num_bits/4),
+    # '%X' create a hex representation from the binary string's integer value
     hex_str = "%0*X" % ((len(bin_str) + 3) // 4, int(bin_str, 2))
     hex_str = hex_str.lower()
 

--- a/python-threatexchange/threatexchange/hashing/pdq_utils.py
+++ b/python-threatexchange/threatexchange/hashing/pdq_utils.py
@@ -7,11 +7,7 @@ BITS_IN_PDQ = 256
 def simple_distance_binary(bin_a, bin_b):
     assert len(bin_a) == BITS_IN_PDQ
     assert len(bin_b) == BITS_IN_PDQ
-    distance = 0
-    for i in range(BITS_IN_PDQ):
-        if bin_a[i] != bin_b[i]:
-            distance += 1
-    return distance
+    return sum(bin_a[i] != bin_b[i] for i in range(BITS_IN_PDQ))
 
 
 def simple_distance(hex_a, hex_b):

--- a/python-threatexchange/threatexchange/hashing/pdq_utils.py
+++ b/python-threatexchange/threatexchange/hashing/pdq_utils.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+BITS_IN_PDQ = 256
+
+
+def simple_distance_binary(bin_a, bin_b):
+    assert len(bin_a) == BITS_IN_PDQ
+    assert len(bin_b) == BITS_IN_PDQ
+    distance = 0
+    for i in range(BITS_IN_PDQ):
+        if bin_a[i] != bin_b[i]:
+            distance += 1
+    return distance
+
+
+def simple_distance(hex_a, hex_b):
+    return simple_distance_binary(hex_to_binary_str(hex_a), hex_to_binary_str(hex_b))
+
+
+def hex_to_binary_str(pdq_hex):
+    assert len(pdq_hex) == BITS_IN_PDQ / 4
+    # padding to 4 bindigits each hexdigit
+    result = "".join(bin(int(c, 16))[2:].zfill(4) for c in pdq_hex)
+    assert len(result) == BITS_IN_PDQ
+    return result
+
+
+def pdq_match(pdq_hex_a: str, pdq_hex_b: str, threshold: int) -> bool:
+    distance = simple_distance(pdq_hex_a, pdq_hex_b)
+    return distance <= threshold

--- a/python-threatexchange/threatexchange/signal_type/pdq.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq.py
@@ -43,19 +43,15 @@ class PdqSignal(signal_base.SimpleSignalType, signal_base.FileMatcher):
         except:
             warnings.warn(
                 "PDQ from file require Pillow and pdqhash to be installed; install threatexchange with the [pdq_hasher] extra to use them",
-                category=ImportWarning,
+                category=UserWarning,
             )
             return []
         pdq_hash, quality = pdq_from_file(file)
         return self.match_hash(pdq_hash)
 
     def match_hash(self, signal_str: str) -> t.List[signal_base.SignalMatch]:
-        result = []
-        for pdq_hash, signal_attr in self.state.items():
-            if pdq_match(pdq_hash, signal_str, self.PDQ_CONFIDENT_MATCH_THRESHOLD):
-                result.append(
-                    signal_base.SignalMatch(
-                        signal_attr.labels, signal_attr.first_descriptor_id
-                    )
-                )
-        return result
+        return [
+            signal_base.SignalMatch(signal_attr.labels, signal_attr.first_descriptor_id)
+            for pdq_hash, signal_attr in self.state.items()
+            if pdq_match(pdq_hash, signal_str, self.PDQ_CONFIDENT_MATCH_THRESHOLD)
+        ]

--- a/python-threatexchange/threatexchange/signal_type/pdq.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq.py
@@ -6,12 +6,15 @@ Wrapper around the Photo PDQ signal type.
 """
 
 import typing as t
+import pathlib
+import warnings
 
 from ..descriptor import SimpleDescriptorRollup, ThreatDescriptor
 from . import signal_base
+from ..hashing.pdq_utils import pdq_match
 
 
-class PdqSignal(signal_base.SimpleSignalType):
+class PdqSignal(signal_base.SimpleSignalType, signal_base.FileMatcher):
     """
     PDQ is an open source photo similarity algorithm.
 
@@ -29,4 +32,30 @@ class PdqSignal(signal_base.SimpleSignalType):
     INDICATOR_TYPE = "HASH_PDQ"
     TYPE_TAG = "media_type_photo"
 
-    # TODO at least hash distance functionality
+    # This may need to be updated (TODO make more configurable)
+    # Hashes of distance less than or equal to this threshold are considered a 'match'
+    PDQ_CONFIDENT_MATCH_THRESHOLD = 31
+
+    def match_file(self, file: pathlib.Path) -> t.List[signal_base.SignalMatch]:
+        """Simple PDQ file match."""
+        try:
+            from threatexchange.hashing.pdq_hasher import pdq_from_file
+        except:
+            warnings.warn(
+                "PDQ from file require Pillow and pdqhash to be installed; install threatexchange with the [pdq_hasher] extra to use them",
+                category=ImportWarning,
+            )
+            return []
+        pdq_hash, quality = pdq_from_file(file)
+        return self.match_hash(pdq_hash)
+
+    def match_hash(self, signal_str: str) -> t.List[signal_base.SignalMatch]:
+        result = []
+        for pdq_hash, signal_attr in self.state.items():
+            if pdq_match(pdq_hash, signal_str, self.PDQ_CONFIDENT_MATCH_THRESHOLD):
+                result.append(
+                    signal_base.SignalMatch(
+                        signal_attr.labels, signal_attr.first_descriptor_id
+                    )
+                )
+        return result


### PR DESCRIPTION
Summary
Add Simple pdq matching functionality.

Test Plan
`python3 -m pytest python-threatexchange/tests/hashing/test_pdq_utils.py`
