### PR TITLE
[py-tx] Fix formatting of top level help

### DIFF
--- a/python-threatexchange/threatexchange/cli/command_base.py
+++ b/python-threatexchange/threatexchange/cli/command_base.py
@@ -71,8 +71,11 @@ class Command:
     def get_help(cls) -> str:
         """The short help of the command"""
         line = cls.get_description().strip().partition("\n")[0]
+        # Good luck debugging this! Slightly reformat short description
+        # (toplevel --help)
         if line[0].isupper():
-            line = line[0].lower() + line[1:]
+            first_word, sp, rem = line.partition(" ")
+            line = f"{first_word.lower()}{sp}{rem}"
         if line[-1] == ".":
             line = line[:-1]
         return line


### PR DESCRIPTION
### Summary 
Was just bothering me. I also wrote the code that broke it,
so /shrug

### Test Plan
Before:
```
$ threatexchange --help
verbs:
  {fetch,experimental-fetch,match,label}
                        which action to do
    fetch               download content from ThreatExchange to disk
    experimental-fetch  wARNING: This is experimental, you probably want
to
                        use "Fetch" instead
...
```

After:
```
$ threatexchange --help
verbs:
  {fetch,experimental-fetch,match,label}
                        which action to do
    fetch               download content from ThreatExchange to disk
    experimental-fetch  warning: This is experimental, you probably want
to
                        use "Fetch" instead
...
```

Summary
---------

<!--Replace with a summary of your change-->

Test Plan
---------

<!--Replace with a description of how you tested this change, did you add test, run something locally...-->
