### PR TITLE
[py-tx][high impact] Rename api methods

### DIFF
--- a/python-threatexchange/threatexchange/cli/fetch.py
+++ b/python-threatexchange/threatexchange/cli/fetch.py
@@ -245,7 +245,7 @@ class FetchCommand(command_base.Command):
                 return len(descriptors)
 
             for tag_name in tags_to_fetch:
-                tag_id = api.getTagIDFromName(tag_name)
+                tag_id = api.get_tag_id(tag_name)
                 if not tag_id:
                     continue
                 pending_futures = collections.deque()
@@ -320,7 +320,7 @@ class FetchCommand(command_base.Command):
         """Do the bulk ThreatDescriptor fetch"""
         return [
             ThreatDescriptor.from_te_json(ThreatDescriptor.MY_APP_ID, td_json)
-            for td_json in api.getInfoForIDs(td_ids)
+            for td_json in api.get_threat_descriptors(td_ids)
         ]
 
 
@@ -344,6 +344,6 @@ class _TagQueryFetchCheckpoint:
         return bool(self._next_url)
 
     def next(self) -> t.Dict[id, t.Any]:
-        response = self.api.getJSONFromURL(self._next_url)
+        response = self.api.get_json_from_url(self._next_url)
         self._next_url = response.get("paging", {}).get("next")
         return [d["id"] for d in response["data"] if d["type"] == "THREAT_DESCRIPTOR"]

--- a/python-threatexchange/threatexchange/cli/label.py
+++ b/python-threatexchange/threatexchange/cli/label.py
@@ -58,7 +58,7 @@ class LabelCommand(command_base.Command):
     def execute(self, api: ThreatExchangeAPI, dataset: Dataset) -> None:
         if not self.false_positive_reaction:
             raise NotImplementedError
-        err_message, ex, response = api.reactToThreatDescriptor(
+        err_message, ex, response = api.react_to_threat_descriptor(
             self.descriptor_id, "DISAGREE_WITH_TAGS"
         )
         if ex:

--- a/python-threatexchange/threatexchange/descriptor.py
+++ b/python-threatexchange/threatexchange/descriptor.py
@@ -58,7 +58,7 @@ class ThreatDescriptor(t.NamedTuple):
         cls.MY_APP_ID = my_app_id
         owner_id_str = td_json["owner"]["id"]
         tags = td_json.get("tags", [])
-        # This is needed because ThreatExchangeAPI.getInfoForIDs()
+        # This is needed because ThreatExchangeAPI.get_threat_descriptors()
         # does a transform, but other locations do not
         if isinstance(tags, dict):
             tags = sorted(tag["text"] for tag in tags["data"])


### PR DESCRIPTION
Summary
---------
General python conventions (https://www.python.org/dev/peps/pep-0008/) hold that method names are lower_with_under.

I didn't finish a checkpoint of my main work, and I wanted to put something up before the end of the day, so here you go.

Test Plan
---------
Used only programmatic tools:
```
codemod getJSONFromURL get_json_from_url
codemod getTagIDFromName get_tag_id
codemod getInfoForIDs get_threat_descriptors
codemod validatePostPararmsForSubmit _validate_post_params_for_submit
codemod validatePostPararmsForCopy _validate_post_pararms_for_copy
codemod reactToThreatDescriptor react_to_threat_descriptor
codemod submitThreatDescriptor upload_threat_descriptor
codemod copyThreatDescriptor copy_threat_descriptor
```

Ran 
```
threatexchange fetch
```
To check that it didn't explode