### PR TITLE
Storm submissions API with the same image repeatedly

### DIFF
--- a/hasher-matcher-actioner/scripts/storm_submissions_api
+++ b/hasher-matcher-actioner/scripts/storm_submissions_api
@@ -7,6 +7,11 @@ Storms the submissions API for a running HMA instance with images.
 Try to resist the urge to add any hmalib dependencies here. This script can be
 run on a server which does not have hmalib.
 
+Sample Usage:
+```
+$ ./storm_submissions_api https://m....f.execute-api.us-east-1.amazonaws.com/ ../copydays-extended/200100.jpg 100
+```
+
 TODO:
 [x] Make a single successful request with a stolen JWT
 [x] Make threadpooled requests
@@ -45,10 +50,7 @@ def _send_single_submission(api_url: str, filepath: str, metadata: t.Dict) -> in
 
         req = request.Request(submission_path, method="POST")
         req.add_header("Content-Type", "application/json")
-        req.add_header(
-            "Authorization",
-            "eyJraWQiOiJZMUNQdFRkcjIrOCtjRUJOMjF4cjBGWEFRc1VmbFMyODBKKzVmNnhGVkFJPSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiIzZGE3ZGE3ZS01YTYzLTQwODMtODEyMy1lYmE5OGEzYWFkNWEiLCJldmVudF9pZCI6ImRjMzBhOTM3LTFiZGUtNGExZS05ZWE0LTBkZTMyZmM1YTFjNiIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MTkwMjQwODQsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC51cy1lYXN0LTEuYW1hem9uYXdzLmNvbVwvdXMtZWFzdC0xX3J1dzcxR0N3UCIsImV4cCI6MTYxOTgwMTg1OCwiaWF0IjoxNjE5Nzk4MjU5LCJqdGkiOiJmYTg3ZWVhNS0yZjk1LTRkMjMtYWYzNy1iYjZhNDI2YWU4MWIiLCJjbGllbnRfaWQiOiI3cTh0MjltdTRiMTdibGE0Y2YxZ2RqNWlyZiIsInVzZXJuYW1lIjoiZGlwYW5qYW5tIn0.uFe7PUt1tMtSuH3nf0EMM6lZck9NNRhy0RWlP69qdj2qDzfibXmgeEwYtR4LaCklHeoqa1rYoMC6wuQH85dMJQWr6f7IZvss-cYr1O3DT9qNNlGnjqcjKy_NP3ZBypHW_nNC6Yxc9zmoiTYasEfvRoh9PxZ41chKpn2NkPn8FMF5FcaDl7sxv800dPm3o3GCNon8sGHlVqHOWy94sl-4_7yO5Z5gAo5BSoFFckAb2iSoWJr_tu2BJMBz3QXpUh1WbhTqauMakLgHhfleXvz6dEIBS-sHQ2_mGKoJUxauHmUzzggp5FehlsoVfPXNgCKKn7_YXjsl80GjQe589NS6dA",
-        )
+        req.add_header("Authorization", "<STOLEN_JWT_TOKEN>")
         payload = json.dumps(payload)
         payload = payload.encode()
 

--- a/hasher-matcher-actioner/scripts/storm_submissions_api
+++ b/hasher-matcher-actioner/scripts/storm_submissions_api
@@ -1,0 +1,115 @@
+#! /usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Storms the submissions API for a running HMA instance with images.
+
+Try to resist the urge to add any hmalib dependencies here. This script can be
+run on a server which does not have hmalib.
+
+TODO:
+[x] Make a single successful request with a stolen JWT
+[x] Make threadpooled requests
+[x] Simple Stats for the submission API calls
+[ ] Get JWT without stealing from browser
+"""
+
+import os
+import base64
+import argparse
+import typing as t
+import json
+import uuid
+import datetime
+from urllib import request
+import concurrent.futures
+from time import perf_counter
+
+
+def _send_single_submission(api_url: str, filepath: str, metadata: t.Dict) -> int:
+    """
+    Submit a single file and return the time it took in ms.
+    """
+    submission_path = f"{api_url}submit/"
+    file_name = os.path.split(filepath)[-1]
+    start_time = perf_counter()
+
+    with open(filepath, "rb") as f:
+        payload = {
+            "submission_type": "UPLOAD",
+            "content_id": f"storm/{datetime.date.today().isoformat()}/{str(uuid.uuid4())}-{file_name}",
+            "content_type": "photo",
+            "content_ref": str(base64.b64encode(f.read()), "utf-8"),
+            "metadata": [],
+        }
+
+        req = request.Request(submission_path, method="POST")
+        req.add_header("Content-Type", "application/json")
+        req.add_header(
+            "Authorization",
+            "eyJraWQiOiJZMUNQdFRkcjIrOCtjRUJOMjF4cjBGWEFRc1VmbFMyODBKKzVmNnhGVkFJPSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiIzZGE3ZGE3ZS01YTYzLTQwODMtODEyMy1lYmE5OGEzYWFkNWEiLCJldmVudF9pZCI6ImRjMzBhOTM3LTFiZGUtNGExZS05ZWE0LTBkZTMyZmM1YTFjNiIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MTkwMjQwODQsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC51cy1lYXN0LTEuYW1hem9uYXdzLmNvbVwvdXMtZWFzdC0xX3J1dzcxR0N3UCIsImV4cCI6MTYxOTgwMTg1OCwiaWF0IjoxNjE5Nzk4MjU5LCJqdGkiOiJmYTg3ZWVhNS0yZjk1LTRkMjMtYWYzNy1iYjZhNDI2YWU4MWIiLCJjbGllbnRfaWQiOiI3cTh0MjltdTRiMTdibGE0Y2YxZ2RqNWlyZiIsInVzZXJuYW1lIjoiZGlwYW5qYW5tIn0.uFe7PUt1tMtSuH3nf0EMM6lZck9NNRhy0RWlP69qdj2qDzfibXmgeEwYtR4LaCklHeoqa1rYoMC6wuQH85dMJQWr6f7IZvss-cYr1O3DT9qNNlGnjqcjKy_NP3ZBypHW_nNC6Yxc9zmoiTYasEfvRoh9PxZ41chKpn2NkPn8FMF5FcaDl7sxv800dPm3o3GCNon8sGHlVqHOWy94sl-4_7yO5Z5gAo5BSoFFckAb2iSoWJr_tu2BJMBz3QXpUh1WbhTqauMakLgHhfleXvz6dEIBS-sHQ2_mGKoJUxauHmUzzggp5FehlsoVfPXNgCKKn7_YXjsl80GjQe589NS6dA",
+        )
+        payload = json.dumps(payload)
+        payload = payload.encode()
+
+        r = request.urlopen(req, data=payload)
+        response = r.read().decode("utf-8")
+
+    # convert seconds to miliseconds.
+    return int((perf_counter() - start_time) * 1000)
+
+
+def unleash_storm(
+    api_url: str,
+    filepath: str,
+    msg_count: int,
+):
+    sent_message_count = 0
+    jobs = []
+
+    execution_times = []
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=50) as executor:
+        while sent_message_count < msg_count:
+            jobs.append(executor.submit(_send_single_submission, api_url, filepath, {}))
+
+            sent_message_count += 1
+
+        for i, completed_future in enumerate(concurrent.futures.as_completed(jobs)):
+            execution_times.append(completed_future.result())
+            # Report progress
+            print(f"{i} of {msg_count} sent!", end="\r")
+
+    print(f"Sent all {msg_count} submissions.")
+
+    # Compute some beginner stats.
+    execution_times = sorted(execution_times)
+    print(
+        f"""Percentiles in ms:
+  p75: {execution_times[int(len(execution_times)*0.75)]}
+  p95: {execution_times[int(len(execution_times)*0.95)]}
+  p99: {execution_times[int(len(execution_times)*0.99)]}
+    """
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Storm the submisisons API with photo uploads. Will trigger lambdas and cost some $$"
+    )
+    parser.add_argument(
+        "api_url",
+        help="HMA API URL. Can be obtained by using terraform outputs. Look for 'api_url'",
+    )
+    parser.add_argument("file", help="The photo to upload.")
+    parser.add_argument(
+        "count",
+        type=int,
+        help="Approximately how many times do we want to send this photo?",
+    )
+
+    args = parser.parse_args()
+
+    api_url = args.api_url
+    file = args.file
+    unleash_storm(args.api_url, args.file, args.count)

--- a/hasher-matcher-actioner/terraform/outputs.tf
+++ b/hasher-matcher-actioner/terraform/outputs.tf
@@ -21,3 +21,7 @@ output "image_folder_key" {
 output "prefix" {
   value = var.prefix
 }
+
+output "api_url" {
+  value = module.api.invoke_url
+}

--- a/hasher-matcher-actioner/webapp/README.md
+++ b/hasher-matcher-actioner/webapp/README.md
@@ -63,3 +63,16 @@ npx prettier --write src
 # ensure app builds
 npm run build
 ```
+
+# Deploying to S3
+
+Terraform takes care of most of it. But it is not smart enough to do the deploy. It must be instructed to do so. Use the terraform taint command as outlined below.
+
+Run these in the `hasher-matcher-actioner` directory.
+
+```shell
+$ terraform -chdir=terraform taint "null_resource.build_and_deploy_webapp"
+$ terraform -chdir=terraform apply -var prefix="$(whoami)"
+```
+
+You might need to force refresh your browser for the changes to take effect. S3 sends liberal caching headers. `<Cmd>+<Shift>+R` on Firefox and potentially other browsers.


### PR DESCRIPTION
Summary
---------
* Do not be alarmed by the access token. It is an expired JWT and non-reverse-engineer-able.
* Also slight adjustment to the README to allow for redeploying of webapp

Test Plan
---------
Copy pasted script on an ec2 instance. Ran it with a violating image. Verified that matches appeared on the matches page ~15 seconds later.