### PR TITLE
[hma] Create signal metadata db obj and surface on UI

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -13,7 +13,13 @@ from bottle import response, error
 from hmalib import metrics
 from hmalib.common.logging import get_logger
 from hmalib.common.s3_adapters import ThreatExchangeS3PDQAdapter, S3ThreatDataConfig
-from hmalib.models import PDQMatchRecord, PipelinePDQHashRecord, PDQRecordBase
+from hmalib.models import (
+    PDQMatchRecord,
+    PipelinePDQHashRecord,
+    PDQRecordBase,
+    PDQSignalMetadata,
+)
+from threatexchange.descriptor import ThreatDescriptor
 
 # Set to 10MB for /upload
 bottle.BaseRequest.MEMFILE_MAX = 10 * 1024 * 1024
@@ -237,10 +243,9 @@ def get_matches() -> t.List[MatchesResult]:
 
 
 class MatchDetailsMetadata(t.TypedDict):
-    type: str
+    pg: str
     tags: t.List[str]
-    status: str
-    opinions: t.List[str]
+    opinion: str
 
 
 class MatchDetailsResult(t.TypedDict):
@@ -249,9 +254,9 @@ class MatchDetailsResult(t.TypedDict):
     signal_id: t.Union[str, int]
     signal_hash: str
     signal_source: str
+    signal_type: str
     updated_at: str
-    meta_data: MatchDetailsMetadata
-    actions: t.List[str]
+    metadata: t.List[MatchDetailsMetadata]
 
 
 def get_match_details(content_id: str) -> t.List[MatchDetailsResult]:
@@ -261,16 +266,6 @@ def get_match_details(content_id: str) -> t.List[MatchDetailsResult]:
     records = PDQMatchRecord.get_from_content_id(
         table, f"{IMAGE_FOLDER_KEY}{content_id}"
     )
-    # TODO these mocked metadata should either be added to
-    # PDQMatchRecord or some other look up in the data model
-    mocked_metadata = MatchDetailsMetadata(
-        type="HASH_PDQ",
-        tags=["mocked_t1", "mocked_t2"],
-        status="MOCKED_STATUS",
-        opinions=["mocked_a1", "mocked_a2"],
-    )
-
-    mocked_actions = ["Mocked_False_Postive", "Mocked_Delete"]
     return [
         {
             "content_id": record.content_id[IMAGE_FOLDER_KEY_LEN:],
@@ -278,12 +273,50 @@ def get_match_details(content_id: str) -> t.List[MatchDetailsResult]:
             "signal_id": record.signal_id,
             "signal_hash": record.signal_hash,
             "signal_source": record.signal_source,
+            "signal_type": record.SIGNAL_TYPE,
             "updated_at": record.updated_at.isoformat(),
-            "meta_data": mocked_metadata,
-            "actions": mocked_actions,
+            "metadata": get_signal_details(record.signal_id, record.signal_source),
         }
         for record in records
     ]
+
+
+def get_signal_details(
+    signal_id: t.Union[str, int], signal_source: str
+) -> t.List[MatchDetailsMetadata]:
+    if not signal_id or not signal_source:
+        return []
+    table = dynamodb.Table(DYNAMODB_TABLE)
+    return [
+        MatchDetailsMetadata(
+            pg=metadata.pg_id,
+            tags=[
+                tag
+                for tag in metadata.tags
+                if tag
+                not in [
+                    ThreatDescriptor.TRUE_POSITIVE,
+                    ThreatDescriptor.FALSE_POSITIVE,
+                    ThreatDescriptor.DISPUTED,
+                ]
+            ],
+            opinion=get_opinion_from_tags(metadata.tags),
+        )
+        for metadata in PDQSignalMetadata.get_from_signal(
+            table, signal_id, signal_source
+        )
+    ]
+
+
+def get_opinion_from_tags(tags: t.List[str]):
+    # see python-threatexchange descriptor.py for origins
+    if ThreatDescriptor.TRUE_POSITIVE in tags:
+        return "True Positive"
+    if ThreatDescriptor.FALSE_POSITIVE in tags:
+        return "False Positive"
+    if ThreatDescriptor.DISPUTED in tags:
+        return "Unknown (Disputed)"
+    return "Unknown"
 
 
 class HashResult(t.TypedDict):

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
@@ -117,6 +117,7 @@ def lambda_handler(event, context):
                 ).write_to_table(records_table)
 
                 for pg in metadata.get("privacy_groups", []):
+                    # TODO: we might be able to get away with some 'if exists/upsert' here
                     PDQSignalMetadata(
                         signal_id,
                         pg,

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
@@ -11,7 +11,13 @@ from mypy_boto3_sns import SNSClient
 from threatexchange.signal_type.pdq_index import PDQIndex
 
 from hmalib import metrics
-from hmalib.models import PDQMatchRecord, Label, MatchMessage, DatasetMatchDetails
+from hmalib.models import (
+    PDQMatchRecord,
+    Label,
+    MatchMessage,
+    DatasetMatchDetails,
+    PDQSignalMetadata,
+)
 from hmalib.common.logging import get_logger
 
 logger = get_logger(__name__)
@@ -109,6 +115,16 @@ def lambda_handler(event, context):
                     metadata["source"],
                     metadata["hash"],
                 ).write_to_table(records_table)
+
+                for pg in metadata.get("privacy_groups", []):
+                    PDQSignalMetadata(
+                        signal_id,
+                        pg,
+                        current_datetime,
+                        metadata["source"],
+                        metadata["hash"],
+                        metadata["tags"].get(pg, []),
+                    ).write_to_table(records_table)
 
                 match_ids.append(signal_id)
 

--- a/hasher-matcher-actioner/hmalib/tests/test_models.py
+++ b/hasher-matcher-actioner/hmalib/tests/test_models.py
@@ -13,7 +13,7 @@ class TestPDQModels(unittest.TestCase):
     TEST_CONTENT_ID = "image/test_photo.jpg"
     TEST_SIGNAL_ID = "5555555555555555"
     TEST_SIGNAL_SOURCE = "test_source"
-    TEST_PG_ID = "sample_data"
+    TEST_DATASET_ID = "sample_data"
 
     @staticmethod
     def mock_aws_credentials():
@@ -122,7 +122,7 @@ class TestPDQModels(unittest.TestCase):
         pdq_hash = "a0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"
         return models.PDQSignalMetadata(
             TestPDQModels.TEST_SIGNAL_ID,
-            TestPDQModels.TEST_PG_ID,
+            TestPDQModels.TEST_DATASET_ID,
             datetime.datetime.now(),
             TestPDQModels.TEST_SIGNAL_SOURCE,
             pdq_hash,
@@ -244,7 +244,7 @@ class TestPDQModels(unittest.TestCase):
         result = self.table.get_item(
             Key={
                 "PK": f"s#{TestPDQModels.TEST_SIGNAL_SOURCE}#{TestPDQModels.TEST_SIGNAL_ID}",
-                "SK": f"pg#{TestPDQModels.TEST_PG_ID}",
+                "SK": f"ds#{TestPDQModels.TEST_DATASET_ID}",
             },
         )
         items = result.get("Item")

--- a/hasher-matcher-actioner/hmalib/tests/test_models.py
+++ b/hasher-matcher-actioner/hmalib/tests/test_models.py
@@ -13,6 +13,7 @@ class TestPDQModels(unittest.TestCase):
     TEST_CONTENT_ID = "image/test_photo.jpg"
     TEST_SIGNAL_ID = "5555555555555555"
     TEST_SIGNAL_SOURCE = "test_source"
+    TEST_PG_ID = "sample_data"
 
     @staticmethod
     def mock_aws_credentials():
@@ -114,6 +115,18 @@ class TestPDQModels(unittest.TestCase):
             TestPDQModels.TEST_SIGNAL_ID,
             TestPDQModels.TEST_SIGNAL_SOURCE,
             signal_hash,
+        )
+
+    @staticmethod
+    def get_example_pdq_signal_metadata():
+        pdq_hash = "a0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"
+        return models.PDQSignalMetadata(
+            TestPDQModels.TEST_SIGNAL_ID,
+            TestPDQModels.TEST_PG_ID,
+            datetime.datetime.now(),
+            TestPDQModels.TEST_SIGNAL_SOURCE,
+            pdq_hash,
+            ["test_tag1", "test_tag2"],
         )
 
     def test_write_hash_record(self):
@@ -219,6 +232,42 @@ class TestPDQModels(unittest.TestCase):
         query_record = models.PDQMatchRecord.get_from_time_range(self.table)[0]
 
         assert record == query_record
+
+    def test_pdq_signal_metadata_manually(self):
+        """
+        Test PDQSignalMetadata write table
+        """
+        metadata = self.get_example_pdq_signal_metadata()
+
+        metadata.write_to_table(self.table)
+
+        result = self.table.get_item(
+            Key={
+                "PK": f"s#{TestPDQModels.TEST_SIGNAL_SOURCE}#{TestPDQModels.TEST_SIGNAL_ID}",
+                "SK": f"pg#{TestPDQModels.TEST_PG_ID}",
+            },
+        )
+        items = result.get("Item")
+        query_hash = items.get("SignalHash")
+        assert metadata.signal_hash == query_hash
+        for tag in metadata.tags:
+            assert tag in items.get("Tags")
+
+    def test_pdq_signal_metadata_by_signal(self):
+        """
+        Test PDQSignalMetadata write table with get_from_signal
+        """
+        metadata = self.get_example_pdq_signal_metadata()
+
+        metadata.write_to_table(self.table)
+
+        query_metadata = models.PDQSignalMetadata.get_from_signal(
+            self.table, TestPDQModels.TEST_SIGNAL_ID, TestPDQModels.TEST_SIGNAL_SOURCE
+        )[0]
+
+        assert metadata.signal_hash == query_metadata.signal_hash
+        for tag in metadata.tags:
+            assert tag in query_metadata.tags
 
 
 class LabelsTestCase(unittest.TestCase):

--- a/hasher-matcher-actioner/webapp/src/MatchDetails.jsx
+++ b/hasher-matcher-actioner/webapp/src/MatchDetails.jsx
@@ -175,11 +175,11 @@ function MatchesList(props) {
                 {matchDetails !== null && matchDetails.length ? (
                   matchDetails.map((match, index) => (
                     <>
-                      {match.metadata.map((data, subIndex) => (
+                      {match.metadata.map((metadata, subIndex) => (
                         <tr
                           style={index % 2 ? {} : {background: '#dddddd'}}
                           className="align-middle"
-                          key={match.signal_id + data.pg}>
+                          key={match.signal_id + metadata.dataset}>
                           {subIndex === 0 ? (
                             <>
                               <td>
@@ -197,9 +197,9 @@ function MatchesList(props) {
                               <td />
                             </>
                           )}
-                          <td>{data.pg}</td>
-                          <td>{data.opinion}</td>
-                          <td>{data.tags.join(', ')}</td>
+                          <td>{metadata.dataset}</td>
+                          <td>{metadata.opinion}</td>
+                          <td>{metadata.tags.join(', ')}</td>
                         </tr>
                       ))}
                     </>

--- a/hasher-matcher-actioner/webapp/src/MatchDetails.jsx
+++ b/hasher-matcher-actioner/webapp/src/MatchDetails.jsx
@@ -21,7 +21,7 @@ export default function MatchDetails() {
   const history = useHistory();
   const {id} = useParams();
   const [showNewReactionButtons, setShowNewReactionButtons] = useState(false);
-  const [reaction, setReaction] = useState('Seen');
+  const [reaction, setReaction] = useState('Mocked');
   const [hashDetails, setHashDetails] = useState(null);
   const [img, setImage] = useState(null);
 
@@ -91,26 +91,26 @@ export default function MatchDetails() {
                       size="sm"
                       variant="outline-primary"
                       onClick={() => {
-                        const newStatus = 'Positive (Mocked)';
+                        const newStatus = 'Status 1 (Mocked)';
                         updateContentStatus(id, newStatus).then(() => {
                           setShowNewReactionButtons(false);
                           setReaction(newStatus);
                         });
                       }}>
-                      Positive
+                      Action 1
                     </Button>
                     <Button
                       className="ml-2"
                       size="sm"
                       variant="outline-primary"
                       onClick={() => {
-                        const newStatus = 'False Positive (Mocked)';
+                        const newStatus = 'Status 2 (Mocked)';
                         updateContentStatus(id, newStatus).then(() => {
                           setShowNewReactionButtons(false);
                           setReaction(newStatus);
                         });
                       }}>
-                      False Positive
+                      Action 2
                     </Button>
                     <Button
                       className="ml-2"
@@ -159,34 +159,50 @@ function MatchesList(props) {
         <Row>
           <Col md={12}>
             <h3>Matches</h3>
-            <Table className="mt-4" title="Matches">
+            <Table responsive className="mt-4" title="Matches">
               <thead>
                 <tr>
                   <th>ID</th>
                   <th>Type</th>
                   <th>Indicator</th>
                   <th>Last Updated</th>
+                  <th>Dataset</th>
+                  <th>Opinion</th>
                   <th>Tags</th>
-                  <th>Status</th>
-                  <th>Partners with Opinions</th>
-                  <th>Actions Taken:</th>
                 </tr>
               </thead>
               <tbody>
                 {matchDetails !== null && matchDetails.length ? (
-                  matchDetails.map(match => (
-                    <tr className="align-middle" key={match.signal_id}>
-                      <td>
-                        <CopyableTextField text={match.signal_id} />
-                      </td>
-                      <td>{match.meta_data.type}</td>
-                      <CopyableHashField text={match.signal_hash} />
-                      <td>{formatTimestamp(match.updated_at)}</td>
-                      <td>{match.meta_data.tags.join(', ')}</td>
-                      <td>{match.meta_data.status}</td>
-                      <td>{match.meta_data.opinions.join(', ')}</td>
-                      <td>{match.actions.join(', ')}</td>
-                    </tr>
+                  matchDetails.map((match, index) => (
+                    <>
+                      {match.metadata.map((data, subIndex) => (
+                        <tr
+                          style={index % 2 ? {} : {background: '#dddddd'}}
+                          className="align-middle"
+                          key={match.signal_id + data.pg}>
+                          {subIndex === 0 ? (
+                            <>
+                              <td>
+                                <CopyableTextField text={match.signal_id} />
+                              </td>
+                              <td>{match.signal_type}</td>
+                              <CopyableHashField text={match.signal_hash} />
+                              <td>{formatTimestamp(match.updated_at)}</td>
+                            </>
+                          ) : (
+                            <>
+                              <td />
+                              <td />
+                              <td />
+                              <td />
+                            </>
+                          )}
+                          <td>{data.pg}</td>
+                          <td>{data.opinion}</td>
+                          <td>{data.tags.join(', ')}</td>
+                        </tr>
+                      ))}
+                    </>
                   ))
                 ) : (
                   <tr>


### PR DESCRIPTION
Summary
---------

The goal of this PR is getting us closer to closing the loop on reactions/opinions by building off of the existing structure in [descriptor.py](https://github.com/facebook/ThreatExchange/blob/master/python-threatexchange/threatexchange/descriptor.py). This takes the metadata from the index for matches and creates an object that can be updated later by a syncer/fetcher (or actioner) that can also be surfaced on the UI.

Feel free to review/provide feedback at the commit level as the 3 commits of this PR could probably be there own diffs but testing them really only works all together. 

Commits:
1) creates the new metadata object class + unit test
2) update pdq_matcher to create these object
3) updates the match details API and page to surface this metadata

What's next:
a) have the syncer/fetcher also update this metadata object
b) add the ability to send a post request from the details page to propagate an update the 'opinion' column


Test Plan
---------
By commits:
1) Added to test_models.py
`pytest hmalib`
2) After deployments, run `make dev_upload_test_data` and confirm the new object is in the dynamodb 
3) Same as two but update the dynamodb to have more elements to make sure nested cases and all special case tags work as expected. (see screenshot attached)

<img width="1668" alt="Screen Shot 2021-04-15 at 5 06 04 PM" src="https://user-images.githubusercontent.com/7664526/114939910-13ded200-9e0f-11eb-83a8-77766c205c8a.png">
