### PR TITLE
Add support for PDQ_OCR signal type

### DIFF
--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -25,10 +25,7 @@ extras_require = {
         "pdqhash>=0.2.2",
         "Pillow",
     ],
-    "pdq_ocr": [
-        "numpy",
-        "pdqhash>=0.2.2",
-        "Pillow",
+    "ocr": [
         "pytesseract",
     ],
 }

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -25,6 +25,12 @@ extras_require = {
         "pdqhash>=0.2.2",
         "Pillow",
     ],
+    "pdq_ocr": [
+        "numpy",
+        "pdqhash>=0.2.2",
+        "Pillow",
+        "pytesseract",
+    ],
 }
 
 all_extras = set(sum(extras_require.values(), []))

--- a/python-threatexchange/threatexchange/content_type/photo.py
+++ b/python-threatexchange/threatexchange/content_type/photo.py
@@ -6,7 +6,7 @@ Wrapper around the video content type.
 """
 import typing as t
 
-from ..signal_type import md5, pdq
+from ..signal_type import md5, pdq, pdq_ocr
 from ..signal_type.signal_base import SignalType
 from .content_base import ContentType
 
@@ -25,4 +25,4 @@ class PhotoContent(ContentType):
 
     @classmethod
     def get_signal_types(cls) -> t.List[t.Type[SignalType]]:
-        return [md5.PhotoMD5Signal, pdq.PdqSignal]
+        return [md5.PhotoMD5Signal, pdq.PdqSignal, pdq_ocr.PdqOcrSignal]

--- a/python-threatexchange/threatexchange/hashing/ocr_utils.py
+++ b/python-threatexchange/threatexchange/hashing/ocr_utils.py
@@ -3,7 +3,7 @@
 
 """
 Util file for Optical character recognition (OCR) related functions.
-Use of pytesseract will required additional libaries, see https://github.com/madmaze/pytesseract#installation
+Use of pytesseract requires additional libaries already be installed, see https://github.com/madmaze/pytesseract#installation
 """
 
 import pdqhash

--- a/python-threatexchange/threatexchange/hashing/ocr_utils.py
+++ b/python-threatexchange/threatexchange/hashing/ocr_utils.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Util file for Optical character recognition (OCR) related functions.
+Use of pytesseract will required additional libaries, see https://github.com/madmaze/pytesseract#installation
+"""
+
+import pdqhash
+import pathlib
+import pytesseract
+from PIL import Image, ImageOps
+
+
+def text_from_image_file(path: pathlib.Path):
+    """
+    Given a path to a file return predicted OCR text
+    Current Supported file types: jpg
+    """
+    img_pil = Image.open(path)
+    return pytesseract.image_to_string(img_pil)

--- a/python-threatexchange/threatexchange/signal_type/pdq.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq.py
@@ -11,7 +11,7 @@ import warnings
 
 from ..descriptor import SimpleDescriptorRollup, ThreatDescriptor
 from . import signal_base
-from ..hashing.pdq_utils import pdq_match
+from ..hashing.pdq_utils import pdq_match, BITS_IN_PDQ
 
 
 class PdqSignal(signal_base.SimpleSignalType, signal_base.FileMatcher):
@@ -50,6 +50,8 @@ class PdqSignal(signal_base.SimpleSignalType, signal_base.FileMatcher):
         return self.match_hash(pdq_hash)
 
     def match_hash(self, signal_str: str) -> t.List[signal_base.SignalMatch]:
+        if len(signal_str) != BITS_IN_PDQ / 4:
+            return []
         return [
             signal_base.SignalMatch(signal_attr.labels, signal_attr.first_descriptor_id)
             for pdq_hash, signal_attr in self.state.items()

--- a/python-threatexchange/threatexchange/signal_type/pdq.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq.py
@@ -50,8 +50,12 @@ class PdqSignal(signal_base.SimpleSignalType, signal_base.FileMatcher):
         return self.match_hash(pdq_hash)
 
     def match_hash(self, signal_str: str) -> t.List[signal_base.SignalMatch]:
+
+        # for case where cli tries to match against non-pdq type hashes
+        # (filtering should likely be moved up in future to avoid silent errors)
         if len(signal_str) != BITS_IN_PDQ / 4:
             return []
+
         return [
             signal_base.SignalMatch(signal_attr.labels, signal_attr.first_descriptor_id)
             for pdq_hash, signal_attr in self.state.items()

--- a/python-threatexchange/threatexchange/signal_type/pdq_ocr.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_ocr.py
@@ -46,7 +46,7 @@ class PdqOcrSignal(signal_base.SimpleSignalType, signal_base.FileMatcher):
             from ..hashing.ocr_utils import text_from_image_file
         except:
             warnings.warn(
-                "Getting both PDQ hash and text of an image file using OCR will require additional libraries to be installed; install threatexchange with the [pdq_ocr] extra to use them",
+                "Getting both PDQ hash and text of an image file using OCR requires additional libraries already be installed; install threatexchange with the [pdq_hasher & ocr] extra and see ocr_utils.py",
                 category=UserWarning,
             )
             return []

--- a/python-threatexchange/threatexchange/signal_type/pdq_ocr.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_ocr.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Wrapper around the Photo PDQ plus OCR signal type.
+Requires the installations of Optical character recognition (OCR) tools
+"""
+
+import math
+import typing as t
+import pathlib
+import warnings
+
+import Levenshtein
+
+from ..descriptor import SimpleDescriptorRollup, ThreatDescriptor
+from . import signal_base
+from ..hashing.pdq_utils import pdq_match
+from .. import common
+
+
+class PdqOcrSignal(signal_base.SimpleSignalType, signal_base.FileMatcher):
+    """
+    PDQ is an open source photo similarity algorithm. See 'pdq.py'
+    This signal type combines pdq hashes with a text string found using
+    optical character recognition (OCR) on the image hashed. This adds an
+    additional 'distance' using levenshtein string comparison.
+
+    Accuracy of matches will depend on quality of OCR implementations and selected thresholds.
+    (ocr_utils uses the open source pytesseract wrapper of tesseract)
+    """
+
+    INDICATOR_TYPE = "HASH_PDQ_OCR"
+    TYPE_TAG = "media_type_photo"
+
+    # This may need to be updated (TODO make more configurable)
+    # Hashes of distance less than or equal to this threshold are considered a 'match'
+    PDQ_PLUS_OCR_CONFIDENT_MATCH_THRESHOLD = 31
+    # Match considered if 90% of the strings match
+    LEVENSHTEIN_DISTANCE_PERCENT_THRESHOLD = 0.10
+
+    def match_file(self, file: pathlib.Path) -> t.List[signal_base.SignalMatch]:
+        """Simple PDQ file match."""
+        try:
+            from ..hashing.pdq_hasher import pdq_from_file
+            from ..hashing.ocr_utils import text_from_image_file
+        except:
+            warnings.warn(
+                "Getting both PDQ hash and text of an image file using OCR will require additional libraries to be installed; install threatexchange with the [pdq_ocr] extra to use them",
+                category=UserWarning,
+            )
+            return []
+
+        pdq_hash, quality = pdq_from_file(file)
+        ocr_text = text_from_image_file(file)
+
+        pdq_hash_plus_ocr = pdq_hash + "," + ocr_text
+
+        return self.match_hash(pdq_hash_plus_ocr)
+
+    def match_hash(self, signal_str: str) -> t.List[signal_base.SignalMatch]:
+        content_pdq_hash, content_ocr_text = signal_str.split(",", maxsplit=1)
+        matches = []
+        for pdq_hash_plus_ocr, signal_attr in self.state.items():
+            te_pdq_hash, te_ocr_text = pdq_hash_plus_ocr.split(",", maxsplit=1)
+            # PDQ Hash Match
+            if pdq_match(
+                te_pdq_hash,
+                content_pdq_hash,
+                self.PDQ_PLUS_OCR_CONFIDENT_MATCH_THRESHOLD,
+            ):
+                # Check for text match
+                normalized_content_str = common.normalize_string(content_ocr_text)
+                normalized_te_str = common.normalize_string(te_ocr_text)
+                if self._levenshtein_text_match(
+                    normalized_content_str,
+                    normalized_te_str,
+                    self.LEVENSHTEIN_DISTANCE_PERCENT_THRESHOLD,
+                ):
+                    matches.append(
+                        signal_base.SignalMatch(
+                            signal_attr.labels, signal_attr.first_descriptor_id
+                        )
+                    )
+        return matches
+
+    def _levenshtein_text_match(self, str_a: str, str_b: str, threshold: float) -> bool:
+        """
+        Returns true if strings match within the percent threshold using Levenshtein distance
+        """
+        # TODO find way to reuse similar code in raw_text.py without sacrificing performance.
+        match_threshold = math.floor(len(str_a) * threshold)
+        ldiff = abs(len(str_a) - len(str_b))
+        # Filter out anything that can't possibly match due to len difference
+        if ldiff > match_threshold:
+            return False
+        distance = Levenshtein.distance(str_a, str_b)
+        return distance <= match_threshold


### PR DESCRIPTION
Summary
---------

This PR adds fetching and matching functionality for the PDQ_OCR signal type. 
(Experimental: If https://github.com/tesseract-ocr/tesseract is installed it can also attempt to get the text from a given file and use it for matching.)

Test Plan
---------

```
$ threatexchange fetch --full 
Looks like you haven't set up a collaboration config, so using the sample one against public data
video_md5: 2
raw_text: 3
pdq_ocr: 2
video_tmk_pdqf: 1
photo_md5: 1
url: 1
trend_query: 1
pdq: 138
```

```
$ threatexchange match photo -H '<PDQ-HASH>,This is a sample text string' --show-false-positives 
Looks like you haven't set up a collaboration config, so using the sample one against public data
<ThreatDescriptor ID>  pdq_ocr disputed
```
