### PR TITLE
Add description matcher active hmaconfig

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/fetcher_models.py
+++ b/hasher-matcher-actioner/hmalib/common/fetcher_models.py
@@ -17,8 +17,10 @@ class ThreatExchangeConfig(HMAConfig):
     # TODO - consider hiding name field and always populating with ID
     fetcher_active: bool
     privacy_group_name: str
+    description: str
     in_use: bool
     write_back: bool
+    matcher_active: bool
 
     @property
     def privacy_group_id(self) -> int:

--- a/hasher-matcher-actioner/hmalib/common/tests/test_writebacker.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_writebacker.py
@@ -29,8 +29,12 @@ class WritebackerTestCase(unittest.TestCase):
     # Writebacks are enabled for the trustworth privacy group not for
     # the untrustworthy one
     configs = [
-        ThreatExchangeConfig("pg 4", True, "Trustworthy PG", True, True),
-        ThreatExchangeConfig("pg 3", True, "UnTrustworthy PG", True, False),
+        ThreatExchangeConfig(
+            "pg 4", True, "Trustworthy PG", "test description", True, True, True
+        ),
+        ThreatExchangeConfig(
+            "pg 3", True, "UnTrustworthy PG", "test description", True, True, False
+        ),
     ]
 
     for config in configs:

--- a/hasher-matcher-actioner/hmalib/common/tests/test_writebacker.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_writebacker.py
@@ -33,7 +33,7 @@ class WritebackerTestCase(unittest.TestCase):
             "pg 4", True, "Trustworthy PG", "test description", True, True, True
         ),
         ThreatExchangeConfig(
-            "pg 3", True, "UnTrustworthy PG", "test description", True, True, False
+            "pg 3", True, "UnTrustworthy PG", "test description", True, False, True
         ),
     ]
 

--- a/hasher-matcher-actioner/hmalib/common/threatexchange_config.py
+++ b/hasher-matcher-actioner/hmalib/common/threatexchange_config.py
@@ -23,8 +23,7 @@ def sync_privacy_groups():
     api = ThreatExchangeAPI(api_key)
     privacy_group_member_list = api.get_threat_privacy_groups_member()
     privacy_group_owner_list = api.get_threat_privacy_groups_owner()
-    unique_privacy_groups = set(
-        privacy_group_member_list + privacy_group_owner_list)
+    unique_privacy_groups = set(privacy_group_member_list + privacy_group_owner_list)
     priavcy_group_id_in_use = set()
 
     for privacy_group in unique_privacy_groups:

--- a/hasher-matcher-actioner/hmalib/common/threatexchange_config.py
+++ b/hasher-matcher-actioner/hmalib/common/threatexchange_config.py
@@ -13,9 +13,9 @@ from hmalib.common.fetcher_models import ThreatExchangeConfig
 from botocore.exceptions import ClientError
 
 logger = get_logger(__name__)
-FETCHER_ACTIVE = True
-WRITE_BACK = True
-MATCHER_ACTIVE = True
+FETCHER_ACTIVE_DEFAULT = True
+WRITE_BACK_DEFAULT = True
+MATCHER_ACTIVE_DEFAULT = True
 
 
 def sync_privacy_groups():
@@ -37,12 +37,12 @@ def sync_privacy_groups():
                 privacy_group.id,
                 # TODO Currently default to True for testing purpose,
                 # need to switch it to False before v0 launch
-                fetcher_active=FETCHER_ACTIVE,
+                fetcher_active=FETCHER_ACTIVE_DEFAULT,
                 privacy_group_name=privacy_group.name,
                 in_use=True,
                 description=privacy_group.description,
-                matcher_active=MATCHER_ACTIVE,
-                write_back=WRITE_BACK,
+                matcher_active=MATCHER_ACTIVE_DEFAULT,
+                write_back=WRITE_BACK_DEFAULT,
             )
             try:
                 hmaconfig.create_config(config)

--- a/hasher-matcher-actioner/hmalib/lambdas/api/datasets_api.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/datasets_api.py
@@ -108,8 +108,7 @@ def get_datasets_api(hma_config_table: str) -> bottle.Bottle:
         """
         collabs = ThreatExchangeConfig.get_all()
         return DatasetsResponse(
-            datasets_response=[Dataset.from_collab(
-                collab) for collab in collabs]
+            datasets_response=[Dataset.from_collab(collab) for collab in collabs]
         )
 
     @datasets_api.post("/update", apply=[jsoninator(UpdateDatasetRequest)])

--- a/hasher-matcher-actioner/hmalib/lambdas/api/datasets_api.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/datasets_api.py
@@ -17,7 +17,9 @@ from hmalib.common.threatexchange_config import sync_privacy_groups
 class Dataset(JSONifiable):
     privacy_group_id: int
     privacy_group_name: str
+    description: str
     fetcher_active: bool
+    matcher_active: bool
     write_back: bool
     in_use: bool
 
@@ -29,7 +31,9 @@ class Dataset(JSONifiable):
         return cls(
             int(d["privacy_group_id"]),
             d["privacy_group_name"],
+            d["description"],
             d["fetcher_active"],
+            d["matcher_active"],
             d["write_back"],
             d["in_use"],
         )
@@ -39,7 +43,9 @@ class Dataset(JSONifiable):
         return cls(
             collab.privacy_group_id,
             collab.privacy_group_name,
+            collab.description,
             collab.fetcher_active,
+            collab.matcher_active,
             collab.write_back,
             collab.in_use,
         )
@@ -77,6 +83,7 @@ class DeleteDatasetResponse(JSONifiable):
 class UpdateDatasetRequest(DictParseable):
     privacy_group_id: int
     fetcher_active: bool
+    matcher_active: bool
     write_back: bool
 
     @classmethod
@@ -84,6 +91,7 @@ class UpdateDatasetRequest(DictParseable):
         return cls(
             d["privacy_group_id"],
             d["fetcher_active"],
+            d["matcher_active"],
             d["write_back"],
         )
 
@@ -100,17 +108,19 @@ def get_datasets_api(hma_config_table: str) -> bottle.Bottle:
         """
         collabs = ThreatExchangeConfig.get_all()
         return DatasetsResponse(
-            datasets_response=[Dataset.from_collab(collab) for collab in collabs]
+            datasets_response=[Dataset.from_collab(
+                collab) for collab in collabs]
         )
 
     @datasets_api.post("/update", apply=[jsoninator(UpdateDatasetRequest)])
     def update_dataset(request: UpdateDatasetRequest) -> Dataset:
         """
-        Update dataset fetcher_active and write_back
+        Update dataset fetcher_active, write_back and matcher_active
         """
         config = ThreatExchangeConfig.getx(str(request.privacy_group_id))
         config.fetcher_active = request.fetcher_active
         config.write_back = request.write_back
+        config.matcher_active = request.matcher_active
         updated_config = hmaconfig.update_config(config).__dict__
         updated_config["privacy_group_id"] = updated_config["name"]
         return Dataset.from_dict(updated_config)

--- a/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
+++ b/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
@@ -82,6 +82,8 @@ def load_defaults(_args):
             privacy_group_name="Test Config 1",
             write_back=True,
             in_use=True,
+            description="test description",
+            matcher_active=True,
         ),
         ThreatExchangeConfig(
             name="258601789084078",
@@ -89,6 +91,8 @@ def load_defaults(_args):
             privacy_group_name="Test Config 2",
             write_back=True,
             in_use=True,
+            description="test description",
+            matcher_active=True,
         ),
         WebhookPostActionPerformer(
             name="EnqueueForReview",
@@ -176,7 +180,10 @@ if __name__ == "__main__":
             elif field.type is bool:
                 parse_type = better_bool_type
             elif field.type in (t.Set[str], t.List[str]):
-                parse_type = lambda x: set(x.split(","))
+
+                def parse_type(x):
+                    return set(x.split(","))
+
             else:
                 raise Exception(f"Unsupported type in config: {field.type}")
             arg = field.name

--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -146,10 +146,16 @@ export function deleteDataset(key) {
   return apiPost(`/datasets/delete/${key}`);
 }
 
-export function updateDataset(privacyGroupId, fetcherActive, writeBack) {
+export function updateDataset(
+  privacyGroupId,
+  fetcherActive,
+  writeBack,
+  matcherActive,
+) {
   return apiPost('/datasets/update', {
     privacy_group_id: privacyGroupId,
     fetcher_active: fetcherActive,
     write_back: writeBack,
+    matcher_active: matcherActive,
   });
 }

--- a/hasher-matcher-actioner/webapp/src/components/ThreatExchangePrivacyGroupCard.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/ThreatExchangePrivacyGroupCard.jsx
@@ -1,13 +1,22 @@
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {Col, Button, Form, Card} from 'react-bootstrap';
+import {
+  Col,
+  Button,
+  Form,
+  Card,
+  OverlayTrigger,
+  Popover,
+} from 'react-bootstrap';
 import {CopyableTextField} from '../utils/TextFieldsUtils';
 
 export default function ThreatExchangePrivacyGroupCard({
   fetcherActive,
+  matcherActive,
   inUse,
   privacyGroupId,
   privacyGroupName,
+  description,
   writeBack,
   onSave,
   onDelete,
@@ -16,13 +25,20 @@ export default function ThreatExchangePrivacyGroupCard({
     fetcherActive,
   );
   const [originalWriteBack, setOriginalWriteBack] = useState(writeBack);
+  const [originalMatcherActive, setOriginalMatcherActive] = useState(
+    matcherActive,
+  );
   const [localFetcherActive, setLocalFetcherActive] = useState(fetcherActive);
   const [localWriteBack, setLocalWriteBack] = useState(writeBack);
+  const [localMatcherActive, setLocalMatcherActive] = useState(matcherActive);
   const onSwitchFetcherActive = () => {
     setLocalFetcherActive(!localFetcherActive);
   };
   const onSwitchWriteBack = () => {
     setLocalWriteBack(!localWriteBack);
+  };
+  const onSwitchMatcherActive = () => {
+    setLocalMatcherActive(!localMatcherActive);
   };
 
   return (
@@ -40,15 +56,17 @@ export default function ThreatExchangePrivacyGroupCard({
           </Card.Subtitle>
           <Card.Body className="text-left">
             <Form>
-              {privacyGroupId === 258601789084078 ||
-              privacyGroupId === 303636684709969 ? (
-                <a
-                  href="https://lear.inrialpes.fr/~jegou/data.php#copydays"
-                  target="_blank"
-                  rel="noopener noreferrer">
-                  Copydays
-                </a>
-              ) : null}
+              <OverlayTrigger
+                trigger="click"
+                placement="right"
+                overlay={
+                  <Popover id={`popover-basic${privacyGroupId}`}>
+                    <Popover.Title as="h3">Information</Popover.Title>
+                    <Popover.Content>{description}</Popover.Content>
+                  </Popover>
+                }>
+                <Button variant="info">more info</Button>
+              </OverlayTrigger>
               <Form.Switch
                 onChange={onSwitchFetcherActive}
                 id={`fetcherActiveSwitch${privacyGroupId}`}
@@ -56,6 +74,13 @@ export default function ThreatExchangePrivacyGroupCard({
                 checked={localFetcherActive}
                 disabled={!inUse}
                 style={{marginTop: 10}}
+              />
+              <Form.Switch
+                onChange={onSwitchMatcherActive}
+                id={`matcherSwitch${privacyGroupId}`}
+                label="Matcher Active"
+                checked={localMatcherActive}
+                disabled={!inUse}
               />
               <Form.Switch
                 onChange={onSwitchWriteBack}
@@ -68,17 +93,20 @@ export default function ThreatExchangePrivacyGroupCard({
           </Card.Body>
           <Card.Footer>
             {localWriteBack === originalWriteBack &&
-            localFetcherActive === originalFetcherActive ? null : (
+            localFetcherActive === originalFetcherActive &&
+            localMatcherActive === originalMatcherActive ? null : (
               <div>
                 <Button
                   variant="primary"
                   onClick={() => {
                     setOriginalFetcherActive(localFetcherActive);
                     setOriginalWriteBack(localWriteBack);
+                    setOriginalMatcherActive(localMatcherActive);
                     onSave({
                       privacyGroupId,
                       localFetcherActive,
                       localWriteBack,
+                      localMatcherActive,
                     });
                   }}>
                   Save
@@ -105,9 +133,11 @@ export default function ThreatExchangePrivacyGroupCard({
 
 ThreatExchangePrivacyGroupCard.propTypes = {
   fetcherActive: PropTypes.bool.isRequired,
+  matcherActive: PropTypes.bool.isRequired,
   inUse: PropTypes.bool.isRequired,
   privacyGroupId: PropTypes.number.isRequired,
   privacyGroupName: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
   writeBack: PropTypes.bool.isRequired,
   onSave: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,

--- a/hasher-matcher-actioner/webapp/src/components/ThreatExchangePrivacyGroupCard.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/ThreatExchangePrivacyGroupCard.jsx
@@ -56,17 +56,19 @@ export default function ThreatExchangePrivacyGroupCard({
           </Card.Subtitle>
           <Card.Body className="text-left">
             <Form>
-              <OverlayTrigger
-                trigger="click"
-                placement="right"
-                overlay={
-                  <Popover id={`popover-basic${privacyGroupId}`}>
-                    <Popover.Title as="h3">Information</Popover.Title>
-                    <Popover.Content>{description}</Popover.Content>
-                  </Popover>
-                }>
-                <Button variant="info">more info</Button>
-              </OverlayTrigger>
+              <div style={{display: 'flex', justifyContent: 'flex-end'}}>
+                <OverlayTrigger
+                  trigger="click"
+                  placement="bottom"
+                  overlay={
+                    <Popover id={`popover-basic${privacyGroupId}`}>
+                      <Popover.Title as="h3">Information</Popover.Title>
+                      <Popover.Content>{description}</Popover.Content>
+                    </Popover>
+                  }>
+                  <Button variant="info">more info</Button>
+                </OverlayTrigger>
+              </div>
               <Form.Switch
                 onChange={onSwitchFetcherActive}
                 id={`fetcherActiveSwitch${privacyGroupId}`}

--- a/hasher-matcher-actioner/webapp/src/components/ThreatExchangePrivacyGroupCard.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/ThreatExchangePrivacyGroupCard.jsx
@@ -40,12 +40,22 @@ export default function ThreatExchangePrivacyGroupCard({
           </Card.Subtitle>
           <Card.Body className="text-left">
             <Form>
+              {privacyGroupId === 258601789084078 ||
+              privacyGroupId === 303636684709969 ? (
+                <a
+                  href="https://lear.inrialpes.fr/~jegou/data.php#copydays"
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  Copydays
+                </a>
+              ) : null}
               <Form.Switch
                 onChange={onSwitchFetcherActive}
                 id={`fetcherActiveSwitch${privacyGroupId}`}
                 label="Fetcher Active"
                 checked={localFetcherActive}
                 disabled={!inUse}
+                style={{marginTop: 10}}
               />
               <Form.Switch
                 onChange={onSwitchWriteBack}

--- a/hasher-matcher-actioner/webapp/src/settings/ThreatExchangeSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/settings/ThreatExchangeSettingsTab.jsx
@@ -31,6 +31,7 @@ export default function ThreatExchangeSettingsTab() {
       privacyGroup.privacyGroupId,
       privacyGroup.localFetcherActive,
       privacyGroup.localWriteBack,
+      privacyGroup.localMatcherActive,
     )
       .then(response => {
         setToastBody('Changes are saved!');
@@ -137,7 +138,9 @@ export default function ThreatExchangeSettingsTab() {
                 <ThreatExchangePrivacyGroupCard
                   key={dataset.privacy_group_id}
                   privacyGroupName={dataset.privacy_group_name}
+                  description={dataset.description}
                   fetcherActive={dataset.fetcher_active}
+                  matcherActive={dataset.matcher_active}
                   inUse={dataset.in_use}
                   privacyGroupId={dataset.privacy_group_id}
                   writeBack={dataset.write_back}


### PR DESCRIPTION
Summary
---------
previous PR : https://github.com/facebook/ThreatExchange/pull/516 , https://github.com/facebook/ThreatExchange/pull/544, https://github.com/facebook/ThreatExchange/pull/546
Task : T88063259
     this task is to create ThreatExchange setting page.
     this PR is to add two fields, matcher_active and privacy group description 

Future Actions
---------
 1. Change buttons to icons and adding more tooltips
 2. Add copy text feature for privacy group name(currently has style conflict, might need to rewrite "CopyableTextField" module later)
 3. use matcher_active to disable matching  
 4. update description to add copydays link

Test Plan
---------
1. black hmalib
2. mypy hmalib
3. python -m py.test to pass all tests
4. make docker
5. make upload_docker 
6. terraform apply
7. test get/update/sync/delete api for matcher_active and description

https://user-images.githubusercontent.com/81996660/117205046-148bd800-adbf-11eb-9477-794e540d946c.mov


