### PR TITLE
[py-tx] Fix bug with sample fetch from match

### DIFF
--- a/python-threatexchange/threatexchange/cli/match.py
+++ b/python-threatexchange/threatexchange/cli/match.py
@@ -148,7 +148,7 @@ class MatchCommand(command_base.Command):
             self.stderr(
                 "Looks like you are running this for the first time. Fetching some sample data."
             )
-            fetch.FetchCommand(sample=True).execute(dataset)
+            fetch.FetchCommand(sample=True).execute(api, dataset)
 
         all_signal_types = dataset.load_cache(
             s() for s in self.content_type.get_signal_types()


### PR DESCRIPTION
Summary
---------

One of our partners ran into a silly bug, leftover from the API refactor. Maybe somebody (me) should have done some more tests.

Test Plan
---------
### Before
```
$ threatexchange match text -T 'bball now?'
Looks like you haven't set up a collaboration config, so using the sample one against public data
Looks like you are running this for the first time. Fetching some sample data.
Traceback (most recent call last):
  File "/home/dcallies/.venv/threatexchange/bin/threatexchange", line 33, in <module>
    sys.exit(load_entry_point('threatexchange', 'console_scripts', 'threatexchange')())
  File "/data/users/dcallies/fork_te/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 194, in main
    execute_command(namespace)
  File "/data/users/dcallies/fork_te/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 110, in execute_command
    command.execute(api, dataset)
  File "/data/users/dcallies/fork_te/ThreatExchange/python-threatexchange/threatexchange/cli/match.py", line 151, in execute
    fetch.FetchCommand(api=api, sample=True).execute(dataset)
TypeError: __init__() got an unexpected keyword argument 'api'
[Exit 1]
```

### After
```
$ threatexchange match text -T 'bball now?'
Looks like you haven't set up a collaboration config, so using the sample one against public data
Looks like you are running this for the first time. Fetching some sample data.
url: 1
trend_query: 1
pdq: 138
raw_text: 3
pdq_ocr: 2
video_tmk_pdqf: 1
photo_md5: 1
video_md5: 2
3425830734108278 raw_text disputed media_priority_samples
3261912580534814 trend_query disputed media_priority_samples

```
