### PR TITLE
Update experimentalfetch to work with the new version of threat_updates

### DIFF
--- a/python-threatexchange/threatexchange/TE.py
+++ b/python-threatexchange/threatexchange/TE.py
@@ -180,9 +180,9 @@ class Net:
     # ----------------------------------------------------------------
     # Gets threat updates for the given privacy group.
     @classmethod
-    def getThreatUpdates(self, privacy_group, **kwargs):
-        if kwargs["next_page"] is not None:
-            url = kwargs["next_page"]
+    def getThreatUpdates(self, privacy_group, next_page=None, **kwargs):
+        if next_page is not None:
+            url = next_page
         else:
             url = (
                 self.TE_BASE_URL
@@ -195,7 +195,7 @@ class Net:
             )
             for arg, value in kwargs.items():
                 if value is not None:
-                    if arg == "threat_type":
+                    if arg == "threat_types":
                         url += "&threat_types=" + ",".join(value)
                     else:
                         url += "&" + arg + "=" + str(value)

--- a/python-threatexchange/threatexchange/TE.py
+++ b/python-threatexchange/threatexchange/TE.py
@@ -191,15 +191,11 @@ class Net:
                 + "/threat_updates/"
                 + "?access_token="
                 + self.APP_TOKEN
-                + "&fields=id,indicator,type,creation_time,last_updated,is_expired,expire_time,tags,status,applications_with_opinions"
+                + "&fields=id,indicator,type,creation_time,last_updated,should_delete,tags,status,applications_with_opinions"
             )
             for arg, value in kwargs.items():
                 if value is not None:
-                    if arg == "additional_tags":
-                        url += "&additional_tags=" + ",".join(
-                            [str(app) for app in value]
-                        )
-                    elif arg == "threat_type":
+                    if arg == "threat_type":
                         url += "&threat_types=" + ",".join(value)
                     else:
                         url += "&" + arg + "=" + str(value)

--- a/python-threatexchange/threatexchange/TE.py
+++ b/python-threatexchange/threatexchange/TE.py
@@ -181,8 +181,8 @@ class Net:
     # Gets threat updates for the given privacy group.
     @classmethod
     def getThreatUpdates(self, privacy_group, **kwargs):
-        if "next" in kwargs:
-            url = kwargs["next"]
+        if "next_page" in kwargs and kwargs["next_page"] is not None:
+            url = kwargs["next_page"]
         else:
             url = (
                 self.TE_BASE_URL

--- a/python-threatexchange/threatexchange/TE.py
+++ b/python-threatexchange/threatexchange/TE.py
@@ -195,8 +195,8 @@ class Net:
             )
             for arg, value in kwargs.items():
                 if value is not None:
-                    if arg == "threat_types":
-                        url += "&threat_types=" + ",".join(value)
+                    if arg == "types":
+                        url += "&types=" + ",".join(value)
                     else:
                         url += "&" + arg + "=" + str(value)
         return self.getJSONFromURL(url)

--- a/python-threatexchange/threatexchange/TE.py
+++ b/python-threatexchange/threatexchange/TE.py
@@ -181,7 +181,7 @@ class Net:
     # Gets threat updates for the given privacy group.
     @classmethod
     def getThreatUpdates(self, privacy_group, **kwargs):
-        if "next_page" in kwargs and kwargs["next_page"] is not None:
+        if kwargs["next_page"] is not None:
             url = kwargs["next_page"]
         else:
             url = (

--- a/python-threatexchange/threatexchange/cli/experimental_fetch.py
+++ b/python-threatexchange/threatexchange/cli/experimental_fetch.py
@@ -52,8 +52,8 @@ class ExperimentalFetchCommand(command_base.Command):
         ap.add_argument(
             "--page-size",
             type=int,
-            help="The number of updates to fetch per request, defaults to 100",
-            default=100,
+            help="The number of updates to fetch per request, defaults to 500",
+            default=500,
         )
 
     def __init__(
@@ -93,7 +93,6 @@ class ExperimentalFetchCommand(command_base.Command):
 
         more_to_fetch = True
         remaining_attempts = 5
-
         while more_to_fetch:
             try:
                 result = TE.Net.getThreatUpdates(
@@ -126,6 +125,9 @@ class ExperimentalFetchCommand(command_base.Command):
         dataset.record_indicator_checkpoint(
             privacy_group, self.stop_time, request_time, self.threat_types, next_page
         )
+
+        if remaining_attempts == 5:
+            print("Just like that we are done!")
         print("\nHere is a summary from this run:")
         for threat_type in self.counts:
             print(f"{threat_type}: {self.counts[threat_type]}")

--- a/python-threatexchange/threatexchange/cli/experimental_fetch.py
+++ b/python-threatexchange/threatexchange/cli/experimental_fetch.py
@@ -101,12 +101,11 @@ class ExperimentalFetchCommand(command_base.Command):
                 ti_json.get("indicator"),
                 ti_json.get("type"),
                 int(ti_json.get("creation_time")),
-                int(ti_json.get("last_updated")),
+                int(ti_json.get("last_updated")) if "last_updated" in ti_json else None,
                 ti_json.get("status"),
-                ti_json.get("is_expired"),
+                ti_json.get("should_delete"),
                 ti_json.get("tags"),
                 [int(app) for app in ti_json.get("applications_with_opinions")],
-                int(ti_json.get("expire_time")) if "expire_time" in ti_json else None,
             )
 
             match = False

--- a/python-threatexchange/threatexchange/cli/experimental_fetch.py
+++ b/python-threatexchange/threatexchange/cli/experimental_fetch.py
@@ -61,7 +61,7 @@ class ExperimentalFetchCommand(command_base.Command):
     def execute(self, dataset: Dataset) -> None:
         privacy_group = dataset.config.privacy_groups[0]
         self.indicator_signals = signal_base.IndicatorSignals(privacy_group)
-        self.indicator_signals.load_indicators()
+        dataset.load_indicator_cache(self.indicator_signals)
 
         # TODO: [Potential] Force full fetch if it has been 90 days since the last fetch.
         # self.start_time = (
@@ -89,7 +89,7 @@ class ExperimentalFetchCommand(command_base.Command):
             more_to_fetch = "paging" in result and "next" in result["paging"]
             next_page = result["paging"]["next"] if more_to_fetch else None
 
-        self.indicator_signals.store_indicators()
+        dataset.store_indicator_cache(self.indicator_signals)
         for threat_type in self.counts:
             print(f"{threat_type}: {self.counts[threat_type]}")
         return
@@ -109,7 +109,9 @@ class ExperimentalFetchCommand(command_base.Command):
                 ti_json.get("status"),
                 ti_json.get("should_delete"),
                 ti_json.get("tags") if "tags" in ti_json else [],
-                [int(app) for app in ti_json.get("applications_with_opinions")] if "applications_with_opinions" in ti_json else [],
+                [int(app) for app in ti_json.get("applications_with_opinions")]
+                if "applications_with_opinions" in ti_json
+                else [],
             )
 
             self.indicator_signals.process_indicator(ti)

--- a/python-threatexchange/threatexchange/cli/experimental_fetch.py
+++ b/python-threatexchange/threatexchange/cli/experimental_fetch.py
@@ -25,8 +25,10 @@ class ExperimentalFetchCommand(command_base.Command):
     """
 
     PROGRESS_PRINT_INTERVAL_SEC = 30
-    # We use a DEFAULT_REFETCH_SEC of 85 days because threat_updates tombstones last for 90 days
-    # If you don't fetch for updates within the 90 days you may miss some deletion notifications
+    # If a client does not resume tailing the threat_updates endpoint fast enough, 
+    # deletion records will be removed, making it impossible to determine which
+    # records should be retained without refetching the entire dataset from scratch.
+    # The current implementation will retain for 90 days: TODO: Link to documentation
     DEFAULT_REFETCH_SEC = 3600 * 24 * 85  # 85 days
     MAX_CONSECUTIVE_RETRIES = 5
 

--- a/python-threatexchange/threatexchange/cli/experimental_fetch.py
+++ b/python-threatexchange/threatexchange/cli/experimental_fetch.py
@@ -99,17 +99,17 @@ class ExperimentalFetchCommand(command_base.Command):
                     self._process_indicators(result["data"])
                 more_to_fetch = "paging" in result and "next" in result["paging"]
                 next_page = result["paging"]["next"] if more_to_fetch else ""
-            except:
+            except Exception as e:
                 remaining_attempts -= 1
                 if remaining_attempts > 0:
                     print(
-                        f"An error occured while fetching, trying again {remaining_attempts} more times."
+                        f"The following error occured while fetching:\n{e.read()}\nTrying again {remaining_attempts} more times."
                     )
                     time.sleep(5)
                     continue
                 else:
                     print(
-                        "5 consecutive errors occured, please run 'threatexchange -c {config} experimental-fetch --continue' shortly to try again from the last successful point."
+                        "5 consecutive errors occured, please try again later by running 'threatexchange -c {config} experimental-fetch --continuation' to continue from the last successful point."
                     )
                     break
             remaining_attempts = 5

--- a/python-threatexchange/threatexchange/cli/experimental_fetch.py
+++ b/python-threatexchange/threatexchange/cli/experimental_fetch.py
@@ -37,34 +37,20 @@ class ExperimentalFetchCommand(command_base.Command):
             help="Fetch updates that occured before this timestamp",
         )
         ap.add_argument(
-            "--owner",
-            type=int,
-            help="Only fetch updates for indicators that the given app has a descriptor for",
-        )
-        ap.add_argument(
             "--threat-types",
             nargs="+",
             help="Only fetch updates for indicators of the given type",
-        )
-        ap.add_argument(
-            "--additional-tags",
-            nargs="+",
-            help="Only fetch updates for indicators that have a descriptor with each of these tags",
         )
 
     def __init__(
         self,
         start_time: int,
         stop_time: int,
-        owner: int,
         threat_types: t.List[str],
-        additional_tags: t.List[str],
     ) -> None:
         self.start_time = start_time
         self.stop_time = stop_time
-        self.owner = owner
         self.threat_types = threat_types
-        self.additional_tags = additional_tags
         self.signal_types_by_name = {
             name: signal() for name, signal in meta.get_signal_types_by_name().items()
         }
@@ -88,9 +74,7 @@ class ExperimentalFetchCommand(command_base.Command):
                 dataset.config.privacy_groups[0],
                 start_time=self.start_time,
                 stop_time=self.stop_time,
-                owner=self.owner,
                 threat_type=self.threat_types,
-                additional_tags=self.additional_tags,
                 next_page=next_page,
             )
             if "data" in result:

--- a/python-threatexchange/threatexchange/dataset.py
+++ b/python-threatexchange/threatexchange/dataset.py
@@ -113,14 +113,14 @@ class Dataset:
     ) -> None:
         types = " ".join(threat_types) if threat_types is not None else ""
         url = url if url is not None else ""
-        values = f"{stop_time}\n{request_time}\n{types}\n{url}\n"
         with self._indicator_checkpoint_path(privacy_group).open("w+") as f:
-            f.writelines(values)
+            f.writelines(f"{stop_time}\n{request_time}\n{types}\n{url}\n")
 
-    def _signal_state_file(
-        self, signal_type: signal_base.SignalType, suffix: str = ""
-    ) -> pathlib.Path:
-        return self.state_dir / f"{signal_type.get_name()}{suffix}{self.EXTENSION}"
+    def _signal_state_file(self, signal_type: signal_base.SignalType) -> pathlib.Path:
+        return self.state_dir / f"{signal_type.get_name()}{self.EXTENSION}"
+
+    def get_indicator_store(self, privacy_group: int) -> signal_base.IndicatorSignals:
+        return signal_base.IndicatorSignals(self.state_dir, privacy_group)
 
     def load_cache(
         self, signal_types: t.Optional[t.Iterable[signal_base.SignalType]] = None
@@ -140,7 +140,7 @@ class Dataset:
         self, indicator_signals: signal_base.IndicatorSignals
     ) -> None:
         """Load indicator files"""
-        indicator_signals.load_indicators(self.state_dir)
+        indicator_signals.load_indicators()
 
     def store_cache(self, signal_type: signal_base.SignalType) -> None:
         if not self.state_dir.exists():
@@ -152,4 +152,4 @@ class Dataset:
     ) -> None:
         if not self.state_dir.exists():
             self.state_dir.mkdir()
-        indicator_signals.store_indicators(self.state_dir)
+        indicator_signals.store_indicators()

--- a/python-threatexchange/threatexchange/dataset.py
+++ b/python-threatexchange/threatexchange/dataset.py
@@ -112,6 +112,7 @@ class Dataset:
         url: str = "",
     ) -> None:
         types = " ".join(threat_types) if threat_types is not None else ""
+        url = url if url is not None else ""
         values = f"{stop_time}\n{request_time}\n{types}\n{url}\n"
         with self._indicator_checkpoint_path(privacy_group).open("w+") as f:
             f.writelines(values)

--- a/python-threatexchange/threatexchange/dataset.py
+++ b/python-threatexchange/threatexchange/dataset.py
@@ -103,7 +103,7 @@ class Dataset:
             values["url"] = values["url"] if values["url"] != "" else None
         return values
 
-    def record_indicator_checkpoint(
+    def set_indicator_checkpoint(
         self,
         privacy_group: int,
         stop_time: int,

--- a/python-threatexchange/threatexchange/dataset.py
+++ b/python-threatexchange/threatexchange/dataset.py
@@ -81,6 +81,7 @@ class Dataset:
         return FetchCheckpoint.deserialize(checkpoint.read_text())
 
     def get_indicator_checkpoint(self, privacy_group) -> t.Dict:
+        # get types by breaking string delimited by -, if --continue command then continue from where left off and override other stuff
         values = {"last_stop_time": 0, "last_run_time": 0, "url": None}
         checkpoint = self._indicator_checkpoint_path(privacy_group)
         if not checkpoint.exists():
@@ -94,6 +95,7 @@ class Dataset:
     def record_indicator_checkpoint(
         self, privacy_group: int, stop_time: int, request_time: int, url: str = ""
     ) -> None:
+        # turn types into string delimited by -
         self._indicator_checkpoint_path(privacy_group).write_text(
             f"{stop_time} {request_time} {url}"
         )

--- a/python-threatexchange/threatexchange/dataset.py
+++ b/python-threatexchange/threatexchange/dataset.py
@@ -105,27 +105,19 @@ class Dataset:
         return ret
 
     def load_indicator_cache(
-        self, signal_types: t.Optional[t.Iterable[signal_base.SignalType]] = None
+        self, indicator_signals: signal_base.IndicatorSignals
     ) -> None:
-        """Load indicator files in the state directory and initialize signal types"""
-        signal_types = (
-            [s() for s in meta.get_all_signal_types()]
-            if signal_types is None
-            else signal_types
-        )
-        for signal_type in signal_types:
-            signal_type.load_indicators(
-                self._signal_state_file(signal_type, self.INDICATOR_SUFFIX)
-            )
+        """Load indicator files"""
+        indicator_signals.load_indicators(self.state_dir)
 
     def store_cache(self, signal_type: signal_base.SignalType) -> None:
         if not self.state_dir.exists():
             self.state_dir.mkdir()
         signal_type.store(self._signal_state_file(signal_type))
 
-    def store_indicator_cache(self, signal_type: signal_base.SignalType) -> None:
+    def store_indicator_cache(
+        self, indicator_signals: signal_base.IndicatorSignals
+    ) -> None:
         if not self.state_dir.exists():
             self.state_dir.mkdir()
-        signal_type.store_indicators(
-            self._signal_state_file(signal_type, self.INDICATOR_SUFFIX)
-        )
+        indicator_signals.store_indicators(self.state_dir)

--- a/python-threatexchange/threatexchange/indicator.py
+++ b/python-threatexchange/threatexchange/indicator.py
@@ -22,7 +22,7 @@ class ThreatIndicator(t.NamedTuple):
       "creation_time": 1601513795,
       "last_updated": 1601513796,
       "status": "MALICIOUS",
-      "is_expired": false,
+      "should_delete": false,
       "tags": [
         "tag1",
         "tag2",
@@ -31,7 +31,6 @@ class ThreatIndicator(t.NamedTuple):
       "applications_with_opinions": [
         "123456789055502"
       ],
-      "expire_time": 9601513796
     }
     """
 
@@ -41,12 +40,11 @@ class ThreatIndicator(t.NamedTuple):
     creation_time: int
     last_updated: int
     status: str
-    is_expired: bool
+    should_delete: bool
     tags: t.List[str]
     applications_with_opinions: t.List[int]
-    expire_time: int
 
-    def as_row(self) -> t.Tuple[int, str, str, int, int, str, bool, str, str, int]:
+    def as_row(self) -> t.Tuple[int, str, str, int, int, str, str, str]:
         """Simple conversion to CSV row"""
         return (
             self.id,
@@ -55,27 +53,26 @@ class ThreatIndicator(t.NamedTuple):
             self.creation_time,
             self.last_updated,
             self.status,
-            self.is_expired,
             " ".join(self.tags),
             " ".join([str(app) for app in self.applications_with_opinions]),
-            self.expire_time,
         )
 
     @classmethod
     def from_row(self, row: t.Iterable) -> "ThreatIndicator":
         """Simple conversion from CSV row"""
-        tags = row[7].split(" ") if row[7] else []
-        apps = [int(app) for app in (row[8].split(" ") if row[8] else [])]
-        expire_time = int(row[9]) if row[9] else None
+        last_updated = int(row[4]) if row[4] else None
+        # should_delete won't be saved to the CSV as if it is true we delete the record
+        should_delete = False
+        tags = row[6].split(" ") if row[6] else []
+        apps = [int(app) for app in (row[7].split(" ") if row[7] else [])]
         return ThreatIndicator(
             int(row[0]),
             row[1],
             row[2],
             int(row[3]),
-            int(row[4]),
+            last_updated
             row[5],
-            row[6] == "True",
+            should_delete,
             tags,
             apps,
-            expire_time,
         )

--- a/python-threatexchange/threatexchange/indicator.py
+++ b/python-threatexchange/threatexchange/indicator.py
@@ -61,7 +61,8 @@ class ThreatIndicator(t.NamedTuple):
     def from_row(self, row: t.Iterable) -> "ThreatIndicator":
         """Simple conversion from CSV row"""
         last_updated = int(row[4]) if row[4] else None
-        # should_delete won't be saved to the CSV as if it is true we delete the record
+        # should_delete isn't saved in the CSV as if it is true we delete the record
+        # so all loaded descriptors should have a should_delete value of False
         should_delete = False
         tags = row[6].split(" ") if row[6] else []
         apps = [int(app) for app in (row[7].split(" ") if row[7] else [])]

--- a/python-threatexchange/threatexchange/indicator.py
+++ b/python-threatexchange/threatexchange/indicator.py
@@ -70,7 +70,7 @@ class ThreatIndicator(t.NamedTuple):
             row[1],
             row[2],
             int(row[3]),
-            last_updated
+            last_updated,
             row[5],
             should_delete,
             tags,

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -102,9 +102,12 @@ class IndicatorSignals:
         for store in path.glob(f"[!_]*{dataset.Dataset.EXTENSION}"):
             csv.field_size_limit(store.stat().st_size)  # dodge field size problems
             with store.open("r", newline="") as s:
-                for row in csv.reader(s):
-                    ti = ThreatIndicator.from_row(row)
-                    self.process_indicator(ti)
+                try:
+                    for row in csv.reader(s):
+                        ti = ThreatIndicator.from_row(row)
+                        self.process_indicator(ti)
+                except Exception as e:
+                    print(f"Encountered {e} while loading an indicator from {store}")
 
 
 class HashMatcher:

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -99,7 +99,7 @@ class IndicatorSignals:
         if not path.exists():
             return
 
-        for store in path.glob(f"*{dataset.Dataset.EXTENSION}"):
+        for store in path.glob(f"[!_]*{dataset.Dataset.EXTENSION}"):
             csv.field_size_limit(store.stat().st_size)  # dodge field size problems
             with store.open("r", newline="") as s:
                 for row in csv.reader(s):


### PR DESCRIPTION
Summary
---------

Update experimentalfetch to work with the new version of threat_updates. Make experimentalfetch more resilient by adding error handling and more thorough checkpointing. Update the indicator "storage system" to no longer rely on signal types and instead store based on indicator type.

Test Plan
---------

1. verify fetch still works:
Ran: "threatexchange -c ~/large_dataset_collab.te.cfg fetch --until-timestamp `date -j -vMarm -v1d -v2018y '+%s'`" to competition.
Also used fetch to query the entire large dataset set.

2. Verify experimentalfetch gets everything:
Ran: "threatexchange -c ~/large_dataset_collab.te.cfg experimental-fetch" on the large dataset collaboration and it queried to completion getting ~1.93m records

3. Verify experimentalfetch  --start-time and --end-time
Ran with various combinations of --start-time and --end-time and things worked as expected (only data updated within the time range was returned)

4. Verify experimentalfetch --threat-types
Ran "threatexchange -c ~/other_collab.te.cfg experimental-fetch --threat-types HASH_PDQ URL" on another collaboration and things worked as expected (only data with indicator types of HASH_PDQ or URL were returned)

5. Verify experimentalfetch --continuation
Ran "threatexchange -c ~/other_collab.te.cfg experimental-fetch --continuation" and this works as described:
i.e.
* When no url/cursor is check-pointed threat_updates is queried using the check-pointed last_stop_time as the new start-time and the check-pointed indicator types (if given) as filters
* When a url/cursor is check-pointed we continue fetching from that url/cursor

6. Verify experimentalfetch forces a full update if you haven't fetched in 85 days
* Modified the checkpoint to be > 85 days old
* Tried to run with --continuation
* Got the following message "It's been a long time since a full fetch, forcing one now." and started to fetch the entire collaboration

7. Tested error handling by both explicitly throwing errors and mucking with the url being queried