### PR TITLE
use matcher_active to pause on matching, use dompurify to sanitize innerHTML

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
@@ -15,6 +15,8 @@ from hmalib.models import PDQMatchRecord
 from hmalib.common.message_models import BankedSignal, MatchMessage
 from hmalib.common.signal_models import PDQSignalMetadata
 from hmalib.common.logging import get_logger
+from hmalib.common.config import HMAConfig
+from hmalib.common.fetcher_models import ThreatExchangeConfig
 
 logger = get_logger(__name__)
 s3_client = boto3.client("s3")
@@ -29,6 +31,8 @@ PDQ_INDEX_KEY = os.environ["PDQ_INDEX_KEY"]
 OUTPUT_TOPIC_ARN = os.environ["PDQ_MATCHES_TOPIC_ARN"]
 
 DYNAMODB_TABLE = os.environ["DYNAMODB_TABLE"]
+HMA_CONFIG_TABLE = os.environ["HMA_CONFIG_TABLE"]
+HMAConfig.initialize(HMA_CONFIG_TABLE)
 
 
 def get_index(bucket_name, key):
@@ -44,6 +48,14 @@ def get_index(bucket_name, key):
         result = pickle.load(open(LOCAL_INDEX_FILENAME, "rb"))
 
     return result
+
+
+def get_privacy_group_matcher_active(privacy_group_id: str) -> bool:
+    config = ThreatExchangeConfig.get(privacy_group_id)
+    if not config:
+        return True
+    logger.info("matcher_active for %s is %s", privacy_group_id, config.matcher_active)
+    return config.matcher_active
 
 
 def lambda_handler(event, context):
@@ -87,6 +99,11 @@ def lambda_handler(event, context):
                 metadata = match.metadata
                 logger.info(
                     "Match found for key: %s, hash %s -> %s", key, hash_str, metadata
+                )
+                privacy_group_list = metadata.get("privacy_groups", [])
+                metadata["privacy_groups"] = filter(
+                    lambda x: get_privacy_group_matcher_active(str(x)),
+                    privacy_group_list,
                 )
                 signal_id = metadata["id"]
 

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -103,6 +103,7 @@ module "pdq_signals" {
   log_retention_in_days = var.log_retention_in_days
   additional_tags       = merge(var.additional_tags, local.common_tags)
   measure_performance   = var.measure_performance
+  config_table          = local.config_table
 }
 
 module "fetcher" {

--- a/hasher-matcher-actioner/terraform/pdq-signals/main.tf
+++ b/hasher-matcher-actioner/terraform/pdq-signals/main.tf
@@ -80,8 +80,8 @@ resource "aws_iam_role" "pdq_indexer" {
 
 data "aws_iam_policy_document" "pdq_indexer" {
   statement {
-    effect    = "Allow"
-    actions   = [
+    effect = "Allow"
+    actions = [
       "s3:GetObject",
     ]
     resources = [
@@ -89,8 +89,8 @@ data "aws_iam_policy_document" "pdq_indexer" {
     ]
   }
   statement {
-    effect    = "Allow"
-    actions   = [
+    effect = "Allow"
+    actions = [
       "s3:ListBucket"
     ]
     resources = [
@@ -282,6 +282,7 @@ resource "aws_lambda_function" "pdq_matcher" {
       DYNAMODB_TABLE        = var.datastore.name
       MEASURE_PERFORMANCE   = var.measure_performance ? "True" : "False"
       METRICS_NAMESPACE     = var.metrics_namespace
+      HMA_CONFIG_TABLE      = var.config_table.name
     }
   }
   tags = merge(
@@ -348,6 +349,12 @@ data "aws_iam_policy_document" "pdq_matcher" {
     effect    = "Allow"
     actions   = ["cloudwatch:PutMetricData"]
     resources = ["*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan"]
+    resources = [var.config_table.arn]
   }
 }
 

--- a/hasher-matcher-actioner/terraform/pdq-signals/variables.tf
+++ b/hasher-matcher-actioner/terraform/pdq-signals/variables.tf
@@ -90,3 +90,11 @@ variable "metrics_namespace" {
   type        = string
   default     = "ThreatExchange/HMA"
 }
+
+variable "config_table" {
+  description = "The name and arn of the DynamoDB table used for persisting configs."
+  type = object({
+    arn  = string
+    name = string
+  })
+}

--- a/hasher-matcher-actioner/webapp/package-lock.json
+++ b/hasher-matcher-actioner/webapp/package-lock.json
@@ -17,6 +17,7 @@
         "classnames": "^2.3.1",
         "clipboard-copy": "^4.0.1",
         "date-fns": "^2.21.0",
+        "dompurify": "^2.2.8",
         "node-sass": "^5.0.0",
         "prop-types": "^15.7.2",
         "react": "^17.0.1",
@@ -10011,6 +10012,11 @@
       "dependencies": {
         "domelementtype": "1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.8.tgz",
+      "integrity": "sha512-9H0UL59EkDLgY3dUFjLV6IEUaHm5qp3mxSqWw7Yyx4Zhk2Jn2cmLe+CNPP3xy13zl8Bqg+0NehQzkdMoVhGRww=="
     },
     "node_modules/domutils": {
       "version": "1.7.0",
@@ -35512,6 +35518,11 @@
       "requires": {
         "domelementtype": "1"
       }
+    },
+    "dompurify": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.8.tgz",
+      "integrity": "sha512-9H0UL59EkDLgY3dUFjLV6IEUaHm5qp3mxSqWw7Yyx4Zhk2Jn2cmLe+CNPP3xy13zl8Bqg+0NehQzkdMoVhGRww=="
     },
     "domutils": {
       "version": "1.7.0",

--- a/hasher-matcher-actioner/webapp/package.json
+++ b/hasher-matcher-actioner/webapp/package.json
@@ -13,6 +13,7 @@
     "classnames": "^2.3.1",
     "clipboard-copy": "^4.0.1",
     "date-fns": "^2.21.0",
+    "dompurify": "^2.2.8",
     "node-sass": "^5.0.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",

--- a/hasher-matcher-actioner/webapp/src/components/ThreatExchangePrivacyGroupCard.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/ThreatExchangePrivacyGroupCard.jsx
@@ -8,6 +8,7 @@ import {
   OverlayTrigger,
   Popover,
 } from 'react-bootstrap';
+import DOMPurify from 'dompurify';
 import {CopyableTextField} from '../utils/TextFieldsUtils';
 
 export default function ThreatExchangePrivacyGroupCard({
@@ -47,9 +48,11 @@ export default function ThreatExchangePrivacyGroupCard({
         <Card className="text-center">
           <Card.Header
             className={
-              inUse ? 'text-white bg-success' : 'text-white bg-secondary'
+              inUse ? 'text-white bg-primary' : 'text-white bg-secondary'
             }>
-            <h4 className="mb-0">{privacyGroupName}</h4>
+            <h4 className="mb-0">
+              <CopyableTextField text={privacyGroupName} color="white" />
+            </h4>
           </Card.Header>
           <Card.Subtitle className="mt-2 mb-2 text-muted">
             <CopyableTextField text={privacyGroupId} />
@@ -63,7 +66,15 @@ export default function ThreatExchangePrivacyGroupCard({
                   overlay={
                     <Popover id={`popover-basic${privacyGroupId}`}>
                       <Popover.Title as="h3">Information</Popover.Title>
-                      <Popover.Content>{description}</Popover.Content>
+                      <Popover.Content>
+                        <div
+                          dangerouslySetInnerHTML={{
+                            __html: DOMPurify.sanitize(`${description}`, {
+                              ADD_ATTR: ['target'],
+                            }),
+                          }}
+                        />
+                      </Popover.Content>
                     </Popover>
                   }>
                   <Button variant="info">more info</Button>

--- a/hasher-matcher-actioner/webapp/src/utils/TextFieldsUtils.jsx
+++ b/hasher-matcher-actioner/webapp/src/utils/TextFieldsUtils.jsx
@@ -34,7 +34,7 @@ const UpdatingPopover = React.forwardRef(
 );
 
 // eslint-disable-next-line react/prop-types
-export function CopyableTextField({text, tooltip}) {
+export function CopyableTextField({text, tooltip, color}) {
   const helpText = tooltip ?? 'Copy to clipboard?';
   const [message, setMessage] = useState(helpText);
 
@@ -52,8 +52,9 @@ export function CopyableTextField({text, tooltip}) {
     display: 'inline',
     margin: 0,
     padding: 0,
+    color: color ?? 'black',
     hover: {},
-    maxWidth: '245px',
+    maxWidth: '250px',
     overflow: 'hidden',
     focus: {
       textDecoration: 'none',


### PR DESCRIPTION
Summary
---------
previous PR : https://github.com/facebook/ThreatExchange/pull/516 , https://github.com/facebook/ThreatExchange/pull/544
Task : T88063259
     this task is to create ThreatExchange setting page.
     this PR is to do following things:
1. use dompurify to sanitize privacy description which contains HTML tags
2. use matcher_active to pause on matching 
3. Add copy text feature for privacy group name

Future Actions 
---------
 1.Change buttons to icons and adding more tooltips
 2. add last_updated field to HMAConfig table

Test Plan
---------
1. black hmalib
2. mypy hmalib
3. python -m py.test to pass all tests
5. make docker
6. make upload_docker 
7.  terraform apply
Test changes in localhost:
1. test if copy feature works
2. test if description links are working
3. test turn on and off matcher_active


https://user-images.githubusercontent.com/81996660/117511154-489c0000-af5b-11eb-9d0f-ba9a40b48770.mp4

