### PR TITLE
fix pdq_index.serialize to use bytestream param

### DIFF
--- a/hasher-matcher-actioner/hma-lite/hmalite/app.py
+++ b/hasher-matcher-actioner/hma-lite/hmalite/app.py
@@ -68,7 +68,7 @@ def create_index(filepath):
             entries.append(((row["td_raw_indicator"], row)))
         index = pdq_index.PDQIndex.build(entries)
         with open(os.path.join(INDEX_FOLDER, INDEX_FILENAME), "wb") as f:
-            f.write(index.serialize(f))
+            index.serialize(f)
 
 
 def query_index(hash):

--- a/python-threatexchange/threatexchange/signal_type/pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_index.py
@@ -58,7 +58,7 @@ class PDQIndex(SignalTypeIndex):
         """
         Convert the PDQ index into a bytestream (probably a file).
         """
-        return pickle.dumps(self)
+        fout.write(pickle.dumps(self))
 
     @classmethod
     def deserialize(cls, fin: t.BinaryIO) -> "SignalTypeIndex[T]":


### PR DESCRIPTION
Summary
---------

Update serialize for pdq_index to actually follow its type interface 

Test Plan
---------

pytest was green and hmalite ui (to build index still work)
