### PR TITLE
devcontainers: update dev container to handle custom dotfiles

### DIFF
--- a/hasher-matcher-actioner/.devcontainer/Dockerfile
+++ b/hasher-matcher-actioner/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1000 developers \
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
   apt-get -y install --no-install-recommends git make jq sudo \
   software-properties-common apt-transport-https ca-certificates curl \
-  gnupg lsb-release tmux zsh
+  gnupg lsb-release tmux zsh vim
 
 # [Allow sudo] Need sudo later in post-create to open up docker socket
 ARG unixname
@@ -120,13 +120,17 @@ COPY --chown=${unixname} bashrc /home/$unixname/.bashrc
 # [Shell Histories] The volume is mounted in devcontainer.json
 ARG unixname
 RUN BASH_SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-  && ZSH_SNIPPET="export HISTFILE=/commandhistory/.zsh_history" \
+  && ZSH_SNIPPET="HISTFILE=/commandhistory/.zsh_history" \
   && mkdir -p /commandhistory \
   && touch /commandhistory/.bash_history \
   && touch /commandhistory/.zsh_history \
   && chown -R $unixname /commandhistory \
   && echo $BASH_SNIPPET >> "/home/$unixname/.bashrc" \
-  && echo $ZSH_SNIPPET >> "/home/$unixname/.zshrc"
+  && echo $ZSH_SNIPPET >> "/home/$unixname/.zshrc" \
+  && echo $ZSH_SNIPPET >> "/home/$unixname/.profile"
+# Also appends ZSH_SNIPPET to ~/.profile in case users want to overwrite zshrc file
+# e.g. https://code.visualstudio.com/docs/remote/containers#_personalizing-with-dotfile-repositories
+
 
 # [Forward Docker requests to host docker engine]
 # Volume is mounted and so is the socket. The socket configuration is within

--- a/hasher-matcher-actioner/.devcontainer/devcontainer.json
+++ b/hasher-matcher-actioner/.devcontainer/devcontainer.json
@@ -9,7 +9,20 @@
   },
   // Set *default* container specific settings.json values on container create.
   "settings": {
-    "terminal.integrated.shell.linux": "/bin/bash",
+    "terminal.integrated.profiles.linux": {
+      "bash": {
+        "path": "/bin/bash",
+        "args": [
+          "-l"
+        ]
+      },
+      "zsh": {
+        "path": "/bin/zsh",
+        "args": [
+          "-l"
+        ]
+      }
+    },
     "editor.formatOnSave": true,
     "python.formatting.blackPath": "black",
     "[javascriptreact]": {
@@ -38,6 +51,9 @@
       "label": "Hello Remote World",
       "onAutoForward": "notify"
     }
+  },
+  "remoteEnv": {
+    "IN_DEVCONTAINER": "true"
   },
   "remoteUser": "${localEnv:USER}"
 }


### PR DESCRIPTION
Summary
---------

Updates `devcontainer.json` to have support of both zsh and bash using the new prefered settings. (Users can set default for new terminal in their global settings) 

Test Plan
---------
Rebuild container and made sure apply and other dev commands still worked both for `bash` and `zsh`