### PR TITLE
Add Fetch Trigger event to terraform

### DIFF
--- a/hasher-matcher-actioner/terraform/fetcher/variables.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/variables.tf
@@ -46,3 +46,9 @@ variable "log_retention_in_days" {
   description = "How long to retain cloudwatch logs for lambda functions in days"
   type        = number
 }
+
+variable "fetch_frequency_min" {
+  description = "How many minutes to wait between queries to ThreatExchange for updates"
+  type        = number
+  default     = 15
+}


### PR DESCRIPTION
Summary
---------

Adds to the fetcher terraform, the fetcher rule that triggers the fectcher function to be called on some regular cadence this will 

Test Plan
---------

`terraform validate`
`terraform apply`
AWS looks correct correctly

Set variable to be 1 minute and see that the lambda `jeberl_fetcher` in aws is called every minute by viewing monitoring here: https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions/jeberl_fetcher?tab=monitoring