### PR TITLE
[py-tx] update pdq_hasher to handle grayscale

### DIFF
--- a/python-threatexchange/threatexchange/hashing/pdq_hasher.py
+++ b/python-threatexchange/threatexchange/hashing/pdq_hasher.py
@@ -19,7 +19,9 @@ def pdq_from_file(path: pathlib.Path) -> PDQOutput:
     Given a path to a file return the PDQ Hash string in hex.
     Current tested against: jpg
     """
-    img_pil = Image.open(path)
+    # Convert to RGB makes sure the resulting array has the number of dimensions
+    # expected by 'pdqhash' (without this black and white images result in errors).
+    img_pil = Image.open(path).convert("RGB")
     image = numpy.asarray(img_pil)
     return _pdq_from_numpy_array(image)
 


### PR DESCRIPTION
Summary
---------

#455 called out a bug in 'python-threatexchange/threatexchange/hashing/pdq_hasher.py' Did some digging and found what I think should be a one line fix. 

Using the photo attached to the issue I compared the output with the changes to `threatexchange.hashing.pdq_hasher.pdq_from_file`with our cpp version of pdq (`./pdq/cpp/pdq-photo-hasher` after running make) and found the hashes matched.


Test Plan
---------

See methodology above in summary, unfortunately testing is hard until the fixes in #464 are merged. 