### PR TITLE
Add zsh to devcontainer, track history for it

### DIFF
--- a/hasher-matcher-actioner/.devcontainer/Dockerfile
+++ b/hasher-matcher-actioner/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1000 developers \
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
   apt-get -y install --no-install-recommends git make jq sudo \
   software-properties-common apt-transport-https ca-certificates curl \
-  gnupg lsb-release
+  gnupg lsb-release tmux zsh
 
 # [Allow sudo] Need sudo later in post-create to open up docker socket
 ARG unixname
@@ -110,13 +110,23 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0 \
   && apt update \
   && apt install gh
 
-# [Bash History] The volume is mounted in devcontainer.json
+# [Shell Dotfiles]
 ARG unixname
-RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-  && mkdir /commandhistory \
+COPY --chown=${unixname} zshrc /home/$unixname/.zshrc
+
+ARG unixname
+COPY --chown=${unixname} bashrc /home/$unixname/.bashrc
+
+# [Shell Histories] The volume is mounted in devcontainer.json
+ARG unixname
+RUN BASH_SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  && ZSH_SNIPPET="export HISTFILE=/commandhistory/.zsh_history" \
+  && mkdir -p /commandhistory \
   && touch /commandhistory/.bash_history \
+  && touch /commandhistory/.zsh_history \
   && chown -R $unixname /commandhistory \
-  && echo $SNIPPET >> "/home/$unixname/.bashrc"
+  && echo $BASH_SNIPPET >> "/home/$unixname/.bashrc" \
+  && echo $ZSH_SNIPPET >> "/home/$unixname/.zshrc"
 
 # [Forward Docker requests to host docker engine]
 # Volume is mounted and so is the socket. The socket configuration is within

--- a/hasher-matcher-actioner/.devcontainer/bashrc
+++ b/hasher-matcher-actioner/.devcontainer/bashrc
@@ -1,0 +1,6 @@
+source /etc/bash.bashrc
+
+# Make path respect local binaries from pip
+export PATH=$PATH:~/.local/bin
+
+# Last line must have a newline char!

--- a/hasher-matcher-actioner/.devcontainer/post-create
+++ b/hasher-matcher-actioner/.devcontainer/post-create
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# Make $PATH respect user binaries
-echo "\n\nexport PATH=$PATH:~/.local/bin" >> ~/.bashrc
-
 # Link aws configuration directory paths
 ln -s /var/run/aws-config/ ~/.aws
 

--- a/hasher-matcher-actioner/.devcontainer/zshrc
+++ b/hasher-matcher-actioner/.devcontainer/zshrc
@@ -1,0 +1,15 @@
+export SAVEHIST=10000000
+
+# Allow history file to be sooper large
+export HISTFILESIZE=1000000000
+
+# Allow zsh to load as much history as it needs 
+export HISTSIZE=1000000000
+
+# Incrementally add to the history file.
+setopt INC_APPEND_HISTORY
+
+# Make path respect local binaries from pip
+export PATH=$PATH:~/.local/bin
+
+# Last line must have a newline char!


### PR DESCRIPTION
Summary
---------
* also create bashrc and zshrc files that are copied at build
  * Allows further customizing of prompts and general shell goodness

Test Plan
---------
- Rebuilt container fired it up.
- verified that bash history is retained by tailing bash_history on host
- verified that zsh history is retained by tailing zsh_history on host after switching to zsh on guest
