### PR TITLE
[py-tx] More progress towards indices, dataset command

### DIFF
--- a/python-threatexchange/threatexchange/cli/dataset_cmd.py
+++ b/python-threatexchange/threatexchange/cli/dataset_cmd.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import argparse
+import collections
+import csv
+import sys
+import typing as t
+
+from .. import threat_updates
+from ..api import ThreatExchangeAPI
+from ..content_type import meta
+from ..dataset import Dataset
+from . import command_base
+from .dataset.simple_serialization import CliIndicatorSerialization
+
+
+class DatasetCommand(command_base.Command):
+    """
+    Introspect the local ThreatExchange dataset.
+
+    Can print out contents in simple formats
+    (ideal for sending to another system), or regenerate
+    index files (ideal if distributing indices for some reason)
+    """
+
+    @classmethod
+    def init_argparse(cls, ap) -> None:
+        ap.add_argument(
+            "--rebuild-indices",
+            "-r",
+            action="store_true",
+            help="rebuild indices",
+        )
+        ap.add_argument(
+            "--print",
+            "-p",
+            action="store_true",
+            dest="print_records",
+            help="print records to screen",
+        )
+        ap.add_argument(
+            "--type", "-t", dest="only_type", metavar="STR", help="only process one type of indicators (or signals)"
+        )
+        ap.add_argument(
+            "--indicator-only", "-i", action="store_true", help="only print indicators"
+        )
+        ap.add_argument(
+            "--signal-summary",
+            "-s",
+            action="store_true",
+            help="print summary in terms of signals",
+        )
+
+    def __init__(
+        self,
+        rebuild_indices: bool,
+        only_type: t.Optional[str],
+        indicator_only: bool,
+        signal_summary: bool,
+        print_records: bool,
+    ) -> None:
+        self.rebuild_indices = rebuild_indices
+        self.only_type = only_type
+        self.indicator_only = indicator_only
+        self.signal_summary = signal_summary
+        self.print_records = print_records
+
+    def execute(self, api: ThreatExchangeAPI, dataset: Dataset) -> None:
+        stores = [
+            threat_updates.ThreatUpdateFileStore(
+                dataset.state_dir,
+                privacy_group,
+                api.app_id,
+                serialization=CliIndicatorSerialization,
+            )
+            for privacy_group in dataset.config.privacy_groups
+        ]
+        indicators = {}
+        for store in stores:
+            indicators.update(store.load_state())
+        if self.only_type:
+            s_type = meta.get_signal_types_by_name().get(self.only_type)
+            if s_type:
+                self.signal_summary = True
+
+            indicators = {
+                k: v
+                for k, v in indicators.items()
+                if v.indicator_type == self.only_type
+                or s_type
+                and s_type.indicator_applies(v.indicator_type, v.rollup.labels)
+            }
+        if self.rebuild_indices:
+            generate_cli_indices(dataset, stores)
+        if self.print_records:
+            self._print_records(indicators)
+        elif self.signal_summary:
+            self.print_signal_summary(indicators)
+        else:
+            self.print_summary(indicators)
+
+    def print_summary(self, indicators: t.Dict[str, CliIndicatorSerialization]):
+        by_type = collections.Counter()
+        for indicator in indicators.values():
+            by_type[indicator.indicator_type] += 1
+        for name, count in sorted(by_type.items(), key=lambda i: -i[1]):
+            self.stderr(f"{name}: {count}")
+
+    def print_signal_summary(self, indicators: t.Dict[str, CliIndicatorSerialization]):
+        signal_types = meta.get_signal_types_by_name()
+        by_signal = collections.Counter()
+        for indicator in indicators.values():
+            for name, signal_type in signal_types.items():
+                if signal_type.indicator_applies(
+                    indicator.indicator_type, indicator.rollup.labels
+                ):
+                    by_signal[name] += 1
+        for name, count in sorted(by_signal.items(), key=lambda i: -i[1]):
+            self.stderr(f"{name}: {count}")
+
+    def _print_records(self, indicators: t.Dict[str, CliIndicatorSerialization]):
+        csv_writer = csv.writer(sys.stdout)
+        for indicator in indicators.values():
+            if self.indicator_only:
+                print(indicator.indicator)
+            else:
+                csv_writer.writerow(indicator.as_csv_row())
+
+
+def generate_cli_indices(dataset: Dataset, indicator_stores):
+    signal_types = meta.get_signal_types_by_name()
+    indicators = {name: [] for name in signal_types}
+    for store in indicator_stores:
+        for indicator in store.load_state().values():
+            for name, signal_type in signal_types.items():
+                if signal_type.indicator_applies(
+                    indicator.indicator_type, indicator.rollup.labels
+                ):
+                    indicators[name].append(indicator)
+
+    for name, signal_type in signal_types.items():
+        index_cls = signal_type.get_index_cls()
+        index = None
+        indicators_for_signal = indicators[name]
+        if indicators_for_signal:
+            index = index_cls.build(
+                (indicator.indicator_type, indicator.rollup)
+                for indicator in indicators_for_signal
+            )
+        dataset.store_index(signal_type, index)

--- a/python-threatexchange/threatexchange/cli/dataset_cmd.py
+++ b/python-threatexchange/threatexchange/cli/dataset_cmd.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import argparse

--- a/python-threatexchange/threatexchange/cli/dataset_cmd.py
+++ b/python-threatexchange/threatexchange/cli/dataset_cmd.py
@@ -40,7 +40,11 @@ class DatasetCommand(command_base.Command):
             help="print records to screen",
         )
         ap.add_argument(
-            "--type", "-t", dest="only_type", metavar="STR", help="only process one type of indicators (or signals)"
+            "--type",
+            "-t",
+            dest="only_type",
+            metavar="STR",
+            help="only process one type of indicators (or signals)",
         )
         ap.add_argument(
             "--indicator-only", "-i", action="store_true", help="only print indicators"

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -25,7 +25,7 @@ from .. import descriptor
 from ..api import ThreatExchangeAPI
 from ..collab_config import CollaborationConfig
 from ..dataset import Dataset
-from . import command_base as base, fetch, experimental_fetch, label, match
+from . import command_base as base, fetch, experimental_fetch, label, match, dataset_cmd
 
 
 def get_subcommands() -> t.List[t.Type[base.Command]]:
@@ -34,6 +34,7 @@ def get_subcommands() -> t.List[t.Type[base.Command]]:
         experimental_fetch.ExperimentalFetchCommand,
         match.MatchCommand,
         label.LabelCommand,
+        dataset_cmd.DatasetCommand,
     ]
 
 

--- a/python-threatexchange/threatexchange/signal_type/trend_query.py
+++ b/python-threatexchange/threatexchange/signal_type/trend_query.py
@@ -109,3 +109,7 @@ class TrendQuerySignal(signal_base.SignalType, signal_base.StrMatcher):
             writer = csv.writer(f, dialect="excel-tab")
             for k, v in self.state.items():
                 writer.writerow((k,) + v[1].as_row())
+
+    @classmethod
+    def indicator_applies(cls, indicator_type: str, tags: t.List[str]) -> bool:
+        return indicator_type == "DEBUG_STRING" and "media_type_trend_query" in tags


### PR DESCRIPTION
Summary
---------

Another diff that should have been more diffs! This diff:
1. Adds a formal relationship between indices and signal types
2. Adds a new cli command called "dataset" which can introspect the local store
3. Adds index generation at the end of experimental-fetch

Test Plan
---------
### Dataset command

```
$ threatexchange dataset --help
usage: threatexchange dataset [-h] [--rebuild-indices] [--print] [--type STR]
                              [--indicator-only] [--signal-summary]

    Introspect the local ThreatExchange dataset.

    Can print out contents in simple formats
    (ideal for sending to another system), or regenerate
    index files (ideal if distributing indices for some reason)


optional arguments:
  -h, --help            show this help message and exit
  --rebuild-indices, -r
                        rebuild indices
  --print, -p           print records to screen
  --type STR, -t STR    only process one type of indicators (or signals)
  --indicator-only, -i  only print indicators
  --signal-summary, -s  print summary in terms of signals

$ threatexchange dataset
DEBUG_STRING: 4024
HASH_PDQ: 282
HASH_PDQ_OCR: 221
RAW_URI: 207
HASH_TMK: 4
HASH_MD5: 2

$ threatexchange dataset -s
raw_text: 4020
pdq: 282
pdq_ocr: 221
url: 207
video_tmk_pdqf: 4
trend_query: 3
video_md5: 2

$ threatexchange dataset -t DEBUG_STRING
DEBUG_STRING: 4024

$ threatexchange dataset -t raw_text
DEBUG_STRING: 4020

$ threatexchange dataset -t DEBUG_STRING
DEBUG_STRING: 4024

$ threatexchange dataset -t raw_text
raw_text: 4020

$ threatexchange dataset -t video_md5 -p
facedaa5e3b6b12fa239bf638edffe16,3546336225434510,2021-01-15T22:17:05+0000,media_priority_XXX media_type_video true_positive
face29d5c964c30b740afd22efb904de,3459269117534444,2021-01-28T18:10:46+0000,media_priority_XXX media_type_video true_positive

$ threatexchange dataset -t HASH_MD5 -p
facedaa5e3b6b12fa239bf638edffe16,3546336225434510,2021-01-15T22:17:05+0000,media_priority_XXX media_type_video true_positive
face29d5c964c30b740afd22efb904de,3459269117534444,2021-01-28T18:10:46+0000,media_priority_XXX media_type_video true_positive

$ threatexchange dataset -r

```

### File sizes
For comparison, here's the simple format we've been using up until now vs pickle - pickle appears to be pretty smart about squashing stuff when text in it, and appears at least to be the same order of magnitude as the simple serializations
```
$ ls -1sh
 60K pdq.index.te
 48K pdq_ocr.index.te
844K raw_text.index.te
1.3M simple.DEBUG_STRING.te
4.0K simple.HASH_MD5.te
152K simple.HASH_PDQ_OCR.te
 56K simple.HASH_PDQ.te
1.4M simple.HASH_TMK.te
 40K simple.RAW_URI.te
4.0K trend_query.index.te
 44K url.index.te
4.0K video_md5.index.te
4.0K video_tmk_pdqf.index.te

```

