### PR TITLE
Changed CloudFront behavior to redirect http traffic to https

### DIFF
--- a/hasher-matcher-actioner/terraform/webapp/main.tf
+++ b/hasher-matcher-actioner/terraform/webapp/main.tf
@@ -47,7 +47,7 @@ resource "aws_cloudfront_distribution" "webapp" {
     max_ttl                = 1200
     min_ttl                = 0
     target_origin_id       = "${var.organization}-${var.prefix}-hma-webapp-origin"
-    viewer_protocol_policy = "allow-all"
+    viewer_protocol_policy = "redirect-to-https"
     forwarded_values {
       query_string = false
       cookies {


### PR DESCRIPTION
Summary
---------

Updated /webapp/main.tf and changed CloudFront behavior to redirect http traffic to https.

Test Plan
---------

1. Set up terraform.tfvars to create a CloudFront distribution (i.e., `include_cloudfront_distribution = true`)
2. `terraform apply`
3. Add a user to the user pool
4. Look up CloudFront domain name
5. Open a browser and go to http://<CloudFront-domain-name> and validate that the browser redirects to https://<CloudFront-domain-name> 
