### PR TITLE
[hma] Have fetcher update dynamo for signal objects 

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/s3_adapters.py
+++ b/hasher-matcher-actioner/hmalib/common/s3_adapters.py
@@ -20,6 +20,8 @@ HashRowT = t.Tuple[str, t.Dict[str, t.Any]]
 @dataclass
 class S3ThreatDataConfig:
 
+    SOURCE_STR = "te"
+
     threat_exchange_data_bucket_name: str
     threat_exchange_data_folder: str
     threat_exchange_pdq_file_extension: str
@@ -121,7 +123,7 @@ class ThreatExchangeS3Adapter:
                 {
                     "id": int(row["id"]),
                     "hash": row["hash"],
-                    "source": "te",  # default for now to make downstream easier to generalize
+                    "source": self.config.SOURCE_STR,  # default for now to make downstream easier to generalize
                     "privacy_groups": set(
                         [privacy_group]
                     ),  # read privacy group from key

--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -28,6 +28,8 @@ from hmalib.aws_secrets import AWSSecrets
 from hmalib.common.config import HMAConfig
 from hmalib.common import config as hmaconfig
 from hmalib.common.logging import get_logger
+from hmalib.common.s3_adapters import S3ThreatDataConfig
+from hmalib.models import PDQSignalMetadata
 from threatexchange import threat_updates as tu
 from threatexchange.api import ThreatExchangeAPI
 from threatexchange.cli.dataset.simple_serialization import CliIndicatorSerialization
@@ -68,14 +70,17 @@ class FetcherConfig:
     s3_bucket: str
     s3_te_data_folder: str
     collab_config_table: str
+    data_store_table: str
 
     @classmethod
-    @lru_cache(maxsize=1)  # probably overkill, but at least it's consistent
+    @lru_cache(maxsize=None)  # probably overkill, but at least it's consistent
     def get(cls):
+        # These defaults are naive but can be updated for testing purposes.
         return cls(
             s3_bucket=os.environ["THREAT_EXCHANGE_DATA_BUCKET_NAME"],
             s3_te_data_folder=os.environ["THREAT_EXCHANGE_DATA_FOLDER"],
             collab_config_table=os.environ["THREAT_EXCHANGE_CONFIG_DYNAMODB"],
+            data_store_table=os.environ["DYNAMODB_DATASTORE_TABLE"],
         )
 
 
@@ -137,6 +142,7 @@ def lambda_handler(event, context):
             api.app_id,
             te_data_bucket,
             config.s3_te_data_folder,
+            config.data_store_table,
         )
         stores.append(indicator_store)
         indicator_store.load_checkpoint()
@@ -162,7 +168,9 @@ def lambda_handler(event, context):
         finally:
             if delta:
                 logging.info("Fetch complete, applying %d updates", len(delta.updates))
-                indicator_store.apply_updates(delta)
+                indicator_store.apply_updates(
+                    delta, post_apply_fn=indicator_store.post_apply
+                )
             else:
                 logging.error("Failed before fetching any records")
 
@@ -211,12 +219,14 @@ class ThreatUpdateS3PDQStore(tu.ThreatUpdatesStore):
         app_id: int,
         s3_bucket: t.Any,  # Not typable?
         s3_te_data_folder: str,
+        data_store_table: str,
     ) -> None:
         super().__init__(privacy_group)
         self.app_id = app_id
         self._cached_state: t.Optional[t.Dict] = None
         self.s3_bucket = s3_bucket
         self.s3_te_data_folder = s3_te_data_folder
+        self.data_store_table = data_store_table
 
     @property
     def checkpoint_s3_key(self) -> str:
@@ -321,8 +331,13 @@ class ThreatUpdateS3PDQStore(tu.ThreatUpdatesStore):
             write_s3_text(txt_content, self.s3_bucket, self.data_s3_key)
             logger.info("%d rows stored for %d", len(items), self.privacy_group)
 
-    def _apply_updates_impl(self, delta: tu.ThreatUpdatesDelta) -> None:
+    def _apply_updates_impl(
+        self,
+        delta: tu.ThreatUpdatesDelta,
+        post_apply_fn=lambda x: None,
+    ) -> None:
         state: t.Dict = {}
+        updated: t.Dict = {}
         if delta.start > 0:
             state = self.load_state()
         for update in delta:
@@ -333,9 +348,39 @@ class ThreatUpdateS3PDQStore(tu.ThreatUpdatesStore):
                 state.pop(item.key, None)
             else:
                 state[item.key] = item
+                updated[item.key] = item
 
         self._store_state(state.values())
         self._cached_state = state
+
+        post_apply_fn(updated)
+
+    def post_apply(self, updated: t.Dict = {}):
+        """
+        After the fetcher applies an update, check to see if
+        matches for any of the updated signals and if so update
+        their tags.
+        """
+        table = dynamodb.Table(self.data_store_table)
+
+        for update in updated.values():
+            row = update.as_csv_row()
+            # example row format: ('<signal>', '<id>', '<time added>', '<tag1 tags2>')
+            # e.g ('096a6f9...064f', 1234567891234567, '2020-07-31T18:47:45+0000', 'true_positive hma_test')
+            if PDQSignalMetadata(
+                signal_id=int(row[1]),
+                ds_id=str(self.privacy_group),
+                updated_at=datetime.now(),
+                signal_source=S3ThreatDataConfig.SOURCE_STR,
+                signal_hash=row[0],  # note: not used by update_tags_in_table_if_exists
+                tags=row[3].split(" ") if row[3] else [],
+            ).update_tags_in_table_if_exists(table):
+                logger.info(
+                    "Updated Signal Tags in DB for signal id: %s source: %s for privacy group: %d",
+                    row[1],
+                    S3ThreatDataConfig.SOURCE_STR,
+                    self.privacy_group,
+                )
 
 
 def read_s3_text(bucket, key: str) -> t.Optional[io.StringIO]:

--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -357,8 +357,8 @@ class ThreatUpdateS3PDQStore(tu.ThreatUpdatesStore):
 
     def post_apply(self, updated: t.Dict = {}):
         """
-        After the fetcher applies an update, check to see if
-        matches for any of the updated signals and if so update
+        After the fetcher applies an update, check for matches
+        to any of the signals in data_store_table and if found update
         their tags.
         """
         table = dynamodb.Table(self.data_store_table)

--- a/hasher-matcher-actioner/mypy.ini
+++ b/hasher-matcher-actioner/mypy.ini
@@ -17,3 +17,6 @@ ignore_missing_imports = True
 
 [mypy-botocore.errorfactory.*]
 ignore_missing_imports = True
+
+[mypy-botocore.exceptions.*]
+ignore_missing_imports = True

--- a/hasher-matcher-actioner/setup.py
+++ b/hasher-matcher-actioner/setup.py
@@ -10,7 +10,7 @@ setup(
     install_requires=[
         "boto3",
         "boto3-stubs[essential,sns]==1.17.14.0",
-        "threatexchange[faiss,pdq_hasher]>=0.0.15",
+        "threatexchange[faiss,pdq_hasher]>=0.0.18",
         "bottle",
         "apig_wsgi",
     ],

--- a/hasher-matcher-actioner/terraform/fetcher/main.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/main.tf
@@ -36,10 +36,11 @@ resource "aws_lambda_function" "fetcher" {
   memory_size = 512
   environment {
     variables = {
-      THREAT_EXCHANGE_DATA_BUCKET_NAME = var.threat_exchange_data.bucket_name
-      THREAT_EXCHANGE_CONFIG_DYNAMODB  = aws_dynamodb_table.threatexchange_config.name
-      THREAT_EXCHANGE_DATA_FOLDER      = var.threat_exchange_data.data_folder
+      THREAT_EXCHANGE_DATA_BUCKET_NAME      = var.threat_exchange_data.bucket_name
+      THREAT_EXCHANGE_CONFIG_DYNAMODB       = aws_dynamodb_table.threatexchange_config.name
+      THREAT_EXCHANGE_DATA_FOLDER           = var.threat_exchange_data.data_folder
       THREAT_EXCHANGE_API_TOKEN_SECRET_NAME = var.te_api_token_secret.name
+      DYNAMODB_DATASTORE_TABLE              = var.datastore.name
     }
   }
   tags = merge(
@@ -116,6 +117,11 @@ data "aws_iam_policy_document" "fetcher" {
     effect    = "Allow"
     actions   = ["dynamodb:Scan"]
     resources = [var.config_arn]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["dynamodb:UpdateItem"]
+    resources = [var.datastore.arn]
   }
   statement {
     effect    = "Allow"

--- a/hasher-matcher-actioner/terraform/fetcher/variables.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/variables.tf
@@ -27,11 +27,20 @@ variable "lambda_docker_info" {
   })
 }
 
+
+variable "datastore" {
+  description = "DynamoDB Table to store hash and match information into"
+  type = object({
+    name = string
+    arn  = string
+  })
+}
+
 variable "threat_exchange_data" {
   description = "Configuration information for the S3 Bucket that will hold ThreatExchange Data. data_folder is actually just a key prefix to search for but this is displyed as a folder in AWS UI"
   type = object({
-    bucket_name       = string
-    data_folder       = string
+    bucket_name = string
+    data_folder = string
   })
 }
 
@@ -59,12 +68,12 @@ variable "te_api_token" {
 
 variable "collab_file" {
   description = "An optional file name of ThreatExchange Collaborations objects to prepopulate. See collabs_example.json for the correct formatting"
-  type = string
+  type        = string
 }
 
 variable "config_arn" {
   description = "The ARN of the DynamoDB table with configs"
-  type = string
+  type        = string
 }
 
 variable "te_api_token_secret" {

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -105,6 +105,11 @@ module "fetcher" {
     }
   }
 
+  datastore = {
+    name = module.hashing_data.hma_datastore.name
+    arn  = module.hashing_data.hma_datastore.arn
+  }
+
   threat_exchange_data = {
     bucket_name = module.hashing_data.threat_exchange_data_folder_info.bucket_name
     data_folder = local.te_data_folder


### PR DESCRIPTION
Summary
---------

Second (and actually significant)  half of the split of #503

This modifies the fetcher to update `PDQSignalMetadata` this has already been mostly reviewed by @schatten as a part of #503. 

Test Plan
---------

I was able to confirm that the fetcher was able to update the db objects in a deployed lambda via cloudwatch log:

After the first fetch and a match was created I went to s3 and deleted the .pdq.te and .checkpoint files. 
I then triggered the fetcher to make sure it wold complete without error and checked the logs to make sure the db object was updated, (paste of one of the logs below.)

```
[INFO]	2021-04-20T17:55:37.849Z	730a56a1-06a8-4204-b448-e03e9425f554	Updated Signal Tags in DB for signal id: <REDACTED> source: te for privacy group: 303636684709969
```
 