### PR TITLE
Store TE api access token in AWS as a secret

### DIFF
--- a/hasher-matcher-actioner/terraform/fetcher/main.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/main.tf
@@ -208,3 +208,14 @@ resource "aws_dynamodb_table" "threatexchange_config" {
     }
   )
 }
+
+### ThreatExchange API Token Secret ###
+
+resource "aws_secretsmanager_secret" "api_token" {
+  name = "threatexchange/${var.prefix}_api_tokens"
+}
+
+resource "aws_secretsmanager_secret_version" "example" {
+  secret_id     = aws_secretsmanager_secret.api_token.id
+  secret_string = var.te_api_token
+}

--- a/hasher-matcher-actioner/terraform/fetcher/variables.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/variables.tf
@@ -52,3 +52,9 @@ variable "fetch_frequency_min" {
   type        = number
   default     = 15
 }
+
+variable "te_api_token" {
+  description = "Token to read data from ThreatExchange"
+  type        = string
+  sensitive   = true
+}

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -65,6 +65,7 @@ module "pdq_signals" {
 module "fetcher" {
   source = "./fetcher"
   prefix = var.prefix
+  te_api_token = "${var.te_app_id}|${var.te_app_secret}"
   lambda_docker_info = {
     uri = var.hma_lambda_docker_uri
     commands = {

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -65,7 +65,7 @@ module "pdq_signals" {
 module "fetcher" {
   source = "./fetcher"
   prefix = var.prefix
-  te_api_token = "${var.te_app_id}|${var.te_app_secret}"
+  te_api_token = var.te_api_token
   lambda_docker_info = {
     uri = var.hma_lambda_docker_uri
     commands = {

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -46,3 +46,14 @@ variable "include_cloudfront_distribution" {
   type        = bool
   default     = false
 }
+
+variable "te_app_id" {
+  description = "The App ID used to access to ThreatExchange"
+  type = string
+}
+
+variable "te_app_secret" {
+  description = "The secret token used to authenticate your access to the ThreatExchange app. You can find this by navigating to https://developers.facebook.com/apps/<YOUR-APP-ID>/settings/basic/ "
+  type = string
+  sensitive = true
+}

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -47,13 +47,8 @@ variable "include_cloudfront_distribution" {
   default     = false
 }
 
-variable "te_app_id" {
-  description = "The App ID used to access to ThreatExchange"
-  type = string
-}
-
-variable "te_app_secret" {
-  description = "The secret token used to authenticate your access to the ThreatExchange app. You can find this by navigating to https://developers.facebook.com/apps/<YOUR-APP-ID>/settings/basic/ "
-  type = string
-  sensitive = true
+variable "te_api_token" {
+  description = "The secret token used to authenticate your access to ThreatExchange. You can find this by navigating to https://developers.facebook.com/tools/accesstoken/"
+  type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
Summary
---------
Added secret that user inputs as a terraform variable

Test Plan
---------
1. Edit `terraform.tfvars` to include the variables `te_api_token`
2. 
```
terraform init
terraform validate
terraform apply
```
3. validate that the new secret shows up correctly in aws