### PR TITLE
Convert Fetcher to Use ThreatExchangeConfig (HMAConfig version)

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -38,6 +38,7 @@ from threatexchange.signal_type.pdq import PdqSignal
 
 logger = get_logger(__name__)
 s3 = boto3.resource("s3")
+dynamodb = boto3.resource("dynamodb")
 
 # Lambda init tricks
 @lru_cache(maxsize=1)

--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -36,10 +36,7 @@ from threatexchange.cli.dataset.simple_serialization import CliIndicatorSerializ
 from threatexchange.descriptor import SimpleDescriptorRollup
 from threatexchange.signal_type.pdq import PdqSignal
 
-
 logger = get_logger(__name__)
-
-dynamodb = boto3.resource("dynamodb")
 s3 = boto3.resource("s3")
 
 # Lambda init tricks
@@ -79,7 +76,7 @@ class FetcherConfig:
         return cls(
             s3_bucket=os.environ["THREAT_EXCHANGE_DATA_BUCKET_NAME"],
             s3_te_data_folder=os.environ["THREAT_EXCHANGE_DATA_FOLDER"],
-            collab_config_table=os.environ["THREAT_EXCHANGE_CONFIG_DYNAMODB"],
+            collab_config_table=os.environ["HMA_CONFIG_TABLE"],
             data_store_table=os.environ["DYNAMODB_DATASTORE_TABLE"],
         )
 
@@ -88,40 +85,32 @@ class FetcherConfig:
 class ThreatExchangeConfig(HMAConfig):
     """
     Config for ThreatExchange integrations
+
     Consumed by the fetcher to get data from the right places in
     ThreatExchange, downstream to control write-back information
     like reactions and uploads, and possibly other places that
     need to join HMA and ThreatExchange data.
     """
 
+    # TODO - consider hiding name field and always populating with ID
     fetcher_active: bool
     privacy_group_name: str
+
+    @property
+    def privacy_group_id(self) -> int:
+        """TE Configs are keyed by their privacy group ID"""
+        return int(self.name)
 
 
 def lambda_handler(event, context):
     lambda_init_once()
     config = FetcherConfig.get()
-
-    paginator = dynamodb.meta.client.get_paginator("scan")
-
-    response_iterator = paginator.paginate(
-        TableName=config.collab_config_table,
-        ProjectionExpression=",".join(
-            ("#Name", "privacy_group_id", "tags", "fetcher_active")
-        ),
-        ExpressionAttributeNames={"#Name": "Name"},
-    )
-
-    collabs = []
-    for page in response_iterator:
-        for item in page["Items"]:
-            if item["fetcher_active"]:
-                collabs.append((item["Name"], item["privacy_group_id"]))
+    collabs = ThreatExchangeConfig.get_all()
 
     now = datetime.now()
     current_time = now.strftime("%H:%M:%S")
 
-    names = [collab[0] for collab in collabs[:5]]
+    names = [collab.privacy_group_name for collab in collabs[:5]]
     if len(names) < len(collabs):
         names[-1] = "..."
 
@@ -134,11 +123,13 @@ def lambda_handler(event, context):
     te_data_bucket = s3.Bucket(config.s3_bucket)
 
     stores = []
-    for name, privacy_group in collabs:
-        logger.info("Processing updates for collaboration %s", name)
+    for collab in collabs:
+        logger.info(
+            "Processing updates for collaboration %s", collab.privacy_group_name
+        )
 
         indicator_store = ThreatUpdateS3PDQStore(
-            privacy_group,
+            collab.privacy_group_id,
             api.app_id,
             te_data_bucket,
             config.s3_te_data_folder,
@@ -147,7 +138,11 @@ def lambda_handler(event, context):
         stores.append(indicator_store)
         indicator_store.load_checkpoint()
         if indicator_store.stale:
-            logger.warning("Store for %s - %d stale! Resetting.", name, privacy_group)
+            logger.warning(
+                "Store for %s - %d stale! Resetting.",
+                collab.privacy_group_name,
+                collab.privacy_group_id,
+            )
             indicator_store.reset()
 
         if indicator_store.fetch_checkpoint >= now.timestamp():
@@ -196,15 +191,19 @@ def sync_privacy_groups():
     unique_privacy_groups = set(privacy_group_member_list + privacy_group_owner_list)
 
     for privacy_group in unique_privacy_groups:
-        if (
-            privacy_group.threat_updates_enabled
-        ):  # HMA can only read from privacy groups that have threat_updates enabled. See here for more details: https://developers.facebook.com/docs/threat-exchange/reference/apis/threat-updates/v9.0
+        if privacy_group.threat_updates_enabled:
+            # HMA can only read from privacy groups that have threat_updates enabled.
+            # # See here for more details:
+            # https://developers.facebook.com/docs/threat-exchange/reference/apis/threat-updates/v9.0
             logger.info("Adding collaboration name %s", privacy_group.name)
             config = ThreatExchangeConfig(
                 privacy_group.id,
-                fetcher_active=True,  # TODO Currently default to True for testing purpose, need to switch it to False before v0 launch
+                # TODO Currently default to True for testing purpose,
+                # need to switch it to False before v0 launch
+                fetcher_active=True,
                 privacy_group_name=privacy_group.name,
             )
+            # Warning! Will stomp on existing configs (including if you disable them)
             hmaconfig.update_config(config)
 
 
@@ -405,7 +404,6 @@ def write_s3_text(txt_content: io.StringIO, bucket, key: str) -> None:
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-
     # This will only kinda work for so long - eventually will
     # need to use a proper harness
     lambda_handler(None, None)

--- a/hasher-matcher-actioner/terraform/fetcher/main.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/main.tf
@@ -37,7 +37,7 @@ resource "aws_lambda_function" "fetcher" {
   environment {
     variables = {
       THREAT_EXCHANGE_DATA_BUCKET_NAME      = var.threat_exchange_data.bucket_name
-      THREAT_EXCHANGE_CONFIG_DYNAMODB       = aws_dynamodb_table.threatexchange_config.name
+      HMA_CONFIG_TABLE                      = var.hma_config.table_name
       THREAT_EXCHANGE_DATA_FOLDER           = var.threat_exchange_data.data_folder
       THREAT_EXCHANGE_API_TOKEN_SECRET_NAME = var.te_api_token_secret.name
       DYNAMODB_DATASTORE_TABLE              = var.datastore.name
@@ -111,12 +111,7 @@ data "aws_iam_policy_document" "fetcher" {
   statement {
     effect    = "Allow"
     actions   = ["dynamodb:Scan"]
-    resources = [aws_dynamodb_table.threatexchange_config.arn]
-  }
-  statement {
-    effect    = "Allow"
-    actions   = ["dynamodb:Scan"]
-    resources = [var.config_arn]
+    resources = [var.hma_config.arn]
   }
   statement {
     effect    = "Allow"
@@ -207,28 +202,4 @@ resource "aws_iam_policy" "fetcher_trigger" {
 resource "aws_iam_role_policy_attachment" "fetcher_trigger" {
   role       = aws_iam_role.fetcher_trigger.name
   policy_arn = aws_iam_policy.fetcher_trigger.arn
-}
-
-### Config storage ###
-
-resource "aws_dynamodb_table" "threatexchange_config" {
-  name         = "${var.prefix}-ThreatExchangeConfig"
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "Name"
-
-  attribute {
-    name = "Name"
-    type = "S"
-  }
-
-  tags = merge(
-    var.additional_tags,
-    {
-      Name = "ThreatExchangeConfig"
-    }
-  )
-
-  provisioner "local-exec" {
-    command = "python3 ../scripts/populate_config_db ${var.collab_file} ${aws_dynamodb_table.threatexchange_config.name}"
-  }
 }

--- a/hasher-matcher-actioner/terraform/fetcher/variables.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/variables.tf
@@ -71,15 +71,18 @@ variable "collab_file" {
   type        = string
 }
 
-variable "config_arn" {
-  description = "The ARN of the DynamoDB table with configs"
-  type        = string
-}
-
 variable "te_api_token_secret" {
   description = "The aws secret where the ThreatExchange API token is stored"
   type = object({
     name = string
     arn  = string
+  })
+}
+
+variable "hma_config" {
+  description = "Config settings for dynamodb table"
+  type = object({
+    arn        = string
+    table_name = string
   })
 }

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -47,6 +47,18 @@ resource "aws_dynamodb_table" "hma_config" {
       Name = "HMAConfig"
     }
   )
+
+  # TODO(dcallies) allow creation of initial configs
+  # provisioner "local-exec" {
+  #  command = "python3 ../scripts/populate_config_db ${var.collab_file} ${aws_dynamodb_table.threatexchange_config.name}"
+  # }
+}
+
+locals {
+  hma_config = {
+    arn        = aws_dynamodb_table.hma_config.arn
+    table_name = aws_dynamodb_table.hma_config.name
+  }
 }
 
 module "hashing_data" {
@@ -120,8 +132,8 @@ module "fetcher" {
   additional_tags       = merge(var.additional_tags, local.common_tags)
   fetch_frequency       = var.fetch_frequency
 
-  config_arn = aws_dynamodb_table.hma_config.arn
   te_api_token_secret  = aws_secretsmanager_secret.te_api_token
+  hma_config = local.hma_config
 }
 
 resource "aws_sns_topic" "matches" {


### PR DESCRIPTION
Summary
---------

Makes it so the fetcher uses the HMAConfig version of its configs as the source of truth, rather than the old table.


Split of #499, interleving with #494.


Test Plan
---------

terraform apply, populate test configs with script, manually trigger fetcher, see logs showing it's doing things.
