### PR TITLE
aws_dataclass

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/aws_dataclass.py
+++ b/hasher-matcher-actioner/hmalib/common/aws_dataclass.py
@@ -75,7 +75,7 @@ def py_to_aws(py_field: t.Any, in_type: t.Optional[t.Type[T]] = None) -> T:
         return {
             field.name: py_to_aws(getattr(py_field, field.name), field.type)
             for field in fields(in_type)
-        }
+        }  # type: ignore # mypy/issues/10003
 
     raise AWSSerializationFailure(f"Missing Serialization logic for {in_type!r}")
 
@@ -138,7 +138,7 @@ def aws_to_py(in_type: t.Type[T], aws_field: t.Any) -> T:
             if val is None:
                 continue  # Hopefully missing b/c default or version difference
             kwargs[field.name] = aws_to_py(field.type, val)
-        return in_type(**kwargs)
+        return in_type(**kwargs)  # type: ignore  # No idea how to correctly type this
 
     raise AWSSerializationFailure(f"Missing deserialization logic for {in_type!r}")
 

--- a/hasher-matcher-actioner/hmalib/common/aws_dataclass.py
+++ b/hasher-matcher-actioner/hmalib/common/aws_dataclass.py
@@ -1,0 +1,154 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Helpers for converting python dataclasses to/from aws-friendly formats.
+
+There's likely already an existing library that exists somewhere that does 
+this much better, but after spending 5 minutes looking, just try and write
+something on our own.
+
+
+"""
+
+from decimal import Decimal
+from dataclasses import dataclass, field, fields, is_dataclass
+import typing as t
+
+T = t.TypeVar("T")
+
+
+class AWSSerializationFailure(ValueError):
+    pass
+
+
+def py_to_aws(py_field: t.Any, in_type: t.Optional[t.Type[T]] = None) -> T:
+    """
+    Convert a py item into its AWS equivalent.
+
+    Should exactly inverse aws_to_py
+    """
+    if in_type is None:
+        in_type = type(py_field)
+    origin = t.get_origin(in_type)
+    args = t.get_args(in_type)
+
+    check_type = origin or in_type
+
+    if not isinstance(py_field, check_type):
+        raise AWSSerializationFailure(
+            "Serialization error: "
+            f"Expected {check_type} got {type(py_field)} ({py_field!r})"
+        )
+
+    if in_type is int:  # N
+        # Technically, this also needs to be converted to decimal,
+        # but the boto3 translater seems to handle it fine
+        return py_field  # type: ignore # mypy/issues/10003
+    if in_type is float:  # N
+        # WARNING WARNING
+        # floating point is not truly supported in dynamodb
+        # We can fake it for numbers without too much precision
+        # but Decimal("3.4") != float(3.4)
+        return Decimal(str(py_field))  # type: ignore # mypy/issues/10003
+    if in_type is Decimal:  # N
+        return py_field  # type: ignore # mypy/issues/10003
+    if in_type is str:  # S
+        return py_field  # type: ignore # mypy/issues/10003
+    if in_type is bool:  # BOOL
+        return py_field  # type: ignore # mypy/issues/10003
+    if in_type is t.Set[str]:  # SS
+        return py_field  # type: ignore # mypy/issues/10003
+    if in_type is t.Set[int]:  # SN
+        return {i for i in py_field}  # type: ignore # mypy/issues/10003
+    if in_type is t.Set[float]:  # SN
+        # WARNING WARNING
+        # floating point is not truly supported in dynamodb
+        # See note above
+        return {Decimal(str(s)) for s in py_field}  # type: ignore # mypy/issues/10003
+
+    if origin is list:  # L
+        return [py_to_aws(v, args[0]) for v in py_field]  # type: ignore # mypy/issues/10003
+
+    if origin is dict and args[0] is str:  # M
+        return {k: py_to_aws(v, args[1]) for k, v in py_field.items()}  # type: ignore # mypy/issues/10003
+    if is_dataclass(in_type):
+        return {
+            field.name: py_to_aws(getattr(py_field, field.name), field.type)
+            for field in fields(in_type)
+        }
+
+    raise AWSSerializationFailure(f"Missing Serialization logic for {in_type!r}")
+
+
+def aws_to_py(in_type: t.Type[T], aws_field: t.Any) -> T:
+    """
+    Convert an AWS item back into its py equivalent
+
+    This might not even be strictly required, but we check that
+    all the types are roughly what we expect, and convert
+    Decimals back into ints/floats
+    """
+    origin = t.get_origin(in_type)
+    args = t.get_args(in_type)
+
+    check_type = origin
+    if in_type is float:
+        check_type = Decimal
+    elif in_type is int:
+        check_type = (int, Decimal)
+    elif is_dataclass(in_type):
+        check_type = dict
+
+    if not isinstance(aws_field, check_type or in_type):
+        raise AWSSerializationFailure(
+            "Deserialization error: "
+            f"Expected {in_type} got {type(aws_field)} ({aws_field!r})"
+        )
+
+    if in_type is int:  # N
+        return int(aws_field)  # type: ignore # mypy/issues/10003
+    if in_type is float:  # N
+        return float(aws_field)  # type: ignore # mypy/issues/10003
+    if in_type is Decimal:  # N
+        return aws_field  # type: ignore # mypy/issues/10003
+    if in_type is str:  # S
+        return aws_field  # type: ignore # mypy/issues/10003
+    if in_type is bool:  # BOOL
+        return aws_field  # type: ignore # mypy/issues/10003
+    if in_type is t.Set[str]:  # SS
+        return aws_field  # type: ignore # mypy/issues/10003
+    if in_type is t.Set[int]:  # SN
+        return {int(s) for s in aws_field}  # type: ignore # mypy/issues/10003
+    if in_type is t.Set[float]:  # SN
+        return {float(s) for s in aws_field}  # type: ignore # mypy/issues/10003
+
+    if origin is list:  # L
+        return [aws_to_py(args[0], v) for v in aws_field]  # type: ignore # mypy/issues/10003
+    # It would be possible to add support for nested dataclasses here, which
+    # just become maps with the keys as their attributes
+    # Another option would be adding a new class that adds methods to convert
+    # to an AWS-friendly struct and back
+    if origin is dict and args[0] is str:  # M
+        # check if value type of map origin is explicitly set
+        return {k: aws_to_py(args[1], v) for k, v in aws_field.items()}  # type: ignore # mypy/issues/10003
+    if is_dataclass(in_type):
+        kwargs = {}
+        for field in fields(in_type):
+            val = aws_field.get(field.name)
+            if val is None:
+                continue  # Hopefully missing b/c default or version difference
+            kwargs[field.name] = aws_to_py(field.type, val)
+        return in_type(**kwargs)
+
+    raise AWSSerializationFailure(f"Missing deserialization logic for {in_type!r}")
+
+
+class HasAWSSerialization:
+    """Convenience mixin to add serialization to a class"""
+
+    def to_aws(self):
+        return py_to_aws(self)
+
+    @classmethod
+    def from_aws(cls: t.Type[T], val: t.Dict[str, t.Any]) -> T:
+        return aws_to_py(cls, val)

--- a/hasher-matcher-actioner/hmalib/common/tests/aws_dataclass_test.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/aws_dataclass_test.py
@@ -1,0 +1,107 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from dataclasses import dataclass, field
+import unittest
+import typing as t
+
+from hmalib.common import aws_dataclass
+
+
+@dataclass
+class Simple(aws_dataclass.HasAWSSerialization):
+    a: int = 1
+    b: str = "a"
+    c: float = 1.2
+    d: t.Set[int] = field(default_factory=lambda: {1, 4})
+    e: t.Set[float] = field(default_factory=lambda: {1.3, 4.2})
+    f: t.Set[str] = field(default_factory=lambda: set("abdeg"))
+
+
+@dataclass
+class Complicated:
+    a: t.List[int] = field(default_factory=lambda: [1, 6, 1, 2])
+    b: t.Dict[str, str] = field(default_factory=lambda: {"a": "b", "c": "z"})
+    c: t.List[t.Dict[str, t.List[int]]] = field(
+        default_factory=lambda: [{"x": [5, 4, 3]}]
+    )
+
+
+@dataclass
+class SimpleInt:
+    a: int = 2
+
+
+@dataclass
+class SimpleStr:
+    a: str = "b"
+
+
+@dataclass
+class ListOfSet:
+    a: t.List[t.Set[int]] = field(default_factory=lambda: [{5}, {5, 4}])
+
+
+@dataclass
+class Nested:
+    x: SimpleInt = field(default_factory=SimpleInt)
+    y: SimpleStr = field(default_factory=SimpleStr)
+    z: ListOfSet = field(default_factory=ListOfSet)
+
+
+# @dataclass
+# class SelfNested:
+#     i: SimpleInt = field(default_factory=SimpleInt)
+#     n: "SelfNested" = None  # lies
+
+
+class AWSDataclassTest(unittest.TestCase):
+
+    DEFAULT_OBJECTS = [
+        Simple(),
+        Complicated(),
+        SimpleInt(),
+        SimpleStr(),
+        ListOfSet(),
+        Nested(),
+        # SelfNested(),
+    ]
+
+    def assertSerializesCorrectly(self, d):
+        serialized = aws_dataclass.py_to_aws(d)
+        unserialized = aws_dataclass.aws_to_py(type(d), serialized)
+        double_serialized = aws_dataclass.py_to_aws(d)
+
+        self.assertEqual(unserialized, d)
+        self.assertEqual(serialized, double_serialized)
+
+    def test_simple(self):
+        """Tests a simple config class"""
+
+        s = Simple()
+        self.assertSerializesCorrectly(s)
+
+        # Now test the helper methods
+        serialized = s.to_aws()
+        unserialized = Simple.from_aws(serialized)
+        double_serialized = unserialized.to_aws()
+
+        self.assertEqual(unserialized, s)
+        self.assertEqual(serialized, double_serialized)
+
+    def test_all_objects(self):
+        for o in self.DEFAULT_OBJECTS:
+            self.assertSerializesCorrectly(o)
+
+    @unittest.skip("Not yet supported")
+    def test_self_nested_object(self):
+        head = None
+        for i in range(10, 0, -1):
+            head = SelfNested(i, head)
+        self.assertSerializesCorrectly(head)
+
+    @unittest.skip("Not yet supported")
+    def test_recursive(self):
+        n = SelfNested()
+        n.n = n
+        # No recursion guard currently
+        self.assertSerializesCorrectly(head)

--- a/hasher-matcher-actioner/hmalib/common/tests/aws_dataclass_test.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/aws_dataclass_test.py
@@ -34,6 +34,10 @@ class SimpleInt:
 @dataclass
 class SimpleStr:
     a: str = "b"
+    b: str = "c"
+
+    def __hash__(self):
+        return hash((self.a, self.b))
 
 
 @dataclass
@@ -43,9 +47,9 @@ class ListOfSet:
 
 @dataclass
 class Nested:
-    x: SimpleInt = field(default_factory=SimpleInt)
-    y: SimpleStr = field(default_factory=SimpleStr)
-    z: ListOfSet = field(default_factory=ListOfSet)
+    w: SimpleInt = field(default_factory=SimpleInt)
+    x: t.Set[SimpleStr] = field(default_factory=lambda: {SimpleStr()})
+    y: ListOfSet = field(default_factory=ListOfSet)
 
 
 # @dataclass


### PR DESCRIPTION
Summary
---------

Breaks out the magic of converting dataclasses to aws-friendly dictionaries to another class. I have no idea if this works for more than just dynamodb items, and so this might be misnamed.

Bonus: 
* Supported for nested datastructures
* And arbitrary sets

Test Plan
---------

added unittest
