### PR TITLE
[hma] fix missing lambda env values and refactor to assign in the handler

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/s3_adapters.py
+++ b/hasher-matcher-actioner/hmalib/common/s3_adapters.py
@@ -24,18 +24,6 @@ class S3ThreatDataConfig:
     threat_exchange_data_folder: str
     threat_exchange_pdq_file_extension: str
 
-    @classmethod
-    def get(cls):
-        return cls(
-            threat_exchange_data_bucket_name=os.environ[
-                "THREAT_EXCHANGE_DATA_BUCKET_NAME"
-            ],
-            threat_exchange_data_folder=os.environ["THREAT_EXCHANGE_DATA_FOLDER"],
-            threat_exchange_pdq_file_extension=os.environ[
-                "THREAT_EXCHANGE_PDQ_FILE_EXTENSION"
-            ],
-        )
-
 
 @dataclass
 class ThreatExchangeS3Adapter:
@@ -51,7 +39,7 @@ class ThreatExchangeS3Adapter:
     metrics_logger: metrics.lambda_with_datafiles
 
     S3FileT = t.Dict[str, t.Any]
-    config: S3ThreatDataConfig = S3ThreatDataConfig.get()
+    config: S3ThreatDataConfig
 
     def load_data(self) -> t.Dict[str, t.List[HashRowT]]:
         """

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -11,7 +11,7 @@ from bottle import response, error
 
 from hmalib import metrics
 from hmalib.common.logging import get_logger
-from hmalib.common.s3_adapters import ThreatExchangeS3PDQAdapter
+from hmalib.common.s3_adapters import ThreatExchangeS3PDQAdapter, S3ThreatDataConfig
 from hmalib.models import PDQMatchRecord, PipelinePDQHashRecord
 
 # Set to 10MB for /upload
@@ -25,6 +25,9 @@ logger = get_logger(__name__)
 s3_client = boto3.client("s3")
 dynamodb = boto3.resource("dynamodb")
 
+THREAT_EXCHANGE_DATA_BUCKET_NAME = os.environ["THREAT_EXCHANGE_DATA_BUCKET_NAME"]
+THREAT_EXCHANGE_DATA_FOLDER = os.environ["THREAT_EXCHANGE_DATA_FOLDER"]
+THREAT_EXCHANGE_PDQ_FILE_EXTENSION = os.environ["THREAT_EXCHANGE_PDQ_FILE_EXTENSION"]
 DYNAMODB_TABLE = os.environ["DYNAMODB_TABLE"]
 IMAGE_BUCKET_NAME = os.environ["IMAGE_BUCKET_NAME"]
 IMAGE_FOLDER_KEY = os.environ["IMAGE_FOLDER_KEY"]
@@ -391,8 +394,13 @@ def get_dashboard_system_status() -> DashboardSystemStatus:
 
 
 def get_hash_count() -> t.Dict[str, int]:
+    s3_config = S3ThreatDataConfig(
+        threat_exchange_data_bucket_name=THREAT_EXCHANGE_DATA_BUCKET_NAME,
+        threat_exchange_data_folder=THREAT_EXCHANGE_DATA_FOLDER,
+        threat_exchange_pdq_file_extension=THREAT_EXCHANGE_PDQ_FILE_EXTENSION,
+    )
     pdq_storage = ThreatExchangeS3PDQAdapter(
-        metrics_logger=metrics.names.api_hash_count()
+        config=s3_config, metrics_logger=metrics.names.api_hash_count()
     )
     pdq_data_files = pdq_storage.load_data()
 

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_indexer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_indexer.py
@@ -13,7 +13,11 @@ from threatexchange.signal_type.pdq_index import PDQIndex
 
 from hmalib import metrics
 from hmalib.common.logging import get_logger
-from hmalib.common.s3_adapters import ThreatExchangeS3PDQAdapter, HashRowT
+from hmalib.common.s3_adapters import (
+    ThreatExchangeS3PDQAdapter,
+    S3ThreatDataConfig,
+    HashRowT,
+)
 
 logger = get_logger(__name__)
 s3_client = boto3.client("s3")
@@ -95,7 +99,15 @@ def lambda_handler(event, context):
     logger.info("PDQ Data Updated, updating pdq hash index")
     metrics_logger = metrics.names.pdq_indexer_lambda
 
-    pdq_data_files = ThreatExchangeS3PDQAdapter(metrics_logger).load_data()
+    s3_config = S3ThreatDataConfig(
+        threat_exchange_data_bucket_name=THREAT_EXCHANGE_DATA_BUCKET_NAME,
+        threat_exchange_data_folder=THREAT_EXCHANGE_DATA_FOLDER,
+        threat_exchange_pdq_file_extension=THREAT_EXCHANGE_PDQ_FILE_EXTENSION,
+    )
+
+    pdq_data_files = ThreatExchangeS3PDQAdapter(
+        config=s3_config, metrics_logger=metrics_logger
+    ).load_data()
 
     with metrics.timer(metrics_logger.merge_datafiles):
         logger.info("Merging PDQ Hash files")

--- a/hasher-matcher-actioner/hmalib/metrics/__init__.py
+++ b/hasher-matcher-actioner/hmalib/metrics/__init__.py
@@ -79,7 +79,7 @@ class names:
         _prefix = "api.hashcount"
 
         def prefix_impl(self):
-            return _prefix
+            return self._prefix
 
 
 _METRICS_NAMESPACE_ENVVAR = "METRICS_NAMESPACE"

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -36,9 +36,12 @@ resource "aws_lambda_function" "api_root" {
   memory_size = 512
   environment {
     variables = {
-      DYNAMODB_TABLE    = var.datastore.name
-      IMAGE_BUCKET_NAME = var.image_data_storage.bucket_name
-      IMAGE_FOLDER_KEY  = var.image_data_storage.image_folder_key
+      DYNAMODB_TABLE                     = var.datastore.name
+      IMAGE_BUCKET_NAME                  = var.image_data_storage.bucket_name
+      IMAGE_FOLDER_KEY                   = var.image_data_storage.image_folder_key
+      THREAT_EXCHANGE_DATA_BUCKET_NAME   = var.threat_exchange_data.bucket_name
+      THREAT_EXCHANGE_DATA_FOLDER        = var.threat_exchange_data.data_folder
+      THREAT_EXCHANGE_PDQ_FILE_EXTENSION = var.threat_exchange_data.pdq_file_extension
     }
   }
   tags = merge(
@@ -81,6 +84,24 @@ data "aws_iam_policy_document" "api_root" {
     effect    = "Allow"
     actions   = ["s3:GetObject", "s3:PutObject"]
     resources = ["arn:aws:s3:::${var.image_data_storage.bucket_name}/${var.image_data_storage.image_folder_key}*"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = [
+      "arn:aws:s3:::${var.threat_exchange_data.bucket_name}/${var.threat_exchange_data.data_folder}*",
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.threat_exchange_data.bucket_name}",
+    ]
   }
   statement {
     effect = "Allow"

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -46,6 +46,15 @@ variable "image_data_storage" {
   })
 }
 
+variable "threat_exchange_data" {
+  description = "Configuration information for the S3 Bucket that will hold ThreatExchange Data"
+  type = object({
+    bucket_name        = string
+    pdq_file_extension = string
+    data_folder        = string
+  })
+}
+
 variable "datastore" {
   description = "DynamoDB Table to store hash and match information into"
   type = object({

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -181,6 +181,11 @@ module "api" {
     bucket_name      = module.hashing_data.image_folder_info.bucket_name
     image_folder_key = module.hashing_data.image_folder_info.key
   }
+  threat_exchange_data = {
+    bucket_name        = module.hashing_data.threat_exchange_data_folder_info.bucket_name
+    pdq_file_extension = local.pdq_file_extension
+    data_folder        = local.te_data_folder
+  }
 
   log_retention_in_days = var.log_retention_in_days
   additional_tags       = merge(var.additional_tags, local.common_tags)


### PR DESCRIPTION
Summary
---------

#472 unintentionally broke the api_root lambda as the use of ThreatExchangeS3PDQAdapter depended on environment variables not passed to the api lambda in terraform. 

This adds the environment vars and refactors s3_adapters.py to require the config be created by pulling from the environment var in the same file as the lambda handler.


Test Plan
---------

before all endpoints were returning a 500 error. With these fixes the UI page loads values again and the \hash_count endpoint actually returns a result to Postman (which required a small fix in metrics/__init__.py).
