### PR TITLE
Adds pdq index wrap for faiss index lib to signal_type

### DIFF
--- a/python-threatexchange/threatexchange/signal_type/index.py
+++ b/python-threatexchange/threatexchange/signal_type/index.py
@@ -44,6 +44,7 @@ class IndexMatch(t.Generic[T]):
 
     def __init__(self, distance: int, metadata: T) -> None:
         self.distance = distance
+        self.metadata = metadata
 
 
 class SignalTypeIndex(t.Generic[T]):

--- a/python-threatexchange/threatexchange/signal_type/pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_index.py
@@ -1,17 +1,15 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 """
-Implementation of SignalTypeIndex abstraction for PDQ by wrapping hashing.pdq_faiss_matcher.
+Implementation of SignalTypeIndex abstraction for PDQ by wrapping 
+hashing.pdq_faiss_matcher.
 """
 
 import typing as t
 import pickle
 
-from threatexchange.signal_type.index import SignalTypeIndex, IndexMatch
+from threatexchange.signal_type.index import SignalTypeIndex, IndexMatch, T as IndexT
 from threatexchange.hashing.pdq_faiss_matcher import PDQMultiHashIndex
-
-T = t.TypeVar("T")
-PDQ_CONFIDENT_MATCH_THRESHOLD = 31
 
 
 class PDQIndex(SignalTypeIndex):
@@ -19,13 +17,16 @@ class PDQIndex(SignalTypeIndex):
     Wrapper around the pdq faiss index lib
     """
 
+    PDQ_CONFIDENT_MATCH_THRESHOLD = 31
+    T = IndexT
+
     def __init__(self, entries: t.Iterable[t.Tuple[str, T]]) -> None:
         super().__init__()
-        self.local_id_to_entry = dict()
-        hashes = list()
-        for i in range(len(entries)):
-            self.local_id_to_entry[i] = entries[i]
-            hashes.append(entries[i][0])
+        self.local_id_to_entry = {}
+        hashes = []
+        for i, entry in enumerate(entries):
+            self.local_id_to_entry[i] = entry
+            hashes.append(entry[0])
         self.index = PDQMultiHashIndex.create(
             hashes, custom_ids=self.local_id_to_entry.keys()
         )
@@ -34,10 +35,12 @@ class PDQIndex(SignalTypeIndex):
         """
         Look up entries against the index, up to the max supported distance.
         """
+
+        # query takes a signal hash but index supports banch quries hence [hash]
         results = self.index.search(
-            [hash], PDQ_CONFIDENT_MATCH_THRESHOLD, return_as_ids=True
+            [hash], self.PDQ_CONFIDENT_MATCH_THRESHOLD, return_as_ids=True
         )
-        matches = list()
+        matches = []
         for result_ids in results:
             for id in result_ids:
                 # distance = -1 (index does not currently support distance)

--- a/python-threatexchange/threatexchange/signal_type/pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_index.py
@@ -1,0 +1,65 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Implementation of SignalTypeIndex abstraction for PDQ by wrapping hashing.pdq_faiss_matcher.
+"""
+
+import typing as t
+import pickle
+
+from threatexchange.signal_type.index import SignalTypeIndex, IndexMatch
+from threatexchange.hashing.pdq_faiss_matcher import PDQMultiHashIndex
+
+T = t.TypeVar("T")
+PDQ_CONFIDENT_MATCH_THRESHOLD = 31
+
+
+class PDQIndex(SignalTypeIndex):
+    """
+    Wrapper around the pdq faiss index lib
+    """
+
+    def __init__(self, entries: t.Iterable[t.Tuple[str, T]]) -> None:
+        super().__init__()
+        self.local_id_to_entry = dict()
+        hashes = list()
+        for i in range(len(entries)):
+            self.local_id_to_entry[i] = entries[i]
+            hashes.append(entries[i][0])
+        self.index = PDQMultiHashIndex.create(
+            hashes, custom_ids=self.local_id_to_entry.keys()
+        )
+
+    def query(self, hash: str) -> t.List[IndexMatch[T]]:
+        """
+        Look up entries against the index, up to the max supported distance.
+        """
+        results = self.index.search(
+            [hash], PDQ_CONFIDENT_MATCH_THRESHOLD, return_as_ids=True
+        )
+        matches = list()
+        for result_ids in results:
+            for id in result_ids:
+                # distance = -1 (index does not currently support distance)
+                matches.append(IndexMatch(-1, self.local_id_to_entry[id][1]))
+        return matches
+
+    @classmethod
+    def build(cls, entries: t.Iterable[t.Tuple[str, T]]) -> "SignalTypeIndex[T]":
+        """
+        Build an PDQ index from a set of entries.
+        """
+        return PDQIndex(entries)
+
+    def serialize(self, fout: t.BinaryIO) -> None:
+        """
+        Convert the PDQ index into a bytestream (probably a file).
+        """
+        return pickle.dumps(self)
+
+    @classmethod
+    def deserialize(cls, fin: t.BinaryIO) -> "SignalTypeIndex[T]":
+        """
+        Instanciate an index from a previous call to serialize
+        """
+        return pickle.loads(fin)

--- a/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index.py
@@ -1,0 +1,100 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+import pickle
+
+from threatexchange.signal_type.index import IndexMatch
+from threatexchange.signal_type.pdq_index import PDQIndex
+
+test_entries = [
+    (
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        dict(
+            {
+                "hash_type": "pdq",
+                "system_id": 9,
+            }
+        ),
+    ),
+    (
+        "000000000000000000000000000000000000000000000000000000000000ffff",
+        dict(
+            {
+                "hash_type": "pdq",
+                "system_id": 8,
+            }
+        ),
+    ),
+    (
+        "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f",
+        dict(
+            {
+                "hash_type": "pdq",
+                "system_id": 7,
+            }
+        ),
+    ),
+    (
+        "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
+        dict(
+            {
+                "hash_type": "pdq",
+                "system_id": 6,
+            }
+        ),
+    ),
+    (
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        dict(
+            {
+                "hash_type": "pdq",
+                "system_id": 5,
+            }
+        ),
+    ),
+]
+
+
+class TestPDQIndex(unittest.TestCase):
+    def setUp(self):
+        self.index = PDQIndex.build(test_entries)
+
+    def assertEqualPDQIndexMatchResults(self, result, expected):
+        self.assertEqual(
+            len(result), len(expected), "search results not of expected length"
+        )
+        for (r, e) in zip(result, expected):
+            assert r.distance == e.distance, "result distance does not match"
+            self.assertDictEqual(r.metadata, e.metadata)
+
+    def test_search_index_for_matches(self):
+        entry_hash = test_entries[1][0]
+        result = self.index.query(entry_hash)
+        self.assertEqualPDQIndexMatchResults(
+            result,
+            [IndexMatch(-1, test_entries[1][1]), IndexMatch(-1, test_entries[0][1])],
+        )
+
+    def test_search_index_with_no_match(self):
+        query_hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        result = self.index.query(query_hash)
+        self.assertEqualPDQIndexMatchResults(result, [])
+
+    def test_supports_pickling(self):
+        pickled_data = pickle.dumps(self.index)
+        assert pickled_data != None, "index does not support pickling to a data stream"
+
+        reconstructed_index = pickle.loads(pickled_data)
+        assert (
+            reconstructed_index != None
+        ), "index does not support unpickling from data stream"
+        assert (
+            reconstructed_index.index.faiss_index != self.index.index.faiss_index
+        ), "unpickling should create it's own faiss index in memory"
+
+        query = test_entries[0][0]
+        result = reconstructed_index.query(query)
+        self.assertEqualPDQIndexMatchResults(
+            result,
+            [IndexMatch(-1, test_entries[1][1]), IndexMatch(-1, test_entries[0][1])],
+        )


### PR DESCRIPTION
Summary
---------

See title. 
~Draft as I am worried this might break imports. 

Test Plan
---------
Created Test
`pytest python-threatexchange/threatexchange/signal_type/tests/test_pdq_index.py`