### PR TITLE
Modularize matches api

### DIFF
--- a/hasher-matcher-actioner/.devcontainer/devcontainer.json
+++ b/hasher-matcher-actioner/.devcontainer/devcontainer.json
@@ -19,6 +19,8 @@
 		"rvest.vs-code-prettier-eslint",
 		"ms-azuretools.vscode-docker",
 		"hashicorp.terraform",
+		"eamodio.gitlens",
+		"stkb.rewrap"
 	],
 
 	"mounts": [

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -314,7 +314,10 @@ def get_hash_count() -> t.Dict[str, int]:
 
 
 app.mount(
-    "/matches/v1/", get_matches_api(dynamodb_table=dynamodb.Table(DYNAMODB_TABLE))
+    "/matches/",
+    get_matches_api(
+        dynamodb_table=dynamodb.Table(DYNAMODB_TABLE), image_folder_key=IMAGE_FOLDER_KEY
+    ),
 )
 
 

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -1,0 +1,149 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import bottle
+from dataclasses import dataclass, asdict
+import os
+from mypy_boto3_dynamodb.service_resource import Table
+import typing as t
+
+from hmalib.models import PDQMatchRecord
+from .middleware import jsoninator, JSONifiable
+
+
+# TODO: Remove dependency on image folder key, use a common interface for
+# s3 and non-s3 HMA requests.
+IMAGE_FOLDER_KEY = os.environ["IMAGE_FOLDER_KEY"]
+IMAGE_FOLDER_KEY_LEN = len(IMAGE_FOLDER_KEY)
+
+
+@dataclass
+class MatchSummary(JSONifiable):
+    content_id: str
+    signal_id: t.Union[str, int]
+    signal_source: str
+    updated_at: str
+    reactions: str
+
+    def to_json(self) -> t.Dict:
+        return asdict(self)
+
+
+@dataclass
+class MatchSummariesResponse(JSONifiable):
+    match_summaries: t.List[MatchSummary]
+
+    def to_json(self) -> t.Dict:
+        return {
+            "match_summaries": [summary.to_json() for summary in self.match_summaries]
+        }
+
+
+@dataclass
+class MatchDetailMetadata(JSONifiable):
+    type: str
+    tags: t.List[str]
+    status: str
+    opinions: t.List[str]
+
+    def to_json(self) -> t.Dict:
+        return asdict(self)
+
+
+@dataclass
+class MatchDetail(JSONifiable):
+    content_id: str
+    content_hash: str
+    signal_id: t.Union[str, int]
+    signal_hash: str
+    signal_source: str
+    updated_at: str
+    meta_data: MatchDetailMetadata
+    actions: t.List[str]
+
+    def to_json(self) -> t.Dict:
+        result = asdict(self)
+        result.update(meta_data=self.meta_data.to_json())
+        return result
+
+
+@dataclass
+class MatchDetailsResponse(JSONifiable):
+    match_details: t.List[MatchDetail]
+
+    def to_json(self) -> t.Dict:
+        return {"match_details": [detail.to_json() for detail in self.match_details]}
+
+
+def get_match_details(table: Table, content_id: str) -> t.List[MatchDetail]:
+    if not content_id:
+        return []
+
+    records = PDQMatchRecord.get_from_content_id(
+        table, f"{IMAGE_FOLDER_KEY}{content_id}"
+    )
+
+    # TODO these mocked metadata should either be added to
+    # PDQMatchRecord or some other look up in the data model
+    mocked_metadata = MatchDetailMetadata(
+        type="HASH_PDQ",
+        tags=["mocked_t1", "mocked_t2"],
+        status="MOCKED_STATUS",
+        opinions=["mocked_a1", "mocked_a2"],
+    )
+
+    mocked_actions = ["Mocked_False_Postive", "Mocked_Delete"]
+    return [
+        MatchDetail(
+            content_id=record.content_id[IMAGE_FOLDER_KEY_LEN:],
+            content_hash=record.content_hash,
+            signal_id=record.signal_id,
+            signal_hash=record.signal_hash,
+            signal_source=record.signal_source,
+            updated_at=record.updated_at.isoformat(),
+            meta_data=mocked_metadata,
+            actions=mocked_actions,
+        )
+        for record in records
+    ]
+
+
+def get_matches_api(dynamodb_table: Table) -> bottle.Bottle:
+    """
+    A Closure that includes all dependencies that MUST be provided by the root
+    API that this API plugs into. Declare dependencies here, but initialize in
+    the root API alone.
+    """
+
+    # A prefix to all routes must be provided by the api_root app
+    # The documentation below expects prefix to be '/matches/v1'
+    matches_api = bottle.Bottle()
+
+    @matches_api.get("/matches/", apply=[jsoninator])
+    def matches() -> MatchSummariesResponse:
+        """
+        Returns all, or a filtered list of matches.
+        """
+        records = PDQMatchRecord.get_from_time_range(dynamodb_table)
+        return MatchSummariesResponse(
+            match_summaries=[
+                MatchSummary(
+                    content_id=record.content_id[IMAGE_FOLDER_KEY_LEN:],
+                    signal_id=record.signal_id,
+                    signal_source=record.signal_source,
+                    updated_at=record.updated_at.isoformat(),
+                    reactions="Mocked",
+                )
+                for record in records
+            ]
+        )
+
+    @matches_api.get("/match/<key>/", apply=[jsoninator])
+    def match_details(key=None) -> MatchDetailsResponse:
+        """
+        matche details API endpoint:
+        return format: match_details : [MatchDetailsResult]
+        """
+        results = get_match_details(dynamodb_table, key)
+        return MatchDetailsResponse(match_details=results)
+
+    return matches_api

--- a/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
@@ -1,0 +1,50 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import json
+import typing as t
+from bottle import response, install
+
+"""
+Inspired by Java's JAX-RS standards and perhaps most sane web frameworks. Allows
+you to specify the •type* of a view.
+
+Sample usage:
+>>> @dataclass
+... class CupcakesResponse(JSONifiable):
+...    num_cupcakes: int
+...    flavor: string = int
+
+...    def to_json(self) -> t.Dict:
+...        return {
+...            "num_cupcakes": self.num_cupcakes,
+...            "flavor": self.flavor,
+...        }
+
+>>>@app.get("/all", apply=[jsoninator])
+...def get_all_datasets() -> CupcakesResponse:
+...    response.status_code = 200 # optional
+...    return CupcakesResponse(12, "key_lime")
+"""
+
+
+class JSONifiable:
+    def to_json(self) -> t.Dict:
+        raise NotImplementedError
+
+
+def jsoninator(view_fn: t.Callable[[int, int], JSONifiable]):
+    """
+    Bottle plugin which allows you to create 'typed' views.
+
+    Views are expected to return an object which has a to_json method. The
+    content_type header will be automatically set, but if you need to set
+    anything else, eg. status code or other headers, continue to use
+    `bottle.response`.
+    """
+
+    def wrapper(*args, **kwargs):
+        body = view_fn(*args, **kwargs)
+        response.content_type = "application/json"
+        return json.dumps(body.to_json())
+
+    return wrapper


### PR DESCRIPTION
Summary
---------
Move `matches` functionality into a module of its own. Add a middleware for easy JSON wrangling. 

Also adds some git-blame-friendly and comment-rewrap-friendly vscode extensions to the devcontainer.


Test Plan
---------
Post refactoring, ran the API locally using `python -m ...`,

<img width="1227" alt="Screen Shot 2021-04-14 at 15 09 19" src="https://user-images.githubusercontent.com/217056/114766002-dce7be00-9d33-11eb-8c6c-f97d2fde3437.png">

 took screenshots of both APIs being served on localhost.

<img width="793" alt="Screen Shot 2021-04-14 at 15 10 44" src="https://user-images.githubusercontent.com/217056/114766032-e53ff900-9d33-11eb-9cdc-c3630c25804f.png">

<img width="592" alt="Screen Shot 2021-04-14 at 15 10 52" src="https://user-images.githubusercontent.com/217056/114766042-e8d38000-9d33-11eb-8df6-16e011087e9b.png">

