### PR TITLE
[hma] Submit Content API

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -9,7 +9,6 @@ import datetime
 import typing as t
 from apig_wsgi import make_lambda_handler
 from bottle import response, error
-from enum import Enum
 
 from hmalib import metrics
 from hmalib.common.logging import get_logger
@@ -22,6 +21,7 @@ from hmalib.models import (
 from hmalib.models import PipelinePDQHashRecord
 
 from .matches import get_matches_api
+from .submit import get_submit_api
 
 # Set to 10MB for /upload
 bottle.BaseRequest.MEMFILE_MAX = 10 * 1024 * 1024
@@ -314,6 +314,15 @@ app.mount(
     "/matches/",
     get_matches_api(
         dynamodb_table=dynamodb.Table(DYNAMODB_TABLE),
+        image_folder_key=IMAGE_FOLDER_KEY,
+    ),
+)
+
+app.mount(
+    "/submit/",
+    get_submit_api(
+        dynamodb_table=dynamodb.Table(DYNAMODB_TABLE),
+        image_bucket_key=IMAGE_BUCKET_NAME,
         image_folder_key=IMAGE_FOLDER_KEY,
     ),
 )

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -193,7 +193,7 @@ def get_matches_api(dynamodb_table: Table, image_folder_key: str) -> bottle.Bott
     @matches_api.get("/match/<key>/", apply=[jsoninator])
     def match_details(key=None) -> MatchDetailsResponse:
         """
-        matche details API endpoint:
+        match details API endpoint:
         return format: match_details : [MatchDetailsResult]
         """
         results = get_match_details(dynamodb_table, key, image_folder_key)

--- a/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
@@ -121,7 +121,7 @@ def jsoninator(
                         "Failed to deserialize JSON for type: %s", str(request_type)
                     )
                     logger.exception(e)
-                    bottle.response.status_code = 400
+                    bottle.response.status = 400
                     return "Could not parse JSON."
 
                 response_object = view_fn(request_object, *args, **kwargs)

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -1,0 +1,89 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import bottle
+import boto3
+import base64
+
+from dataclasses import dataclass, asdict
+from mypy_boto3_dynamodb.service_resource import Table
+import typing as t
+
+from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
+from hmalib.common.logging import get_logger
+
+logger = get_logger(__name__)
+s3_client = boto3.client("s3")
+dynamodb = boto3.resource("dynamodb")
+
+
+@dataclass
+class SubmitContentRequestBody(DictParseable):
+    submission_type: str  # TODO Enum
+    content_id: str
+    content_type: str  # TODO Enum
+    content_ref: t.Union[str, bytes]
+    metadata: t.Optional[t.List]
+
+    @classmethod
+    def from_dict(cls, d):
+        # ToDo Cleaner error handling
+        return cls(
+            d["submission_type"],
+            d["content_id"],
+            d["content_type"],
+            d["content_ref"],
+            d["metadata"],
+        )
+
+
+@dataclass
+class SubmitContentResponse(JSONifiable):
+    content_id_submitted: str
+    submit_successful: bool
+
+    def to_json(self) -> t.Dict:
+        return asdict(self)
+
+
+def get_submit_api(
+    dynamodb_table: Table, image_bucket_key: str, image_folder_key: str
+) -> bottle.Bottle:
+    """
+    A Closure that includes all dependencies that MUST be provided by the root
+    API that this API plugs into. Declare dependencies here, but initialize in
+    the root API alone.
+    """
+
+    # A prefix to all routes must be provided by the api_root app
+    # The documentation below expects prefix to be '/submit/'
+    submit_api = bottle.Bottle()
+
+    @submit_api.post("/", apply=[jsoninator(SubmitContentRequestBody)])
+    def submit(request: SubmitContentRequestBody) -> SubmitContentResponse:
+        """
+        Endpoint to allow for the general submission of content to the system
+        """
+
+        assert isinstance(request, SubmitContentRequestBody)
+        logger.debug(f"Content Submit Request Received {request.content_id}")
+
+        if request.submission_type == "UPLOAD":
+            fileName = request.content_id
+            fileContents = base64.b64decode(request.content_ref)
+            # TODO a whole bunch more validation and error checking...
+            s3_client.put_object(
+                Body=fileContents,
+                Bucket=image_bucket_key,
+                Key=f"{image_folder_key}{fileName}",
+            )
+
+            return SubmitContentResponse(
+                content_id_submitted=request.content_id, submit_successful=True
+            )
+
+        # Other possible submission types are not supported so just echo content_id for testing
+        return SubmitContentResponse(
+            content_id_submitted=request.content_id, submit_successful=False
+        )
+
+    return submit_api


### PR DESCRIPTION
Summary
---------

Creates a new API by which a user can upload content to the system. Functions very similarly to  `/upload` 

this new endpoint will be `/submit/` and will take the following fields:
- submission_type: (always UPLOAD for now)
- content_id: (formerly   only used filename: this will correspond to s3 key (+ image prefix)
- content_type: str (always PHOTO for now)
- content_ref: encoded bytes of the image
- metadata: optional additional fields

Test Plan
---------
Used Postman and built out a UI that will be visible in my next PR (#536) to fully test upload functionality. Works just like the existing upload page except you can pick (must specify) an id for the content, instead of just using the filename.