### PR TITLE
[pytx] check if _cached_state exists before clear in threat_updates.py

### DIFF
--- a/python-threatexchange/threatexchange/threat_updates.py
+++ b/python-threatexchange/threatexchange/threat_updates.py
@@ -368,7 +368,8 @@ class ThreatUpdateFileStore(ThreatUpdatesStore):
 
     def reset(self):
         super().reset()
-        self._cached_state.clear()
+        if self._cached_state:
+            self._cached_state.clear()
 
     def _load_checkpoint(self) -> ThreatUpdateCheckpoint:
         """Load the state of the threat_updates checkpoints from state directory"""


### PR DESCRIPTION
Summary
---------

`threatexchange experimental-fetch` seem to be broken for first fetch (at least with the `--full` command). Traced the issue to ThreatUpdateFileStore.reset and added a hotfix (probably could also be fixed upstream of this call but haven't investigated further).

Test Plan
---------

Before:
```

$ threatexchange --config '/Users/barrett/dev/tmp/config_te.json' experimental-fetch --full 
Traceback (most recent call last):
  File "/Users/barrett/.venv/hma/bin/threatexchange", line 33, in <module>
    sys.exit(load_entry_point('threatexchange', 'console_scripts', 'threatexchange')())
  File "/Users/barrett/dev/github/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 194, in main
    execute_command(namespace)
  File "/Users/barrett/dev/github/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 110, in execute_command
    command.execute(api, dataset)
  File "/Users/barrett/dev/github/ThreatExchange/python-threatexchange/threatexchange/cli/experimental_fetch.py", line 91, in execute
    indicator_store.reset()
  File "/Users/barrett/dev/github/ThreatExchange/python-threatexchange/threatexchange/threat_updates.py", line 371, in reset
    self._cached_state.clear()
AttributeError: 'NoneType' object has no attribute 'clear'
```
After:
```
$ threatexchange --config '/Users/barrett/dev/tmp/config_te.json' experimental-fetch --full 
Currently at ages long past
Processed 78 updates:
HASH_PDQ: +77
TEXT_STRING: +1
Rebuilding match indices...
```