### PR TITLE
add copydays link

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/ThreatExchangePrivacyGroupCard.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/ThreatExchangePrivacyGroupCard.jsx
@@ -40,12 +40,22 @@ export default function ThreatExchangePrivacyGroupCard({
           </Card.Subtitle>
           <Card.Body className="text-left">
             <Form>
+              {privacyGroupId === 258601789084078 ||
+              privacyGroupId === 303636684709969 ? (
+                <a
+                  href="https://lear.inrialpes.fr/~jegou/data.php#copydays"
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  Copydays
+                </a>
+              ) : null}
               <Form.Switch
                 onChange={onSwitchFetcherActive}
                 id={`fetcherActiveSwitch${privacyGroupId}`}
                 label="Fetcher Active"
                 checked={localFetcherActive}
                 disabled={!inUse}
+                style={{marginTop: 10}}
               />
               <Form.Switch
                 onChange={onSwitchWriteBack}


### PR DESCRIPTION
Summary
---------
previous PR : https://github.com/facebook/ThreatExchange/pull/516 , https://github.com/facebook/ThreatExchange/pull/544, https://github.com/facebook/ThreatExchange/pull/546
Task : T88063259
     this task is to create ThreatExchange setting page.
     this PR is to add copydays link  

Future Actions
---------
 1. Change buttons to icons and adding more tooltips
 2. Add copy text feature for privacy group name(currently has style conflict, might need to rewrite "CopyableTextField" module later)
 3. Add matcher active feature to disable matching from privacy group level 

Test Plan
---------
test localhost UI changes
  copydays link should be there only for 258601789084078 and 303636684709969

https://user-images.githubusercontent.com/81996660/117063877-70892a80-acf3-11eb-8b86-4d8e0cd9e519.mov

