### PR TITLE
[hma] Force delete s3 buckets (for now)

### DIFF
--- a/hasher-matcher-actioner/hashing-data/main.tf
+++ b/hasher-matcher-actioner/hashing-data/main.tf
@@ -25,6 +25,10 @@ resource "aws_s3_bucket" "data_bucket" {
   versioning {
     enabled = true
   }
+  # For development, this makes cleanup easier
+  # If deploying for real, this should not be used
+  # Could also be set with a variable
+  force_destroy = true
 }
 
 resource "aws_s3_bucket_public_access_block" "data_bucket" {


### PR DESCRIPTION
Summary
---------

It's very easy to leave dangling s3 buckets in our current setup. Allow force deletion for non-empty stuff.

Test Plan
---------
terragraph plan
```
  # module.hashing_data.aws_s3_bucket.data_bucket will be created
  + resource "aws_s3_bucket" "data_bucket" {
      + acceleration_status         = (known after apply)
      + acl                         = "private"
      + arn                         = (known after apply)
      + bucket                      = (known after apply)
      + bucket_domain_name          = (known after apply)
      + bucket_prefix               = "hma-hashing-data"
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = true
```