### PR TITLE
Use requests instead of urllib for TE.py

### DIFF
--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -53,6 +53,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         "python-Levenshtein",
+        "requests",
     ],
     extras_require=extras_require,
     entry_points={"console_scripts": ["threatexchange = threatexchange.cli.main:main"]},

--- a/python-threatexchange/threatexchange/TE.py
+++ b/python-threatexchange/threatexchange/TE.py
@@ -68,6 +68,7 @@ def get_fb_graph_api():
 
     TODO: Identify if requests Session object can be used across threads in a
     `concurrent.futures.ThreadPoolExecutor`
+    Filed:  https://github.com/facebook/ThreatExchange/issues/348
     - because a session is created per call to get_fb_graph_api(), the underlying conn
       pool can't be used.
     - this might become a performance concern if the pre-flight latencies become

--- a/python-threatexchange/threatexchange/TE.py
+++ b/python-threatexchange/threatexchange/TE.py
@@ -3,7 +3,7 @@
 """
 This is an entire copy of a file from ThreatExchange/hashing
 
-TODO: Slim down to only what we need, and switch to using requests
+TODO: Slim down to only what we need
 """
 
 import copy
@@ -45,12 +45,12 @@ class TimeoutHTTPAdapter(HTTPAdapter):
 
 
 DEFAULT_TE_BASE_URL = "https://graph.facebook.com/v6.0"
-retry_strategy = Retry(
+_retry_strategy = Retry(
     total=4,
     status_forcelist=[429, 500, 502, 503, 504],
     method_whitelist=["HEAD", "GET", "OPTIONS"],
 )
-adapter = TimeoutHTTPAdapter(timeout=60, max_retries=retry_strategy)
+_adapter = TimeoutHTTPAdapter(timeout=60, max_retries=_retry_strategy)
 
 
 def get_fb_graph_api():
@@ -78,7 +78,7 @@ def get_fb_graph_api():
       requests.get() equivalents
     """
     session = requests.Session()
-    session.mount(DEFAULT_TE_BASE_URL, adapter=adapter)
+    session.mount(DEFAULT_TE_BASE_URL, adapter=_adapter)
     return session
 
 

--- a/python-threatexchange/threatexchange/TE.py
+++ b/python-threatexchange/threatexchange/TE.py
@@ -73,7 +73,7 @@ class Net:
 
     @classmethod
     def getJSONFromURL(self, url):
-        """ Perform an HTTP GET request, and return the JSON response payload.
+        """Perform an HTTP GET request, and return the JSON response payload.
         Same timeouts and retry strategy as `fb_graph_api` above.
         """
         return fb_graph_api.get(url).json()

--- a/python-threatexchange/threatexchange/TE.py
+++ b/python-threatexchange/threatexchange/TE.py
@@ -23,6 +23,7 @@ import urllib.parse
 
 DEFAULT_TIMEOUT = 5  # seconds
 
+
 class TimeoutHTTPAdapter(HTTPAdapter):
     """
     Plug into requests to get a well-behaved session that does not wait for eternity.

--- a/python-threatexchange/threatexchange/common.py
+++ b/python-threatexchange/threatexchange/common.py
@@ -8,7 +8,6 @@ If this file starts getting large, break it up.
 """
 
 import re
-from requests.adapters import HTTPAdapter
 
 
 def class_name_to_human_name(name: str, suffix: str) -> str:
@@ -27,25 +26,3 @@ def camel_case_to_underscore(name: str) -> str:
     """
     s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
     return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
-
-
-DEFAULT_TIMEOUT = 5  # seconds
-
-
-class TimeoutHTTPAdapter(HTTPAdapter):
-    """Plug into requests to get a well-behaved session that does not wait for eternity.
-    H/T: https://findwork.dev/blog/advanced-usage-python-requests-timeouts-retries-hooks/#setting-default-timeouts
-    """
-
-    def __init__(self, *args, **kwargs):
-        self.timeout = DEFAULT_TIMEOUT
-        if "timeout" in kwargs:
-            self.timeout = kwargs["timeout"]
-            del kwargs["timeout"]
-        super().__init__(*args, **kwargs)
-
-    def send(self, request, **kwargs):
-        timeout = kwargs.get("timeout")
-        if timeout is None:
-            kwargs["timeout"] = self.timeout
-        return super().send(request, **kwargs)


### PR DESCRIPTION
Summary
---------
Because requests is much more high-level, it allows easily setting up
retries / timeouts and can be configured going ahead to support proxies
and .netrc and all the goodness!

Test Plan
---------
Two changes were made. The GET and POST commands.

For GET, I removed 'threatexchange_samples' and ran a random command. The directory was setup as expected using the requests code.

**Output**
```shell
$> threatexchange match text "ball now?"                                                                          ~
Looks like you haven't set up a collaboration config, so using the sample one against public data
Looks like you are running this for the first time. Fetching some sample data.
raw_text: 3
url: 1
pdq: 138
video_tmk_pdqf: 1
photo_md5: 1
video_md5: 2
trend_query: 1  
```

For the POST request, I'm still working on it. 
```shell
$> threatexchange label false_positive descriptor 3261912580534814 
```

This did not throw any errors, but I'll have to check if it is getting correctly received on the server.
