### PR TITLE
Get Label command to work

### DIFF
--- a/python-threatexchange/threatexchange/cli/label.py
+++ b/python-threatexchange/threatexchange/cli/label.py
@@ -22,11 +22,8 @@ class LabelCommand(command_base.Command):
     matches by default in the match command.
 
     Examples:
-      # Label text
-      $ threatexchange -c te.cfg label violating_label_from_config,other_label text "this is an example bad text"
-
       # Label descriptor
-      $ threatexchange -c te.cfg label false_positive descriptor 12345
+      $> threatexchange -c te.cfg label,other_label false_positive descriptor 12345
     """
 
     @classmethod
@@ -44,8 +41,10 @@ class LabelCommand(command_base.Command):
         )
         ap.add_argument("content", help="the content to label")
 
-    def __init__(self, descriptor_id: int, labels: t.List[str]) -> None:
-        self.descriptor_id = descriptor_id
+    def __init__(self, content_type: str, content: str, labels: t.List[str]) -> None:
+        if content_type == "descriptor":
+            self.descriptor_id = content
+
         # Remove any of the special tags that someone included for whatever reason
         self.labels = [
             l for l in labels if l not in descriptor.ThreatDescriptor.SPECIAL_TAGS

--- a/python-threatexchange/threatexchange/cli/label.py
+++ b/python-threatexchange/threatexchange/cli/label.py
@@ -23,7 +23,7 @@ class LabelCommand(command_base.Command):
 
     Examples:
       # Label descriptor
-      $> threatexchange -c te.cfg label,other_label false_positive descriptor 12345
+      $> threatexchange -c te.cfg label false_positive,other_label descriptor 12345
     """
 
     @classmethod


### PR DESCRIPTION
Summary
---------
LabelCommand argument spec is used to translate argparse arguments into constructor arguments. These were not in sync. The diff addresses that. It ensures the `LabelCommand.__init__(...)` arg spec is the same as the argparse spec defined in [LabelCommand.init_argparse](https://github.com/facebook/ThreatExchange/blob/64767362c3489c9057ba7a554d330b2ad3ad740c/python-threatexchange/threatexchange/cli/label.py#L33) method.

Test Plan
---------
Command:
```shell
$> threatexchange label false_positive descriptor 3425830734108278       
```

Used to fail with
```
Traceback (most recent call last):
  File "/Users/dipanjanm/.pyenv/versions/3.8.6/bin/threatexchange", line 33, in <module>
    sys.exit(load_entry_point('threatexchange', 'console_scripts', 'threatexchange')())
  File "/Users/dipanjanm/Repositories/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 149, in main
    execute_command(namespace)
  File "/Users/dipanjanm/Repositories/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 84, in execute_command
    command = command_cls(
TypeError: __init__() missing 1 required positional argument: 'descriptor_id'
```


This is now fixed. It exits with status code 0.