### PR TITLE
Update aws_secretsmanager_secret.recovery_window_in_days to 0 for easy apply/destroy

### DIFF
--- a/hasher-matcher-actioner/terraform/.terraform.lock.hcl
+++ b/hasher-matcher-actioner/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 3.0"
   hashes = [
     "h1:aY98OcgyLZJVEoqWB8tro023Fx3khJUWQOxwAfd94pQ=",
+    "h1:tY5R3hRBB1v8v3MT+ofoCJ/Vz/b/4PXo3xtBKtw7T4A=",
     "zh:04e4f700c21b1f58e7603638160bd5ad3b85519c35dc75bada3e52b164d06d3e",
     "zh:09f2338404d4b2d4dcb29781ac59a6955d935745e896d4ee661d83cac8d7c677",
     "zh:16bdf96d8139268766921d5b891b865f67936190dc302283ba50b94e42510ec5",

--- a/hasher-matcher-actioner/terraform/fetcher/main.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/main.tf
@@ -213,9 +213,10 @@ resource "aws_dynamodb_table" "threatexchange_config" {
 
 resource "aws_secretsmanager_secret" "api_token" {
   name = "threatexchange/${var.prefix}_api_tokens"
+  recovery_window_in_days = 0
 }
 
-resource "aws_secretsmanager_secret_version" "example" {
+resource "aws_secretsmanager_secret_version" "api_token" {
   secret_id     = aws_secretsmanager_secret.api_token.id
   secret_string = var.te_api_token
 }


### PR DESCRIPTION
Summary
---------

aws secret defaults to recovery_window_in_days of 7 and while a secret is 'scheduled for deletion' it can't be created. If we set this to 0 we avoid this. 

Test Plan
---------

`terraform -chdir=terraform apply`
`terraform -chdir=terraform destroy`
`terraform -chdir=terraform apply`
