### PR TITLE
Actions rule config UI

### DIFF
--- a/hasher-matcher-actioner/webapp/public/index.html
+++ b/hasher-matcher-actioner/webapp/public/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>HMA</title>
+    <script type="module" src="https://unpkg.com/ionicons@5.4.0/dist/ionicons/ionicons.esm.js"></script>
+    <script nomodule="" src="https://unpkg.com/ionicons@5.4.0/dist/ionicons/ionicons.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/hasher-matcher-actioner/webapp/src/App.jsx
+++ b/hasher-matcher-actioner/webapp/src/App.jsx
@@ -3,7 +3,12 @@
  */
 
 import React from 'react';
-import {BrowserRouter as Router, Route, Switch} from 'react-router-dom';
+import {
+  BrowserRouter as Router,
+  Redirect,
+  Route,
+  Switch,
+} from 'react-router-dom';
 import {AmplifyAuthenticator, AmplifySignIn} from '@aws-amplify/ui-react';
 
 import './styles/_app.scss';
@@ -46,8 +51,11 @@ export default function App() {
               <Route path="/submit">
                 <SubmitContent />
               </Route>
-              <Route path="/settings">
+              <Route path="/settings/:tab">
                 <Settings />
+              </Route>
+              <Route path="/settings">
+                <Redirect to="/settings/signals" />
               </Route>
               <Route path="/">
                 <Dashboard />

--- a/hasher-matcher-actioner/webapp/src/Settings.jsx
+++ b/hasher-matcher-actioner/webapp/src/Settings.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import Tab from 'react-bootstrap/Tab';
 import Tabs from 'react-bootstrap/Tabs';
 import {useHistory, useParams} from 'react-router-dom';
+import ActionRuleSettingsTab from './settings/ActionRuleSettingsTab';
 import ActionSettingsTab from './settings/ActionSettingsTab';
 import ThreatExchangeSettingsTab from './settings/ThreatExchangeSettingsTab';
 
@@ -18,7 +19,8 @@ export default function Settings() {
     (tab !== 'threatexchange' &&
       tab !== 'signals' &&
       tab !== 'pipeline' &&
-      tab !== 'actions')
+      tab !== 'actions' &&
+      tab !== 'action-rules')
   ) {
     window.location = '/settings/threatexchange';
   }
@@ -41,6 +43,9 @@ export default function Settings() {
         </Tab>
         <Tab eventKey="actions" title="Actions">
           <ActionSettingsTab />
+        </Tab>
+        <Tab eventKey="action-rules" title="Action Rules">
+          <ActionRuleSettingsTab />
         </Tab>
       </Tabs>
     </>

--- a/hasher-matcher-actioner/webapp/src/Settings.jsx
+++ b/hasher-matcher-actioner/webapp/src/Settings.jsx
@@ -5,15 +5,36 @@
 import React from 'react';
 import Tab from 'react-bootstrap/Tab';
 import Tabs from 'react-bootstrap/Tabs';
+import {useHistory, useParams} from 'react-router-dom';
 import ActionSettingsTab from './settings/ActionSettingsTab';
 import ThreatExchangeSettingsTab from './settings/ThreatExchangeSettingsTab';
 
 export default function Settings() {
+  const {tab} = useParams();
+  const history = useHistory();
+  if (
+    tab === undefined ||
+    !tab ||
+    (tab !== 'threatexchange' &&
+      tab !== 'signals' &&
+      tab !== 'pipeline' &&
+      tab !== 'actions')
+  ) {
+    window.location = '/settings/threatexchange';
+  }
   return (
     <>
-      <Tabs defaultActiveKey="threatexchange" id="setting-tabs">
+      <Tabs
+        activeKey={tab}
+        id="setting-tabs"
+        onSelect={key => {
+          history.push(`/settings/${key}`);
+        }}>
         <Tab eventKey="threatexchange" title="ThreatExchange">
           <ThreatExchangeSettingsTab />
+        </Tab>
+        <Tab eventKey="signals" title="Signals">
+          <SignalSettingsTab />
         </Tab>
         <Tab eventKey="pipeline" title="Pipeline">
           Todo!

--- a/hasher-matcher-actioner/webapp/src/Settings.jsx
+++ b/hasher-matcher-actioner/webapp/src/Settings.jsx
@@ -17,7 +17,6 @@ export default function Settings() {
     tab === undefined ||
     !tab ||
     (tab !== 'threatexchange' &&
-      tab !== 'signals' &&
       tab !== 'pipeline' &&
       tab !== 'actions' &&
       tab !== 'action-rules')
@@ -34,9 +33,6 @@ export default function Settings() {
         }}>
         <Tab eventKey="threatexchange" title="ThreatExchange">
           <ThreatExchangeSettingsTab />
-        </Tab>
-        <Tab eventKey="signals" title="Signals">
-          <SignalSettingsTab />
         </Tab>
         <Tab eventKey="pipeline" title="Pipeline">
           Todo!

--- a/hasher-matcher-actioner/webapp/src/settings/ActionRuleSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/settings/ActionRuleSettingsTab.jsx
@@ -132,6 +132,21 @@ export default function ActionRuleSettingsTab() {
     false,
   );
 
+  const resetForm = () => {
+    nameRef.current.value = '';
+    mustHaveLabelsRef.current.value = '';
+    mustNotHaveLabelsRef.current.value = '';
+    actionRef.current.value = '0';
+  };
+
+  const addActionRule = newActionRule => {
+    actionRules.push(newActionRule);
+    actionRules.sort((a, b) =>
+      a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1,
+    );
+    setActionRules([...actionRules]);
+  };
+
   const deleteActionRule = name => {
     const indexToDelete = actionRules.findIndex(
       actionRule => actionRule.name === name,
@@ -142,6 +157,14 @@ export default function ActionRuleSettingsTab() {
     setShowDeletedActionRuleToast(true);
   };
 
+  const saveActionRule = (oldName, editedActionRule) => {
+    const indexToUpdate = actionRules.findIndex(
+      actionRule => actionRule.name === oldName,
+    );
+    deleteActionRule(oldName);
+    addActionRule(editedActionRule);
+  };
+
   const actionRulesTableRows = actionRules.map(actionRule => (
     <ActionRulesTableRow
       key={actionRule.name}
@@ -150,6 +173,7 @@ export default function ActionRuleSettingsTab() {
       mustNotHaveLabels={actionRule.must_not_have_labels}
       actionId={actionRule.action_id}
       onDeleteActionRule={deleteActionRule}
+      onSaveEditedActionRule={saveActionRule}
     />
   ));
 
@@ -212,14 +236,8 @@ export default function ActionRuleSettingsTab() {
                         setShowActionRequired(false);
 
                         if (actionRuleIsValid(newActionRule, actionRules)) {
-                          actionRules.push(newActionRule);
-
-                          actionRules.sort((a, b) =>
-                            a.name.toLowerCase() > b.name.toLowerCase()
-                              ? 1
-                              : -1,
-                          );
-
+                          addActionRule(newActionRule);
+                          resetForm();
                           setAdding(false);
                         } else {
                           setShowNameRequired(!newActionRule.name);
@@ -247,10 +265,7 @@ export default function ActionRuleSettingsTab() {
                       variant="outline-secondary"
                       className="table-action-button"
                       onClick={() => {
-                        nameRef.current.value = '';
-                        mustHaveLabelsRef.current.value = '';
-                        mustNotHaveLabelsRef.current.value = '';
-                        actionRef.current.value = '0';
+                        resetForm();
                         setShowNameRequired(false);
                         setShowNameMustBeUnique(false);
                         setShowMustHaveLabelsRequired(false);
@@ -298,6 +313,7 @@ function ActionRulesTableRow(props) {
     mustNotHaveLabels,
     actionId,
     onDeleteActionRule,
+    onSaveEditedActionRule,
   } = props;
   const [editing, setEditing] = useState(false);
   const [
@@ -316,7 +332,13 @@ function ActionRulesTableRow(props) {
         <td>
           <Button
             className="mb-2 table-action-button"
-            onClick={() => setEditing(true)}>
+            onClick={() => {
+              nameRef.current.value = name;
+              mustHaveLabelsRef.current.value = mustHaveLabels;
+              mustNotHaveLabelsRef.current.value = mustNotHaveLabels;
+              actionRef.current.value = actionId;
+              setEditing(true);
+            }}>
             <ion-icon name="pencil" size="large" className="ion-icon-white" />
           </Button>{' '}
           <Button
@@ -371,7 +393,16 @@ function ActionRulesTableRow(props) {
           <Button
             variant="outline-primary"
             className="mb-2 table-action-button"
-            onClick={() => setEditing(false)}>
+            onClick={() => {
+              const editedActionRule = {
+                name: nameRef.current.value,
+                must_have_labels: mustHaveLabelsRef.current.value,
+                must_not_have_labels: mustNotHaveLabelsRef.current.value,
+                action_id: actionRef.current.value,
+              };
+              onSaveEditedActionRule(name, editedActionRule);
+              setEditing(false);
+            }}>
             <ion-icon
               name="checkmark"
               size="large"

--- a/hasher-matcher-actioner/webapp/src/settings/ActionRuleSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/settings/ActionRuleSettingsTab.jsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+/* eslint-disable react/prop-types */
+
+import React from 'react';
+import Col from 'react-bootstrap/Col';
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+
+export default function ActionRuleSettingsTab() {
+  return (
+    <>
+      <Container>
+        <Row className="mt-3">
+          <Col>
+            <h1>Action Rules</h1>
+            <p>
+              Each rule indicates an action to be taken based on labels (e.g.,
+              classification labels of a matching signal)
+            </p>
+          </Col>
+        </Row>
+      </Container>
+    </>
+  );
+}

--- a/hasher-matcher-actioner/webapp/src/settings/ActionRuleSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/settings/ActionRuleSettingsTab.jsx
@@ -115,7 +115,7 @@ function ActionRuleFormColumns(props) {
           value={action}
           onChange={e => onChange({action_id: e.target.value})}
           isInvalid={showErrors && action === '0'}>
-          <option value="0" key="0" selected>
+          <option value="0" key="0">
             Select an action...
           </option>
           {actionOptions}

--- a/hasher-matcher-actioner/webapp/src/settings/ActionRuleSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/settings/ActionRuleSettingsTab.jsx
@@ -4,12 +4,93 @@
 
 /* eslint-disable react/prop-types */
 
-import React from 'react';
+import React, {useState} from 'react';
+import Button from 'react-bootstrap/Button';
 import Col from 'react-bootstrap/Col';
 import Container from 'react-bootstrap/Container';
+import Form from 'react-bootstrap/Form';
 import Row from 'react-bootstrap/Row';
+import Table from 'react-bootstrap/Table';
+
+const actionRules = [
+  {
+    name: 'Bank ID 303636684709969 Except Sailboat',
+    must_have_labels:
+      'BankIDClassificationLabel(303636684709969), ClassificationLabel(true_positive)',
+    must_not_have_labels:
+      'BankedContentIDClassificationLabel(3364504410306721)',
+    action_id: '1',
+  },
+  {
+    name: 'Bank ID 303636684709969, Sailboat',
+    must_have_labels:
+      'BankIDClassificationLabel(303636684709969), ClassificationLabel(true_positive), BankedContentIDClassificationLabel(3364504410306721)',
+    must_not_have_labels: '',
+    action_id: '2',
+  },
+];
+
+const actions = [
+  {
+    name: 'EnqueueMiniCastleForReview',
+    id: '1',
+  },
+  {
+    name: 'EnqueueSailboatForReview',
+    id: '2',
+  },
+];
+
+function ActionRuleFormColumns(props) {
+  const {nameRef, mustHaveLabelsRef, mustNotHaveLabelsRef, actionRef} = props;
+
+  const actionOptions = actions.map(action => (
+    <option key={action.id} value={action.id}>
+      {action.name}
+    </option>
+  ));
+
+  return (
+    <>
+      <td>
+        <Form.Control type="text" required ref={nameRef} />
+        <Form.Text>An action rule&rsquo;s name must be unique.</Form.Text>
+      </td>
+      <td>
+        <Form.Control as="textarea" rows={4} required ref={mustHaveLabelsRef} />
+      </td>
+      <td>
+        <Form.Control as="textarea" rows={4} ref={mustNotHaveLabelsRef} />
+      </td>
+      <td>
+        <Form.Control as="select" required ref={actionRef}>
+          <option value="0" key="0" selected>
+            Select an action...
+          </option>
+          {actionOptions}
+        </Form.Control>
+      </td>
+    </>
+  );
+}
 
 export default function ActionRuleSettingsTab() {
+  const [adding, setAdding] = useState(false);
+  const [nameRef] = useState(React.createRef());
+  const [mustHaveLabelsRef] = useState(React.createRef());
+  const [mustNotHaveLabelsRef] = useState(React.createRef());
+  const [actionRef] = useState(React.createRef());
+
+  const actionRulesTableRows = actionRules.map(actionRule => (
+    <ActionRulesTableRow
+      key={actionRule.name}
+      name={actionRule.name}
+      mustHaveLabels={actionRule.must_have_labels}
+      mustNotHaveLabels={actionRule.must_not_have_labels}
+      actionId={actionRule.action_id}
+    />
+  ));
+
   return (
     <>
       <Container>
@@ -22,7 +103,155 @@ export default function ActionRuleSettingsTab() {
             </p>
           </Col>
         </Row>
+        <Row>
+          <Col>
+            <Table bordered>
+              <thead>
+                <tr>
+                  <th>
+                    <Button
+                      className="table-action-button"
+                      onClick={() => {
+                        setAdding(true);
+                      }}>
+                      <ion-icon name="add" size="large" />
+                    </Button>
+                  </th>
+                  <th>Name</th>
+                  <th>Labeled As</th>
+                  <th>Not Labeled As</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr hidden={!adding}>
+                  <td>
+                    <Button
+                      variant="outline-primary"
+                      className="mb-2 table-action-button"
+                      onClick={() => {
+                        const newActionRule = {
+                          name: nameRef.current.value,
+                          must_have_labels: mustHaveLabelsRef.current.value,
+                          must_not_have_labels:
+                            mustNotHaveLabelsRef.current.value,
+                          action_id: actionRef.current.value,
+                        };
+
+                        actionRules.push(newActionRule);
+
+                        actionRules.sort((a, b) =>
+                          a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1,
+                        );
+
+                        setAdding(false);
+                      }}>
+                      <ion-icon
+                        name="checkmark"
+                        size="large"
+                        className="ion-icon-white"
+                      />
+                    </Button>{' '}
+                    <Button
+                      variant="outline-secondary"
+                      className="table-action-button"
+                      onClick={() => {
+                        nameRef.current.value = '';
+                        mustHaveLabelsRef.current.value = '';
+                        mustNotHaveLabelsRef.current.value = '';
+                        actionRef.current.value = '0';
+                        setAdding(false);
+                      }}>
+                      <ion-icon
+                        name="close"
+                        size="large"
+                        className="ion-icon-white"
+                      />
+                    </Button>
+                  </td>
+                  <ActionRuleFormColumns
+                    nameRef={nameRef}
+                    mustHaveLabelsRef={mustHaveLabelsRef}
+                    mustNotHaveLabelsRef={mustNotHaveLabelsRef}
+                    actionRef={actionRef}
+                  />
+                </tr>
+                {actionRulesTableRows}
+              </tbody>
+            </Table>
+          </Col>
+        </Row>
       </Container>
+    </>
+  );
+}
+
+function ActionRulesTableRow(props) {
+  const {name, mustHaveLabels, mustNotHaveLabels, actionId} = props;
+  const [editing, setEditing] = useState(false);
+  const [deleted, setDeleted] = useState(false);
+  const [nameRef] = useState(React.createRef());
+  const [mustHaveLabelsRef] = useState(React.createRef());
+  const [mustNotHaveLabelsRef] = useState(React.createRef());
+  const [actionRef] = useState(React.createRef());
+
+  return (
+    <>
+      <tr hidden={editing || deleted}>
+        <td>
+          <Button
+            className="mb-2 table-action-button"
+            onClick={() => setEditing(true)}>
+            <ion-icon name="pencil" size="large" className="ion-icon-white" />
+          </Button>{' '}
+          <Button
+            variant="secondary"
+            className="table-action-button"
+            onClick={() => setDeleted(true)}>
+            <ion-icon
+              name="trash-bin"
+              size="large"
+              className="ion-icon-white"
+            />
+          </Button>
+        </td>
+        <td>{name}</td>
+        <td className="action-rule-classification-column">{mustHaveLabels}</td>
+        <td className="action-rule-classification-column">
+          {mustNotHaveLabels.length > 0 ? (
+            mustNotHaveLabels
+          ) : (
+            <span>&mdash;</span>
+          )}
+        </td>
+        <td>{actions.find(action => action.id === actionId).name}</td>
+      </tr>
+      <tr hidden={!editing || deleted}>
+        <td>
+          <Button
+            variant="outline-primary"
+            className="mb-2 table-action-button"
+            onClick={() => setEditing(false)}>
+            <ion-icon
+              name="checkmark"
+              size="large"
+              className="ion-icon-white"
+            />
+          </Button>{' '}
+          <Button
+            variant="outline-secondary"
+            className="table-action-button"
+            onClick={() => setEditing(false)}>
+            <ion-icon name="close" size="large" className="ion-icon-white" />
+          </Button>
+        </td>
+        <ActionRuleFormColumns
+          nameRef={nameRef}
+          mustHaveLabelsRef={mustHaveLabelsRef}
+          mustNotHaveLabelsRef={mustNotHaveLabelsRef}
+          actionRef={actionRef}
+        />
+      </tr>
     </>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/settings/ActionSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/settings/ActionSettingsTab.jsx
@@ -11,16 +11,18 @@ import Table from 'react-bootstrap/Table';
 import Form from 'react-bootstrap/Form';
 
 export default function ActionSettingsTab() {
+  /**
+   * TODO This used to have an ActionLabel Settings component here. The
+   * action rules are now in a separate tab. We can now rename this
+   * outer component to ActionPerformerSettingsTab and start the
+   * implementation of that component here. Not doing that now because
+   * someone else is actively working in this space.
+   */
   return (
     <>
       <ActionPerformerSettings />
-      <ActionLabelSettings />
     </>
   );
-}
-
-function ActionLabelSettings() {
-  return <>Action Label Settings coming here</>;
 }
 
 const ActionerTypes = {
@@ -264,18 +266,20 @@ function ActionPerformerSettings() {
   );
   return (
     <>
-      <Card.Header>
-        <h2 className="mt-2">Action Definitions</h2>
-        <h5 className="mt-5">Define what to do for different Actions</h5>
-      </Card.Header>
-      <Card.Body>
-        <Table striped bordered hover>
-          <thead>
-            <tr>{headerBlock}</tr>
-          </thead>
-          <tbody>{performerBlocks}</tbody>
-        </Table>
-      </Card.Body>
+      <Card>
+        <Card.Header>
+          <h2 className="mt-2">Action Definitions</h2>
+          <h5 className="mt-5">Define what to do for different Actions</h5>
+        </Card.Header>
+        <Card.Body>
+          <Table striped bordered hover>
+            <thead>
+              <tr>{headerBlock}</tr>
+            </thead>
+            <tbody>{performerBlocks}</tbody>
+          </Table>
+        </Card.Body>
+      </Card>
     </>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/styles/_app.scss
+++ b/hasher-matcher-actioner/webapp/src/styles/_app.scss
@@ -29,3 +29,10 @@ div#root {
   display: block;
   margin: auto;
 }
+
+.feedback-toast-container {
+  position: fixed;
+  top: 0;
+  right: 0;
+  padding: 25px;
+}

--- a/hasher-matcher-actioner/webapp/src/styles/_app.scss
+++ b/hasher-matcher-actioner/webapp/src/styles/_app.scss
@@ -13,7 +13,7 @@ div#root {
 
 .main {
   height: 100vh;
-  overflow-y:auto;
+  overflow-y: auto;
 }
 
 .action-rule-classification-column {

--- a/hasher-matcher-actioner/webapp/src/styles/_app.scss
+++ b/hasher-matcher-actioner/webapp/src/styles/_app.scss
@@ -13,4 +13,19 @@ div#root {
 
 .main {
   height: 100vh;
+  overflow-y:auto;
+}
+
+.action-rule-classification-column {
+  word-wrap: break-word;
+  max-width: 250px;
+}
+
+.ion-icon-white {
+  color: white;
+}
+
+.table-action-button {
+  display: block;
+  margin: auto;
 }


### PR DESCRIPTION
Summary
---------

This PR introduces a first draft of the Action Rules (in Settings). 

This PR is organized as a "stacked diff". It's easiest to review per commit:

1. Added the concept of a route at the tab level so that page refreshes don't go back to the default tab.
2. Added the Action Rules tab without any real functionality (just getting the main component in place).
3. Added the main functionality: a table with the rules configured so far; the ability to add a rule; editing and deleting a rule is mocked (incomplete functionality).
4. Added validation: Name required and must be unique; Labeled As required; Action required.
5. (skip - just fixing formatting)
6. Added delete functionality.
7. Added edit functionality.

Test Plan
---------

Run the web app, navigate to Settings --> Action Rules then exercise the UI. You should see what's captured in the attached video.

https://user-images.githubusercontent.com/8974354/116909103-b79eef00-ac11-11eb-933a-28e7bab014f0.mp4


