### PR TITLE
Messages for actions and reactions queues

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -69,7 +69,7 @@ TUrl = t.Union[t.Text, bytes]
 class ActionMessage(MatchMessage):
     """
     The action performer needs the match message plus which action to perform
-    TODO Create a reflection / introspection-based helper that implements 
+    TODO Create a reflection / introspection-based helper that implements
     to_ / from_aws_message code (and maybe from_match_message_and_label(), too)
     for ActionMessage and MatchMessage.
     """

--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -78,7 +78,9 @@ class ActionMessage(MatchMessage):
             {
                 "ContentKey": self.content_key,
                 "ContentHash": self.content_hash,
-                "MatchingBankedSignals": [x.to_dict() for x in self.matching_banked_signals],
+                "MatchingBankedSignals": [
+                    x.to_dict() for x in self.matching_banked_signals
+                ],
                 "ActionLabelValue": self.action_label.value,
             }
         )
@@ -121,7 +123,9 @@ class ReactionMessage(MatchMessage):
             {
                 "ContentKey": self.content_key,
                 "ContentHash": self.content_hash,
-                "MatchingBankedSignals": [x.to_dict() for x in self.matching_banked_signals],
+                "MatchingBankedSignals": [
+                    x.to_dict() for x in self.matching_banked_signals
+                ],
                 "ReactionLabelValue": self.reaction_label.value,
             }
         )

--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -69,6 +69,9 @@ TUrl = t.Union[t.Text, bytes]
 class ActionMessage(MatchMessage):
     """
     The action performer needs the match message plus which action to perform
+    TODO Create a reflection / introspection-based helper that implements 
+    to_ / from_aws_message code (and maybe from_match_message_and_label(), too)
+    for ActionMessage and MatchMessage.
     """
 
     action_label: ActionLabel = ActionLabel("UnspecifiedAction")

--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -1,16 +1,33 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import hmalib.common.config as config
+import json
 import typing as t
 
 from dataclasses import dataclass, fields
+from hmalib.common.logging import get_logger
+from hmalib.models import BankedSignal, MatchMessage
 from requests import get, post, put, delete, Response
 
-import hmalib.common.config as config
-
-from hmalib.models import Label, MatchMessage, BankedSignal
-from hmalib.common.logging import get_logger
-
 logger = get_logger(__name__)
+
+
+@dataclass
+class Label:
+    key: str
+    value: str
+
+    def to_dynamodb_dict(self) -> dict:
+        return {"K": self.key, "V": self.value}
+
+    @classmethod
+    def from_dynamodb_dict(cls, d: dict):
+        return cls(d["K"], d["V"])
+
+    def __eq__(self, another_label: object) -> bool:
+        if not isinstance(another_label, Label):
+            return NotImplemented
+        return self.key == another_label.key and self.value == another_label.value
 
 
 class LabelWithConstraints(Label):
@@ -49,6 +66,91 @@ TUrl = t.Union[t.Text, bytes]
 
 
 @dataclass
+class ActionMessage(MatchMessage):
+    """
+    The action performer needs the match message plus which action to perform
+    """
+
+    action_label: ActionLabel = ActionLabel("UnspecifiedAction")
+
+    def to_aws_message(self) -> str:
+        return json.dumps(
+            {
+                "ContentKey": self.content_key,
+                "ContentHash": self.content_hash,
+                "MatchingBankedSignals": [x.to_dict() for x in self.matching_banked_signals],
+                "ActionLabelValue": self.action_label.value,
+            }
+        )
+
+    @classmethod
+    def from_aws_message(cls, message: str) -> "ActionMessage":
+        parsed = json.loads(message)
+        return cls(
+            parsed["ContentKey"],
+            parsed["ContentHash"],
+            [BankedSignal.from_dict(d) for d in parsed["MatchingBankedSignals"]],
+            ActionLabel(parsed["ActionLabelValue"]),
+        )
+
+    @classmethod
+    def from_match_message_and_label(
+        cls, match_message: MatchMessage, action_label: ActionLabel
+    ) -> "ActionMessage":
+        return cls(
+            match_message.content_key,
+            match_message.content_hash,
+            match_message.matching_banked_signals,
+            action_label,
+        )
+
+
+@dataclass
+class ReactionMessage(MatchMessage):
+    """
+    The reactioner needs the match message plus which reaction to send back
+    to the source of the signal (for now, ThreatExchange).
+    """
+
+    reaction_label: ThreatExchangeReactionLabel = ThreatExchangeReactionLabel(
+        "UnspecifiedThreatExchangeReaction"
+    )
+
+    def to_aws_message(self) -> str:
+        return json.dumps(
+            {
+                "ContentKey": self.content_key,
+                "ContentHash": self.content_hash,
+                "MatchingBankedSignals": [x.to_dict() for x in self.matching_banked_signals],
+                "ReactionLabelValue": self.reaction_label.value,
+            }
+        )
+
+    @classmethod
+    def from_aws_message(cls, message: str) -> "ReactionMessage":
+        parsed = json.loads(message)
+        return cls(
+            parsed["ContentKey"],
+            parsed["ContentHash"],
+            [BankedSignal.from_dict(d) for d in parsed["MatchingBankedSignals"]],
+            ThreatExchangeReactionLabel(parsed["ReactionLabelValue"]),
+        )
+
+    @classmethod
+    def from_match_message_and_label(
+        cls,
+        match_message: MatchMessage,
+        threat_exchange_reaction_label: ThreatExchangeReactionLabel,
+    ) -> "ReactionMessage":
+        return cls(
+            match_message.content_key,
+            match_message.content_hash,
+            match_message.matching_banked_signals,
+            threat_exchange_reaction_label,
+        )
+
+
+@dataclass
 class ActionPerformer:
     """
     A configuration of what action should be performed when a specific label
@@ -73,7 +175,7 @@ class WebhookActionPerformer(ActionPerformer):
     url: TUrl
 
     def perform_action(self, match_message: MatchMessage) -> None:
-        kwargs = {"data": match_message.to_sns_message()}
+        kwargs = {"data": match_message.to_aws_message()}
         self.call(**kwargs)
 
     def call(self, **kwargs) -> Response:

--- a/hasher-matcher-actioner/hmalib/common/tests/test_actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_actioner_models.py
@@ -1,0 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+from hmalib.common.actioner_models import Label
+
+
+class LabelsTestCase(unittest.TestCase):
+    def test_label_validation(self):
+        l = Label("some key", "some value")
+        # Just validate that no error is raised
+
+    def test_label_serde(self):
+        # serde is serialization/deserialization
+        l = Label("some key", "some value")
+        serded_l = Label.from_dynamodb_dict(l.to_dynamodb_dict())
+        self.assertEqual(l, serded_l)

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
@@ -14,6 +14,8 @@ from hmalib.common.logging import get_logger
 from hmalib.models import MatchMessage
 from hmalib.common import config
 
+logger = get_logger(__name__)
+
 
 def perform_label_action(match_message: MatchMessage, action_label: ActionLabel) -> int:
     action_performer = ActionPerformerConfig.get_performer(action_label)

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
@@ -4,12 +4,14 @@ import json
 import typing as t
 from hmalib.common.actioner_models import (
     ActionLabel,
+    ActionMessage,
     ActionPerformerConfig,
+    ActionPerformer,
 )
 
 from dataclasses import dataclass, field
 from hmalib.common.logging import get_logger
-from hmalib.models import MatchMessage, Label, BankedSignal
+from hmalib.models import MatchMessage
 from hmalib.common import config
 
 
@@ -29,15 +31,11 @@ def lambda_handler(event, context):
     """
     for sqs_record in event["Records"]:
         # TODO research max # sqs records / lambda_handler invocation
-        sqs_record_body = json.loads(sqs_record["body"])
+        action_message = ActionMessage.from_aws_message(json.loads(sqs_record["body"]))
 
-        if sqs_record_body.get("Event") == "TestEvent":
-            logger.info("Disregarding test: %s", sqs_record_body)
-            continue
+        logger.info("Performing action: action_message = %s", action_message)
 
-        logger.info("Performing action: sqs_record_body = %s", sqs_record_body)
-
-        # TODO instantiate an instance of ActionMessage here, then call perform_action()
+        perform_label_action(action_message, action_message.action_label)
 
     return {"action_performed": "true"}
 

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/reactioner.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/reactioner.py
@@ -3,6 +3,7 @@
 import json
 
 from hmalib.common.logging import get_logger
+from hmalib.common.actioner_models import ReactionMessage
 
 logger = get_logger(__name__)
 
@@ -15,13 +16,10 @@ def lambda_handler(event, context):
     """
     for sqs_record in event["Records"]:
         # TODO research max # sqs records / lambda_handler invocation
-        sqs_record_body = json.loads(sqs_record["body"])
+        reaction_message = ReactionMessage.from_aws_message(
+            json.loads(sqs_record["body"])
+        )
 
-        if sqs_record_body.get("Event") == "TestEvent":
-            logger.info("Disregarding test: %s", sqs_record_body)
-            continue
-
-        logger.info("Reactin with sqs_record_body = %s", sqs_record_body)
-        # TODO next PR will include implementation of the ReactionMessage class
+        logger.info("Reacting: reaction_message = %s", reaction_message)
 
     return {"reaction_completed": "true"}

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/reactioner.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/reactioner.py
@@ -23,3 +23,7 @@ def lambda_handler(event, context):
         logger.info("Reacting: reaction_message = %s", reaction_message)
 
     return {"reaction_completed": "true"}
+
+
+if __name__ == "__main__":
+    pass

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
@@ -13,7 +13,6 @@ from threatexchange.signal_type.pdq_index import PDQIndex
 from hmalib import metrics
 from hmalib.models import (
     PDQMatchRecord,
-    Label,
     MatchMessage,
     BankedSignal,
     PDQSignalMetadata,
@@ -33,19 +32,6 @@ PDQ_INDEX_KEY = os.environ["PDQ_INDEX_KEY"]
 OUTPUT_TOPIC_ARN = os.environ["PDQ_MATCHES_TOPIC_ARN"]
 
 DYNAMODB_TABLE = os.environ["DYNAMODB_TABLE"]
-
-
-def get_default_labels() -> t.List[Label]:
-    """
-    As a stop gap measure, the matcher will add default labels that instruct the
-    actioner. In the long-term, we expect labels to be the message-passing infra
-    between matched records and post-match phases.
-    """
-    return [
-        Label("SourceDatabase", "threatexchange-all-collabs"),
-        Label("SourceBank", "threatexchange/default"),
-        Label("ViolationType", "any"),
-    ]
 
 
 def get_index(bucket_name, key):
@@ -151,7 +137,7 @@ def lambda_handler(event, context):
 
             # Publish one message for the set of matches.
             sns_client.publish(
-                TopicArn=OUTPUT_TOPIC_ARN, Message=match_message.to_sns_message()
+                TopicArn=OUTPUT_TOPIC_ARN, Message=match_message.to_aws_message()
             )
 
         else:

--- a/hasher-matcher-actioner/hmalib/tests/test_models.py
+++ b/hasher-matcher-actioner/hmalib/tests/test_models.py
@@ -71,7 +71,6 @@ class TestPDQModels(unittest.TestCase):
                             "SignalHash",
                             "SignalSource",
                             "HashType",
-                            "Labels",
                         ],
                     },
                 },
@@ -88,7 +87,6 @@ class TestPDQModels(unittest.TestCase):
                             "SignalHash",
                             "SignalSource",
                             "HashType",
-                            "Labels",
                         ],
                     },
                 },
@@ -301,15 +299,3 @@ class TestPDQModels(unittest.TestCase):
         )[0]
         for tag in replaced_tags:
             assert tag in query_metadata.tags
-
-
-class LabelsTestCase(unittest.TestCase):
-    def test_label_validation(self):
-        l = models.Label("some key", "some value")
-        # Just validate that no error is raised
-
-    def test_label_serde(self):
-        # serde is serialization/deserialization
-        l = models.Label("some key", "some value")
-        serded_l = models.Label.from_dynamodb_dict(l.to_dynamodb_dict())
-        self.assertEqual(l, serded_l)


### PR DESCRIPTION
Summary
---------

This PR introduces two messages based off of MatchMessage: ActionMessage and ReactionMessage. They are instantiated by the action evaluator and consumed by the action performer and reactioner, respectively. Other code changes include moving Labels to actioner_models.py, removing Labels from the concept of matches and match records (we now have metadata and, later, classifications), and other minor cleanup like renaming things from SNS/sns-something-or-other to AWS/aws-something-or-other. 

Test Plan
---------

1. `terraform destroy`
2. `make upload_docker`
3. `terraform apply`
4. `make dev_upload_test_data`
5. wait for hashing and matching to occur
6. validate CloudWatch logs: see that action_performer got an ActionMessage
7. validate CloudWatch logs: see that reactioner got a ReactionMessage
