### PR TITLE
python-threatexchange supports fetching list of privacy groups an app is a member of

### DIFF
--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -58,6 +58,7 @@ setup(
         "python-Levenshtein",
         "requests",
         "dataclasses",
+        "python-dateutil",
     ],
     extras_require=extras_require,
     entry_points={"console_scripts": ["threatexchange = threatexchange.cli.main:main"]},

--- a/python-threatexchange/tests/test_api.py
+++ b/python-threatexchange/tests/test_api.py
@@ -19,7 +19,7 @@ class APIIntegrationTest(unittest.TestCase):
 
     def test_get_threat_privacy_groups_member(self):
         """
-        Assumes that the app (if token is provided) will have atleast one
+        Assumes that the app (if token is provided) will have at least one
         privacy group.
         """
         response = self.api.get_threat_privacy_groups_member()

--- a/python-threatexchange/tests/test_api.py
+++ b/python-threatexchange/tests/test_api.py
@@ -1,0 +1,32 @@
+import os
+import unittest
+import collections.abc
+
+from threatexchange.api import ThreatExchangeAPI, ThreatPrivacyGroup
+
+THREAT_EXCHANGE_INTEGRATION_TEST_TOKEN = os.getenv(
+    "THREAT_EXCHANGE_INTEGRATION_TEST_TOKEN"
+)
+
+
+@unittest.skipUnless(
+    THREAT_EXCHANGE_INTEGRATION_TEST_TOKEN,
+    "Integration Test requires tokens. Use THREAT_EXCHANGE_INTEGRATION_TEST_TOKEN environment variable.",
+)
+class APIIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        self.api = ThreatExchangeAPI(THREAT_EXCHANGE_INTEGRATION_TEST_TOKEN)
+
+    def test_get_threat_privacy_groups_member(self):
+        """
+        Assumes that the app (if token is provided) will have atleast one
+        privacy group.
+        """
+        response = self.api.get_threat_privacy_groups_member()
+        self.assertTrue(
+            isinstance(response, collections.abc.Sequence)
+            and not isinstance(response, staticmethod),
+            "API returned something that's not a list!",
+        )
+
+        self.assertTrue(isinstance(response[0], ThreatPrivacyGroup))

--- a/python-threatexchange/threatexchange/api.py
+++ b/python-threatexchange/threatexchange/api.py
@@ -18,6 +18,8 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
+from .api_models import ThreatPrivacyGroup
+
 
 class TimeoutHTTPAdapter(HTTPAdapter):
     """
@@ -284,6 +286,41 @@ class ThreatExchangeAPI:
 
         url = f"{self._base_url}/{privacy_group}/threat_updates/"
         return _CursoredResponse(self, url, params, decode_fn=decode_fn)
+
+    def get_threat_privacy_groups_member(
+        self,
+    ) -> t.List[ThreatPrivacyGroup]:
+        """
+        Returns a non-paginated list of all privacy groups the current app is a
+        member of.
+        """
+        url = self._get_graph_api_url(f"{self.app_id}/threat_privacy_groups_member")
+        response = self.get_json_from_url(url)
+        return [ThreatPrivacyGroup.from_graph_api_dict(d) for d in response["data"]]
+
+    def _get_graph_api_url(
+        self, sub_path: t.Optional[str], query_dict: t.Dict = {}
+    ) -> str:
+        """
+        Returns a threatexchange URL for a sub-path and a dictionary of query
+        parameters. Automatically adds access_token to the query dictionary.
+        """
+        if "access_token" not in query_dict:
+            query_dict["access_token"] = self.api_token
+
+        query = urllib.parse.urlencode(query_dict)
+
+        base_url_parts = urllib.parse.urlparse(self._base_url)
+        url_parts = urllib.parse.ParseResult(
+            base_url_parts.scheme,
+            base_url_parts.netloc,
+            f"{base_url_parts.path}/{sub_path}",
+            base_url_parts.params,
+            query,
+            base_url_parts.fragment,
+        )
+
+        return urllib.parse.urlunparse(url_parts)
 
     def _validate_post_params_for_submit(self, postParams):
         """

--- a/python-threatexchange/threatexchange/api.py
+++ b/python-threatexchange/threatexchange/api.py
@@ -286,7 +286,7 @@ class ThreatExchangeAPI:
 
         url = f"{self._base_url}/{privacy_group}/threat_updates/"
         return _CursoredResponse(self, url, params, decode_fn=decode_fn)
-
+        
     def get_threat_privacy_groups_member(
         self,
     ) -> t.List[ThreatPrivacyGroup]:
@@ -294,7 +294,19 @@ class ThreatExchangeAPI:
         Returns a non-paginated list of all privacy groups the current app is a
         member of.
         """
-        url = self._get_graph_api_url(f"{self.app_id}/threat_privacy_groups_member")
+        fields = [
+            "id",
+            "members_can_see",
+            "members_can_use",
+            "name",
+            "description",
+            "last_updated",
+            "added_on"
+        ]
+        url = self._get_graph_api_url(
+            f"{self.app_id}/threat_privacy_groups_member",
+            {"fields": ",".join(fields}
+        )
         response = self.get_json_from_url(url)
         return [ThreatPrivacyGroup.from_graph_api_dict(d) for d in response["data"]]
 

--- a/python-threatexchange/threatexchange/api.py
+++ b/python-threatexchange/threatexchange/api.py
@@ -286,7 +286,7 @@ class ThreatExchangeAPI:
 
         url = f"{self._base_url}/{privacy_group}/threat_updates/"
         return _CursoredResponse(self, url, params, decode_fn=decode_fn)
-        
+
     def get_threat_privacy_groups_member(
         self,
     ) -> t.List[ThreatPrivacyGroup]:
@@ -301,11 +301,10 @@ class ThreatExchangeAPI:
             "name",
             "description",
             "last_updated",
-            "added_on"
+            "added_on",
         ]
         url = self._get_graph_api_url(
-            f"{self.app_id}/threat_privacy_groups_member",
-            {"fields": ",".join(fields}
+            f"{self.app_id}/threat_privacy_groups_member", {"fields": ",".join(fields)}
         )
         response = self.get_json_from_url(url)
         return [ThreatPrivacyGroup.from_graph_api_dict(d) for d in response["data"]]

--- a/python-threatexchange/threatexchange/api.py
+++ b/python-threatexchange/threatexchange/api.py
@@ -18,7 +18,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
-from .api_models import ThreatPrivacyGroup
+from .api_representations import ThreatPrivacyGroup
 
 
 class TimeoutHTTPAdapter(HTTPAdapter):

--- a/python-threatexchange/threatexchange/api_models.py
+++ b/python-threatexchange/threatexchange/api_models.py
@@ -1,0 +1,38 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from datetime import datetime
+from dateutil.parser import parse
+from dataclasses import dataclass
+
+"""
+Models (dataclasses only) for interfacing with the threatexchange API.
+"""
+
+
+def _parse_datetime_from_iso_8601(datestr: str) -> datetime:
+    """
+    Parses strings representing date like 2019-05-20T16:44:47+0000 from the
+    graph api into datetime objects.
+    """
+    return parse(datestr)
+
+
+@dataclass
+class ThreatPrivacyGroup:
+    id: str
+    name: str
+    description: str
+    members_can_see: bool
+    members_can_use: bool
+    last_updated: datetime
+
+    @classmethod
+    def from_graph_api_dict(cls, d: dict) -> "ThreatPrivacyGroup":
+        return cls(
+            d["id"],
+            d["name"],
+            d["description"],
+            d["members_can_see"],
+            d["members_can_use"],
+            _parse_datetime_from_iso_8601(d["last_updated"]),
+        )

--- a/python-threatexchange/threatexchange/api_representations.py
+++ b/python-threatexchange/threatexchange/api_representations.py
@@ -1,12 +1,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+"""
+Typed representations (dataclasses only) for interfacing with the
+threatexchange API.
+"""
+
 from datetime import datetime
 from dateutil.parser import parse
 from dataclasses import dataclass
-
-"""
-Models (dataclasses only) for interfacing with the threatexchange API.
-"""
 
 
 def _parse_datetime_from_iso_8601(datestr: str) -> datetime:
@@ -32,7 +33,7 @@ class ThreatPrivacyGroup:
             d["id"],
             d["name"],
             d["description"],
-            d["members_can_see"],
-            d["members_can_use"],
+            bool(d["members_can_see"]),
+            bool(d["members_can_use"]),
             _parse_datetime_from_iso_8601(d["last_updated"]),
         )


### PR DESCRIPTION
Summary
---
Add a method to ThreatExchangeAPI

**Addons:**
- An integration test for the API was missing, so added it. Only executed when appropriate env variables are provided.
- A utility method to create threatexchange graph API urls was missing, so added it. A future PR will convert all handwritten URL mangling to calls to this method.

TestPlan
---
```
$ THREAT_EXCHANGE_INTEGRATION_TEST_TOKEN=$(cat ~/.txtoken) pytest -v
...
==== 58 passed, 3 warnings in 1.01s ====
....
```

Lint
```
$ black .
$ mypy threatexchange # produced no new errors :(
```