### PR TITLE
[hma] Propagate tags to index metadata + minor fixes

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/s3_adapters.py
+++ b/hasher-matcher-actioner/hmalib/common/s3_adapters.py
@@ -124,9 +124,9 @@ class ThreatExchangeS3Adapter:
                     "privacy_groups": [
                         file_name.split("/")[-1].split(".")[0]
                     ],  # read privacy group from key
-                    "tags": row[
-                        "tags"
-                    ],  # note: these are the labels assigned by pytx in descriptor.py (NOT a 1-1 with tags on TE)
+                    "tags": row["tags"].split(" ")
+                    if row["tags"]
+                    else None,  # note: these are the labels assigned by pytx in descriptor.py (NOT a 1-1 with tags on TE)
                 },
             )
             for row in data_reader

--- a/hasher-matcher-actioner/hmalib/common/s3_adapters.py
+++ b/hasher-matcher-actioner/hmalib/common/s3_adapters.py
@@ -126,7 +126,7 @@ class ThreatExchangeS3Adapter:
                     ],  # read privacy group from key
                     "tags": row["tags"].split(" ")
                     if row["tags"]
-                    else None,  # note: these are the labels assigned by pytx in descriptor.py (NOT a 1-1 with tags on TE)
+                    else [],  # note: these are the labels assigned by pytx in descriptor.py (NOT a 1-1 with tags on TE)
                 },
             )
             for row in data_reader

--- a/hasher-matcher-actioner/hmalib/common/s3_adapters.py
+++ b/hasher-matcher-actioner/hmalib/common/s3_adapters.py
@@ -73,7 +73,6 @@ class ThreatExchangeS3Adapter:
                 file_name: self._parse_file(**typed_data_file)
                 for file_name, typed_data_file in typed_data_files.items()
             }
-
         return typed_data
 
     @property
@@ -125,6 +124,9 @@ class ThreatExchangeS3Adapter:
                     "privacy_groups": [
                         file_name.split("/")[-1].split(".")[0]
                     ],  # read privacy group from key
+                    "tags": row[
+                        "tags"
+                    ],  # note: these are the labels assigned by pytx in descriptor.py (NOT a 1-1 with tags on TE)
                 },
             )
             for row in data_reader
@@ -146,4 +148,4 @@ class ThreatExchangeS3PDQAdapter(ThreatExchangeS3Adapter):
 
     @property
     def file_type_str_name(self):
-        "PDQ"
+        return "PDQ"

--- a/hasher-matcher-actioner/hmalib/common/s3_adapters.py
+++ b/hasher-matcher-actioner/hmalib/common/s3_adapters.py
@@ -113,6 +113,7 @@ class ThreatExchangeS3Adapter:
             codecs.getreader("utf-8")(data_file["Body"]),
             fieldnames=self.indicator_type_file_columns,
         )
+        privacy_group = file_name.split("/")[-1].split(".")[0]
         return [
             (
                 row["hash"],
@@ -121,12 +122,12 @@ class ThreatExchangeS3Adapter:
                     "id": int(row["id"]),
                     "hash": row["hash"],
                     "source": "te",  # default for now to make downstream easier to generalize
-                    "privacy_groups": [
-                        file_name.split("/")[-1].split(".")[0]
-                    ],  # read privacy group from key
-                    "tags": row["tags"].split(" ")
+                    "privacy_groups": set(
+                        [privacy_group]
+                    ),  # read privacy group from key
+                    "tags": {privacy_group: row["tags"].split(" ")}
                     if row["tags"]
-                    else [],  # note: these are the labels assigned by pytx in descriptor.py (NOT a 1-1 with tags on TE)
+                    else {},  # note: these are the labels assigned by pytx in descriptor.py (NOT a 1-1 with tags on TE)
                 },
             )
             for row in data_reader

--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -160,6 +160,10 @@ class ThreatUpdateS3PDQStore(tu.ThreatUpdatesStore):
 
     @property
     def data_s3_key(self) -> str:
+        """
+        Creates a 'file_name' structure that is dependent on downstream (see s3_adapters.py)
+        TODO replace ".pdq.te" with os.environ["THREAT_EXCHANGE_PDQ_FILE_EXTENSION"]
+        """
         return f"{self.s3_te_data_folder}{self.privacy_group}.pdq.te"
 
     @property

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_indexer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_indexer.py
@@ -73,7 +73,7 @@ def merge_pdq_files(
     else:
         # Add new privacy group to existing row
         accumulator[hash][1]["privacy_groups"].update(meta_data["privacy_groups"])
-        # Add new labels from privacy group to existing row
+        # Add new 'tags' for privacy group to existing row
         accumulator[hash][1]["tags"].update(meta_data["tags"])
     return accumulator
 

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_indexer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_indexer.py
@@ -72,7 +72,9 @@ def merge_pdq_files(
         accumulator[hash] = hash_row
     else:
         # Add new privacy group to existing row
-        accumulator[hash][1]["privacy_groups"].append(meta_data["privacy_groups"][0])
+        accumulator[hash][1]["privacy_groups"].update(meta_data["privacy_groups"])
+        # Add new labels from privacy group to existing row
+        accumulator[hash][1]["tags"].update(meta_data["tags"])
     return accumulator
 
 

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
@@ -11,7 +11,7 @@ from mypy_boto3_sns import SNSClient
 from threatexchange.signal_type.pdq_index import PDQIndex
 
 from hmalib import metrics
-from hmalib.models import PDQMatchRecord, Label
+from hmalib.models import PDQMatchRecord, Label, MatchMessage, DatasetMatchDetails
 from hmalib.common.logging import get_logger
 
 logger = get_logger(__name__)

--- a/hasher-matcher-actioner/webapp/src/Signals.jsx
+++ b/hasher-matcher-actioner/webapp/src/Signals.jsx
@@ -15,7 +15,9 @@ export default function Signals() {
 
   useEffect(() => {
     fetchSignalSummary().then(summaries => {
-      setSignalSummary(summaries.signals);
+      if (summaries.signals.length) {
+        setSignalSummary(summaries.signals);
+      }
     });
   }, []);
 
@@ -45,7 +47,7 @@ export default function Signals() {
 
 function SignalSummary({summary}) {
   return (
-    <Col key={summary.name} md="8" className="mb-4">
+    <Col key={summary.name} md="12" className="mb-4">
       <Card>
         <Card.Header as="h4" className="text-white bg-primary">
           Dataset: {summary.name}

--- a/hasher-matcher-actioner/webapp/src/Signals.jsx
+++ b/hasher-matcher-actioner/webapp/src/Signals.jsx
@@ -15,6 +15,7 @@ export default function Signals() {
 
   useEffect(() => {
     fetchSignalSummary().then(summaries => {
+      // TODO this will spin forever if no signals are found (we should add a second Collapse)
       if (summaries.signals.length) {
         setSignalSummary(summaries.signals);
       }

--- a/hasher-matcher-actioner/webapp/src/Signals.jsx
+++ b/hasher-matcher-actioner/webapp/src/Signals.jsx
@@ -15,7 +15,7 @@ export default function Signals() {
 
   useEffect(() => {
     fetchSignalSummary().then(summaries => {
-      // TODO this will spin forever if no signals are found (we should add a second Collapse)
+      // TODO this will spin forever if no signals are found (fix: should add second Collapse)
       if (summaries.signals.length) {
         setSignalSummary(summaries.signals);
       }


### PR DESCRIPTION
Summary
---------

This adds the labels/tags to the metadata object in the index. 

Other minor issues I saw from the logs while testing and fixed:
`pdq_matcher.py` imports was missing stuff from models.py and 
`ThreatExchangeS3PDQAdapter.file_type_str_name` was missing a return statement
`webapp/src/Signals.jsx` should handle the case where there are no signals cleaner

Test Plan
---------
made tmp change to `hasher-matcher-actioner/sample_data/pdq.csv` then ran:
`make dev_upload_test_data` 
and used cloudwatch logs to test: 
```
...
Match found for key: images/b.jpg, hash f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22 ->
{'id': 4109214869142910, 'hash': 'f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22', 'source': 'te', 'privacy_groups': {'sample_data'}, 'tags': {'sample_data': ['media_priority_pdq_samples', 'disputed', 'media_priority_samples', 'media_type_photo']}}
```
