### PR TITLE
Refactor hasher lambda, define hash store interface, mypy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@ pdq/java/bazel-genfiles/
 pdq/java/bazel-java/
 pdq/java/bazel-out/
 pdq/java/bazel-testlogs/
-
 .mypy_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ pdq/java/bazel-genfiles/
 pdq/java/bazel-java/
 pdq/java/bazel-out/
 pdq/java/bazel-testlogs/
+
+.mypy_cache/

--- a/hasher-matcher-actioner/hmalib/dto.py
+++ b/hasher-matcher-actioner/hmalib/dto.py
@@ -9,9 +9,6 @@ import typing as t
 
 class PDQHashRecord(t.NamedTuple):
     """Successful execution at the hasher produces this record.
-
-    At present, we only use these records to write to dynamodb, so this is in
-    the storage module, but we can move this out.
     """
 
     content_key: str

--- a/hasher-matcher-actioner/hmalib/dto.py
+++ b/hasher-matcher-actioner/hmalib/dto.py
@@ -24,10 +24,14 @@ class PDQHashRecord(t.NamedTuple):
             "PK": "c#{}".format(self.content_key),
             "SK": "type:pdq",
             "ContentHash": self.content_hash,
-            "Quality": quality,
-            "Timestamp": timestamp.isoformat(),
+            "Quality": self.quality,
+            "Timestamp": self.timestamp.isoformat(),
             "HashType": "pdq",
         }
 
     def to_sqs_message(self) -> dict:
-        return {"hash": pdq_hash, "type": "pdq", "key": key}
+        return {
+            "hash": self.content_hash,
+            "type": "pdq",
+            "key": self.content_key
+        }

--- a/hasher-matcher-actioner/hmalib/dto.py
+++ b/hasher-matcher-actioner/hmalib/dto.py
@@ -1,0 +1,33 @@
+import datetime
+import typing as t
+
+# Not enforceable because named tuples can't have multiple inheritance, but all
+# DTO classes in this module should implement methods
+# `to_dynamodb_item(self)`
+# and `to_sqs_message(self)`
+
+
+class PDQHashRecord(t.NamedTuple):
+    """Successful execution at the hasher produces this record.
+
+    At present, we only use these records to write to dynamodb, so this is in
+    the storage module, but we can move this out.
+    """
+
+    content_key: str
+    content_hash: str
+    quality: int
+    timestamp: datetime.datetime  # ISO-8601 formatted
+
+    def to_dynamodb_item(self) -> dict:
+        return {
+            "PK": "c#{}".format(self.content_key),
+            "SK": "type:pdq",
+            "ContentHash": self.content_hash,
+            "Quality": quality,
+            "Timestamp": timestamp.isoformat(),
+            "HashType": "pdq",
+        }
+
+    def to_sqs_message(self) -> dict:
+        return {"hash": pdq_hash, "type": "pdq", "key": key}

--- a/hasher-matcher-actioner/hmalib/dto.py
+++ b/hasher-matcher-actioner/hmalib/dto.py
@@ -1,14 +1,15 @@
 import datetime
 import typing as t
 
-# Not enforceable because named tuples can't have multiple inheritance, but all
-# DTO classes in this module should implement methods
-# `to_dynamodb_item(self)`
-# and `to_sqs_message(self)`
-
+"""
+Not enforceable because named tuples can't have multiple inheritance, but all
+DTO classes in this module should implement methods `to_dynamodb_item(self)` and
+`to_sqs_message(self)`
+"""
 
 class PDQHashRecord(t.NamedTuple):
-    """Successful execution at the hasher produces this record.
+    """
+    Successful execution at the hasher produces this record.
     """
 
     content_key: str
@@ -16,9 +17,13 @@ class PDQHashRecord(t.NamedTuple):
     quality: int
     timestamp: datetime.datetime  # ISO-8601 formatted
 
+    @staticmethod
+    def get_dynamodb_pk(key: str):
+        return f"c#{key}"
+
     def to_dynamodb_item(self) -> dict:
         return {
-            "PK": "c#{}".format(self.content_key),
+            "PK": PDQHashRecord.get_dynamodb_pk(self.content_key),
             "SK": "type:pdq",
             "ContentHash": self.content_hash,
             "Quality": self.quality,

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_hasher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_hasher.py
@@ -11,6 +11,9 @@ import datetime
 import boto3
 from threatexchange.hashing import pdq_hasher
 
+from hmalib.dto import PDQHashRecord
+from hmalib.storage.hashstore import HashStore
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
@@ -19,50 +22,63 @@ sqs_client = boto3.client("sqs")
 dynamodb = boto3.resource("dynamodb")
 
 OUTPUT_QUEUE_URL = os.environ["PDQ_HASHES_QUEUE_URL"]
-
 DYNAMODB_TABLE = os.environ["DYNAMODB_TABLE"]
 
 
-def save_hash_to_datastore(table, content_key, content_hash, quality, current_datetime):
-    item = {
-        "PK": "c#{}".format(content_key),
-        "SK": "type#pdq",
-        "ContentHash": content_hash,
-        "Quality": quality,
-        "Timestamp": current_datetime.isoformat(),
-        "HashType": "pdq",
-    }
-    table.put_item(Item=item)
-
-
 def lambda_handler(event, context):
-    table = dynamodb.Table(DYNAMODB_TABLE)
+    """
+    Listens to SQS events generated when new files are added to S3. Downloads
+    files to temp-storage, generates PDQ hash and quality from the file.
+
+    Saves hash output to dynamodb.
+
+    Sends a message on an output queue.
+
+    Note: Lambdas have pretty strong tempfile storage limits (512MB as of this
+    writing) [1]. We are using the tempfile module in a context manager block,
+    so the file gets deleted after use. If additional files are created, ensure
+    they are inside their own context managers otherwise the lambda can run out
+    of disk-space.
+
+    1: https://docs.aws.amazon.com/lambda/latest/dg/images-create.html
+    """
+
+    records_table = dynamodb.Table(DYNAMODB_TABLE)
+    store = HashStore(records_table)
+
     for sqs_record in event["Records"]:
         sns_notification = json.loads(sqs_record["body"])
         message = json.loads(sns_notification["Message"])
+
         if message.get("Event") == "s3:TestEvent":
             logger.info("Disregarding S3 Test Event")
             continue
+
         for s3_record in message["Records"]:
-            # Ignore Folders and Empty Files
             bucket_name = s3_record["s3"]["bucket"]["name"]
             key = unquote_plus(s3_record["s3"]["object"]["key"])
+
+            # Ignore Folders and Empty Files
             if s3_record["s3"]["object"]["size"] == 0:
                 logger.info("Disregarding empty file or directory: %s", key)
                 continue
+
             logger.info("generating pdq hash for %s/%s", bucket_name, key)
             with tempfile.NamedTemporaryFile() as tmp_file:
                 path = Path(tmp_file.name)
                 s3_client.download_fileobj(bucket_name, key, tmp_file)
                 pdq_hash, quality = pdq_hasher.pdq_from_file(path)
-
-                save_hash_to_datastore(
-                    table, key, pdq_hash, quality, datetime.datetime.now()
+                hash_record = PDQHashRecord(
+                    key, pdq_hash, quality, datetime.datetime.now()
                 )
 
-                output = {"hash": pdq_hash, "type": "pdq", "key": key}
-                logger.info("publishing new pdq hash")
+                # Add to dynamodb hash store
+                store.add_hash(hash_record)
+
+                # Publish to SQS queue
                 sqs_client.send_message(
                     QueueUrl=OUTPUT_QUEUE_URL,
-                    MessageBody=json.dumps(output),
+                    MessageBody=json.dumps(hash_record.to_sqs_message()),
                 )
+
+                logger.info("Published new PDQ hash")

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_hasher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_hasher.py
@@ -9,6 +9,7 @@ from urllib.parse import unquote_plus
 import datetime
 
 import boto3
+from mypy_boto3_dynamodb import DynamoDBServiceResource
 from threatexchange.hashing import pdq_hasher
 
 from hmalib.dto import PDQHashRecord
@@ -19,7 +20,7 @@ logger.setLevel(logging.INFO)
 
 s3_client = boto3.client("s3")
 sqs_client = boto3.client("sqs")
-dynamodb = boto3.resource("dynamodb")
+dynamodb: DynamoDBServiceResource = boto3.resource("dynamodb")
 
 OUTPUT_QUEUE_URL = os.environ["PDQ_HASHES_QUEUE_URL"]
 DYNAMODB_TABLE = os.environ["DYNAMODB_TABLE"]

--- a/hasher-matcher-actioner/hmalib/storage/hashstore.py
+++ b/hasher-matcher-actioner/hmalib/storage/hashstore.py
@@ -1,0 +1,11 @@
+from boto3.resources.factory import dynamodb
+
+
+class HashStore:
+    """ Stores all kinds of hashes into a dynamodb. """
+
+    def __init__(self, table: dynamodb.Table):
+        self._table = table
+
+    def add_hash(self, record: HashRecord):
+        self._table.put_item(Item=record.to_dynamodb_item())

--- a/hasher-matcher-actioner/hmalib/storage/hashstore.py
+++ b/hasher-matcher-actioner/hmalib/storage/hashstore.py
@@ -1,13 +1,16 @@
 from mypy_boto3_dynamodb.service_resource import Table
 
 class _IDynamoDBItem():
-    """ Clowny type as an interfaces. True interfaces in python are nightmares.
+    """
+    Clowny type as an interfaces. True interfaces in python are nightmares.
     """
     def to_dynamodb_item(self) -> dict:
         pass
 
 class HashStore:
-    """ Stores all kinds of hashes into a dynamodb. """
+    """
+    Stores all kinds of hashes into a dynamodb.
+    """
 
     def __init__(self, table: Table):
         self._table = table

--- a/hasher-matcher-actioner/hmalib/storage/hashstore.py
+++ b/hasher-matcher-actioner/hmalib/storage/hashstore.py
@@ -1,11 +1,16 @@
-from boto3.resources.factory import dynamodb
+from mypy_boto3_dynamodb.service_resource import Table
 
+class _IDynamoDBItem():
+    """ Clowny type as an interfaces. True interfaces in python are nightmares.
+    """
+    def to_dynamodb_item(self) -> dict:
+        pass
 
 class HashStore:
     """ Stores all kinds of hashes into a dynamodb. """
 
-    def __init__(self, table: dynamodb.Table):
+    def __init__(self, table: Table):
         self._table = table
 
-    def add_hash(self, record: HashRecord):
+    def add_hash(self, record: _IDynamoDBItem):
         self._table.put_item(Item=record.to_dynamodb_item())

--- a/hasher-matcher-actioner/mypy.ini
+++ b/hasher-matcher-actioner/mypy.ini
@@ -1,0 +1,2 @@
+[mypy-threatexchange.hashing.*]
+ignore_missing_imports = True

--- a/hasher-matcher-actioner/requirements-dev.txt
+++ b/hasher-matcher-actioner/requirements-dev.txt
@@ -1,3 +1,2 @@
 pytest==6.2.1
-boto3-stubs==1.17.14.0
 mypy==0.812

--- a/hasher-matcher-actioner/requirements-dev.txt
+++ b/hasher-matcher-actioner/requirements-dev.txt
@@ -1,1 +1,3 @@
 pytest==6.2.1
+boto3-stubs==1.17.14.0
+mypy==0.812

--- a/hasher-matcher-actioner/requirements.txt
+++ b/hasher-matcher-actioner/requirements.txt
@@ -1,3 +1,3 @@
 boto3
-boto3-stubs==1.17.14.0
+boto3-stubs[essential]==1.17.14.0
 threatexchange[faiss,pdq_hasher]>=0.0.11

--- a/hasher-matcher-actioner/requirements.txt
+++ b/hasher-matcher-actioner/requirements.txt
@@ -1,2 +1,3 @@
 boto3
+boto3-stubs==1.17.14.0
 threatexchange[faiss,pdq_hasher]>=0.0.11


### PR DESCRIPTION
Summary
---------
The PR turned out to be larger than I had imagined. It does a lot.
1. Adds mypy as a dependency and begins to add type hints to the lambdas. Adds some typing for boto using `boto3-stubs`
1. Converts arbitrary wire-messages (SQS, Dynamo) for hasher lambda into formal data structures
1. Defines a simple wrapper (HashStore) over dynamodb for maintaining hash records, expect more methods from the CLI/Admin surface to go into the wrapper
1. docstring for hasher lambda

Test Plan
---------
```
$> mypy
$> make upload_docker
$> edit hma_lambda_docker_uri variable to point to new sha256 in ECR
$> terraform apply -var "prefix=$(whoami)"
```

Followed by uploading an image to S3 and receiving a match on email.

Note: This was also the first time I edited an existing terraform instance. And it worked out well. The lambdas were switched out and the architecture picked things up automatically.