### PR TITLE
Populate action performers

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -183,7 +183,7 @@ class ActionPerformer(config.HMAConfigWithSubtypes):
 
 
 @dataclass
-class WebhookActionPerformer(ActionPerformer):
+class WebhookActionPerformer(ActionPerformer.Subtype):
     """Superclass for webhooks"""
 
     url: str
@@ -195,6 +195,7 @@ class WebhookActionPerformer(ActionPerformer):
         raise NotImplementedError()
 
 
+@dataclass
 class WebhookPostActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a POST"""
 
@@ -202,6 +203,7 @@ class WebhookPostActionPerformer(WebhookActionPerformer):
         return post(self.url, data)
 
 
+@dataclass
 class WebhookGetActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a GET"""
 
@@ -209,6 +211,7 @@ class WebhookGetActionPerformer(WebhookActionPerformer):
         return get(self.url)
 
 
+@dataclass
 class WebhookPutActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a PUT"""
 
@@ -216,6 +219,7 @@ class WebhookPutActionPerformer(WebhookActionPerformer):
         return put(self.url, data)
 
 
+@dataclass
 class WebhookDeleteActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a DELETE"""
 
@@ -233,11 +237,11 @@ if __name__ == "__main__":
 
     configs: t.List[ActionPerformer] = [
         WebhookDeleteActionPerformer(
-            name="DeleteWebhook",
+            "DeleteWebhook",
             url="https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195",
         ),
         WebhookPutActionPerformer(
-            name="PutWebook",
+            "PutWebook",
             url="https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195",
         ),
     ]

--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -157,7 +157,6 @@ class ReactionMessage(MatchMessage):
         )
 
 
-@dataclass
 class ActionPerformer(config.HMAConfigWithSubtypes):
     """
     An ActionPerfomer is the configuration + the code to perform an action.
@@ -183,7 +182,7 @@ class ActionPerformer(config.HMAConfigWithSubtypes):
 
 
 @dataclass
-class WebhookActionPerformer(ActionPerformer.Subtype):
+class WebhookActionPerformer(ActionPerformer.Subtype):  # type: ignore
     """Superclass for webhooks"""
 
     url: str
@@ -236,13 +235,11 @@ if __name__ == "__main__":
     match_message = MatchMessage("key", "hash", banked_signals)
 
     configs: t.List[ActionPerformer] = [
-        WebhookDeleteActionPerformer(
-            "DeleteWebhook",
-            url="https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195",
+        WebhookDeleteActionPerformer(  # type: ignore
+            "DeleteWebhook", "https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195"
         ),
-        WebhookPutActionPerformer(
-            "PutWebook",
-            url="https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195",
+        WebhookPutActionPerformer(  # type: ignore
+            "PutWebook", "https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195"
         ),
     ]
 

--- a/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
+++ b/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
@@ -18,6 +18,7 @@ import re
 
 from hmalib.lambdas.fetcher import ThreatExchangeConfig
 from hmalib.common import config as hmaconfig
+from hmalib.common.actioner_models import WebhookPostActionPerformer
 
 SUPPORTED_CONFIGS = [
     ThreatExchangeConfig,
@@ -71,6 +72,10 @@ def load_defaults(_args):
             "258601789084078",
             fetcher_active=True,
             privacy_group_name="Test Config 2",
+        ),
+        WebhookPostActionPerformer(
+            name="EnqueForReviewAction",
+            url="https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195",
         ),
     ]
     for config in configs:


### PR DESCRIPTION
Summary
---------

@eriksendc asked for actioners to be automatically populated after a terraform apply. This is done by adding them to the `populate_config_db.py` script which is run on terraform apply.

Specifically I added an actioner that sends a POST webhook to the follwoing url: https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195. For testing you can go to the url to see what it receives

This highlighted some errors with how subtyping in HMAConfig was done. @Dcallies is investegating that portion but the workaround employed here is to ignore different mypy errors

Test Plan
---------

Run the script locally to see that configs are populated:
```
$ python3 -m hmalib.scripts.populate_config_db load_example_configs
ThreatExchangeConfig(name='303636684709969', fetcher_active=True, privacy_group_name='Test Config 1')
ThreatExchangeConfig(name='258601789084078', fetcher_active=True, privacy_group_name='Test Config 2')
WebhookPostActionPerformer(name='EnqueForReviewAction', config_subtype='WebhookPostActionPerformer', url='https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195')
```
