### PR TITLE
Split python dependency and library into docker layers

### DIFF
--- a/hasher-matcher-actioner/Dockerfile
+++ b/hasher-matcher-actioner/Dockerfile
@@ -1,7 +1,15 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-FROM public.ecr.aws/lambda/python:3.8 as build
+FROM public.ecr.aws/lambda/python:3.8@sha256:6fd9eea0292e900c7b8f4186c9e4fbcdb130118b8915ea8243394a7e620e5519 as build
 RUN yum install -y gcc gcc-c++
-COPY setup.py ./setup.py
-COPY hmalib ./hmalib
-RUN pip install --no-cache-dir .
+
+# Install dependencies as a separate step so layers are reuseable.
+COPY setup.py ./
+RUN python setup.py egg_info \
+    && pip install -r hmalib.egg-info/requires.txt \
+    && rm -r hmalib.egg-info setup.py
+
+# LAMBDA_TASK_ROOT is recommended in the image [1]. I'm hoping this will prevent
+# the python path complications from arising.
+# 1: https://hub.docker.com/r/amazon/aws-lambda-python
+COPY hmalib ${LAMBDA_TASK_ROOT}/hmalib


### PR DESCRIPTION
Summary
---
Docker build times were getting unbearable, the following changes were made:
1) Pinned python runtime base image sha
This allows re-use of the base image. If this changes, all our layers must change and that slows us down.
2) Split dependency installation from hmalib installation
libraries + code is around 200MB. Even though library was rarely changing. Using setup.py egg_info to generate a requirements.txt style file at runtime to populate dependencies.
3) Instead of copying hmalib source code into the python package directory, copy it to the recommended lambda task root [1]

1: https://hub.docker.com/r/amazon/aws-lambda-python

Test Plan
---
Used `$ time  make upload_docker` to time the docker upload process.

Before:
```
Run #1: 4:46
Run #2: 5:33
```

After:
```
Run #1: 2:02
Run #2: 0:08
```

Also ran a smoke test to ensure the lambdas are actually functioning after deploy. While things are not working on my setup, that's not because of import paths, so we're good!

References
---
* https://windsock.io/explaining-docker-image-ids/
* https://hub.docker.com/r/amazon/aws-lambda-python
* https://stackoverflow.com/questions/31222377/what-are-docker-image-layers
* https://stackoverflow.com/questions/29696656/finding-the-layers-and-layer-sizes-for-each-docker-image

