### PR TITLE
PDQ Hash photos without temporary files

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_hasher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_hasher.py
@@ -64,27 +64,28 @@ def lambda_handler(event, context):
                 continue
 
             logger.info("generating pdq hash for %s/%s", bucket_name, key)
-            with tempfile.NamedTemporaryFile() as tmp_file:
-                path = Path(tmp_file.name)
 
-                with metrics.timer(metrics.names.pdq_hasher_lambda.download_file):
-                    s3_client.download_fileobj(bucket_name, key, tmp_file)
+            with metrics.timer(metrics.names.pdq_hasher_lambda.download_file):
+                bytes_: bytes = s3_client.get_object(
+                    Bucket=bucket_name,
+                    Key=key
+                )['Body'].read()
 
-                with metrics.timer(metrics.names.pdq_hasher_lambda.hash):
-                    pdq_hash, quality = pdq_hasher.pdq_from_file(path)
+            with metrics.timer(metrics.names.pdq_hasher_lambda.hash):
+                pdq_hash, quality = pdq_hasher.pdq_from_bytes(bytes_)
 
-                hash_record = PipelinePDQHashRecord(
-                    key, pdq_hash, datetime.datetime.now(), quality
-                )
+            hash_record = PipelinePDQHashRecord(
+                key, pdq_hash, datetime.datetime.now(), quality
+            )
 
-                hash_record.write_to_table(records_table)
+            hash_record.write_to_table(records_table)
 
-                # Publish to SQS queue
-                sqs_client.send_message(
-                    QueueUrl=OUTPUT_QUEUE_URL,
-                    MessageBody=json.dumps(hash_record.to_sqs_message()),
-                )
+            # Publish to SQS queue
+            sqs_client.send_message(
+                QueueUrl=OUTPUT_QUEUE_URL,
+                MessageBody=json.dumps(hash_record.to_sqs_message()),
+            )
 
-                logger.info("Published new PDQ hash")
+            logger.info("Published new PDQ hash")
 
     metrics.flush()

--- a/hasher-matcher-actioner/requirements.txt
+++ b/hasher-matcher-actioner/requirements.txt
@@ -1,5 +1,5 @@
 boto3
 boto3-stubs[essential]==1.17.14.0
-threatexchange[faiss,pdq_hasher]>=0.0.11
+threatexchange[faiss,pdq_hasher]>=0.0.15
 bottle
 apig_wsgi


### PR DESCRIPTION
Summary
---
At 1MB, some images were not getting hashed because the buffer wasn't getting automatically flushed. I did some digging around.

It appears that we need not write to a file at all. We can manage everything in memory. This depends on another merged PR in threatexchange #420  and accordingly updates the threatexchange version number from #421.

Test Plan
---
Used a docker image built from these sources to run perf tests on ~300 distinct 1 and 10 MB images. The runs were succesful over 100k hashing requests.