### PR TITLE
[hma] get populate_config_db to work on windows

### DIFF
--- a/hasher-matcher-actioner/scripts/populate_config_db
+++ b/hasher-matcher-actioner/scripts/populate_config_db
@@ -1,0 +1,40 @@
+#! /usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Write simple configs to the HMA config database
+"""
+
+import argparse
+import json
+import tempfile
+import subprocess
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "in_file",
+        type=argparse.FileType(),
+        help="file to read items from",
+    )
+    parser.add_argument(
+        "table_name",
+        help="Name of the config table to add to",
+    )
+
+    args = parser.parse_args()
+    rows = json.load(args.in_file)
+    with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+        # Rewrite so the table name is the key of dicts with these as the results
+        json.dump({args.table_name: rows}, tmp)
+    # Windows environments require file not be held
+    subprocess.check_call(
+        [
+            "aws",
+            "dynamodb",
+            "batch-write-item",
+            "--request-items",
+            f"file://{tmp.name}",
+        ]
+    )

--- a/hasher-matcher-actioner/scripts/storm_images_queue
+++ b/hasher-matcher-actioner/scripts/storm_images_queue
@@ -108,19 +108,16 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "queue_url",
-        type=str,
         help="SQS Queue URL. Must include account id. eg. https://queue.amazonaws.com/<acid>/<queue_name>",
     )
 
     parser.add_argument(
         "s3_bucket",
-        type=str,
         help="S3 Bucket Name. Only provide the name, protocol and slashes are not required."
     )
 
     parser.add_argument(
         "s3_prefix",
-        type=str,
         help="S3 Bucket prefix for images you want to use. Only use a trailing slash. eg. images/100KB"
     )
 

--- a/hasher-matcher-actioner/terraform/.terraform.lock.hcl
+++ b/hasher-matcher-actioner/terraform/.terraform.lock.hcl
@@ -43,6 +43,7 @@ provider "registry.terraform.io/hashicorp/local" {
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.1.0"
   hashes = [
+    "h1:SFT7X3zY18CLWjoH2GfQyapxsRv6GDKsy9cF1aRwncc=",
     "h1:xhbHC6in3nQryvTQBWKxebi3inG5OCgHgc4fRxL0ymc=",
     "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
     "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",

--- a/hasher-matcher-actioner/terraform/fetcher/main.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/main.tf
@@ -205,7 +205,7 @@ resource "aws_iam_role_policy_attachment" "fetcher_trigger" {
 ### Config storage ###
 
 resource "aws_dynamodb_table" "threatexchange_config" {
-  name         = "${var.prefix}ThreatExchangeConfig"
+  name         = "${var.prefix}-ThreatExchangeConfig"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "Name"
 
@@ -222,7 +222,7 @@ resource "aws_dynamodb_table" "threatexchange_config" {
   )
 
   provisioner "local-exec" {
-    command = "bash populate_config_db.sh ${var.collab_file} ${aws_dynamodb_table.threatexchange_config.name}"
+    command = "python3 ../scripts/populate_config_db ${var.collab_file} ${aws_dynamodb_table.threatexchange_config.name}"
   }
 }
 

--- a/hasher-matcher-actioner/terraform/populate_config_db.sh
+++ b/hasher-matcher-actioner/terraform/populate_config_db.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# If a collaboration json exist write the items into aws
-# Argument 1 should be name of collab file to read from
-# Argument 2 should be name of collab table to write to
-if test -f $1; then
-    cat $1 | jq "{ $2 : . }" > aws_collab_configs.json
-    aws dynamodb batch-write-item --request-items file://aws_collab_configs.json
-    rm aws_collab_configs.json
-fi


### PR DESCRIPTION
Summary
---------

Turns out shell quoting in windows (basically required for jq) is difficult. Instead rewrite script in python which is more platform agnostic. 

Fixes  #475

Test Plan
---------

use terraform taint to force recreation of the fetcher configs.

Then apply, see that the new table has the two sample rows.
