### PR TITLE
Root terraform support additional_tags

### DIFF
--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -22,7 +22,7 @@ locals {
 module "hashing_data" {
   source          = "./hashing-data"
   prefix          = var.prefix
-  additional_tags = local.common_tags
+  additional_tags = merge(var.additional_tags, local.common_tags)
 }
 
 module "pdq_signals" {
@@ -58,7 +58,7 @@ module "pdq_signals" {
   matches_sns_topic_arn = aws_sns_topic.matches.arn
 
   log_retention_in_days = var.log_retention_in_days
-  additional_tags       = local.common_tags
+  additional_tags       = merge(var.additional_tags, local.common_tags)
   measure_performance   = var.measure_performance
 }
 
@@ -77,7 +77,7 @@ module "fetcher" {
   }
 
   log_retention_in_days = var.log_retention_in_days
-  additional_tags       = local.common_tags
+  additional_tags       = merge(var.additional_tags, local.common_tags)
 }
 
 resource "aws_sns_topic" "matches" {
@@ -91,6 +91,7 @@ resource "aws_sqs_queue" "pdq_images_queue" {
   visibility_timeout_seconds = 300
   message_retention_seconds  = 1209600
   tags = merge(
+    var.additional_tags,
     local.common_tags,
     {
       Name = "PDQImagesQueue"
@@ -142,8 +143,7 @@ module "api" {
     name = module.hashing_data.hma_datastore.name
     arn  = module.hashing_data.hma_datastore.arn
   }
- 
-  log_retention_in_days = var.log_retention_in_days
-  additional_tags       = local.common_tags
-}
 
+  log_retention_in_days = var.log_retention_in_days
+  additional_tags       = merge(var.additional_tags, local.common_tags)
+}

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -28,3 +28,9 @@ variable "metrics_namespace" {
   type        = string
   default     = "ThreatExchange/HMA"
 }
+
+variable "additional_tags" {
+  description = "Additional resource tags. Will be applied to ALL resources created."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Summary
---
For accurate cost tracking, we should allow partners to specify tags at one place and pass it along to all the sub-modules we create.

This adds a variable definition and passes along the variable's contents to all submodules known at this time.

Test Plan
---
```
$ terraform apply -var "prefix=$(whoami)"
```

Gave me "Plan: 0 to add, 36 to change, 0 to destroy."
And the output showed tags being added.