### PR TITLE
devcontainer: support bash history

### DIFF
--- a/hasher-matcher-actioner/.devcontainer/Dockerfile
+++ b/hasher-matcher-actioner/.devcontainer/Dockerfile
@@ -14,7 +14,9 @@ RUN groupadd --gid 1000 developers \
 
 # [Install Tools!]
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
-    apt-get -y install --no-install-recommends git make jq sudo
+    apt-get -y install --no-install-recommends git make jq sudo \
+    software-properties-common apt-transport-https ca-certificates curl \
+    gnupg lsb-release
 
 # [Allow sudo] Need sudo later in post-create to open up docker socket
 ARG unixname
@@ -90,14 +92,18 @@ RUN set -ex \
 
 # [Install Docker CLI]
 RUN export DEBIAN_FRONTEND=noninteractive \
-   && apt-get -y install apt-transport-https ca-certificates curl \
-    gnupg lsb-release \
    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg \
     --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
    &&  echo \
   "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
    && apt-get update && apt-get -y install docker-ce-cli
+
+# [Install Terraform CLI]
+RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - \
+    && apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
+    && apt-get update && apt-get install terraform
+
 
 # [Forward Docker requests to host docker engine]
 # Volume is mounted and so is the socket. The socket configuration is within

--- a/hasher-matcher-actioner/.devcontainer/Dockerfile
+++ b/hasher-matcher-actioner/.devcontainer/Dockerfile
@@ -104,6 +104,13 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - \
     && apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
     && apt-get update && apt-get install terraform
 
+# [Bash History] The volume is mounted in devcontainer.json
+ARG unixname
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+    && mkdir /commandhistory \
+    && touch /commandhistory/.bash_history \
+    && chown -R $unixname /commandhistory \
+    && echo $SNIPPET >> "/home/$unixname/.bashrc"
 
 # [Forward Docker requests to host docker engine]
 # Volume is mounted and so is the socket. The socket configuration is within

--- a/hasher-matcher-actioner/.devcontainer/devcontainer.json
+++ b/hasher-matcher-actioner/.devcontainer/devcontainer.json
@@ -24,6 +24,7 @@
 	"mounts": [
 		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
 		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws,target=/var/run/aws-config,type=bind,consistency=cached",
+		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.hma-cmdhist,target=/commandhistory,type=bind",
 	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.


### PR DESCRIPTION
Stacked diff alert: Only review [d6bcf46](https://github.com/facebook/ThreatExchange/pull/486/commits/d6bcf4636aef68302137dc9e4041e78db5eae029). Built on #485 
---

Summary
---
Mount a directory from the host to the container. Use a file within it as the bash histfile.

Test Plan
---
1. Rebuilt container once.
2. executed few strange commands
3. Rebuilt container again, verified it has a different container id (implies brand new)
4. ran `history` to find the strange commands

<img width="688" alt="Screen Shot 2021-04-13 at 12 02 54" src="https://user-images.githubusercontent.com/217056/114584805-ff54db00-9c50-11eb-9064-4750317c541c.png">
