### PR TITLE
Remove unused steps from master CI workflow

### DIFF
--- a/.github/workflows/hma-ci-master-push.yaml
+++ b/.github/workflows/hma-ci-master-push.yaml
@@ -32,10 +32,3 @@ jobs:
         run: terraform init -input=false
       - name: Validate terraform files
         run: terraform validate -no-color -input=false
-      - name: Setup Test Environment
-        run: terraform -input=false -var 'prefix=tftest' apply
-      - name: Conduct Test
-        run: sleep 100 # Will validate that an environment is setup and torn down and then test
-      - name: Tear Down Test Environment
-        if: ${{ always() }} # Even if previous steps have failed.
-        run: terraform destroy -input=false -var 'prefix=tftest'


### PR DESCRIPTION
Summary
---------
Remove unused `terraform apply` and `terraform destroy` commands in the master CI workflow.

Test Plan
---------
Nope. Only way to know for sure is to merge into master.