### PR TITLE
Mini-library to measure execution durations and publish to cloudwatch

### DIFF
--- a/hasher-matcher-actioner/hmalib/metrics/__init__.py
+++ b/hasher-matcher-actioner/hmalib/metrics/__init__.py
@@ -55,6 +55,9 @@ class names():
         parse_index = f"{_prefix}.parse_index"
         search_index = f"{_prefix}.search_index"
 
+_METRICS_NAMESPACE_ENVVAR = "METRICS_NAMESPACE"
+METRICS_NAMESPACE = os.getenv(_METRICS_NAMESPACE_ENVVAR, names.hma_namespace)
+
 counts = collections.Counter()
 timers: t.Mapping[str, collections.Counter] = collections.defaultdict(collections.Counter)
 
@@ -96,7 +99,7 @@ if measure_performance:
         timers[duration_name].update({ duration_ms: 1 })
         counts.update({count_name: 1})
 
-    def _metrics_flush(namespace: str = names.hma_namespace):
+    def _metrics_flush(namespace: str = METRICS_NAMESPACE):
         """
         Flushes metrics to an AWS Reporter.
         """

--- a/hasher-matcher-actioner/hmalib/metrics/__init__.py
+++ b/hasher-matcher-actioner/hmalib/metrics/__init__.py
@@ -1,0 +1,127 @@
+import collections
+from contextlib import contextmanager
+from functools import wraps
+import logging
+import time
+import typing as t
+import os
+
+"""
+Defines some wrappers which when invoked with the "correct" environment variable
+will instrument functions and drop their metrics to cloudwatch.
+
+Without the environment variables, will be a no-op.
+"""
+
+_ENABLE_PERF_MEASUREMENTS_ENVVAR = "MEASURE_PERFORMANCE"
+measure_performance : bool = os.getenv(_ENABLE_PERF_MEASUREMENTS_ENVVAR, "False") in ["True", "1"]
+
+logger = logging.getLogger(__name__)
+
+class names():
+    """
+    Not a real class, just a bag of metric names. Ignore the lowercase name if
+    you can. :)
+
+    Because metric naming can have a very real impact on how dashboards are
+    built, use this central location to allow easier following of conventions.
+
+    Conventions:
+    - The metric name should be of the format "{prefix}.{action}_{noun}"
+    - prefixes can be dotted.
+    - action and noun both should be free of special characters
+    - if used as a timer, will be suffixed by "-count" and "-duration"
+    """
+    hma_namespace = "ThreatExchange/HMA"
+
+    class pdq_hasher_lambda():
+        _prefix = "lambdas.pdqhasher"
+
+        download_file = f"{_prefix}.download_file"
+        hash = f"{_prefix}.hash"
+
+    class pdq_indexer_lambda():
+        _prefix = "lambdas.pdqindexer"
+
+        download_datafile = f"{_prefix}.download_datafile"
+        parse_datafile = f"{_prefix}.parse_datafile"
+        build_index = f"{_prefix}.build_index"
+        upload_index = f"{_prefix}.upload_index"
+
+    class pdq_matcher_lambda():
+        _prefix = "lambdas.pdqmatcher"
+
+        download_index = f"{_prefix}.download_index"
+        parse_index = f"{_prefix}.parse_index"
+        search_index = f"{_prefix}.search_index"
+
+counts = collections.Counter()
+timers: t.Mapping[str, collections.Counter] = collections.defaultdict(collections.Counter)
+
+@contextmanager
+def _no_op_timer(name):
+    yield
+
+def _no_op_flush():
+    pass
+
+if measure_performance:
+    logger.info("Performance measurement requested. Supplying appmetrics instrumentation.")
+    from hmalib.metrics.cloudwatch import AWSCloudWatchReporter, AWSCloudWatchUnit
+
+    @contextmanager
+    def _timer_wrapper(name):
+        """
+        While in most other setups you'd see some amount of sampling, lambdas
+        are different. A single container will be used for a batches sized at
+        10/100. At that, sampling will lose information. So, while we stream all
+        data to cloudwatch, cloudwatch on its end will do the necessary
+        statistical math to give us quantiles.
+
+        We don't expect the lambdas to be used in multi-threaded environments.
+        This impl is not guaranteed to be thread-safe.
+
+        A timer does two things. It counts and it times. It will result in two
+        metrics "{name}-duration" and "{name}-count"
+        """
+        count_name = f"{name}-count"
+        duration_name = f"{name}-duration"
+
+        start_ms : int = int(time.perf_counter() * 1000)
+
+        yield
+
+        duration_ms : int = int(time.perf_counter() * 1000) - start_ms
+
+        timers[duration_name].update({ duration_ms: 1 })
+        counts.update({count_name: 1})
+
+    def _metrics_flush(namespace: str = names.hma_namespace):
+        """
+        Flushes metrics to an AWS Reporter.
+        """
+        try:
+            reporter = AWSCloudWatchReporter(namespace)
+            datums = []
+            datums.extend([
+                reporter.get_counter_datum(k, v) for k, v in counts.items()
+            ])
+
+            datums.extend([
+                reporter.get_multi_value_datums(
+                    k,
+                    v,
+                    AWSCloudWatchUnit.Milliseconds
+                ) for k, v in timers.items()
+            ])
+            reporter.report(datums)
+        except Exception as e:
+            logger.exception("Couldn't report metrics to cloudwatch")
+
+    flush = _metrics_flush
+    timer = _timer_wrapper
+else:
+    logger.info("Performance measurement not requested. Supplying no-op instrumentation.")
+
+    flush = _no_op_flush
+    timer = _no_op_timer

--- a/hasher-matcher-actioner/hmalib/metrics/cloudwatch.py
+++ b/hasher-matcher-actioner/hmalib/metrics/cloudwatch.py
@@ -1,0 +1,144 @@
+import boto3
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+import typing as t
+
+from hmalib import metrics
+
+
+class AWSCloudWatchUnit(Enum):
+    Seconds = "Seconds"
+    Microseconds = "Microseconds"
+    Milliseconds = "Milliseconds"
+    Bytes = "Bytes"
+    Kilobytes = "Kilobytes"
+    Megabytes = "Megabytes"
+    Gigabytes = "Gigabytes"
+    Terabytes = "Terabytes"
+    Bits = "Bits"
+    Kilobits = "Kilobits"
+    Megabits = "Megabits"
+    Gigabits = "Gigabits"
+    Terabits = "Terabits"
+    Percent = "Percent"
+    Count = "Count"
+    Bytes_per_Second = "Bytes/Second"
+    Kilobytes_per_Second = "Kilobytes/Second"
+    Megabytes_per_Second = "Megabytes/Second"
+    Gigabytes_per_Second = "Gigabytes/Second"
+    Terabytes_per_Second = "Terabytes/Second"
+    Bits_per_Second = "Bits/Second"
+    Kilobits_per_Second = "Kilobits/Second"
+    Megabits_per_Second = "Megabits/Second"
+    Gigabits_per_Second = "Gigabits/Second"
+    Terabits_per_Second = "Terabits/Second"
+    Count_per_Second = "Count/Second"
+
+
+@dataclass
+class AWSCloudWatchMetricDatum():
+    """
+    AWS Cloudwatch MetricData struct.
+    """
+    metric_name: str
+    value: float = None
+    dimensions: t.Dict[str, str] = None
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+    values: t.List[float] = None
+    counts: t.List[float] = None
+    unit: AWSCloudWatchUnit = field(default=None)
+
+    def to_dict(self) -> t.Dict:
+        result = {
+            'MetricName': self.metric_name,
+        }
+
+        if self.timestamp:
+            result['Timestamp'] = self.timestamp
+
+        if self.value:
+            result['Value'] = self.value
+
+        if self.unit:
+            result['Unit'] = self.unit.value
+
+        if self.values:
+            result['Values'] = self.values
+
+        if self.counts:
+            result['Counts'] = self.counts
+
+        return result
+
+
+class AWSCloudWatchReporter(object):
+    """
+    An metrics reporter that publishes the metrics to cloudwatch when called.
+
+    For now, only timer and counters are supported because that's all you
+    need to measure performance of functions.
+    """
+    def __init__(self, namespace: str):
+        self.client = boto3.client('cloudwatch')
+        self.namespace = namespace
+
+    def get_multi_value_datums(
+        self,
+        name: str,
+        value_count_mapping: t.Mapping[int, int],
+        unit: AWSCloudWatchUnit
+    ) -> AWSCloudWatchMetricDatum:
+        """
+        For reporting multiple values. Requires a dict from values ->
+        recurrence_count.
+
+        Returns a list of datums you can then report.
+
+        eg. If you saw the following latencies, [1, 2, 2, 3, 3, 3, 4, 5, 5, 1],
+        value_count_mapping would look like
+        {
+            1: 2,
+            2: 2,
+            3: 3,
+            4: 1,
+            5: 1
+        }
+        """
+        values = []
+        counts = []
+
+        for k, v in value_count_mapping.items():
+            values.append(k)
+            counts.append(v)
+
+        return AWSCloudWatchMetricDatum(
+                metric_name=name,
+                values=values,
+                counts=counts,
+                unit=unit
+            )
+
+    def get_counter_datum(
+        self,
+        name: str,
+        value: int,
+    ) -> t.List[AWSCloudWatchMetricDatum]:
+        """
+        For reporting counts. Returns a single datum.
+        """
+        return AWSCloudWatchMetricDatum(
+                metric_name=name,
+                value=value,
+                unit=AWSCloudWatchUnit.Count
+            )
+
+    def report(self, metric_datums: t.List[AWSCloudWatchMetricDatum]):
+        # Publish metric datums to cloudwatch
+        self._put_metric_data(self.namespace, metric_datums)
+
+    def _put_metric_data(self, namespace: str, metric_datums: t.List[AWSCloudWatchMetricDatum]):
+        self.client.put_metric_data(
+            Namespace=namespace,
+            MetricData=[x.to_dict() for x in metric_datums]
+        )

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -59,6 +59,7 @@ module "pdq_signals" {
 
   log_retention_in_days = var.log_retention_in_days
   additional_tags       = local.common_tags
+  measure_performance   = var.measure_performance
 }
 
 resource "aws_sns_topic" "matches" {

--- a/hasher-matcher-actioner/terraform/pdq-signals/main.tf
+++ b/hasher-matcher-actioner/terraform/pdq-signals/main.tf
@@ -46,6 +46,7 @@ resource "aws_lambda_function" "pdq_indexer" {
       INDEXES_BUCKET_NAME              = var.index_data_storage.bucket_name
       PDQ_INDEX_KEY                    = local.pdq_index_key
       MEASURE_PERFORMANCE              = var.measure_performance ? "True" : "False"
+      METRICS_NAMESPACE                = var.metrics_namespace
     }
   }
   tags = merge(
@@ -158,6 +159,7 @@ resource "aws_lambda_function" "pdq_hasher" {
       PDQ_HASHES_QUEUE_URL = aws_sqs_queue.hashes_queue.id
       DYNAMODB_TABLE       = var.datastore.name
       MEASURE_PERFORMANCE  = var.measure_performance ? "True" : "False"
+      METRICS_NAMESPACE    = var.metrics_namespace
     }
   }
   tags = merge(
@@ -261,7 +263,8 @@ resource "aws_lambda_function" "pdq_matcher" {
       INDEXES_BUCKET_NAME   = var.index_data_storage.bucket_name
       PDQ_INDEX_KEY         = local.pdq_index_key
       DYNAMODB_TABLE        = var.datastore.name
-      MEASURE_PERFORMANCE  = var.measure_performance ? "True" : "False"
+      MEASURE_PERFORMANCE   = var.measure_performance ? "True" : "False"
+      METRICS_NAMESPACE     = var.metrics_namespace
     }
   }
   tags = merge(

--- a/hasher-matcher-actioner/terraform/pdq-signals/main.tf
+++ b/hasher-matcher-actioner/terraform/pdq-signals/main.tf
@@ -45,7 +45,7 @@ resource "aws_lambda_function" "pdq_indexer" {
       THREAT_EXCHANGE_PDQ_DATA_KEY     = var.threat_exchange_data.pdq_data_file_key
       INDEXES_BUCKET_NAME              = var.index_data_storage.bucket_name
       PDQ_INDEX_KEY                    = local.pdq_index_key
-      MEASURE_PERFORMANCE              = var.measure_performance
+      MEASURE_PERFORMANCE              = var.measure_performance ? "True" : "False"
     }
   }
   tags = merge(
@@ -157,7 +157,7 @@ resource "aws_lambda_function" "pdq_hasher" {
     variables = {
       PDQ_HASHES_QUEUE_URL = aws_sqs_queue.hashes_queue.id
       DYNAMODB_TABLE       = var.datastore.name
-      MEASURE_PERFORMANCE  = var.measure_performance
+      MEASURE_PERFORMANCE  = var.measure_performance ? "True" : "False"
     }
   }
   tags = merge(
@@ -261,7 +261,7 @@ resource "aws_lambda_function" "pdq_matcher" {
       INDEXES_BUCKET_NAME   = var.index_data_storage.bucket_name
       PDQ_INDEX_KEY         = local.pdq_index_key
       DYNAMODB_TABLE        = var.datastore.name
-      MEASURE_PERFORMANCE  = var.measure_performance
+      MEASURE_PERFORMANCE  = var.measure_performance ? "True" : "False"
     }
   }
   tags = merge(

--- a/hasher-matcher-actioner/terraform/pdq-signals/main.tf
+++ b/hasher-matcher-actioner/terraform/pdq-signals/main.tf
@@ -45,6 +45,7 @@ resource "aws_lambda_function" "pdq_indexer" {
       THREAT_EXCHANGE_PDQ_DATA_KEY     = var.threat_exchange_data.pdq_data_file_key
       INDEXES_BUCKET_NAME              = var.index_data_storage.bucket_name
       PDQ_INDEX_KEY                    = local.pdq_index_key
+      MEASURE_PERFORMANCE              = var.measure_performance
     }
   }
   tags = merge(
@@ -96,6 +97,11 @@ data "aws_iam_policy_document" "pdq_indexer" {
       "logs:DescribeLogStreams"
     ]
     resources = ["${aws_cloudwatch_log_group.pdq_indexer.arn}:*"]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["cloudwatch:PutMetricData"]
+    resources = ["*"]
   }
 }
 
@@ -151,6 +157,7 @@ resource "aws_lambda_function" "pdq_hasher" {
     variables = {
       PDQ_HASHES_QUEUE_URL = aws_sqs_queue.hashes_queue.id
       DYNAMODB_TABLE       = var.datastore.name
+      MEASURE_PERFORMANCE  = var.measure_performance
     }
   }
   tags = merge(
@@ -213,6 +220,11 @@ data "aws_iam_policy_document" "pdq_hasher" {
     ]
     resources = ["${aws_cloudwatch_log_group.pdq_hasher.arn}:*"]
   }
+  statement {
+    effect    = "Allow"
+    actions   = ["cloudwatch:PutMetricData"]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "pdq_hasher" {
@@ -249,6 +261,7 @@ resource "aws_lambda_function" "pdq_matcher" {
       INDEXES_BUCKET_NAME   = var.index_data_storage.bucket_name
       PDQ_INDEX_KEY         = local.pdq_index_key
       DYNAMODB_TABLE        = var.datastore.name
+      MEASURE_PERFORMANCE  = var.measure_performance
     }
   }
   tags = merge(
@@ -310,6 +323,11 @@ data "aws_iam_policy_document" "pdq_matcher" {
       "logs:DescribeLogStreams"
     ]
     resources = ["${aws_cloudwatch_log_group.pdq_matcher.arn}:*"]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["cloudwatch:PutMetricData"]
+    resources = ["*"]
   }
 }
 

--- a/hasher-matcher-actioner/terraform/pdq-signals/variables.tf
+++ b/hasher-matcher-actioner/terraform/pdq-signals/variables.tf
@@ -80,6 +80,6 @@ variable "additional_tags" {
 
 variable "measure_performance" {
   description = "Send metrics to cloudwatch. Useful for benchmarking, but can incur costs. Set to string True for this to work."
-  type        = string
-  default     = "False"
+  type        = bool
+  default     = false
 }

--- a/hasher-matcher-actioner/terraform/pdq-signals/variables.tf
+++ b/hasher-matcher-actioner/terraform/pdq-signals/variables.tf
@@ -77,3 +77,9 @@ variable "additional_tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "measure_performance" {
+  description = "Send metrics to cloudwatch. Useful for benchmarking, but can incur costs. Set to string True for this to work."
+  type        = string
+  default     = "False"
+}

--- a/hasher-matcher-actioner/terraform/pdq-signals/variables.tf
+++ b/hasher-matcher-actioner/terraform/pdq-signals/variables.tf
@@ -83,3 +83,9 @@ variable "measure_performance" {
   type        = bool
   default     = false
 }
+
+variable "metrics_namespace" {
+  description = "Cloudwatch namespace for metrics."
+  type        = string
+  default     = "ThreatExchange/HMA"
+}

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -19,6 +19,6 @@ variable "log_retention_in_days" {
 
 variable "measure_performance" {
   description = "Send metrics to cloudwatch. Useful for benchmarking, but can incur costs. Set to string True for this to work."
-  type        = string
-  default     = "False"
+  type        = bool
+  default     = false
 }

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -22,3 +22,9 @@ variable "measure_performance" {
   type        = bool
   default     = false
 }
+
+variable "metrics_namespace" {
+  description = "Cloudwatch namespace for metrics."
+  type        = string
+  default     = "ThreatExchange/HMA"
+}

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -16,3 +16,9 @@ variable "log_retention_in_days" {
   type        = number
   default     = 14
 }
+
+variable "measure_performance" {
+  description = "Send metrics to cloudwatch. Useful for benchmarking, but can incur costs. Set to string True for this to work."
+  type        = string
+  default     = "False"
+}

--- a/hasher-matcher-actioner/tests/scripts/gen-fake-cloudwatch-metrics.py
+++ b/hasher-matcher-actioner/tests/scripts/gen-fake-cloudwatch-metrics.py
@@ -10,7 +10,7 @@ from hmalib.metrics.cloudwatch import AWSCloudWatchReporter
 Does not really have tests, but more of a demo. :)
 
 Run with
-$ MEASURE_PERFORMANCE=1 PYTHONPATH=. python tests/test_metrics_reporter.py
+$ MEASURE_PERFORMANCE=1 PYTHONPATH=. python tests/scripts/gen-fake-cloudwatch-metrics.py
 """
 
 def worker():
@@ -22,7 +22,7 @@ def worker():
         time.sleep(random.random()/100.0)
 
 def main():
-    reporter = AWSCloudWatchReporter(namespace="ThreatExchange/HMA-Test"),
+    reporter = AWSCloudWatchReporter(namespace="ThreatExchange/HMA-Test-Cloudwatch-Reporter"),
 
     # emulate some work
     print("Hit CTRL-C to stop the process. Will publish metrics on being interrupted.")

--- a/hasher-matcher-actioner/tests/test_metrics_reporter.py
+++ b/hasher-matcher-actioner/tests/test_metrics_reporter.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import time
+import random
+
+from hmalib.metrics import timer, names, flush
+from hmalib.metrics.cloudwatch import AWSCloudWatchReporter
+
+"""
+Does not really have tests, but more of a demo. :)
+
+Run with
+$ MEASURE_PERFORMANCE=1 PYTHONPATH=. python tests/test_metrics_reporter.py
+"""
+
+def worker():
+    # just spend some time
+    with timer(names.pdq_hasher_lambda.download_file):
+        time.sleep(random.random()/100.0)
+
+    with timer(names.pdq_hasher_lambda.hash):
+        time.sleep(random.random()/100.0)
+
+def main():
+    reporter = AWSCloudWatchReporter(namespace="ThreatExchange/HMA-Test"),
+
+    # emulate some work
+    print("Hit CTRL-C to stop the process. Will publish metrics on being interrupted.")
+    while True:
+        try:
+            worker()
+        except KeyboardInterrupt:
+            break
+
+    flush('ThreatExchange/HMA-Test')
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary
---------
* Add a mini-library to measure execution durations and publish to AWS 
* Adds instrumentation to PDQ lambdas. At the end of the lambdas, will flush to cloudwatch.
* Terraform variable to allow measuring metrics

The scripts that will be used to generate load on the lambdas will be added after this is merged.

To the Reviewer, please review each commit separately. The commits are arranged for sane reviewing. 

Test Plan
---------
Individual commits have test plans. Wish we could do stacked diffs here. 