### PR TITLE
Implement action rules as config-backed objects.

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -72,7 +72,15 @@ class Action:
 
 
 @dataclass
-class ActionRule:
+class ActionRule(config.HMAConfig):
+    """
+    Action rules are config-backed objects that have a set of labels (both
+    "must have" and "must not have") which, when evaluated against the
+    classifications of a matching banked piece of content, lead to an action
+    to take (specified by the rule's action label). By convention each action
+    rule's name field is also the value field of the rule's action label.
+    """
+
     action_label: ActionLabel
     must_have_labels: t.List[Label]
     must_not_have_labels: t.List[Label]

--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -4,7 +4,7 @@ import hmalib.common.config as config
 import json
 import typing as t
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 from hmalib.common.logging import get_logger
 from hmalib.models import BankedSignal, MatchMessage
 from requests import get, post, put, delete, Response
@@ -12,7 +12,7 @@ from requests import get, post, put, delete, Response
 logger = get_logger(__name__)
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class Label:
     key: str
     value: str
@@ -29,39 +29,35 @@ class Label:
             return NotImplemented
         return self.key == another_label.key and self.value == another_label.value
 
-    def __hash__(self) -> int:
-        return self.value.__hash__()
+
+@dataclass(unsafe_hash=True)
+class ClassificationLabel(Label):
+    key = field(default="Classification", init=False)
 
 
-class LabelWithConstraints(Label):
-    _KEY_CONSTRAINT = "KeyConstraint"
-
-    def __init__(self, value: str):
-        super(LabelWithConstraints, self).__init__(self._KEY_CONSTRAINT, value)
+@dataclass(unsafe_hash=True)
+class BankSourceClassificationLabel(Label):
+    key = field(default="BankSourceClassification", init=False)
 
 
-class ClassificationLabel(LabelWithConstraints):
-    _KEY_CONSTRAINT = "Classification"
+@dataclass(unsafe_hash=True)
+class BankIDClassificationLabel(Label):
+    key = field(default="BankIDClassification", init=False)
 
 
-class BankSourceClassificationLabel(LabelWithConstraints):
-    _KEY_CONSTRAINT = "BankSource"
+@dataclass(unsafe_hash=True)
+class BankedContentIDClassificationLabel(Label):
+    key = field(default="BankedContentIDClassification", init=False)
 
 
-class BankIDClassificationLabel(LabelWithConstraints):
-    _KEY_CONSTRAINT = "BankID"
+@dataclass(unsafe_hash=True)
+class ActionLabel(Label):
+    key = field(default="Action", init=False)
 
 
-class BankedContentIDClassificationLabel(LabelWithConstraints):
-    _KEY_CONSTRAINT = "BankedContentID"
-
-
-class ActionLabel(LabelWithConstraints):
-    _KEY_CONSTRAINT = "Action"
-
-
-class ThreatExchangeReactionLabel(LabelWithConstraints):
-    _KEY_CONSTRAINT = "ThreatExchangeReaction"
+@dataclass(unsafe_hash=True)
+class ThreatExchangeReactionLabel(Label):
+    key = field(default="ThreatExchangeReaction", init=False)
 
 
 @dataclass

--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -32,32 +32,32 @@ class Label:
 
 @dataclass(unsafe_hash=True)
 class ClassificationLabel(Label):
-    key = field(default="Classification", init=False)
+    key: str = field(default="Classification", init=False)
 
 
 @dataclass(unsafe_hash=True)
 class BankSourceClassificationLabel(Label):
-    key = field(default="BankSourceClassification", init=False)
+    key: str = field(default="BankSourceClassification", init=False)
 
 
 @dataclass(unsafe_hash=True)
 class BankIDClassificationLabel(Label):
-    key = field(default="BankIDClassification", init=False)
+    key: str = field(default="BankIDClassification", init=False)
 
 
 @dataclass(unsafe_hash=True)
 class BankedContentIDClassificationLabel(Label):
-    key = field(default="BankedContentIDClassification", init=False)
+    key: str = field(default="BankedContentIDClassification", init=False)
 
 
 @dataclass(unsafe_hash=True)
 class ActionLabel(Label):
-    key = field(default="Action", init=False)
+    key: str = field(default="Action", init=False)
 
 
 @dataclass(unsafe_hash=True)
 class ThreatExchangeReactionLabel(Label):
-    key = field(default="ThreatExchangeReaction", init=False)
+    key: str = field(default="ThreatExchangeReaction", init=False)
 
 
 @dataclass

--- a/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
@@ -34,6 +34,7 @@ class ActionRuleEvaluationTestCase(unittest.TestCase):
 
         action_rules = [
             ActionRule(
+                enqueue_for_review_action_label.value,
                 enqueue_for_review_action_label,
                 [BankIDClassificationLabel(bank_id)],
                 [ClassificationLabel("Foo")],

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -7,6 +7,7 @@ import typing as t
 
 from dataclasses import dataclass, field
 from functools import lru_cache
+from hmalib.common.config import HMAConfig
 from hmalib.common.logging import get_logger
 from hmalib.models import MatchMessage, BankedSignal
 from hmalib.common.actioner_models import (
@@ -41,6 +42,10 @@ class ActionEvaluatorConfig:
     @classmethod
     @lru_cache(maxsize=None)
     def get(cls):
+        logger.info(
+            "Initializing configs using table name %s", os.environ["CONFIG_TABLE_NAME"]
+        )
+        HMAConfig.initialize(os.environ["CONFIG_TABLE_NAME"])
         return cls(
             actions_queue_url=os.environ["ACTIONS_QUEUE_URL"],
             reactions_queue_url=os.environ["REACTIONS_QUEUE_URL"],
@@ -139,20 +144,22 @@ def get_classifications_by_match(match_message: MatchMessage) -> t.List[t.Set[La
 
 def get_action_rules() -> t.List[ActionRule]:
     """
-    TODO implement (get from config)
     Returns the ActionRule objects stored in the config repository. Each ActionRule
     will have the following attributes: MustHaveLabels, MustNotHaveLabels, ActionLabel.
     """
-    return [
-        ActionRule(
-            ActionLabel("EnqueueForReview"),
-            [
-                BankIDClassificationLabel("303636684709969"),
-                ClassificationLabel("true_positive"),
-            ],
-            [BankedContentIDClassificationLabel("3364504410306721")],
-        )
-    ]
+    return ActionRule.get_all()
+    # action_label = ActionLabel("EnqueueForReview")
+    # return [
+    #     ActionRule(
+    #         action_label.value,
+    #         action_label,
+    #         [
+    #             BankIDClassificationLabel("303636684709969"),
+    #             ClassificationLabel("true_positive"),
+    #         ],
+    #         [BankedContentIDClassificationLabel("3364504410306721")],
+    #     )
+    # ]
 
 
 def action_rule_applies_to_classifications(

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -148,18 +148,6 @@ def get_action_rules() -> t.List[ActionRule]:
     will have the following attributes: MustHaveLabels, MustNotHaveLabels, ActionLabel.
     """
     return ActionRule.get_all()
-    # action_label = ActionLabel("EnqueueForReview")
-    # return [
-    #     ActionRule(
-    #         action_label.value,
-    #         action_label,
-    #         [
-    #             BankIDClassificationLabel("303636684709969"),
-    #             ClassificationLabel("true_positive"),
-    #         ],
-    #         [BankedContentIDClassificationLabel("3364504410306721")],
-    #     )
-    # ]
 
 
 def action_rule_applies_to_classifications(

--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -56,7 +56,7 @@ def lambda_init_once():
           components
     """
     cfg = FetcherConfig.get()
-    HMAConfig.initialize(cfg.collab_config_table)
+    HMAConfig.initialize(cfg.config_table_name)
 
 
 @dataclass
@@ -67,7 +67,7 @@ class FetcherConfig:
 
     s3_bucket: str
     s3_te_data_folder: str
-    collab_config_table: str
+    config_table_name: str
     data_store_table: str
 
     @classmethod
@@ -77,7 +77,7 @@ class FetcherConfig:
         return cls(
             s3_bucket=os.environ["THREAT_EXCHANGE_DATA_BUCKET_NAME"],
             s3_te_data_folder=os.environ["THREAT_EXCHANGE_DATA_FOLDER"],
-            collab_config_table=os.environ["HMA_CONFIG_TABLE"],
+            config_table_name=os.environ["CONFIG_TABLE_NAME"],
             data_store_table=os.environ["DYNAMODB_DATASTORE_TABLE"],
         )
 

--- a/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
+++ b/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
@@ -17,6 +17,13 @@ import typing as t
 import re
 
 from hmalib.lambdas.fetcher import ThreatExchangeConfig
+from hmalib.common.actioner_models import (
+    ActionLabel,
+    ActionRule,
+    BankedContentIDClassificationLabel,
+    BankIDClassificationLabel,
+    ClassificationLabel,
+)
 from hmalib.common import config as hmaconfig
 from hmalib.common.actioner_models import WebhookPostActionPerformer
 
@@ -62,6 +69,9 @@ def load_defaults(_args):
     """
 
     # Could also put the default on the class, but seems too fancy
+
+    action_label = ActionLabel("EnqueueForReview")
+
     configs = [
         ThreatExchangeConfig(
             "303636684709969",
@@ -74,8 +84,17 @@ def load_defaults(_args):
             privacy_group_name="Test Config 2",
         ),
         WebhookPostActionPerformer(
-            name="EnqueForReviewAction",
+            name="EnqueueForReview",
             url="https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195",
+        ),
+        ActionRule(
+            action_label.value,
+            action_label,
+            [
+                BankIDClassificationLabel("303636684709969"),
+                ClassificationLabel("true_positive"),
+            ],
+            [BankedContentIDClassificationLabel("3364504410306721")],
         ),
     ]
     for config in configs:

--- a/hasher-matcher-actioner/terraform/actions/main.tf
+++ b/hasher-matcher-actioner/terraform/actions/main.tf
@@ -96,8 +96,9 @@ resource "aws_lambda_function" "action_evaluator" {
 
   environment {
     variables = {
-      ACTIONS_QUEUE_URL = aws_sqs_queue.actions_queue.id,
+      ACTIONS_QUEUE_URL   = aws_sqs_queue.actions_queue.id,
       REACTIONS_QUEUE_URL = aws_sqs_queue.reactions_queue.id,
+      CONFIG_TABLE_NAME   = var.config_table.name,
     }
   }
 }
@@ -205,6 +206,11 @@ data "aws_iam_policy_document" "action_evaluator" {
     effect    = "Allow"
     actions   = ["sqs:SendMessage"]
     resources = [aws_sqs_queue.actions_queue.arn, aws_sqs_queue.reactions_queue.arn]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["dynamodb:Scan"]
+    resources = [var.config_table.arn]
   }
   statement {
     effect = "Allow"

--- a/hasher-matcher-actioner/terraform/actions/variables.tf
+++ b/hasher-matcher-actioner/terraform/actions/variables.tf
@@ -1,6 +1,6 @@
 variable "matches_sns_topic_arn" {
-    description = "ARN for the topic that collects matches from matchers."
-    type = string
+  description = "ARN for the topic that collects matches from matchers."
+  type        = string
 }
 
 variable "lambda_docker_info" {
@@ -10,7 +10,7 @@ variable "lambda_docker_info" {
     commands = object({
       action_evaluator = string
       action_performer = string
-      reactioner = string
+      reactioner       = string
     })
   })
 }
@@ -39,6 +39,14 @@ variable "measure_performance" {
 
 variable "te_api_token_secret" {
   description = "The aws secret where the ThreatExchange API token is stored"
+  type = object({
+    name = string
+    arn  = string
+  })
+}
+
+variable "config_table" {
+  description = "The name and arn of the DynamoDB table used for persisting configs."
   type = object({
     name = string
     arn  = string

--- a/hasher-matcher-actioner/terraform/actions/variables.tf
+++ b/hasher-matcher-actioner/terraform/actions/variables.tf
@@ -48,7 +48,7 @@ variable "te_api_token_secret" {
 variable "config_table" {
   description = "The name and arn of the DynamoDB table used for persisting configs."
   type = object({
-    name = string
     arn  = string
+    name = string
   })
 }

--- a/hasher-matcher-actioner/terraform/fetcher/main.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/main.tf
@@ -37,7 +37,7 @@ resource "aws_lambda_function" "fetcher" {
   environment {
     variables = {
       THREAT_EXCHANGE_DATA_BUCKET_NAME      = var.threat_exchange_data.bucket_name
-      HMA_CONFIG_TABLE                      = var.hma_config.table_name
+      CONFIG_TABLE_NAME                     = var.config_table.name
       THREAT_EXCHANGE_DATA_FOLDER           = var.threat_exchange_data.data_folder
       THREAT_EXCHANGE_API_TOKEN_SECRET_NAME = var.te_api_token_secret.name
       DYNAMODB_DATASTORE_TABLE              = var.datastore.name
@@ -111,7 +111,7 @@ data "aws_iam_policy_document" "fetcher" {
   statement {
     effect    = "Allow"
     actions   = ["dynamodb:Scan"]
-    resources = [var.hma_config.arn]
+    resources = [var.config_table.arn]
   }
   statement {
     effect    = "Allow"

--- a/hasher-matcher-actioner/terraform/fetcher/variables.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/variables.tf
@@ -79,10 +79,10 @@ variable "te_api_token_secret" {
   })
 }
 
-variable "hma_config" {
-  description = "Config settings for dynamodb table"
+variable "config_table" {
+  description = "The name and arn of the DynamoDB table used for persisting configs."
   type = object({
-    arn        = string
-    table_name = string
+    arn  = string
+    name = string
   })
 }

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -26,7 +26,7 @@ locals {
 
 ### Config storage ###
 
-resource "aws_dynamodb_table" "hma_config" {
+resource "aws_dynamodb_table" "config_table" {
   name         = "${var.prefix}-HMAConfig"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "ConfigType"
@@ -55,9 +55,9 @@ resource "aws_dynamodb_table" "hma_config" {
 }
 
 locals {
-  hma_config = {
-    arn        = aws_dynamodb_table.hma_config.arn
-    table_name = aws_dynamodb_table.hma_config.name
+  config_table = {
+    arn  = aws_dynamodb_table.config_table.arn
+    name = aws_dynamodb_table.config_table.name
   }
 }
 
@@ -133,7 +133,7 @@ module "fetcher" {
   fetch_frequency       = var.fetch_frequency
 
   te_api_token_secret = aws_secretsmanager_secret.te_api_token
-  hma_config          = local.hma_config
+  config_table        = local.config_table
 }
 
 resource "aws_sns_topic" "matches" {
@@ -286,10 +286,7 @@ module "actions" {
   additional_tags       = merge(var.additional_tags, local.common_tags)
   measure_performance   = var.measure_performance
   te_api_token_secret   = aws_secretsmanager_secret.te_api_token
-  config_table = {
-    name = aws_dynamodb_table.hma_config.name
-    arn  = aws_dynamodb_table.hma_config.arn
-  }
+  config_table          = local.config_table
 }
 
 ### ThreatExchange API Token Secret ###

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -19,8 +19,8 @@ locals {
   common_tags = {
     "HMAPrefix" = var.prefix
   }
-  pdq_file_extension   = ".pdq.te"
-  te_data_folder       = module.hashing_data.threat_exchange_data_folder_info.key
+  pdq_file_extension       = ".pdq.te"
+  te_data_folder           = module.hashing_data.threat_exchange_data_folder_info.key
   te_api_token_secret_name = "threatexchange/${var.prefix}_api_tokens"
 }
 
@@ -132,8 +132,8 @@ module "fetcher" {
   additional_tags       = merge(var.additional_tags, local.common_tags)
   fetch_frequency       = var.fetch_frequency
 
-  te_api_token_secret  = aws_secretsmanager_secret.te_api_token
-  hma_config = local.hma_config
+  te_api_token_secret = aws_secretsmanager_secret.te_api_token
+  hma_config          = local.hma_config
 }
 
 resource "aws_sns_topic" "matches" {
@@ -285,7 +285,11 @@ module "actions" {
   log_retention_in_days = var.log_retention_in_days
   additional_tags       = merge(var.additional_tags, local.common_tags)
   measure_performance   = var.measure_performance
-  te_api_token_secret      = aws_secretsmanager_secret.te_api_token
+  te_api_token_secret   = aws_secretsmanager_secret.te_api_token
+  config_table = {
+    name = aws_dynamodb_table.hma_config.name
+    arn  = aws_dynamodb_table.hma_config.arn
+  }
 }
 
 ### ThreatExchange API Token Secret ###


### PR DESCRIPTION
Summary
---------

Implement action rules as config-backed HMAConfig objects.

Test Plan
---------

0. python -m py.test
1. `terraform destroy`
2. `make upload_docker`
3. `terraform apply`
4. `python -m hmalib.scripts.populate_config_db load_example_configs`
5. `make dev_upload_test_data`
6. wait for hashing and matching to occur
7. validate Cloudwatch logs: see that action_evaluator got an ActionRule back from the config table
8. validate CloudWatch logs: see that action_performer got an ActionMessage
