### PR TITLE
add headers to WebhookActionPerformer

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -45,6 +45,7 @@ class WebhookActionPerformer(ActionPerformer):
     """Superclass for webhooks"""
 
     url: str
+    headers: str
 
     def perform_action(self, match_message: MatchMessage) -> None:
         self.call(data=json.dumps(match_message.to_aws()))
@@ -58,7 +59,7 @@ class WebhookPostActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a POST"""
 
     def call(self, data: str) -> Response:
-        return post(self.url, data)
+        return post(self.url, data, headers=json.loads(self.headers))
 
 
 @dataclass
@@ -66,7 +67,7 @@ class WebhookGetActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a GET"""
 
     def call(self, _data: str) -> Response:
-        return get(self.url)
+        return get(self.url, headers=json.loads(self.headers))
 
 
 @dataclass
@@ -74,7 +75,7 @@ class WebhookPutActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a PUT"""
 
     def call(self, data: str) -> Response:
-        return put(self.url, data)
+        return put(self.url, data, headers=json.loads(self.headers))
 
 
 @dataclass
@@ -82,4 +83,4 @@ class WebhookDeleteActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a DELETE"""
 
     def call(self, _data: str) -> Response:
-        return delete(self.url)
+        return delete(self.url, headers=json.loads(self.headers))

--- a/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
+++ b/hasher-matcher-actioner/hmalib/scripts/populate_config_db.py
@@ -97,18 +97,21 @@ def load_defaults(_args):
         WebhookPostActionPerformer(
             name="EnqueueForReview",
             url="https://webhook.site/ff7ebc37-514a-439e-9a03-46f86989e195",
+            headers='{"Connection":"keep-alive"}',
             # monitoring page:
             # https://webhook.site/#!/ff7ebc37-514a-439e-9a03-46f86989e195
         ),
         WebhookPostActionPerformer(
             name="EnqueueMiniCastleForReview",
             url="https://webhook.site/01cef721-bdcc-4681-8430-679c75659867",
+            headers='{"Connection":"keep-alive"}',
             # monitoring page:
             # https://webhook.site/#!/01cef721-bdcc-4681-8430-679c75659867
         ),
         WebhookPostActionPerformer(
             name="EnqueueSailboatForReview",
             url="https://webhook.site/fa5c5ad5-f5cc-4692-bf03-a03a4ae3f714",
+            headers='{"Connection":"keep-alive"}',
             # monitoring page:
             # https://webhook.site/#!/fa5c5ad5-f5cc-4692-bf03-a03a4ae3f714
         ),


### PR DESCRIPTION
Summary
---------
This PR is to add "headers" to WebhookActionPerformer in DynamoDB

Future Actions
---------
 Create apis to create/update/read/delete data in DynamoDB 

Test Plan
---------

1. black hmalib
2. mypy hmalib
3. python -m py.test to pass all tests
4. delete all WebhookActionPerformer in DynamoDB, then run ```python -m hmalib.scripts.populate_config_db load_example_configs```
5. test changes in DynamoDB
![Screen Shot 2021-05-11 at 3 00 58 PM](https://user-images.githubusercontent.com/81996660/117870197-c9177500-b269-11eb-9190-b9cc03514736.png)



https://user-images.githubusercontent.com/81996660/117886542-5dd79e00-b27d-11eb-9396-59c1dd7ee692.mov

