### PR TITLE
[hma][config] Delete HMAConfigWithSubtype.SubType

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -198,7 +198,7 @@ class ActionPerformer(config.HMAConfigWithSubtypes):
 
 
 @dataclass
-class WebhookActionPerformer(ActionPerformer.Subtype):  # type: ignore
+class WebhookActionPerformer(ActionPerformer):
     """Superclass for webhooks"""
 
     url: str
@@ -251,10 +251,10 @@ if __name__ == "__main__":
     match_message = MatchMessage("key", "hash", banked_signals)
 
     configs: t.List[ActionPerformer] = [
-        WebhookDeleteActionPerformer(  # type: ignore
+        WebhookDeleteActionPerformer(
             "DeleteWebhook", "https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195"
         ),
-        WebhookPutActionPerformer(  # type: ignore
+        WebhookPutActionPerformer(
             "PutWebook", "https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195"
         ),
     ]

--- a/hasher-matcher-actioner/hmalib/common/config.py
+++ b/hasher-matcher-actioner/hmalib/common/config.py
@@ -163,9 +163,9 @@ class _HMAConfigWithSubtypeMeta(type):
         # Is this the base?
         if cls_name == "HMAConfigWithSubtypes":
             return super().__new__(metacls, cls_name, bases, cls_dict)
-        # Has a CONFIG_TYPE already been applied?
+        # Has a _PARENT already been applied?
         for base in bases:
-            if hasattr(base, "CONFIG_TYPE"):
+            if hasattr(base, "_PARENT"):
                 return super().__new__(metacls, cls_name, bases, cls_dict)
         # Else create magic defaults
         cls_dict.setdefault("CONFIG_TYPE", cls_name)

--- a/hasher-matcher-actioner/hmalib/common/config.py
+++ b/hasher-matcher-actioner/hmalib/common/config.py
@@ -132,6 +132,13 @@ class HMAConfig:
     def _scan_filter(cls):
         return Attr("ConfigType").eq(cls.get_config_type())
 
+    @classmethod
+    def _assert_writable(cls):
+        """
+        Throw an exception if the config should not be writable (i.e. abstract)
+        """
+        pass
+
     @staticmethod
     def initialize(config_table_name: str) -> None:
         """
@@ -153,29 +160,25 @@ class _HMAConfigWithSubtypeMeta(type):
     """
 
     def __new__(metacls, cls_name: str, bases, cls_dict):
-        # Is this one of the bases?
-        if cls_name in ("HMAConfigWithSubtypes", "_HMAConfigSubtype"):
+        # Is this the base?
+        if cls_name == "HMAConfigWithSubtypes":
             return super().__new__(metacls, cls_name, bases, cls_dict)
-        # Has a Subtype already been applied?
+        # Has a CONFIG_TYPE already been applied?
         for base in bases:
-            if hasattr(base, "Subtype"):
+            if hasattr(base, "CONFIG_TYPE"):
                 return super().__new__(metacls, cls_name, bases, cls_dict)
         # Else create magic defaults
-        cls_dict["Subtype"] = None  # Recursion guard, overwrite below
         cls_dict.setdefault("CONFIG_TYPE", cls_name)
-
         new_cls = super().__new__(metacls, cls_name, bases, cls_dict)
-
-        class _SpecializedHMAConfigSubtype(new_cls, _HMAConfigSubtype):  # type: ignore
-            pass
-
-        new_cls.Subtype = _SpecializedHMAConfigSubtype  # type: ignore
+        new_cls._PARENT = new_cls  # type: ignore
         return new_cls
 
 
+@dataclass
 class HMAConfigWithSubtypes(HMAConfig, metaclass=_HMAConfigWithSubtypeMeta):
     """
     An HMAConfig that shares a table with other configs (and therefore names).
+
 
     How to use (version 1: same file - preferred):
 
@@ -225,16 +228,23 @@ class HMAConfigWithSubtypes(HMAConfig, metaclass=_HMAConfigWithSubtypeMeta):
     """
 
     CONFIG_TYPE: t.ClassVar[str]  # Magically defaults to cls name if unset
-    Subtype: t.ClassVar[
-        t.Type["_HMAConfigSubtype"]
-    ]  # Is set by _HMAConfigWithSubtypeMeta
+    _PARENT: t.ClassVar[t.Type["HMAConfigWithSubtypes"]]  # Set by metaclass
+
+    config_subtype: str = field(init=False)
+
+    def __post_init__(self):
+        self.config_subtype = self.get_config_subtype()
 
     @classmethod
     def get_config_type(cls) -> str:
         return cls.CONFIG_TYPE
 
+    @classmethod
+    def get_config_subtype(cls) -> str:
+        return cls.__name__
+
     @staticmethod
-    def get_subtype_classes() -> t.List[t.Type["_HMAConfigSubtype"]]:
+    def get_subtype_classes() -> t.List[t.Type["HMAConfigWithSubtypes"]]:
         """
         All the classes that make up this config class.
 
@@ -247,9 +257,9 @@ class HMAConfigWithSubtypes(HMAConfig, metaclass=_HMAConfigWithSubtypeMeta):
 
     @classmethod
     @functools.lru_cache(maxsize=1)
-    def _get_subtypes_by_name(cls) -> t.Dict[str, t.Type["_HMAConfigSubtype"]]:
+    def _get_subtypes_by_name(cls) -> t.Dict[str, t.Type["HMAConfigWithSubtypes"]]:
         tmp_variable_for_mypy: t.List[
-            t.Type["_HMAConfigSubtype"]
+            t.Type["HMAConfigWithSubtypes"]
         ] = cls.get_subtype_classes()
         return {c.get_config_subtype(): c for c in tmp_variable_for_mypy}
 
@@ -257,49 +267,33 @@ class HMAConfigWithSubtypes(HMAConfig, metaclass=_HMAConfigWithSubtypeMeta):
     def _convert_item(cls, item: t.Dict[str, t.Any]):
         if not item:
             return None
-        item_cls = cls._get_subtypes_by_name().get(item["config_subtype"])
+        item = dict(item)
+        # Remove config_subtype from the dict before conversion
+        item_cls = cls._get_subtypes_by_name().get(item.pop("config_subtype"))
         if not item_cls:
             return None
-        return item_cls._convert_item(item)
-
-
-@dataclass
-class _HMAConfigSubtype(HMAConfigWithSubtypes):
-    """
-    A config with a shared namespace. @see HMAConfigWithSubtypes
-
-    On the tradeoff from making this in the inheiritence heirarchy of
-    HMAConfigWithSubtypes or not, forcing it to be in the same heirarchy
-    preserves the get/get_all typing, and allows you to put common fields
-    on the base class.
-
-    A different option would be to have HMAConfigWithSubtypes not inherit
-    HMAConfig (Subtype would), give it get, getx, and get_all, and if you
-    wanted a base class, you could just make one yourself.
-    """
-
-    config_subtype: str = field(init=False)
-
-    def __post_init__(self):
-        self.config_subtype = self.get_config_subtype()
-
-    @classmethod
-    def get_config_subtype(cls) -> str:
-        return cls.__name__
+        if cls not in (cls._PARENT, item_cls):
+            return None
+        return _dynamodb_item_to_config(item_cls, item)
 
     @classmethod
     def _scan_filter(cls):
-        return super()._scan_filter() and Attr("config_subtype").eq(
-            cls.get_config_subtype
-        )
+        ret = super()._scan_filter()
+        if cls._PARENT is cls:
+            return ret
+        return ret and Attr("config_subtype").eq(cls.get_config_subtype)
 
     @classmethod
-    def _convert_item(cls, item: t.Dict[str, t.Any]):
-        item = dict(item or {})
-        # Remove config_subtype from the dict before conversion
-        if item.pop("config_subtype", None) != cls.get_config_subtype():
-            return None
-        return _dynamodb_item_to_config(cls, item)
+    def _assert_writable(cls):
+        super()._assert_writable()
+        if cls._PARENT is cls:
+            raise ValueError(f"Tried to write {cls.__name__} instead of its subtypes")
+        elif cls.get_config_subtype() not in cls._get_subtypes_by_name():
+            raise ValueError(
+                f"Tried to write subtype {cls.__name__}"
+                " but it's not in get_subtype_classes(), "
+                "is it supposed to be abstract?"
+            )
 
 
 # Methods that mutate the config are separate
@@ -309,16 +303,7 @@ class _HMAConfigSubtype(HMAConfigWithSubtypes):
 def update_config(config: HMAConfig) -> None:
     """Update or create a config. No locking or versioning!"""
     _assert_initialized()
-    if isinstance(config, HMAConfigWithSubtypes):
-        if not isinstance(config, _HMAConfigSubtype):
-            raise ValueError(
-                f"Tried to write {config.__class__.__name__} instead of its subtypes"
-            )
-        elif config.get_config_subtype() not in config._get_subtypes_by_name():
-            raise ValueError(
-                f"Tried to write subtype {config.__class__.__name__}"
-                " but it's not in get_subtype_classes()"
-            )
+    config._assert_writable()
     # TODO - we should probably sanity check here to make sure all the fields
     #        are the expected types, because lolpython. Otherwise, it will
     #        fail to deserialize later

--- a/hasher-matcher-actioner/hmalib/common/tests/config_test.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/config_test.py
@@ -210,15 +210,15 @@ class ConfigTest(unittest.TestCase):
                 ]
 
         @dataclass
-        class SubtypeOne(MultiConfig.Subtype):
+        class SubtypeOne(MultiConfig):
             a: int
 
         @dataclass
-        class SubtypeAbstractParentClass(MultiConfig.Subtype):
+        class SubtypeAbstractParentClass(MultiConfig):
             a: bool
 
         @dataclass
-        class SubtypeTwo(MultiConfig.Subtype):
+        class SubtypeTwo(MultiConfig):
             b: str
 
         @dataclass


### PR DESCRIPTION
Summary
---------

Well, it was worth a shot, but trying to type this is impossible because the type itself is dynamically generated.

Simplify the world by just making a straight inheritance. 

Test Plan
---------

unittests & mypy