### PR TITLE
Copydays information block in ThreatExchange settings page

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/CopydaysInformationBlock.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/CopydaysInformationBlock.jsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React from 'react';
+import {Card} from 'react-bootstrap';
+
+/**
+ * Super simple informational component. Drop in anywhere.
+ */
+export default function CopydaysInformationBlock() {
+  return (
+    <Card bg="light" body style={{maxWidth: '720px'}}>
+      <h2>Test Photos</h2>
+      <p>
+        In addition to ThreatExchange data, HMA also comes with a set of image
+        hashes baked in. The images are from a dataset called the Copydays
+        dataset. Go to{' '}
+        <a href="https://lear.inrialpes.fr/~jegou/data.php">this page</a> and
+        find the link labeled <code>jpg1.tar.gz</code>. Any photo from that
+        archive file will match in the HMA system.
+      </p>
+    </Card>
+  );
+}

--- a/hasher-matcher-actioner/webapp/src/components/CopydaysInformationBlock.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/CopydaysInformationBlock.jsx
@@ -15,11 +15,21 @@ export default function CopydaysInformationBlock() {
       <p>
         In addition to ThreatExchange data, HMA also comes with a set of image
         hashes baked in. The images are from a dataset called the Copydays
-        dataset. Go to{' '}
-        <a href="https://lear.inrialpes.fr/~jegou/data.php">this page</a> and
-        find the link labeled <code>jpg1.tar.gz</code>. Any photo from that
-        archive file will match in the HMA system.
+        dataset.
       </p>
+
+      <ul>
+        <li>
+          Go to{' '}
+          <a href="https://lear.inrialpes.fr/~jegou/data.php">this page</a> and
+          find the link labeled <code>jpg1.tar.gz</code>. Any photo from that
+          archive file will match in the HMA system.
+        </li>
+        <li>
+          The matched photos will have a privacy group of{' '}
+          <code>copydays-test</code>.
+        </li>
+      </ul>
     </Card>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/components/HolidaysDatasetInformationBlock.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/HolidaysDatasetInformationBlock.jsx
@@ -8,26 +8,28 @@ import {Card} from 'react-bootstrap';
 /**
  * Super simple informational component. Drop in anywhere.
  */
-export default function CopydaysInformationBlock() {
+export default function HolidaysDatasetInformationBlock() {
   return (
     <Card bg="light" body style={{maxWidth: '720px'}}>
       <h2>Test Photos</h2>
       <p>
         In addition to ThreatExchange data, HMA also comes with a set of image
-        hashes baked in. The images are from a dataset called the Copydays
+        hashes baked in. The images are from a dataset called the INRIA Holidays
         dataset.
       </p>
 
       <ul>
         <li>
           Go to{' '}
-          <a href="https://lear.inrialpes.fr/~jegou/data.php">this page</a> and
-          find the link labeled <code>jpg1.tar.gz</code>. Any photo from that
-          archive file will match in the HMA system.
+          <a href="https://lear.inrialpes.fr/~jegou/data.php#holidays">
+            this page
+          </a>{' '}
+          and find the link labeled <code>jpg1.tar.gz</code>. Any photo from
+          that archive file will match in the HMA system.
         </li>
         <li>
           The matched photos will have a privacy group of{' '}
-          <code>copydays-test</code>.
+          <code>inria-holidays-test</code>.
         </li>
       </ul>
     </Card>

--- a/hasher-matcher-actioner/webapp/src/pages/Settings.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Settings.jsx
@@ -12,7 +12,7 @@ import ThreatExchangeSettingsTab from './settings/ThreatExchangeSettingsTab';
 
 // This array must include the eventKey attribute value of any Tab in Tabs as
 // a part of the implementation to give each tab its own route.
-const tabEventKeys = ['threatexchange', 'pipeline', 'actions', 'action-rules'];
+const tabEventKeys = ['threatexchange', 'actions', 'action-rules'];
 
 export default function Settings() {
   const {tab} = useParams();
@@ -30,9 +30,6 @@ export default function Settings() {
         }}>
         <Tab eventKey="threatexchange" title="ThreatExchange">
           <ThreatExchangeSettingsTab />
-        </Tab>
-        <Tab eventKey="pipeline" title="Pipeline">
-          Todo!
         </Tab>
         <Tab eventKey="actions" title="Actions">
           <ActionSettingsTab />

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.jsx
@@ -11,8 +11,10 @@ import {
   Tooltip,
   OverlayTrigger,
   Card,
+  Col,
 } from 'react-bootstrap';
 import ThreatExchangePrivacyGroupCard from '../../components/settings/ThreatExchangePrivacyGroupCard';
+import CopydaysInformationBlock from '../../components/CopydaysInformationBlock';
 import {
   fetchAllDatasets,
   syncAllDatasets,
@@ -150,6 +152,10 @@ export default function ThreatExchangeSettingsTab() {
               ))}
         </Row>
       </Card.Body>
+
+      <Col className="mx-1" md="6">
+        <CopydaysInformationBlock />
+      </Col>
     </>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.jsx
@@ -14,7 +14,7 @@ import {
   Col,
 } from 'react-bootstrap';
 import ThreatExchangePrivacyGroupCard from '../../components/settings/ThreatExchangePrivacyGroupCard';
-import CopydaysInformationBlock from '../../components/CopydaysInformationBlock';
+import HolidaysDatasetInformationBlock from '../../components/HolidaysDatasetInformationBlock';
 import {
   fetchAllDatasets,
   syncAllDatasets,
@@ -154,7 +154,7 @@ export default function ThreatExchangeSettingsTab() {
       </Card.Body>
 
       <Col className="mx-1" md="6">
-        <CopydaysInformationBlock />
+        <HolidaysDatasetInformationBlock />
       </Col>
     </>
   );


### PR DESCRIPTION
Summary
--------
Add an information block giving instructions on how to download images from copydays and use them to match.

This is 1 of 2 diffs that fixes #555 The other diff is #560 

Test Plan
---------
No python files were touched. A screenshot from the ThreatExchange settings page is attached.

<img width="1111" alt="Screen Shot 2021-05-10 at 19 58 35" src="https://user-images.githubusercontent.com/217056/117738486-21973580-b1ca-11eb-86e1-e97f7ced6423.png">

Updated the blurb to also reflect the test privacy group id.

<img width="744" alt="Screen Shot 2021-05-11 at 13 54 04" src="https://user-images.githubusercontent.com/217056/117862366-9452f000-b260-11eb-9095-8e434e18ab63.png">

