### PR TITLE
[py-te] Add some simple tests to learn py.test

### DIFF
--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -165,9 +165,9 @@ def _verify_directory(raw: str) -> pathlib.Path:
     return ret
 
 
-def main() -> None:
+def main(args: t.Optional[t.Sequence[t.Text]] = None) -> None:
     ap = get_argparse()
-    namespace = ap.parse_args()
+    namespace = ap.parse_args(args)
     execute_command(namespace)
 
 

--- a/python-threatexchange/threatexchange/cli/tests/cli_smoke_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/cli_smoke_test.py
@@ -1,0 +1,26 @@
+import sys
+
+import pytest
+
+from threatexchange.cli import main
+
+
+def test_all_helps():
+    """
+    Just executes all the commands to make sure they don't throw on help.
+
+    View the pretty output with py.test -s
+    """
+
+    def help(command=None):
+        args = [command.get_name()] if command else []
+        args.append("--help")
+
+        with pytest.raises(SystemExit) as exc:
+            print("\n$ threatexchange", " ".join(args), file=sys.stderr)
+            main.main(args)
+        assert exc.value.code == 0
+
+    help()  # root help
+    for command in main.get_subcommands():
+        help(command)


### PR DESCRIPTION
Summary
---------
I've never used pytest, so play with it to write a simple
test that just makes sure all the helps print.

Test Plan
---------
```
$ py.test -s
================================================================= test
session starts
==================================================================
platform linux -- Python 3.6.8, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir:
/data/users/dcallies/fork_te/ThreatExchange/python-threatexchange
collected 1 item

cli/tests/cli_smoke_test.py
$ threatexchange --help
usage: py.test [-h] [--config CONFIG] [--app-token TOKEN] [--state-dir
DIR]
               {fetch,experimental-fetch,match,label} ...

A wrapper around multi-stage ThreatExchange operations.

Includes simple matching and writing back. Useful for quickly validating
new
sources of ThreatExchange data. A possible template for a native
implementation in your own architecture.

This helper heavily relies on a config file to provide consistent
behavior
between stages, and a state file to store hashes.

optional arguments:
  -h, --help            show this help message and exit
  --config CONFIG, -c CONFIG
                        a ThreatExchange collaboration config
  --app-token TOKEN, -a TOKEN
                        the App token for ThreatExchange
  --state-dir DIR, -s DIR
                        the directory with the config state

verbs:
  {fetch,experimental-fetch,match,label}
                        which action to do
    fetch               download content from ThreatExchange to disk
    experimental-fetch  warning: This is experimental, you probably want
to
                        use "Fetch" instead
    match               match content to items in ThreatExchange
    label               apply labels to items in ThreatExchange

$ threatexchange fetch --help
usage: py.test fetch [-h] [--sample] [--clear] [--full]
                     [--until-timestamp UNTIL_TIMESTAMP]
                     [--only-signals signal [signal ...]]
                     [--not-signals signal [signal ...]]

    Download content from ThreatExchange to disk.

    Using the CollaborationConfig, identify ThreatDescriptors that
    correspond to a single collaboration, and store them in the state
    directory.

    You can then use the match command to search against this directory
for
    the simple content, or you can use the produced files (which by
default
    live in your home directory with a name based on the collaboration,
but
    can be overridden with the --state-dir argument) to load into your
own
    infrastructure to more efficiently match against the downloaded
hashes.

    The exact format of each file is determined by the implementation of
the
    signal types, but or usually optimized for easy re-use, such as .csv
or
    .tsv.

optional arguments:
  -h, --help            show this help message and exit
  --sample              Only fetch a sample of data instead of the whole
                        dataset
  --clear               Don't fetch anything, just clear the dataset
  --full                Force a full refresh of data.
  --until-timestamp UNTIL_TIMESTAMP
                        Instead of fetching all the data, incrementally
fetch
                        up to this time
  --only-signals signal [signal ...], -o signal [signal ...]
                        Only download the specified signal types.
  --not-signals signal [signal ...], -n signal [signal ...]
                        Don't fetch the specified signal types.

$ threatexchange experimental-fetch --help
usage: py.test experimental-fetch [-h] [--continuation]
                                  [--start-time START_TIME]
                                  [--stop-time STOP_TIME]
                                  [--types TYPES [TYPES ...]]
                                  [--page-size PAGE_SIZE]

    WARNING: This is experimental, you probably want to use "Fetch"
instead.

    Download content from ThreatExchange to disk.

    Using the CollaborationConfig, identify ThreatPrivacyGroup that
    corresponds to a single collaboration and fetch related threat
updates.

optional arguments:
  -h, --help            show this help message and exit
  --continuation        Continue fetching updates from where you last
stopped
                        with the same threat types. This will ignore all
other
                        options given aside from --page-size.
  --start-time START_TIME
                        Fetch updates that occured on or after this
timestamp
  --stop-time STOP_TIME
                        Fetch updates that occured before this timestamp
  --types TYPES [TYPES ...]
                        Only fetch updates for indicators of the given
type
  --page-size PAGE_SIZE
                        The number of updates to fetch per request,
defaults
                        to 500

$ threatexchange match --help
usage: py.test match [-h] [--hashes] [--as-text]
[--show-false-positives]
                     [--hide-disputed]
                     {text,video,photo} content [content ...]

    Match content to items in ThreatExchange.

    Using the dataset from the fetch command, try to match content. Not
all
    content and hashing types are implemented, so it's possible that you
    can download signals, but not match them via this command. In some
cases
    the implementation in this package is sub-optimal, either in
completeness
    (i.e. only matching exact when near-matching is supported), or in
runtime
    (i.e. using a linear implementation when a sublinear implementation
exists)

    The output of this command is in the following format:

      <matched descriptor id> <signal type> <label1> <label2...>

    If tying this into your own integrity systems, if the result of this
match
    is human review, you'll want to store the matched descriptor id and
make
    a call to

      all_in_one label descriptor <matched descriptor id>

    with the results of that review.

positional arguments:
  {text,video,photo}    what kind of content to match
  content               what to match against. Accepts filenames, quoted
                        strings, or '-' to read newline-separated stdin

optional arguments:
  -h, --help            show this help message and exit
  --hashes, -H          instead of content (i.e. videos), input contains
                        intermediate representations (i.e. video MD5s)
  --as-text, -T         force input to be interpreted as text instead of
as
                        filenames
  --show-false-positives
                        show matches even if you've marked them
false_positive
  --hide-disputed       hide matches if someone has disputed them

$ threatexchange label --help
usage: py.test label [-h] CSV {descriptor} content

    Apply labels to items in ThreatExchange.

    Labeling descriptors as false_positive will cause them to stop
triggering
    matches by default in the match command.

    Examples:
      # Label descriptor
      $> threatexchange -c te.cfg label false_positive,other_label
descriptor 12345

positional arguments:
  CSV           labels to apply to item
  {descriptor}  what kind of content to label
  content       the content to label

optional arguments:
  -h, --help    show this help message and exit
.

=== 1 passed in 0.29s ===
```
