### PR TITLE
[hma] Wrap hmalib with setup, install with pip

### DIFF
--- a/hasher-matcher-actioner/Dockerfile
+++ b/hasher-matcher-actioner/Dockerfile
@@ -1,16 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-ARG DEPS_PATH=/hma-deps
-ARG CODE_DIRECTORY=/hma-lambda
-
 FROM public.ecr.aws/lambda/python:3.8 as build
 RUN yum install -y gcc gcc-c++
-COPY requirements.txt .
-ARG DEPS_PATH
-RUN pip install --no-cache-dir -r requirements.txt --target "${DEPS_PATH}"
-
-FROM public.ecr.aws/lambda/python:3.8 as prod
-ARG DEPS_PATH
-COPY --from=build $DEPS_PATH $DEPS_PATH
-ENV PYTHONPATH $DEPS_PATH
+COPY setup.py ./setup.py
 COPY hmalib ./hmalib
+RUN pip install --no-cache-dir .

--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -39,7 +39,6 @@ dynamodb = boto3.resource("dynamodb")
 s3 = boto3.resource("s3")
 
 
-
 @dataclass
 class FetcherConfig:
     """

--- a/hasher-matcher-actioner/requirements.txt
+++ b/hasher-matcher-actioner/requirements.txt
@@ -1,5 +1,1 @@
-boto3
-boto3-stubs[essential]==1.17.14.0
-threatexchange[faiss,pdq_hasher]>=0.0.15
-bottle
-apig_wsgi
+.

--- a/hasher-matcher-actioner/setup.py
+++ b/hasher-matcher-actioner/setup.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from setuptools import setup
+
+
+setup(
+    name="hmalib",
+    description="Python Library for Facebook ThreatExchange",
+
+    install_requires=[
+        "boto3",
+        "boto3-stubs[essential]==1.17.14.0",
+        "threatexchange[faiss,pdq_hasher]>=0.0.15",
+        "bottle",
+        "apig_wsgi",
+    ],
+)

--- a/hasher-matcher-actioner/setup.py
+++ b/hasher-matcher-actioner/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name="hmalib",
-    description="Python Library for Facebook ThreatExchange",
+    description="Convenience package for hmalib. Probably don't distribute it.",
 
     install_requires=[
         "boto3",

--- a/hasher-matcher-actioner/setup.py
+++ b/hasher-matcher-actioner/setup.py
@@ -7,7 +7,6 @@ from setuptools import setup
 setup(
     name="hmalib",
     description="Convenience package for hmalib. Probably don't distribute it.",
-
     install_requires=[
         "boto3",
         "boto3-stubs[essential]==1.17.14.0",

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -57,6 +57,7 @@ setup(
     install_requires=[
         "python-Levenshtein",
         "requests",
+        "dataclasses",
     ],
     extras_require=extras_require,
     entry_points={"console_scripts": ["threatexchange = threatexchange.cli.main:main"]},


### PR DESCRIPTION
Summary
---------

dataclass is forwards compatible, but only if properly shadowed by the real library. @schatten theorized this was because we were messing with the python path, which seems to be correct.

Fixes  #440

Test Plan
---------

```
$ cd hasher-matcher-actioner
$ docker build . - testington
$ docker run -p 9000:8080 testington hmalib.lambdas.fetcher.lambda_handler
# Trigger CLI from the docker desktop
$ sh-4.2# python3.8 -m hmalib.lambdas.pdq.pdq_hasher
# Get another environment variable error, but not the dataclass one
```
