### PR TITLE
Support typing request bodies using the jsoninator middleware

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
@@ -2,7 +2,11 @@
 
 import json
 import typing as t
-from bottle import response, install
+import bottle
+
+from hmalib.common.logging import get_logger
+
+logger = get_logger(__name__)
 
 """
 Inspired by Java's JAX-RS standards and perhaps most sane web frameworks. Allows
@@ -24,7 +28,26 @@ Sample usage:
 ...def get_all_datasets() -> CupcakesResponse:
 ...    response.status_code = 200 # optional
 ...    return CupcakesResponse(12, "key_lime")
+
+
+You can also specify the type of the request payload. If the request
+Content-Type is application/json and it can be parsed into the shape requested,
+your view will be called. Else, a 400 Bad request will be sent to the client.
+
+Sample usage:
+>>> @dataclass
+... class CupcakesRequest(DictParseable):
+...   @classmethod
+...   def from_dict(cls, d: t.Dict) -> 'CupcakesRequest':
+...     return CupcakesRequest(...)
+...
+>>> @app.post("/order-cupcakes/", apply=[jsoninator(CupcakesRequest)])
+... def order_cupcakes(request:CupcakesRequest) -> CupcakesResponse:
+...    <do stuff with request>
 """
+
+# This module is tested in ./tests/test_middleware.py. You can also refer to
+# that for sample usage.
 
 
 class JSONifiable:
@@ -32,7 +55,19 @@ class JSONifiable:
         raise NotImplementedError
 
 
-def jsoninator(view_fn: t.Callable[[int, int], JSONifiable]):
+class DictParseable:
+    @classmethod
+    def from_dict(cls, d: t.Dict) -> "DictParseable":
+        # Someday, include a vanilla de-serializer that uses dataclasses.fields
+        # to construct a dataclass on the fly.
+        raise NotImplementedError
+
+
+def jsoninator(
+    view_fn_or_request_type: t.Union[
+        t.Callable[[int, int], JSONifiable], t.Type[DictParseable]
+    ]
+):
     """
     Bottle plugin which allows you to create 'typed' views.
 
@@ -40,11 +75,48 @@ def jsoninator(view_fn: t.Callable[[int, int], JSONifiable]):
     content_type header will be automatically set, but if you need to set
     anything else, eg. status code or other headers, continue to use
     `bottle.response`.
+
+    If request type provided like jsoninator(RequestType), will de-serialize
+    request payload into the first argument to the view function.
     """
 
-    def wrapper(*args, **kwargs):
-        body = view_fn(*args, **kwargs)
-        response.content_type = "application/json"
-        return json.dumps(body.to_json())
+    # I feel like I'm doing a lot of work to support a common API for typed
+    # request payloads and untyped request payloads.  All this could be avoided
+    # by having `jsoninator` and `jsoninator_typed_request(RequestType)`, but
+    # meh! This looks shinier.
 
-    return wrapper
+    # Can't use isinstance because Class types are t.Callable as well.
+    if hasattr(view_fn_or_request_type, "from_dict"):
+        request_type: DictParseable = t.cast(DictParseable, view_fn_or_request_type)
+
+        def _jsoninantor_internal_for_typed_request_objects(
+            view_fn: t.Callable[[int, int], t.Type[JSONifiable]]
+        ):
+            def wrapper(*args, **kwargs):
+                try:
+                    request_object = request_type.from_dict(bottle.request.json)
+                except Exception as e:
+                    logger.error(
+                        "Failed to deserialize JSON for type: %s", str(request_type)
+                    )
+                    logger.exception(e)
+
+                response_object = view_fn(request_object, *args, **kwargs)
+                bottle.response.content_type = "application/json"
+                return json.dumps(response_object.to_json())
+
+            return wrapper
+
+        return _jsoninantor_internal_for_typed_request_objects
+
+    else:
+        view_fn: t.Callable[[int, int], JSONifiable] = t.cast(
+            t.Callable[[int, int], JSONifiable], view_fn_or_request_type
+        )
+
+        def wrapper(*args, **kwargs):
+            body = view_fn(*args, **kwargs)
+            bottle.response.content_type = "application/json"
+            return json.dumps(body.to_json())
+
+        return wrapper

--- a/hasher-matcher-actioner/hmalib/lambdas/api/tests/test_middleware.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/tests/test_middleware.py
@@ -1,0 +1,66 @@
+import unittest
+import json
+from dataclasses import asdict, dataclass
+from webtest import TestApp as TApp  # TestApp gets detected as a test
+from bottle import Bottle
+
+from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
+
+
+@dataclass
+class ResponseClass(JSONifiable):
+    foo: str
+    bar: int
+
+    def to_json(self):
+        return {"foo": self.foo, "bar": self.bar}
+
+
+@dataclass
+class RequestBody(DictParseable):
+    foo: str
+    bar: int
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(d["foo"], d["bar"])
+
+
+mock_app = Bottle()
+
+
+@mock_app.route("/response-is-json/", apply=[jsoninator])
+def response_is_json() -> ResponseClass:
+    return ResponseClass("X", 10)
+
+
+@mock_app.post("/response-and-request-is-json/", apply=[jsoninator(RequestBody)])
+def response_and_request_is_json(request: RequestBody) -> ResponseClass:
+    assert isinstance(request, RequestBody)
+    assert request.foo == "X"
+    assert request.bar == 10
+    return ResponseClass("C", 20)
+
+
+if __name__ == "__main__":
+    mock_app.run(port=9090)
+
+
+class MiddlewareUnitTest(unittest.TestCase):
+    def test_json_response_body(self):
+        app = TApp(mock_app)
+
+        response = app.get("/response-is-json/")
+        self.assertEqual(response.status, "200 OK")
+        self.assertEqual(response.body, b'{"foo": "X", "bar": 10}')
+
+    def test_json_response_body_and_request_payload(self):
+        app = TApp(mock_app)
+
+        # The asserts are actually inside the route handler, so no asserts after
+        # this statement.
+        response = app.post(
+            "/response-and-request-is-json/",
+            params=json.dumps({"foo": "X", "bar": 10}),
+            content_type="application/json",
+        )

--- a/hasher-matcher-actioner/mypy.ini
+++ b/hasher-matcher-actioner/mypy.ini
@@ -20,3 +20,6 @@ ignore_missing_imports = True
 
 [mypy-botocore.exceptions.*]
 ignore_missing_imports = True
+
+[mypy-webtest.*]
+ignore_missing_imports = True

--- a/hasher-matcher-actioner/requirements-dev.txt
+++ b/hasher-matcher-actioner/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest==6.2.1
 mypy==0.812
 black
 moto
+WebTest==2.0.35


### PR DESCRIPTION
Summary
---
Ammends jsoninator, enabling it to provide an optional type class for the request payload.

Test Plan
---
```
$ python -m py.test
```

Adds a dependency and tests. The test adds an in-process HTTP server. Both old (without typed req bodies) and new (with typed req bodies) APIs are tested.