### PR TITLE
ActionRule: list to set refactor for must and must not have labels

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -78,8 +78,8 @@ class ActionRule(config.HMAConfig):
     """
 
     action_label: ActionLabel
-    must_have_labels: t.List[Label]
-    must_not_have_labels: t.List[Label]
+    must_have_labels: t.Set[Label]
+    must_not_have_labels: t.Set[Label]
 
 
 TUrl = t.Union[t.Text, bytes]

--- a/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
@@ -62,27 +62,29 @@ class ActionRuleEvaluationTestCase(unittest.TestCase):
 
         action_rules = [
             ActionRule(
-                "Enqueue Mini-Castle for Review",
-                enqueue_mini_castle_for_review_action_label,
-                set(
+                name="Enqueue Mini-Castle for Review",
+                action_label=enqueue_mini_castle_for_review_action_label,
+                must_have_labels=set(
                     [
                         BankIDClassificationLabel("303636684709969"),
                         ClassificationLabel("true_positive"),
                     ]
                 ),
-                set([BankedContentIDClassificationLabel("3364504410306721")]),
+                must_not_have_labels=set(
+                    [BankedContentIDClassificationLabel("3364504410306721")]
+                ),
             ),
             ActionRule(
-                "Enqueue Sailboat for Review",
-                enqueue_sailboat_for_review_action_label,
-                set(
+                name="Enqueue Sailboat for Review",
+                action_label=enqueue_sailboat_for_review_action_label,
+                must_have_labels=set(
                     [
                         BankIDClassificationLabel("303636684709969"),
                         ClassificationLabel("true_positive"),
                         BankedContentIDClassificationLabel("3364504410306721"),
                     ]
                 ),
-                set(),
+                must_not_have_labels=set(),
             ),
         ]
 

--- a/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
@@ -8,6 +8,7 @@ from hmalib.models import MatchMessage, BankedSignal
 from hmalib.common.actioner_models import (
     ActionLabel,
     ActionRule,
+    BankedContentIDClassificationLabel,
     BankIDClassificationLabel,
     ClassificationLabel,
     Label,
@@ -36,8 +37,8 @@ class ActionRuleEvaluationTestCase(unittest.TestCase):
             ActionRule(
                 enqueue_for_review_action_label.value,
                 enqueue_for_review_action_label,
-                {BankIDClassificationLabel(bank_id)},
-                {ClassificationLabel("Foo")},
+                set([BankIDClassificationLabel(bank_id)]),
+                set([ClassificationLabel("Foo")]),
             )
         ]
 
@@ -51,3 +52,72 @@ class ActionRuleEvaluationTestCase(unittest.TestCase):
         action_labels = get_action_labels(match_message_with_foo, action_rules)
 
         assert len(action_labels) == 0
+
+        enqueue_mini_castle_for_review_action_label = ActionLabel(
+            "EnqueueMiniCastleForReview"
+        )
+        enqueue_sailboat_for_review_action_label = ActionLabel(
+            "EnqueueSailboatForReview"
+        )
+
+        action_rules = [
+            ActionRule(
+                "Enqueue Mini-Castle for Review",
+                enqueue_mini_castle_for_review_action_label,
+                set(
+                    [
+                        BankIDClassificationLabel("303636684709969"),
+                        ClassificationLabel("true_positive"),
+                    ]
+                ),
+                set([BankedContentIDClassificationLabel("3364504410306721")]),
+            ),
+            ActionRule(
+                "Enqueue Sailboat for Review",
+                enqueue_sailboat_for_review_action_label,
+                set(
+                    [
+                        BankIDClassificationLabel("303636684709969"),
+                        ClassificationLabel("true_positive"),
+                        BankedContentIDClassificationLabel("3364504410306721"),
+                    ]
+                ),
+                set(),
+            ),
+        ]
+
+        mini_castle_match_message = MatchMessage(
+            content_key="images/mini-castle.jpg",
+            content_hash="361da9e6cf1b72f5cea0344e5bb6e70939f4c70328ace762529cac704297354a",
+            matching_banked_signals=[
+                BankedSignal(
+                    banked_content_id="4169895076385542",
+                    bank_id="303636684709969",
+                    bank_source="te",
+                    classifications=["true_positive"],
+                )
+            ],
+        )
+
+        sailboat_match_message = MatchMessage(
+            content_key="images/sailboat-mast-and-sun.jpg",
+            content_hash="388ff5e1084efef10096df9cb969296dff2b04d67a94065ecd292129ef6b1090",
+            matching_banked_signals=[
+                BankedSignal(
+                    banked_content_id="3364504410306721",
+                    bank_id="303636684709969",
+                    bank_source="te",
+                    classifications=["true_positive"],
+                )
+            ],
+        )
+
+        action_labels = get_action_labels(mini_castle_match_message, action_rules)
+
+        assert len(action_labels) == 1
+        assert action_labels.pop() == enqueue_mini_castle_for_review_action_label
+
+        action_labels = get_action_labels(sailboat_match_message, action_rules)
+
+        assert len(action_labels) == 1
+        assert action_labels.pop() == enqueue_sailboat_for_review_action_label

--- a/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
@@ -36,8 +36,8 @@ class ActionRuleEvaluationTestCase(unittest.TestCase):
             ActionRule(
                 enqueue_for_review_action_label.value,
                 enqueue_for_review_action_label,
-                [BankIDClassificationLabel(bank_id)],
-                [ClassificationLabel("Foo")],
+                {BankIDClassificationLabel(bank_id)},
+                {ClassificationLabel("Foo")},
             )
         ]
 

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -81,7 +81,7 @@ def lambda_handler(event, context):
             )
             config.sqs_client.send_message(
                 QueueUrl=config.actions_queue_url,
-                MessageBody=json.dumps(action_message.to_aws_message()),
+                MessageBody=action_message.to_aws_message(),
             )
 
         if threat_exchange_reacting_is_enabled(match_message):
@@ -97,9 +97,7 @@ def lambda_handler(event, context):
                     )
                     config.sqs_client.send_message(
                         QueueUrl=config.reactions_queue_url,
-                        MessageBody=json.dumps(
-                            threat_exchange_reaction_message.to_aws_message()
-                        ),
+                        MessageBody=threat_exchange_reaction_message.to_aws_message(),
                     )
 
     return {"evaluation_completed": "true"}

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -144,6 +144,7 @@ def get_classifications_by_match(match_message: MatchMessage) -> t.List[t.Set[La
 
 def get_action_rules() -> t.List[ActionRule]:
     """
+    TODO Research caching rules for a short bit of time (1 min? 5 min?) use @lru_cache to implement
     Returns the ActionRule objects stored in the config repository. Each ActionRule
     will have the following attributes: MustHaveLabels, MustNotHaveLabels, ActionLabel.
     """
@@ -157,12 +158,9 @@ def action_rule_applies_to_classifications(
     Evaluate if the action rule applies to the classifications. Return True if the action rule's "must have"
     labels are all present and none of the "must not have" labels are present in the classifications, otherwise return False.
     """
-    must_have_labels: t.Set[Label] = set(action_rule.must_have_labels)
-    must_not_have_labels: t.Set[Label] = set(action_rule.must_not_have_labels)
-
-    return must_have_labels.issubset(
+    return action_rule.must_have_labels.issubset(
         classifications
-    ) and must_not_have_labels.isdisjoint(classifications)
+    ) and action_rule.must_not_have_labels.isdisjoint(classifications)
 
 
 def get_actions() -> t.List[Action]:

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/reactioner.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/reactioner.py
@@ -16,9 +16,7 @@ def lambda_handler(event, context):
     """
     for sqs_record in event["Records"]:
         # TODO research max # sqs records / lambda_handler invocation
-        reaction_message = ReactionMessage.from_aws_message(
-            json.loads(sqs_record["body"])
-        )
+        reaction_message = ReactionMessage.from_aws_message(sqs_record["body"])
 
         logger.info("Reacting: reaction_message = %s", reaction_message)
 

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
@@ -120,7 +120,7 @@ def lambda_handler(event, context):
                 # to dataset[s]
                 for privacy_group in metadata.get("privacy_groups", []):
                     banked_signal = BankedSignal(
-                        signal_id, privacy_group, metadata["source"]
+                        str(signal_id), str(privacy_group), str(metadata["source"])
                     )
                     for tag in metadata["tags"].get(privacy_group, []):
                         banked_signal.classifications.append(tag)

--- a/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
+++ b/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
@@ -72,12 +72,12 @@ def load_defaults(_args):
 
     configs = [
         ThreatExchangeConfig(
-            "303636684709969",
+            name="303636684709969",
             fetcher_active=True,
             privacy_group_name="Test Config 1",
         ),
         ThreatExchangeConfig(
-            "258601789084078",
+            name="258601789084078",
             fetcher_active=True,
             privacy_group_name="Test Config 2",
         ),
@@ -100,27 +100,29 @@ def load_defaults(_args):
             # https://webhook.site/#!/fa5c5ad5-f5cc-4692-bf03-a03a4ae3f714
         ),
         ActionRule(
-            "Enqueue Mini-Castle for Review",
-            ActionLabel("EnqueueMiniCastleForReview"),
-            set(
+            name="Enqueue Mini-Castle for Review",
+            action_label=ActionLabel("EnqueueMiniCastleForReview"),
+            must_have_labels=set(
                 [
                     BankIDClassificationLabel("303636684709969"),
                     ClassificationLabel("true_positive"),
                 ]
             ),
-            set([BankedContentIDClassificationLabel("3364504410306721")]),
+            must_not_have_labels=set(
+                [BankedContentIDClassificationLabel("3364504410306721")]
+            ),
         ),
         ActionRule(
-            "Enqueue Sailboat for Review",
-            ActionLabel("EnqueueSailboatForReview"),
-            set(
+            name="Enqueue Sailboat for Review",
+            action_label=ActionLabel("EnqueueSailboatForReview"),
+            must_have_labels=set(
                 [
                     BankIDClassificationLabel("303636684709969"),
                     ClassificationLabel("true_positive"),
                     BankedContentIDClassificationLabel("3364504410306721"),
                 ]
             ),
-            set(),
+            must_not_have_labels=set(),
         ),
     ]
 

--- a/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
+++ b/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
@@ -84,14 +84,20 @@ def load_defaults(_args):
         WebhookPostActionPerformer(
             name="EnqueueForReview",
             url="https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195",
+            # monitoring page:
+            # https://webhook.site/#!/ff7ebc37-514a-439e-9a03-46f86989e195
         ),
         WebhookPostActionPerformer(
             name="EnqueueMiniCastleForReview",
             url="https://webhook.site/01cef721-bdcc-4681-8430-679c75659867",
+            # monitoring page:
+            # https://webhook.site/#!/01cef721-bdcc-4681-8430-679c75659867
         ),
         WebhookPostActionPerformer(
             name="EnqueueSailboatForReview",
             url="https://webhook.site/fa5c5ad5-f5cc-4692-bf03-a03a4ae3f714",
+            # monitoring page:
+            # https://webhook.site/#!/fa5c5ad5-f5cc-4692-bf03-a03a4ae3f714
         ),
         ActionRule(
             "Enqueue Mini-Castle for Review",

--- a/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
+++ b/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
@@ -70,8 +70,6 @@ def load_defaults(_args):
 
     # Could also put the default on the class, but seems too fancy
 
-    action_label = ActionLabel("EnqueueForReview")
-
     configs = [
         ThreatExchangeConfig(
             "303636684709969",
@@ -87,16 +85,39 @@ def load_defaults(_args):
             name="EnqueueForReview",
             url="https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195",
         ),
+        WebhookPostActionPerformer(
+            name="EnqueueMiniCastleForReview",
+            url="https://webhook.site/01cef721-bdcc-4681-8430-679c75659867",
+        ),
+        WebhookPostActionPerformer(
+            name="EnqueueSailboatForReview",
+            url="https://webhook.site/fa5c5ad5-f5cc-4692-bf03-a03a4ae3f714",
+        ),
         ActionRule(
-            action_label.value,
-            action_label,
-            [
-                BankIDClassificationLabel("303636684709969"),
-                ClassificationLabel("true_positive"),
-            ],
-            [BankedContentIDClassificationLabel("3364504410306721")],
+            "Enqueue Mini-Castle for Review",
+            ActionLabel("EnqueueMiniCastleForReview"),
+            set(
+                [
+                    BankIDClassificationLabel("303636684709969"),
+                    ClassificationLabel("true_positive"),
+                ]
+            ),
+            set([BankedContentIDClassificationLabel("3364504410306721")]),
+        ),
+        ActionRule(
+            "Enqueue Sailboat for Review",
+            ActionLabel("EnqueueSailboatForReview"),
+            set(
+                [
+                    BankIDClassificationLabel("303636684709969"),
+                    ClassificationLabel("true_positive"),
+                    BankedContentIDClassificationLabel("3364504410306721"),
+                ]
+            ),
+            set(),
         ),
     ]
+
     for config in configs:
         # Someday maybe can do filtering or something, I dunno
         hmaconfig.update_config(config)


### PR DESCRIPTION
Summary
---------

The `ActionRule` dataclass had two lists of labels. It's more efficient if they're sets, as we'd been converting the lists to sets on each rule evaluation. Storing as sets straight away prevents the need for that conversion.

Test Plan
---------

0. python -m py.test
1. `terraform destroy`
2. `make upload_docker`
3. `terraform apply`
4. `python -m hmalib.scripts.populate_config_db load_example_configs`
5. upload "mini-castle.jpg"
6. wait for hashing, matching and actioning to occur
7. validate that the EnqueueMiniCastleForReview WebhookPostActionPerformer is exercised (https://webhook.site/#!/01cef721-bdcc-4681-8430-679c75659867) 
8. upload "sailboat-mast-and-sun.jpg"
9. wait for hashing, matching and actioning to occur 
10. validate that the EnqueueSailboatForReview WebhookPostActionPerformer is exercised (https://webhook.site/#!/fa5c5ad5-f5cc-4692-bf03-a03a4ae3f714)
