### PR TITLE
[hma] fetcher_active default to true

### DIFF
--- a/hasher-matcher-actioner/terraform/collabs_example.json
+++ b/hasher-matcher-actioner/terraform/collabs_example.json
@@ -11,7 +11,7 @@
                 "L" : []
             },
             "fetcher_active" : {
-                "BOOL": false
+                "BOOL": true
             }
         }
     }
@@ -29,7 +29,7 @@
                 "L" : []
             },
             "fetcher_active" : {
-                "BOOL": false
+                "BOOL": true
             }
         }
     }


### PR DESCRIPTION
Summary
---------

While we are iterating quickly @eriksendc said he'd prefer the fetcher to default 'on' for testing.

I know both @mengyangwang  and @Dcallies have been ~working in this area. So I just went with the smallest change to get the desired behavior. Depending on what falls out of the config conversations, this could also be solved by adding a new file and updating: https://github.com/facebook/ThreatExchange/blob/master/hasher-matcher-actioner/terraform/variables.tf#L64 and .tfvars

Personally I think defaulting to off once we get closer to a complete v0 (and settings can be updated in the UI) is a likely end-state. 

Test Plan
---------

Running destroy and apply.
Checking the DynamoDB to confirm fetcher_active=true.
Check tfvars a valid access token to pull test data from TE.
Check s3 bucket for datafiles (or UI signals page) and that index file is created.

