### PR TITLE
[py-tx] Trim newlines from .txtoken, better validation

### DIFF
--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -94,7 +94,7 @@ def execute_command(namespace) -> None:
 
 
 def get_app_token(cli_option: str = None) -> str:
-    """Initialize the API key from a variety of fallback sources"""
+    """Get the API key from a variety of fallback sources"""
 
     file_loc = pathlib.Path("~/.txtoken").expanduser()
     environment_var = "TX_ACCESS_TOKEN"
@@ -104,7 +104,7 @@ def get_app_token(cli_option: str = None) -> str:
         source = "cli argument"
         token = cli_option
     elif os.environ.get(environment_var):
-        source = "TX_ACCESS_TOKEN environment variable"
+        source = f"{environment_var} environment variable"
         token = os.environ[environment_var]
     elif file_loc.exists() and file_loc.read_text():
         source = file_loc

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -17,13 +17,14 @@ import inspect
 import os
 import os.path
 import pathlib
+import re
 import sys
 import typing as t
 
 from .. import TE
-from . import command_base as base, fetch, experimental_fetch, label, match
 from ..collab_config import CollaborationConfig
 from ..dataset import Dataset
+from . import command_base as base, fetch, experimental_fetch, label, match
 
 
 def get_subcommands() -> t.List[t.Type[base.Command]]:
@@ -48,7 +49,6 @@ def get_argparse() -> argparse.ArgumentParser:
     ap.add_argument(
         "--app-token",
         "-a",
-        type=CollaborationConfig.load,
         metavar="TOKEN",
         help="the App token for ThreatExchange",
     )
@@ -73,7 +73,7 @@ def execute_command(namespace) -> None:
     command_cls = namespace.command_cls
     try:
         # Init TE lib
-        init_app_token(namespace.app_token)
+        TE.Net.APP_TOKEN = get_app_token(namespace.app_token)
         # Init collab config
         cfg = init_config_file(namespace.config)
         # "Init" dataset
@@ -93,25 +93,47 @@ def execute_command(namespace) -> None:
         sys.exit(130)
 
 
-def init_app_token(cli_option: str = None) -> None:
+def get_app_token(cli_option: str = None) -> str:
     """Initialize the API key from a variety of fallback sources"""
 
     file_loc = pathlib.Path("~/.txtoken").expanduser()
     environment_var = "TX_ACCESS_TOKEN"
+    token = ""
+    source = ""
     if cli_option:
-        TE.Net.APP_TOKEN = cli_option
+        source = "cli argument"
+        token = cli_option
     elif os.environ.get(environment_var):
-        TE.Net.APP_TOKEN = os.environ[environment_var]
+        source = "TX_ACCESS_TOKEN environment variable"
+        token = os.environ[environment_var]
     elif file_loc.exists() and file_loc.read_text():
-        TE.Net.APP_TOKEN = file_loc.read_text()
+        source = file_loc
+        token = file_loc.read_text()
     else:
         raise base.CommandError(
             (
-                "Can't find API key - pass as an argument, in the environment as "
-                f"{environment_var} or put it in {file_loc}"
+                "Can't find App Token, pass it in using one of: \n"
+                "  * a cli argument\n"
+                f"  * in the environment as {environment_var}\n"
+                f"  * in a file at {file_loc}\n"
+                "https://developers.facebook.com/tools/accesstoken/"
             ),
             2,
         )
+    token = token.strip()
+    if not is_valid_app_token(token):
+        raise base.CommandError(
+            f"Your current app token (from {source}) is invalid.\n"
+            "Double check that it's an 'App Token' from "
+            "https://developers.facebook.com/tools/accesstoken/",
+            2,
+        )
+    return token
+
+
+def is_valid_app_token(token: str) -> bool:
+    """Returns true if the string looks like a valid token"""
+    return bool(re.match("[0-9]{8,}(?:%7C|\\|)[a-zA-Z0-9_\\-]{20,}", token))
 
 
 def init_config_file(cli_provided: t.IO = None) -> CollaborationConfig:


### PR DESCRIPTION
Summary
---------
Pasting in the txtoken can be a pain to get right.
One user ran into issues trying to store the file, where
they had a dangling newline at the end. Fix that issue
and try and do better error messages.

Independently, I found that the argument validation
was incorrect, making it extra hard to tell what is
happening.

Fixes #345

Test Plan
---------
```
$ mv ~/.txtoken ~/.txtoken.bak
$ threatexchange fetch
Can't find App Token, pass it in using one of:
  * a cli argument
  * in the environment as TX_ACCESS_TOKEN
  * in a file at /home/dcallies/.txtoken
https://developers.facebook.com/tools/accesstoken/
[Exit 2]

$ TX_ACCESS_TOKEN=238423849asdf threatexchange fetch
Your current app token (from TX_ACCESS_TOKEN environment variable) is invalid.
Double check that it's an 'App Token' from https://developers.facebook.com/tools/accesstoken/

$ TX_ACCESS_TOKEN="$(cat ~/.txtoken.bak; echo)" threatexchange fetch
# Fetches despite trailing newline
$ threatexchange -a "$(cat ~/.txtoken.bak)" fetch
# Fetches
$ mv ~/.txtoken.bak ~/.txtoken
$ vim ~/.txtoken (adding a newline to end)
$ threatexchange fetch
# Fetches
```