### PR TITLE
give action performer environment variables

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
@@ -1,17 +1,42 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import json
+import os
+import typing as t
+from functools import lru_cache
 from hmalib.common.actioner_models import (
     ActionLabel,
     ActionMessage,
     ActionPerformer,
+    BankedSignal,
+    WebhookPostActionPerformer,
 )
 
 from hmalib.common.logging import get_logger
 from hmalib.models import MatchMessage
 
+from hmalib.common import config
+
 
 logger = get_logger(__name__)
+
+
+@lru_cache(maxsize=1)
+def lambda_init_once():
+    """
+    Do some late initialization for required lambda components.
+
+    Lambda initialization is weird - despite the existence of perfectly
+    good constructions like __name__ == __main__, there don't appear
+    to be easy ways to split your lambda-specific logic from your
+    module logic except by splitting up the files and making your
+    lambda entry as small as possible.
+
+    TODO: Just refactor this file to separate the lambda and functional
+          components
+    """
+    config_table = os.environ["CONFIG_TABLE_NAME"]
+    config.HMAConfig.initialize(config_table)
 
 
 def perform_label_action(
@@ -29,12 +54,41 @@ def lambda_handler(event, context):
     an action message on the actions queue and here's where they're popped
     off and dealt with.
     """
+    lambda_init_once()
     for sqs_record in event["Records"]:
         # TODO research max # sqs records / lambda_handler invocation
-        action_message = ActionMessage.from_aws_message(json.loads(sqs_record["body"]))
+        action_message = ActionMessage.from_aws_message(sqs_record["body"])
 
         logger.info("Performing action: action_message = %s", action_message)
 
         perform_label_action(action_message, action_message.action_label)
 
     return {"action_performed": "true"}
+
+
+if __name__ == "__main__":
+    lambda_init_once()
+
+    banked_signals = [
+        BankedSignal("2862392437204724", "bank 4", "te"),
+        BankedSignal("4194946153908639", "bank 4", "te"),
+    ]
+    match_message = MatchMessage("key", "hash", banked_signals)
+
+    configs: t.List[ActionPerformer] = [
+        WebhookPostActionPerformer(  # type: ignore
+            "EnqueueForReview",
+            "https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195",
+        ),
+    ]
+    for performer_config in configs:
+        config.update_config(performer_config)
+
+    action_message = ActionMessage(
+        "key",
+        "hash",
+        matching_banked_signals=banked_signals,
+        action_label=ActionLabel("EnqueForReview"),
+    )
+    event = {"Records": [{"body": action_message.to_aws_message()}]}
+    lambda_handler(event, None)

--- a/hasher-matcher-actioner/terraform/.terraform.lock.hcl
+++ b/hasher-matcher-actioner/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 3.0"
   hashes = [
     "h1:aY98OcgyLZJVEoqWB8tro023Fx3khJUWQOxwAfd94pQ=",
+    "h1:l8jJYQ4bPEbNwZUoHYmeR1woajPzJSX5hPCLWuRVFwc=",
     "h1:tY5R3hRBB1v8v3MT+ofoCJ/Vz/b/4PXo3xtBKtw7T4A=",
     "zh:04e4f700c21b1f58e7603638160bd5ad3b85519c35dc75bada3e52b164d06d3e",
     "zh:09f2338404d4b2d4dcb29781ac59a6955d935745e896d4ee661d83cac8d7c677",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version = "2.1.0"
   hashes = [
     "h1:/OpJKWupvFd8WJX1mTt8vi01pP7dkA6e//4l4C3TExE=",
+    "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
     "h1:KfieWtVyGWwplSoLIB5usKAUnrIkDQBkWaR5TI+4WYg=",
     "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
     "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
@@ -44,6 +46,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version = "3.1.0"
   hashes = [
     "h1:SFT7X3zY18CLWjoH2GfQyapxsRv6GDKsy9cF1aRwncc=",
+    "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
     "h1:xhbHC6in3nQryvTQBWKxebi3inG5OCgHgc4fRxL0ymc=",
     "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
     "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",

--- a/hasher-matcher-actioner/terraform/actions/main.tf
+++ b/hasher-matcher-actioner/terraform/actions/main.tf
@@ -117,6 +117,12 @@ resource "aws_lambda_function" "action_performer" {
 
   timeout     = 300
   memory_size = 512
+
+  environment {
+    variables = {
+      CONFIG_TABLE_NAME = var.config_table.name,
+    }
+  }
 }
 
 # Reactioner reacts to ThreatExchange.
@@ -270,6 +276,14 @@ data "aws_iam_policy_document" "action_performer" {
     effect    = "Allow"
     actions   = ["secretsmanager:GetSecretValue"]
     resources = [var.te_api_token_secret.arn]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:Get*",
+    ]
+    resources = [var.config_table.arn]
   }
 }
 

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -286,7 +286,10 @@ module "actions" {
   additional_tags       = merge(var.additional_tags, local.common_tags)
   measure_performance   = var.measure_performance
   te_api_token_secret   = aws_secretsmanager_secret.te_api_token
-  config_table          = local.config_table
+  config_table = {
+    name = aws_dynamodb_table.config_table.name
+    arn  = aws_dynamodb_table.config_table.arn
+  }
 }
 
 ### ThreatExchange API Token Secret ###


### PR DESCRIPTION
Summary
---------

This is needed to read actioner configs from the configs table

Test Plan
---------

Pushed to aws, ran with the following event, and saw that no errors emerged
```
{
  "Records": [
    {
      "body": "{\"ContentKey\": \"key\", \"ContentHash\": \"hash\", \"MatchingBankedSignals\": [{\"BankedContentId\": \"2862392437204724\", \"BankId\": \"bank 4\", \"BankSource\": \"te\", \"Classifications\": []}, {\"BankedContentId\": \"4194946153908639\", \"BankId\": \"bank 4\", \"BankSource\": \"te\", \"Classifications\": []}], \"ActionLabelValue\": \"EnqueForReview\"}"}
  ]
}
```
