### PR TITLE
[py-tx] Better hashing interfaces

### DIFF
--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -53,14 +53,6 @@ class HashCommand(command_base.Command):
         )
 
         ap.add_argument(
-            "--read-stdin",
-            "-I",
-            dest="content",
-            action="store_const",
-            const=[cls.USE_STDIN],
-        )
-
-        ap.add_argument(
             "content",
             nargs="+",
             help=(

--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 """
-Match command for parsing simple data sources against the dataset.
+Hash command to convert content into signatures.
 """
 
 import argparse
@@ -18,9 +18,10 @@ from ..signal_type.signal_base import FileHasher, StrHasher
 from . import command_base, fetch
 
 
+# TODO consider refactor to handle overlap with match
 class HashCommand(command_base.Command):
     """
-    Hash content into signatures.
+    Hash content into signatures (aka hashes).
 
     Reads inputs as filenames by default, or as text with --as-text.
 

--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Match command for parsing simple data sources against the dataset.
+"""
+
+import argparse
+import pathlib
+import sys
+import typing as t
+
+from ..api import ThreatExchangeAPI
+from ..content_type import meta
+from ..dataset import Dataset
+from ..descriptor import ThreatDescriptor
+from ..signal_type.signal_base import FileHasher, StrHasher
+from . import command_base, fetch
+
+
+class HashCommand(command_base.Command):
+    """
+    Hash content into signatures.
+
+    Reads inputs as filenames by default, or as text with --as-text.
+
+    You can also pass in via stdin by using "-" as the input.
+    """
+
+    USE_STDIN = "-"
+
+    @classmethod
+    def init_argparse(cls, ap) -> None:
+
+        ap.add_argument(
+            "content_type",
+            choices=[t.get_name() for t in meta.get_all_content_types()],
+            help="what kind of content to hash",
+        )
+
+        ap.add_argument(
+            "--signal-type",
+            "-S",
+            choices=[t.get_name() for t in meta.get_all_signal_types()],
+            help="only generate these signal types",
+        )
+
+        ap.add_argument(
+            "--as-text",
+            "-T",
+            action="store_true",
+            help="force input to be interpreted as text instead of as filenames",
+        )
+
+        ap.add_argument(
+            "--read-stdin",
+            "-I",
+            dest="content",
+            action="store_const",
+            const=[cls.USE_STDIN],
+        )
+
+        ap.add_argument(
+            "content",
+            nargs="+",
+            help=(
+                "what to match against. Accepts filenames, "
+                "quoted strings, or '-' to read newline-separated stdin"
+            ),
+        )
+
+    def __init__(
+        self,
+        content_type: str,
+        signal_type: t.Optional[str],
+        as_text: bool,
+        content: t.List[str],
+    ) -> None:
+        self.content_type = [
+            c for c in meta.get_all_content_types() if c.get_name() == content_type
+        ][0]
+        self.signal_type = signal_type
+
+        if content == [self.USE_STDIN]:
+            content = sys.stdin
+        self.input_generator = self._parse_input(content, as_text)
+
+    def _parse_input(
+        self,
+        input_: t.Iterable[str],
+        force_input_to_text: bool,
+    ) -> t.Generator[t.Union[str, pathlib.Path], None, None]:
+        for token in input_:
+            token = token.rstrip()
+            if force_input_to_text:
+                yield token
+            else:
+                yield pathlib.Path(token)
+
+    def execute(self, api: ThreatExchangeAPI, dataset: Dataset) -> None:
+
+        all_signal_types = dataset.load_cache(
+            s
+            for s in self.content_type.get_signal_types()
+            if self.signal_type in (None, s.get_name())
+        )
+
+        file_hashers = [s for s in all_signal_types if issubclass(s, FileHasher)]
+        str_hashers = [s for s in all_signal_types if issubclass(s, StrHasher)]
+
+        for inp in self.input_generator:
+            hash_fn = lambda s, t: s.hash_file(t)
+            signal_types = file_hashers
+            if isinstance(inp, str):
+                hash_fn = lambda s, t: s.hash_from_str(t)
+                signal_types = str_hashers
+
+            for signal_type in signal_types:
+                hash_str = hash_fn(signal_type, inp)
+                if hash_str:
+                    print(signal_type.get_name(), hash_str)

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -25,7 +25,15 @@ from .. import descriptor
 from ..api import ThreatExchangeAPI
 from ..collab_config import CollaborationConfig
 from ..dataset import Dataset
-from . import command_base as base, fetch, experimental_fetch, label, match, dataset_cmd, hash_cmd
+from . import (
+    command_base as base,
+    fetch,
+    experimental_fetch,
+    label,
+    match,
+    dataset_cmd,
+    hash_cmd,
+)
 
 
 def get_subcommands() -> t.List[t.Type[base.Command]]:

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -25,7 +25,7 @@ from .. import descriptor
 from ..api import ThreatExchangeAPI
 from ..collab_config import CollaborationConfig
 from ..dataset import Dataset
-from . import command_base as base, fetch, experimental_fetch, label, match, dataset_cmd
+from . import command_base as base, fetch, experimental_fetch, label, match, dataset_cmd, hash_cmd
 
 
 def get_subcommands() -> t.List[t.Type[base.Command]]:
@@ -35,6 +35,7 @@ def get_subcommands() -> t.List[t.Type[base.Command]]:
         match.MatchCommand,
         label.LabelCommand,
         dataset_cmd.DatasetCommand,
+        hash_cmd.HashCommand,
     ]
 
 

--- a/python-threatexchange/threatexchange/signal_type/md5.py
+++ b/python-threatexchange/threatexchange/signal_type/md5.py
@@ -13,7 +13,7 @@ from ..descriptor import SimpleDescriptorRollup, ThreatDescriptor
 from . import signal_base
 
 
-class VideoMD5Signal(signal_base.SimpleSignalType, signal_base.FileMatcher):
+class VideoMD5Signal(signal_base.SimpleSignalType, signal_base.FileHasher):
     """
     Simple signal type for Video MD5s.
 
@@ -28,8 +28,8 @@ class VideoMD5Signal(signal_base.SimpleSignalType, signal_base.FileMatcher):
     INDICATOR_TYPE = "HASH_MD5"
     TYPE_TAG = "media_type_video"
 
-    def match_file(self, file: pathlib.Path) -> t.List[signal_base.SignalMatch]:
-        """Simple MD5 file match."""
+    @classmethod
+    def hash_file(cls, file: pathlib.Path) -> str:
         file_hash = hashlib.md5()
         blocksize = 8192
         with file.open("rb") as f:
@@ -37,7 +37,7 @@ class VideoMD5Signal(signal_base.SimpleSignalType, signal_base.FileMatcher):
             while chunk:
                 file_hash.update(chunk)
                 chunk = f.read(blocksize)
-        return self.match_hash(file_hash.hexdigest())
+        return file_hash.hexdigest()
 
 
 class PhotoMD5Signal(VideoMD5Signal):

--- a/python-threatexchange/threatexchange/signal_type/pdq.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq.py
@@ -14,7 +14,7 @@ from . import signal_base
 from ..hashing.pdq_utils import pdq_match, BITS_IN_PDQ
 
 
-class PdqSignal(signal_base.SimpleSignalType, signal_base.FileMatcher):
+class PdqSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
     """
     PDQ is an open source photo similarity algorithm.
 
@@ -36,8 +36,8 @@ class PdqSignal(signal_base.SimpleSignalType, signal_base.FileMatcher):
     # Hashes of distance less than or equal to this threshold are considered a 'match'
     PDQ_CONFIDENT_MATCH_THRESHOLD = 31
 
-    def match_file(self, file: pathlib.Path) -> t.List[signal_base.SignalMatch]:
-        """Simple PDQ file match."""
+    @classmethod
+    def hash_file(cls, file: pathlib.Path) -> str:
         try:
             from threatexchange.hashing.pdq_hasher import pdq_from_file
         except:
@@ -45,9 +45,9 @@ class PdqSignal(signal_base.SimpleSignalType, signal_base.FileMatcher):
                 "PDQ from file require Pillow and pdqhash to be installed; install threatexchange with the [pdq_hasher] extra to use them",
                 category=UserWarning,
             )
-            return []
-        pdq_hash, quality = pdq_from_file(file)
-        return self.match_hash(pdq_hash)
+            return ""
+        pdq_hash, _quality = pdq_from_file(file)
+        return pdq_hash
 
     def match_hash(self, signal_str: str) -> t.List[signal_base.SignalMatch]:
 

--- a/python-threatexchange/threatexchange/signal_type/pdq_ocr.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_ocr.py
@@ -19,7 +19,7 @@ from ..hashing.pdq_utils import pdq_match
 from .. import common
 
 
-class PdqOcrSignal(signal_base.SimpleSignalType, signal_base.FileMatcher):
+class PdqOcrSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
     """
     PDQ is an open source photo similarity algorithm. See 'pdq.py'
     This signal type combines pdq hashes with a text string found using
@@ -39,8 +39,8 @@ class PdqOcrSignal(signal_base.SimpleSignalType, signal_base.FileMatcher):
     # Match considered if 90% of the strings match
     LEVENSHTEIN_DISTANCE_PERCENT_THRESHOLD = 0.10
 
-    def match_file(self, file: pathlib.Path) -> t.List[signal_base.SignalMatch]:
-        """Simple PDQ file match."""
+    @classmethod
+    def hash_file(cls, file: pathlib.Path) -> str:
         try:
             from ..hashing.pdq_hasher import pdq_from_file
             from ..hashing.ocr_utils import text_from_image_file
@@ -54,9 +54,7 @@ class PdqOcrSignal(signal_base.SimpleSignalType, signal_base.FileMatcher):
         pdq_hash, quality = pdq_from_file(file)
         ocr_text = text_from_image_file(file)
 
-        pdq_hash_plus_ocr = pdq_hash + "," + ocr_text
-
-        return self.match_hash(pdq_hash_plus_ocr)
+        return f"{pdq_hash},{ocr_text}"
 
     def match_hash(self, signal_str: str) -> t.List[signal_base.SignalMatch]:
         content_pdq_hash, _, content_ocr_text = signal_str.partition(",")

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -150,6 +150,37 @@ class StrMatcher(FileMatcher):
         return self.match(path.read_text())
 
 
+class StrHasher(HashMatcher, StrMatcher):
+    """
+    This class can turn hashes into intermediary representations
+    """
+    @classmethod
+    def hash_from_str(cls, content: str) -> str:
+        """Get a string representation of the hash from a string"""
+        raise NotImplementedError
+
+    def match(self, content: str) -> t.List[SignalMatch]:
+        str_hash = self.hash_from_str(content)
+        return self.match_hash(str_hash)
+
+
+class FileHasher(HashMatcher, FileMatcher):
+    """
+    This class can hash files.
+
+    If also inheiriting from StrHasher, put this second in the inheiretence
+    to prefer file hashing to reading the file in as a Str.
+    """
+    @classmethod
+    def hash_from_file(self, file: pathlib.Path) -> str:
+        """Get a string representation of the hash from a file"""
+        raise NotImplementedError
+
+    def match_file(self, path: pathlib.Path) -> t.List[SignalMatch]:
+        file_hash = self.hash_from_file(path)
+        return self.match_hash(file_hash)
+
+
 class SimpleSignalType(SignalType, HashMatcher):
     """
     Dead simple implementation for loading/storing a SignalType.

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -152,7 +152,7 @@ class StrMatcher(FileMatcher):
 
 class StrHasher(HashMatcher, StrMatcher):
     """
-    This class can turn hashes into intermediary representations
+    This class can turn text into intermediary representations (hashes)
     """
 
     @classmethod

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -154,6 +154,7 @@ class StrHasher(HashMatcher, StrMatcher):
     """
     This class can turn hashes into intermediary representations
     """
+
     @classmethod
     def hash_from_str(cls, content: str) -> str:
         """Get a string representation of the hash from a string"""
@@ -171,6 +172,7 @@ class FileHasher(HashMatcher, FileMatcher):
     If also inheiriting from StrHasher, put this second in the inheiretence
     to prefer file hashing to reading the file in as a Str.
     """
+
     @classmethod
     def hash_from_file(self, file: pathlib.Path) -> str:
         """Get a string representation of the hash from a file"""


### PR DESCRIPTION
Summary
---------

This diff adds the "FileHasher" and "StrHasher" interfaces into SignalType, and additionally adds a CLI command to help hash.

The reason I did this is that the current copydays set isn't matching anything, and I can't tell why. I'm worried I generated with the broken version of the pdqhash library.

Rather than doing what I did to generate the PDQhash library, I figured I'd just make it easier to regenerate.

Test Plan
---------

```
$ threatexchange hash --help
usage: threatexchange hash [-h]
                           [--signal-type {trend_query,raw_text,pdq_ocr,video_tmk_pdqf,photo_md5,video_md5,pdq,url}]
                           [--as-text] [--read-stdin]
                           {text,video,photo} content [content ...]

    Hash content into signatures.

    Reads inputs as filenames by default, or as text with --as-text.

    You can also pass in via stdin by using "-" as the input.


positional arguments:
  {text,video,photo}    what kind of content to hash
  content               what to match against. Accepts filenames, quoted
                        strings, or '-' to read newline-separated stdin

optional arguments:
  -h, --help            show this help message and exit
  --signal-type {trend_query,raw_text,pdq_ocr,video_tmk_pdqf,photo_md5,video_md5,pdq,url}, -S {trend_query,raw_text,pdq_ocr,video_tmk_pdqf,photo_md5,video_md5,pdq,url}
                        only generate these signal types
  --as-text, -T         force input to be interpreted as text instead of as
                        filenames

# These all don't have hashing methods, so don't produce anything
$ threatexchange hash text -T "asdf"
$ threatexchange hash text 200000.jpg
$ threatexchange hash photo -T "asdf"

# Note - I have PDQ installed, but not PDQ+OCR
$ threatexchange hash photo 200000.jpg
photo_md5 36a005317ade979a03840f10dfcff969
/home/dcallies/.venv/threatexchange/lib64/python3.6/site-packages/pdqhash/__init__.py:4: UserWarning: Hash vector order changed between version 0.1.8 and 0.2.0. See https://github.com/faustomorales/pdqhash-python/issues/1 for more details.
  "Hash vector order changed between version 0.1.8 and 0.2.0. "
pdq 388ff5e1084efef10096df9cb969296dff2b04d67a94065ecd292129ef6b1090
/data/users/dcallies/fork_te/ThreatExchange/python-threatexchange/threatexchange/signal_type/pdq_ocr.py:50: UserWarning: Getting both PDQ hash and text of an image file using OCR requires additional libraries already be installed; install threatexchange with the [pdq_hasher & ocr] extra and see ocr_utils.py
  category=UserWarning,

$ threatexchange hash photo 200000.jpg  2>/dev/null
photo_md5 36a005317ade979a03840f10dfcff969
pdq 388ff5e1084efef10096df9cb969296dff2b04d67a94065ecd292129ef6b1090

$ threatexchange hash photo 200000.jpg -S pdq 2>/dev/null
pdq 388ff5e1084efef10096df9cb969296dff2b04d67a94065ecd292129ef6b1090

$ threatexchange hash video 200000.jpg  # lies
video_md5 36a005317ade979a03840f10dfcff969
```
