### PR TITLE
[hma] enable naive url upload to submit api

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -142,3 +142,5 @@ def get_submit_api(
                 content_id=request.content_id,
                 message="submission_type not yet supported",
             )
+
+    return submit_api

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -96,7 +96,7 @@ def get_submit_api(
         assert isinstance(request, SubmitContentRequestBody)
         logger.debug(f"Content Submit Request Received {request.content_id}")
 
-        if request.submission_type == "UPLOAD":
+        if request.submission_type == SubmissionType.UPLOAD.name:
             fileName = request.content_id
             fileContents = base64.b64decode(request.content_ref)
             # TODO a whole bunch more validation and error checking...
@@ -109,7 +109,7 @@ def get_submit_api(
             return SubmitContentResponse(
                 content_id=request.content_id, submit_successful=True
             )
-        elif request.submission_type == "URL":
+        elif request.submission_type == SubmissionType.URL.name:
             fileName = request.content_id
             url = request.content_ref
             response = requests.get(url)

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -19,6 +19,7 @@ s3_client = boto3.client("s3")
 dynamodb = boto3.resource("dynamodb")
 
 
+# TODO use enum in storage class
 class SubmissionType(Enum):
     UPLOAD = "Direct Upload"
     URL = "URL"
@@ -116,8 +117,9 @@ def get_submit_api(
             if response and response.content:
                 # TODO a whole bunch more validation and error checking...
 
-                # Right now this make a local copy in s3, future changes to pdq_hasher
-                # should allow us to avoid storing to our own s3 bucket (or possibly give the user the option)
+                # Right now this makes a local copy in s3 but future changes to
+                # pdq_hasher should allow us to avoid storing to our own s3 bucket
+                # (or possibly give the api/user the option)
                 s3_client.put_object(
                     Body=response.content,
                     Bucket=image_bucket_key,

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -3,10 +3,12 @@
 import bottle
 import boto3
 import base64
-import json
+import requests
 
+from enum import Enum
 from dataclasses import dataclass, asdict
 from mypy_boto3_dynamodb.service_resource import Table
+from botocore.exceptions import ClientError
 import typing as t
 
 from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
@@ -15,6 +17,13 @@ from hmalib.common.logging import get_logger
 logger = get_logger(__name__)
 s3_client = boto3.client("s3")
 dynamodb = boto3.resource("dynamodb")
+
+
+class SubmissionType(Enum):
+    UPLOAD = "Direct Upload"
+    URL = "URL"
+    RAW = "Raw Value (example only)"
+    S3_OBJECT = "S3 Object (example only)"
 
 
 @dataclass
@@ -99,12 +108,35 @@ def get_submit_api(
             return SubmitContentResponse(
                 content_id=request.content_id, submit_successful=True
             )
+        elif request.submission_type == "URL":
+            fileName = request.content_id
+            url = request.content_ref
+            response = requests.get(url)
+            # TODO better checks that the URL actually worked...
+            if response and response.content:
+                # TODO a whole bunch more validation and error checking...
 
-        # Other possible submission types are not supported so just echo content_id for testing
-        bottle.response.status = 422
-        return SubmitContentError(
-            content_id=request.content_id,
-            message="submission_type not yet supported",
-        )
+                # Right now this make a local copy in s3, future changes to pdq_hasher
+                # should allow us to avoid storing to our own s3 bucket (or possibly give the user the option)
+                s3_client.put_object(
+                    Body=response.content,
+                    Bucket=image_bucket_key,
+                    Key=f"{image_folder_key}{fileName}",
+                )
 
-    return submit_api
+                return SubmitContentResponse(
+                    content_id=request.content_id, submit_successful=True
+                )
+            else:
+                bottle.response.status = 400
+                return SubmitContentError(
+                    content_id=request.content_id,
+                    message="url submitted could not be read from",
+                )
+        else:
+            # Other possible submission types are not supported so just echo content_id for testing
+            bottle.response.status = 422
+            return SubmitContentError(
+                content_id=request.content_id,
+                message="submission_type not yet supported",
+            )

--- a/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
@@ -109,8 +109,8 @@ export default function SubmitContent() {
               <h1>Submit Content</h1>
               <p>Provide content to the HMA system to match against.</p>
               <p>
-                Currently only <b>images</b> with Submisson Type -{' '}
-                <b>Direct Upload</b> is supported. URL support comming soon(tm).
+                Currently only <b>images</b> using the submisson type{' '}
+                <b>Direct Upload</b> or <b>URL</b> are supported.
               </p>
             </div>
             <div className="px-4 py-2" />
@@ -152,6 +152,21 @@ export default function SubmitContent() {
                 />
               )}
 
+              {submissionType === SUBMISSION_TYPE.URL && (
+                <Form.Group>
+                  <Form.Label>Provide a URL to the content</Form.Label>
+                  <Form.Control
+                    onChange={handleInputChange}
+                    name="contentRef"
+                    placeholder="presigned url"
+                    required
+                  />
+                  <Form.Text className="text-muted mt-0">
+                    Currently behavior will store a copy of the content
+                  </Form.Text>
+                </Form.Group>
+              )}
+
               {submissionType === SUBMISSION_TYPE.RAW && (
                 <NotYetSupportedField
                   label="Provide content as raw string"
@@ -162,13 +177,6 @@ export default function SubmitContent() {
               {submissionType === SUBMISSION_TYPE.S3_OBJECT && (
                 <NotYetSupportedField
                   label="Existing S3 Object Name"
-                  handleInputChange={handleInputChange}
-                />
-              )}
-
-              {submissionType === SUBMISSION_TYPE.URL && (
-                <NotYetSupportedField
-                  label="Provide a URL to the content"
                   handleInputChange={handleInputChange}
                 />
               )}
@@ -187,7 +195,9 @@ export default function SubmitContent() {
                 className="ml-3"
                 variant="primary"
                 disabled={
-                  submitting || submissionType !== SUBMISSION_TYPE.UPLOAD
+                  submitting ||
+                  submissionType === SUBMISSION_TYPE.RAW ||
+                  submissionType === SUBMISSION_TYPE.S3_OBJECT
                 }
                 type="submit">
                 Submit

--- a/hasher-matcher-actioner/webapp/src/utils/constants.jsx
+++ b/hasher-matcher-actioner/webapp/src/utils/constants.jsx
@@ -18,9 +18,10 @@ export const PENDING_OPINION_CHANGE = Object.freeze({
   NONE: 'none',
 });
 
+// Corseponds  SubmissionType in hmalib/api/submit.py
 export const SUBMISSION_TYPE = Object.freeze({
   UPLOAD: 'Direct Upload',
+  URL: 'URL',
   RAW: 'Raw Value (example only)',
   S3_OBJECT: 'S3 Object (example only)',
-  URL: 'URL (example only)',
 });


### PR DESCRIPTION
Summary
---------

#536 Added upload file. This PR follow the same path but has the API pull filecontents from a url and store it in s3.

Test Plan
---------

https://user-images.githubusercontent.com/7664526/116917105-39941580-ac1c-11eb-8fe4-2fce2c42b269.mov

