### PR TITLE
[hma][dev] update vscode setting default format on save

### DIFF
--- a/hasher-matcher-actioner/.devcontainer/devcontainer.json
+++ b/hasher-matcher-actioner/.devcontainer/devcontainer.json
@@ -1,44 +1,43 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
-	"name": "hma-devserver",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"args": {
-			"unixname": "dipanjanm"
-		}
-	},
-
-	// Set *default* container specific settings.json values on container create.
-	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash"
-	},
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-python.python",
-		"rvest.vs-code-prettier-eslint",
-		"ms-azuretools.vscode-docker",
-		"hashicorp.terraform",
-		"eamodio.gitlens",
-		"stkb.rewrap"
-	],
-
-	"mounts": [
-		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
-		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws,target=/var/run/aws-config,type=bind,consistency=cached",
-		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.hma-cmdhist,target=/commandhistory,type=bind",
-	],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "sh .devcontainer/post-create",
-
-	// Use 'portsAttributes' to set default properties for specific forwarded ports.
-	"portsAttributes": {
-		"3000": {
-			"label": "Hello Remote World",
-			"onAutoForward": "notify"
-		}
-	},
-
-	"remoteUser": "dipanjanm",
+  "name": "hma-devserver",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "unixname": "REPLACEME"
+    }
+  },
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash",
+    "editor.formatOnSave": true,
+    "python.formatting.blackPath": "black",
+    "[javascriptreact]": {
+      "editor.defaultFormatter": "rvest.vs-code-prettier-eslint"
+    }
+  },
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "ms-python.python",
+    "rvest.vs-code-prettier-eslint",
+    "ms-azuretools.vscode-docker",
+    "hashicorp.terraform",
+    "eamodio.gitlens",
+    "stkb.rewrap"
+  ],
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws,target=/var/run/aws-config,type=bind,consistency=cached",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.hma-cmdhist,target=/commandhistory,type=bind"
+  ],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "sh .devcontainer/post-create",
+  // Use 'portsAttributes' to set default properties for specific forwarded ports.
+  "portsAttributes": {
+    "3000": {
+      "label": "Hello Remote World",
+      "onAutoForward": "notify"
+    }
+  },
+  "remoteUser": "REPLACEME"
 }


### PR DESCRIPTION
Summary
---------

Updates the vscode remote containers settings.
The change also formatted inadvertently devcontainer.json (not a huge fan honestly but didn't want to create another rc file /custom case json format right now)

The value changed are the addition of the following to settings:
```
  "settings": {
    "terminal.integrated.shell.linux": "/bin/bash", # already there (maybe sub for zsh??)
    "editor.formatOnSave": true,
    "python.formatting.blackPath": "black",
    "[javascriptreact]": {
      "editor.defaultFormatter": "rvest.vs-code-prettier-eslint"
    }
  },
```
and changing `unixname` and `remoteUser` to "REPLACEME" for clarity. 

Test Plan
---------

Rebuilt the remote container 
Opened both a jsx and python file
Made an edit that should be formatted
Saved
Saw that the file was automatically formatted 
(python required one more step on first save: select 'use black')


