### PR TITLE
Working flask app with dockerfile

### DIFF
--- a/hasher-matcher-actioner/hma-lite/Dockerfile
+++ b/hasher-matcher-actioner/hma-lite/Dockerfile
@@ -1,0 +1,12 @@
+FROM tiangolo/uwsgi-nginx-flask:python3.8
+
+ENV STATIC_URL /static
+ENV STATIC_PATH /var/www/app/static
+
+COPY ./requirements.txt /var/www/requirements.txt
+COPY hmalite/ hmalite/
+
+# This overwrites the provided uwsgi config
+COPY config/uwsgi.ini .
+
+RUN pip install -r /var/www/requirements.txt

--- a/hasher-matcher-actioner/hma-lite/config/uwsgi.ini
+++ b/hasher-matcher-actioner/hma-lite/config/uwsgi.ini
@@ -1,0 +1,3 @@
+[uwsgi]
+module = hmalite.app
+callable = app

--- a/hasher-matcher-actioner/hma-lite/hmalite/app.py
+++ b/hasher-matcher-actioner/hma-lite/hmalite/app.py
@@ -1,0 +1,6 @@
+from flask import Flask
+app = Flask(__name__)
+
+@app.route('/')
+def hello_world():
+    return 'Hello, from the threatexchange API!'

--- a/hasher-matcher-actioner/hma-lite/requirements.txt
+++ b/hasher-matcher-actioner/hma-lite/requirements.txt
@@ -1,0 +1,3 @@
+
+threatexchange[faiss,pdq_hasher]>=0.0.11
+Flask==1.1.2


### PR DESCRIPTION
Summary
---
The flask app doesn't do anything but print "Hello, from the threatexchange API".

Adds a Dockerfile, adds flask to requirements and orchestrates everything with uwsgi, one of the canonical webservers writting in python.

Test Plan
---
```
$> cd hma-lite/
$> docker build -t threatexchange-api:latest -f ThreatExchangeAPI.Dockerfile .
$> docker run -d -p 8080:80 threatexchange-api
```

And then localhost:8080 on your browser.

If you want to develop locally, use flask. First,
```
$> pip install -r requirements.txt # ensures you have flask installed. Only run once.
$> FLASK_APP=hmalite.app:app FLASK_ENV=development flask run
```

And go to the URL you are presented with in the console logs.
