### PR TITLE
[HMA] clean up matches and hash api

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -162,7 +162,7 @@ class MatchDetailsResult(t.TypedDict):
 
 
 def gen_match_details(content_id: str) -> t.List[MatchDetailsResult]:
-    if content_id:
+    if not content_id:
         return []
     table = dynamodb.Table(DYNAMODB_TABLE)
     records = PDQMatchRecord.get_from_content_id(
@@ -188,7 +188,7 @@ class HashResult(t.TypedDict):
 
 
 def gen_hash(content_id: str) -> t.Optional[HashResult]:
-    if content_id:
+    if not content_id:
         return None
     table = dynamodb.Table(DYNAMODB_TABLE)
     record = PipelinePDQHashRecord.get_from_content_id(

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -5,6 +5,7 @@ import bottle
 import boto3
 import json
 import base64
+from dataclasses import dataclass, asdict
 import typing as t
 from boto3.dynamodb.conditions import Attr
 from apig_wsgi import make_lambda_handler
@@ -28,6 +29,7 @@ dynamodb = boto3.resource("dynamodb")
 DYNAMODB_TABLE = os.environ["DYNAMODB_TABLE"]
 IMAGE_BUCKET_NAME = os.environ["IMAGE_BUCKET_NAME"]
 IMAGE_FOLDER_KEY = os.environ["IMAGE_FOLDER_KEY"]
+IMAGE_FOLDER_KEY_LEN = len(IMAGE_FOLDER_KEY)
 
 # Override common errors codes to return json instead of bottle's default html
 @error(404)
@@ -87,16 +89,10 @@ def upload():
 def matches():
     """
     matches API endpoint:
-    returns style { matches: [{
-        content_id: str,
-        signal_id: str,
-        matched_on: str,
-        reaction: str, # TODO
-        }]
-    }
+    returns style { matches: [MatchesResult] }
     """
     results = gen_matches()
-    logger.info(results)
+    logger.debug(results)
     return {"matches": results}
 
 
@@ -104,17 +100,10 @@ def matches():
 def match_details(key=None):
     """
     matche details API endpoint:
-    return format: match_details : [{
-        "content_id": str
-        "content_hash": str,
-        "signal_id": str,
-        "signal_hash": str,
-        "signal_source": str,
-        "updated_at": str, # ISO-8601 formatted
-    }]
+    return format: match_details : [MatchDetailsResult]
     """
     results = gen_match_details(key)
-    logger.info(results)
+    logger.debug(results)
     return {"match_details": results}
 
 
@@ -122,15 +111,11 @@ def match_details(key=None):
 def hashes(key=None):
     """
     hash details API endpoint:
-    return format: {
-        content_id: str,
-        content_hash: str,
-        updated_at: str,
-    }
+    return format: HashResult
     """
     results = gen_hash(key)
-    logger.info(results)
-    return results
+    logger.debug(results)
+    return results if results else {}
 
 
 def lambda_handler(event, context):
@@ -143,13 +128,21 @@ def lambda_handler(event, context):
     return response
 
 
-# TODO move to utils library
-def gen_matches() -> t.List:
+# TODO move to its own library
+class MatchesResult(t.TypedDict):
+    content_id: str
+    signal_id: t.Union[str, int]
+    signal_source: str
+    updated_at: str
+    reactions: str  # TODO
+
+
+def gen_matches() -> t.List[MatchesResult]:
     table = dynamodb.Table(DYNAMODB_TABLE)
     records = PDQMatchRecord.get_from_time_range(table)
-    results = [
+    return [
         {
-            "content_id": record.content_id,
+            "content_id": record.content_id[IMAGE_FOLDER_KEY_LEN:],
             "signal_id": record.signal_id,
             "signal_source": record.signal_source,
             "updated_at": record.updated_at.isoformat(),
@@ -157,19 +150,27 @@ def gen_matches() -> t.List:
         }
         for record in records
     ]
-    return results
 
 
-def gen_match_details(content_id: str) -> t.List:
-    if content_id is None:
+class MatchDetailsResult(t.TypedDict):
+    content_id: str
+    content_hash: str
+    signal_id: t.Union[str, int]
+    signal_hash: str
+    signal_source: str
+    updated_at: str
+
+
+def gen_match_details(content_id: str) -> t.List[MatchDetailsResult]:
+    if content_id:
         return []
     table = dynamodb.Table(DYNAMODB_TABLE)
     records = PDQMatchRecord.get_from_content_id(
         table, f"{IMAGE_FOLDER_KEY}{content_id}"
     )
-    results = [
+    return [
         {
-            "content_id": record.content_id,
+            "content_id": record.content_id[IMAGE_FOLDER_KEY_LEN:],
             "content_hash": record.content_hash,
             "signal_id": record.signal_id,
             "signal_hash": record.signal_hash,
@@ -178,22 +179,25 @@ def gen_match_details(content_id: str) -> t.List:
         }
         for record in records
     ]
-    return results
 
 
-def gen_hash(content_id: str) -> t.Dict:
-    if content_id is None:
-        return {}
+class HashResult(t.TypedDict):
+    content_id: str
+    content_hash: str
+    updated_at: str
+
+
+def gen_hash(content_id: str) -> t.Optional[HashResult]:
+    if content_id:
+        return None
     table = dynamodb.Table(DYNAMODB_TABLE)
     record = PipelinePDQHashRecord.get_from_content_id(
         table, f"{IMAGE_FOLDER_KEY}{content_id}"
     )
-    return (
-        {
-            "content_id": record.content_id,
-            "content_hash": record.content_hash,
-            "updated_at": record.updated_at.isoformat(),
-        }
-        if record
-        else {}
-    )
+    if not record:
+        return None
+    return {
+        "content_id": record.content_id[IMAGE_FOLDER_KEY_LEN:],
+        "content_hash": record.content_hash,
+        "updated_at": record.updated_at.isoformat(),
+    }

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -188,8 +188,12 @@ def gen_hash(content_id: str) -> t.Dict:
     record = PipelinePDQHashRecord.get_from_content_id(
         table, f"{IMAGE_FOLDER_KEY}{content_id}"
     )
-    return {
-        "content_id": record.content_id,
-        "content_hash": record.content_hash,
-        "updated_at": record.updated_at.isoformat(),
-    }
+    return (
+        {
+            "content_id": record.content_id,
+            "content_hash": record.content_hash,
+            "updated_at": record.updated_at.isoformat(),
+        }
+        if record
+        else {}
+    )

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -74,8 +74,8 @@ resource "aws_iam_role" "api_root" {
 data "aws_iam_policy_document" "api_root" {
   statement {
     effect    = "Allow"
-    actions   = ["dynamodb:GetItem", "dynamodb:Scan"]
-    resources = [var.datastore.arn]
+    actions   = ["dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan"]
+    resources = ["${var.datastore.arn}*"]
   }
   statement {
     effect    = "Allow"

--- a/hasher-matcher-actioner/webapp/src/Matches.jsx
+++ b/hasher-matcher-actioner/webapp/src/Matches.jsx
@@ -75,145 +75,90 @@ export default function Matches() {
           </form>
         </div>
       </Collapse>
-      <div className="row mt-3">
-        <div className="col-xs-12">
-          <table className="table table-hover table-sm">
-            <thead>
-              <tr>
-                <th>Image</th>
-                <th>Hash</th>
-                <th>Matched On</th>
-                <th>Reaction</th>
-                <th>Details</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr className="align-middle">
-                <td className="align-middle">file1.jpg</td>
-                <td className="align-middle">
-                  8a551807446ba95400eb032ba8fe51c3857eaaa5570cea70bb87775cbdc1eebe
-                </td>
-                <td className="align-middle">5 Feb 2021 1:47pm</td>
-                <td className="align-middle">Seen</td>
-                <td className="align-middle">
-                  <button
-                    type="button"
-                    className="btn btn-outline-primary btn-sm"
-                    onClick={() => setShowModal(true)}>
-                    Details
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td className="align-middle">file1.jpg</td>
-                <td className="align-middle">
-                  652fe95ab4ae5129c07e92da787e525ab44b736ea5ab5ce4485ba344158b8e86
-                </td>
-                <td className="align-middle">5 Feb 2021 1:44pm</td>
-                <td className="align-middle">Seen</td>
-                <td className="align-middle">
-                  <Link
-                    to="/matches/file1.jpg"
-                    className="btn btn-outline-primary btn-sm">
-                    Details
-                  </Link>
-                </td>
-              </tr>
-              <tr>
-                <td className="align-middle">file2.jpg</td>
-                <td className="align-middle">
-                  652fe95ab4ae5129c07e92da787e525ab44b736ea5ab5ce4485ba344158b8e86
-                </td>
-                <td className="align-middle">5 Feb 2021 1:44pm</td>
-                <td className="align-middle">Positive</td>
-                <td className="align-middle">
-                  <button
-                    type="button"
-                    className="btn btn-outline-primary btn-sm">
-                    Details
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td className="align-middle">file3.jpg</td>
-                <td className="align-middle">
-                  652fe95ab4ae5129c07e92da787e525ab44b736ea5ab5ce4485ba344158b8e86
-                </td>
-                <td className="align-middle">5 Feb 2021 1:44pm</td>
-                <td className="align-middle">Positive</td>
-                <td className="align-middle">
-                  <button
-                    type="button"
-                    className="btn btn-outline-primary btn-sm">
-                    Details
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td className="align-middle">file4.jpg</td>
-                <td className="align-middle">
-                  652fe95ab4ae5129c07e92da787e525ab44b736ea5ab5ce4485ba344158b8e86
-                </td>
-                <td className="align-middle">5 Feb 2021 1:44pm</td>
-                <td className="align-middle">False Positive</td>
-                <td className="align-middle">
-                  <button
-                    type="button"
-                    className="btn btn-outline-primary btn-sm">
-                    Details
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td className="align-middle">file5.jpg</td>
-                <td className="align-middle">
-                  652fe95ab4ae5129c07e92da787e525ab44b736ea5ab5ce4485ba344158b8e86
-                </td>
-                <td className="align-middle">5 Feb 2021 1:44pm</td>
-                <td className="align-middle">Seen</td>
-                <td className="align-middle">
-                  <button
-                    type="button"
-                    className="btn btn-outline-primary btn-sm">
-                    Details
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td className="align-middle">file6.jpg</td>
-                <td className="align-middle">
-                  652fe95ab4ae5129c07e92da787e525ab44b736ea5ab5ce4485ba344158b8e86
-                </td>
-                <td className="align-middle">5 Feb 2021 1:44pm</td>
-                <td className="align-middle">Positive</td>
-                <td className="align-middle">
-                  <button
-                    type="button"
-                    className="btn btn-outline-primary btn-sm">
-                    Details
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td className="align-middle">file7.jpg</td>
-                <td className="align-middle">
-                  652fe95ab4ae5129c07e92da787e525ab44b736ea5ab5ce4485ba344158b8e86
-                </td>
-                <td className="align-middle">5 Feb 2021 1:44pm</td>
-                <td className="align-middle">Seen</td>
-                <td className="align-middle">
-                  <button
-                    type="button"
-                    className="btn btn-outline-primary btn-sm">
-                    Details
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+      <MatchList />
+      <MatchDetailsModal show={showModal} onHide={() => setShowModal(false)} />
+    </>
+  );
+}
+
+function MatchList() {
+  const [matchesData, setMatchesData] = useState(null);
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    fetchMatches().then(matches => setMatchesData(matches.matches));
+    // .catch(err => console.log(err));
+  }, []);
+
+  function formatTimestamp(timestamp) {
+    return new Intl.DateTimeFormat('defualt', {
+      day: 'numeric',
+      weekday: 'short',
+      year: 'numeric',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    }).format(new Date(timestamp));
+  }
+
+  return (
+    <>
+      <Spinner hidden={matchesData !== null} animation="border" role="status">
+        <span className="sr-only">Loading...</span>
+      </Spinner>
+      <Collapse in={matchesData !== null}>
+        <div className="row mt-3">
+          <div className="col-xs-12">
+            <table className="table table-hover table-sm">
+              <thead>
+                <tr>
+                  <th>Content</th>
+                  <th>Matched Signal ID</th>
+                  <th>Source</th>
+                  <th>Last Updated</th>
+                  <th>Reaction</th>
+                  <th>
+                    {/* for now have this at the header button so we still have an example of a model  */}
+                    <button
+                      type="button"
+                      className="btn btn-outline-primary btn-sm"
+                      onClick={() => setShowModal(true)}>
+                      Details
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {matchesData !== null && matchesData.length ? (
+                  matchesData.map(match => (
+                    <tr className="align-middle" key={match.content_id}>
+                      <td className="align-middle">{match.content_id}</td>
+                      <td className="align-middle">{match.signal_id}</td>
+                      <td className="align-middle">{match.signal_source}</td>
+                      <td className="align-middle">
+                        {formatTimestamp(match.updated_at)}
+                      </td>
+                      <td className="align-middle">{match.reactions}</td>
+                      <td className="align-middle">
+                        <Link
+                          to="/matches/file1.jpg"
+                          className="btn btn-outline-primary btn-sm">
+                          Details
+                        </Link>
+                      </td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td colSpan={5}>No Matches Found.</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
         </div>
-      </div>
-      <MatchList2 />
+      </Collapse>
       <MatchDetailsModal show={showModal} onHide={() => setShowModal(false)} />
     </>
   );
@@ -247,66 +192,5 @@ function MatchDetailsModal(props) {
         <Button onClick={onHide}>Close</Button>
       </Modal.Footer>
     </Modal>
-  );
-}
-
-function MatchList2() {
-  const [matchesData, setMatchesData] = useState(null);
-
-  useEffect(() => {
-    fetchMatches().then(matches => setMatchesData(matches.matches));
-    // .catch(err => console.log(err));
-  }, []);
-
-  return (
-    <>
-      <Spinner hidden={matchesData !== null} animation="border" role="status">
-        <span className="sr-only">Loading...</span>
-      </Spinner>
-      <Collapse in={matchesData !== null}>
-        <div className="row mt-3">
-          <div className="col-xs-12">
-            <table className="table table-hover table-sm">
-              <thead>
-                <tr>
-                  <th>Image</th>
-                  <th>Hash</th>
-                  <th>Matched On</th>
-                  <th>Reaction</th>
-                  <th>Details</th>
-                </tr>
-              </thead>
-              <tbody>
-                {matchesData !== null && matchesData.length ? (
-                  matchesData.map(match => {
-                    const imgKey = Object.keys(match)[0];
-                    const teVal = match[imgKey];
-                    return (
-                      <tr className="align-middle" key={imgKey}>
-                        <td className="align-middle">{imgKey}</td>
-                        <td className="align-middle">{teVal}</td>
-                        <td className="align-middle">TODO</td>
-                        <td className="align-middle">TODO</td>
-                        <td className="align-middle">
-                          <Link
-                            to="/matches/file1.jpg"
-                            className="btn btn-outline-primary btn-sm">
-                            Details
-                          </Link>
-                        </td>
-                      </tr>
-                    );
-                  })
-                ) : (
-                  <tr>
-                    <td colSpan={5}>No Matches Found.</td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </Collapse>
-    </>
   );
 }


### PR DESCRIPTION
Summary
---------

Updates the match and hash endpoints to be better keyed and add a docstring to describe the expected return format.
Also made slight changes to the 'matches' UI page that will likely soon be superseded by other changes/designs. My next step will be to hook up the match details section.  

Test Plan
---------

Postman as a little involved to get working but if you have that set up (feel free to reachout)

```
terraform -chdir=terraform apply 
make dev_upload_test_data
```
Go to Postman (on `cd webapp/ && npm run`)
<img width="860" alt="Screen Shot 2021-03-25 at 1 13 38 PM" src="https://user-images.githubusercontent.com/7664526/112514684-f10b5180-8d6b-11eb-83f6-5422a024167b.png">


The following endpoints were updated/added
- `<api-gateway-invoke-url>/matches`
- `<api-gateway-invoke-url>/hash/<content_id>`
  - e.g. `https://<gw-id>.execute-api.us-east-1.amazonaws.com/hash/b.jpg` 
- `<api-gateway-invoke-url>/match/<content_id>`

