### PR TITLE
Add FixedWidthCenterAlignedLayout layout and migrates some pages

### DIFF
--- a/hasher-matcher-actioner/webapp/src/App.jsx
+++ b/hasher-matcher-actioner/webapp/src/App.jsx
@@ -18,7 +18,7 @@ import ContentDetails from './pages/ContentDetails';
 import Matches from './pages/Matches';
 import Dashboard from './pages/Dashboard';
 import Settings from './pages/Settings';
-import Signals from './Signals';
+import Signals from './pages/Signals';
 import Upload from './Upload';
 import SubmitContent from './pages/SubmitContent';
 

--- a/hasher-matcher-actioner/webapp/src/Upload.jsx
+++ b/hasher-matcher-actioner/webapp/src/Upload.jsx
@@ -8,6 +8,7 @@ import {Button, Col, Collapse, Image, Row} from 'react-bootstrap';
 import Spinner from 'react-bootstrap/Spinner';
 
 import {uploadPhoto} from './Api';
+import FixedWidthCenterAlignedLayout from './pages/layouts/FixedWidthCenterAlignedLayout';
 
 export default function Upload() {
   const [fileName, setFileName] = useState('Select Browse to choose a file.');
@@ -16,8 +17,7 @@ export default function Upload() {
   const [image, setImage] = useState({preview: '', raw: ''});
 
   return (
-    <>
-      <h1>Upload</h1>
+    <FixedWidthCenterAlignedLayout title="Upload">
       <Row className="mt-3" float>
         <Col md={6}>
           Checkout WIP{' '}
@@ -95,6 +95,6 @@ export default function Upload() {
           </Collapse>
         </Col>
       </Row>
-    </>
+    </FixedWidthCenterAlignedLayout>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/pages/ContentDetails.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/ContentDetails.jsx
@@ -4,13 +4,14 @@
 
 import React, {useState, useEffect} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
-import {Col, Row, Table, Container} from 'react-bootstrap';
+import {Col, Row, Table, Button} from 'react-bootstrap';
 
 import {fetchHash, fetchImage} from '../Api';
 import {CopyableHashField} from '../utils/TextFieldsUtils';
 import {formatTimestamp} from '../utils/DateTimeUtils';
 import {BlurUntilHoverImage} from '../utils/ImageUtils';
 import ContentMatchTable from '../components/ContentMatchTable';
+import FixedWidthCenterAlignedLayout from './layouts/FixedWidthCenterAlignedLayout';
 
 export default function ContentDetails() {
   const history = useHistory();
@@ -37,14 +38,14 @@ export default function ContentDetails() {
   }, []);
 
   return (
-    <Container fluid>
-      <button
-        type="submit"
-        className="mt-4 float-right btn btn-primary"
-        onClick={() => history.goBack()}>
-        Back
-      </button>
-      <h1>Summary</h1>
+    <FixedWidthCenterAlignedLayout title="Summary">
+      <Row>
+        <Col className="mb-4">
+          <Button variant="link" href="#" onClick={() => history.goBack()}>
+            &larr; Back to Matches
+          </Button>
+        </Col>
+      </Row>
       <Row
         style={{
           minHeight: '450px',
@@ -90,6 +91,6 @@ export default function ContentDetails() {
         </Col>
       </Row>
       <ContentMatchTable contentKey={id} />
-    </Container>
+    </FixedWidthCenterAlignedLayout>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/pages/Dashboard.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Dashboard.jsx
@@ -5,7 +5,6 @@
 import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {
-  Container,
   Row,
   Col,
   Card,
@@ -19,6 +18,7 @@ import {fetchStats} from '../Api';
 import {StatNames, StatsTimeSpans} from '../utils/constants';
 import GraphWithNumberWidget from '../components/GraphWithNumberWidget';
 import shortenNumRepr from '../utils/NumberUtils';
+import FixedWidthCenterAlignedLayout from './layouts/FixedWidthCenterAlignedLayout';
 
 function getDisplayTitle(statName) {
   return (
@@ -76,11 +76,9 @@ export default function Dashboard() {
   const [timeSpan, setTimeSpan] = useState(StatsTimeSpans.HOURS_24);
 
   return (
-    <Container className="m-4">
+    <FixedWidthCenterAlignedLayout title="HMA Dashboard">
       <Row>
-        <Col
-          xs={6}
-          className="mb-4 d-flex align-items-baseline justify-content-end">
+        <Col className="mb-4 d-flex align-items-baseline justify-content-end">
           <div className="align-middle mr-2">Show statistics for the last</div>
           <DropdownButton
             as={ButtonGroup}
@@ -101,12 +99,12 @@ export default function Dashboard() {
         </Col>
       </Row>
       <Row>
-        <Col xs={6}>
+        <Col>
           <StatCard statName={StatNames.HASHES} timeSpan={timeSpan} />
           <StatCard statName={StatNames.MATCHES} timeSpan={timeSpan} />
         </Col>
       </Row>
-    </Container>
+    </FixedWidthCenterAlignedLayout>
   );
 }
 

--- a/hasher-matcher-actioner/webapp/src/pages/Signals.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Signals.jsx
@@ -7,8 +7,9 @@
 import React, {useState, useEffect} from 'react';
 import Spinner from 'react-bootstrap/Spinner';
 import {Collapse, Row, Col, Card, Table} from 'react-bootstrap';
+import FixedWidthCenterAlignedLayout from './layouts/FixedWidthCenterAlignedLayout';
 
-import {fetchSignalSummary} from './Api';
+import {fetchSignalSummary} from '../Api';
 
 export default function Signals() {
   const [signalSummary, setSignalSummary] = useState(null);
@@ -23,8 +24,7 @@ export default function Signals() {
   }, []);
 
   return (
-    <>
-      <h1>Signals</h1>
+    <FixedWidthCenterAlignedLayout title="Signals">
       <Row className="mt-3">
         <Spinner
           hidden={signalSummary !== null}
@@ -42,7 +42,7 @@ export default function Signals() {
           </>
         </Collapse>
       </Row>
-    </>
+    </FixedWidthCenterAlignedLayout>
   );
 }
 

--- a/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
@@ -8,9 +8,9 @@ import {
   Button,
   Row,
   Form,
-  Container,
   Collapse,
   Spinner,
+  Alert,
 } from 'react-bootstrap';
 import {Link} from 'react-router-dom';
 
@@ -23,6 +23,7 @@ import {
   OptionalMetadataField,
   NotYetSupportedField,
 } from '../components/SubmitContentFields';
+import FixedWidthCenterAlignedLayout from './layouts/FixedWidthCenterAlignedLayout';
 
 const FORM_DEFAULTS = {
   submissionType: undefined,
@@ -100,134 +101,128 @@ export default function SubmitContent() {
   };
 
   return (
-    // ToDo header copied from matches page -> standardize into shared component
-    <div className="d-flex flex-column justify-content-start align-items-stretch h-100 w-100">
-      <div className="flex-grow-0">
-        <Container className="bg-dark text-light" fluid>
-          <Row className="d-flex flex-row justify-content-between align-items-end">
-            <div className="px-4 py-2">
-              <h1>Submit Content</h1>
-              <p>Provide content to the HMA system to match against.</p>
-              <p>
-                Currently only <b>images</b> using the submisson type{' '}
-                <b>Direct Upload</b> or <b>URL</b> are supported.
-              </p>
-            </div>
-            <div className="px-4 py-2" />
-          </Row>
-        </Container>
-      </div>
-      <Container className="mt-4" style={{overflowY: 'auto'}}>
-        <Form onSubmit={handleSubmit}>
-          <Form.Group>
-            <Form.Label>Submission Type</Form.Label>
-            <Form.Control
-              as="select"
-              required
-              className="mr-sm-2"
-              name="submissionType"
-              onChange={e => {
-                setSubmissionType(SUBMISSION_TYPE[e.target.value]);
-                handleInputChange(e);
-              }}
-              defaultValue=""
-              custom>
-              <option key="empty" value="" disabled>
-                Select type...
-              </option>
-              {Object.keys(SUBMISSION_TYPE).map(submitType => (
-                <option key={submitType} value={submitType}>
-                  {SUBMISSION_TYPE[submitType]}
+    <FixedWidthCenterAlignedLayout title="Submit Content">
+      <Row>
+        <Col>
+          <Alert variant="secondary">
+            <p>Provide content to the HMA system to match against.</p>
+            <p>
+              Currently only <b>images</b> using the submisson type{' '}
+              <b>Direct Upload</b> or <b>URL</b> are supported.
+            </p>
+          </Alert>
+
+          <Form onSubmit={handleSubmit}>
+            <Form.Group>
+              <Form.Label>Submission Type</Form.Label>
+              <Form.Control
+                as="select"
+                required
+                className="mr-sm-2"
+                name="submissionType"
+                onChange={e => {
+                  setSubmissionType(SUBMISSION_TYPE[e.target.value]);
+                  handleInputChange(e);
+                }}
+                defaultValue=""
+                custom>
+                <option key="empty" value="" disabled>
+                  Select type...
                 </option>
-              ))}
-            </Form.Control>
-          </Form.Group>
-
-          <Form.Group className="mx-4">
-            <Form.Row>
-              {submissionType === SUBMISSION_TYPE.UPLOAD && (
-                <PhotoUploadField
-                  inputs={inputs}
-                  handleInputChangeUpload={handleInputChangeUpload}
-                />
-              )}
-
-              {submissionType === SUBMISSION_TYPE.URL && (
-                <Form.Group>
-                  <Form.Label>Provide a URL to the content</Form.Label>
-                  <Form.Control
-                    onChange={handleInputChange}
-                    name="contentRef"
-                    placeholder="presigned url"
-                    required
-                  />
-                  <Form.Text className="text-muted mt-0">
-                    Currently behavior will store a copy of the content
-                  </Form.Text>
-                </Form.Group>
-              )}
-
-              {submissionType === SUBMISSION_TYPE.RAW && (
-                <NotYetSupportedField
-                  label="Provide content as raw string"
-                  handleInputChange={handleInputChange}
-                />
-              )}
-
-              {submissionType === SUBMISSION_TYPE.S3_OBJECT && (
-                <NotYetSupportedField
-                  label="Existing S3 Object Name"
-                  handleInputChange={handleInputChange}
-                />
-              )}
-            </Form.Row>
-            <ContentIdAndTypeField
-              inputs={inputs}
-              handleInputChange={handleInputChange}
-            />
-            <OptionalMetadataField
-              submissionMetadata={submissionMetadata}
-              setSubmissionMetadata={setSubmissionMetadata}
-            />
-            <Form.Group as={Row}>
-              <Button
-                style={{maxHeight: 38}}
-                className="ml-3"
-                variant="primary"
-                disabled={
-                  submitting ||
-                  submissionType === SUBMISSION_TYPE.RAW ||
-                  submissionType === SUBMISSION_TYPE.S3_OBJECT
-                }
-                type="submit">
-                Submit
-              </Button>
-              <Collapse in={submitting}>
-                <Spinner
-                  as="span"
-                  animation="border"
-                  role="status"
-                  variant="primary"
-                />
-              </Collapse>
-              <Collapse in={submittedId}>
-                <Col className="ml-4">
-                  <Row>
-                    Submitted! It will take a few minutes for the hash to be
-                    generated.
-                  </Row>
-                  <Row>
-                    <Link to={`/matches/${submittedId}`}>
-                      Once created, the hash and any matches found can be viewed
-                      here.
-                    </Link>
-                  </Row>
-                </Col>
-              </Collapse>
+                {Object.keys(SUBMISSION_TYPE).map(submitType => (
+                  <option key={submitType} value={submitType}>
+                    {SUBMISSION_TYPE[submitType]}
+                  </option>
+                ))}
+              </Form.Control>
             </Form.Group>
-          </Form.Group>
-        </Form>
-      </Container>
-    </div>
+
+            <Form.Group className="mx-4">
+              <Form.Row>
+                {submissionType === SUBMISSION_TYPE.UPLOAD && (
+                  <PhotoUploadField
+                    inputs={inputs}
+                    handleInputChangeUpload={handleInputChangeUpload}
+                  />
+                )}
+
+                {submissionType === SUBMISSION_TYPE.URL && (
+                  <Form.Group>
+                    <Form.Label>Provide a URL to the content</Form.Label>
+                    <Form.Control
+                      onChange={handleInputChange}
+                      name="contentRef"
+                      placeholder="presigned url"
+                      required
+                    />
+                    <Form.Text className="text-muted mt-0">
+                      Currently behavior will store a copy of the content
+                    </Form.Text>
+                  </Form.Group>
+                )}
+
+                {submissionType === SUBMISSION_TYPE.RAW && (
+                  <NotYetSupportedField
+                    label="Provide content as raw string"
+                    handleInputChange={handleInputChange}
+                  />
+                )}
+
+                {submissionType === SUBMISSION_TYPE.S3_OBJECT && (
+                  <NotYetSupportedField
+                    label="Existing S3 Object Name"
+                    handleInputChange={handleInputChange}
+                  />
+                )}
+              </Form.Row>
+              <ContentIdAndTypeField
+                inputs={inputs}
+                handleInputChange={handleInputChange}
+              />
+              <OptionalMetadataField
+                submissionMetadata={submissionMetadata}
+                setSubmissionMetadata={setSubmissionMetadata}
+              />
+              <Form.Group as={Row}>
+                <Button
+                  style={{maxHeight: 38}}
+                  className="ml-3"
+                  variant="primary"
+                  disabled={
+                    submitting ||
+                    submissionType === SUBMISSION_TYPE.RAW ||
+                    submissionType === SUBMISSION_TYPE.S3_OBJECT
+                  }
+                  type="submit">
+                  Submit
+                </Button>
+                <Collapse in={submitting}>
+                  <Spinner
+                    as="span"
+                    animation="border"
+                    role="status"
+                    variant="primary"
+                  />
+                </Collapse>
+                <Collapse in={submittedId}>
+                  <Col className="ml-4">
+                    <Row>
+                      Submitted! It will take a few minutes for the hash to be
+                      generated.
+                    </Row>
+                    <Row>
+                      <Link to={`/matches/${submittedId}`}>
+                        Once created, the hash and any matches found can be
+                        viewed here.
+                      </Link>
+                    </Row>
+                  </Col>
+                </Collapse>
+              </Form.Group>
+            </Form.Group>
+          </Form>
+        </Col>
+      </Row>
+    </FixedWidthCenterAlignedLayout>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/pages/layouts/FixedWidthCenterAlignedLayout.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/layouts/FixedWidthCenterAlignedLayout.jsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Container, Row, Col} from 'react-bootstrap';
+
+/**
+ * Uses a bootstrap container to put all content in the center of the main area.
+ * Supports a title and any children.
+ *
+ * Does not provide rows and cols. That is for pages to provide.
+ *
+ * A page impl using this class would look like.
+ *
+ * ```
+ * return (
+ *   <FixedWidthCenterAlignedLayout title="Recipe Details">
+ *     <Row>
+ *       <Col>
+ *         ... your content here.
+ *       </Col>
+ *     </Row>
+ *   </FixedWidthCenterAlignedLayout>
+ * )
+ * ```
+ *
+ * Centralizing the layouts like this allows page authors to focus on the
+ * page.
+ */
+export default function FixedWidthCenterAlignedLayout({title, children}) {
+  return (
+    <Container>
+      <Row>
+        <Col className="mt-4">
+          <h1>{title}</h1>
+        </Col>
+      </Row>
+      {children}
+    </Container>
+  );
+}
+
+FixedWidthCenterAlignedLayout.propTypes = {
+  title: PropTypes.string.isRequired,
+  children: PropTypes.arrayOf(PropTypes.node),
+};
+
+FixedWidthCenterAlignedLayout.defaultProps = {
+  children: [],
+};

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ActionRuleSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ActionRuleSettingsTab.jsx
@@ -6,7 +6,6 @@
 
 import Button from 'react-bootstrap/Button';
 import Col from 'react-bootstrap/Col';
-import Container from 'react-bootstrap/Container';
 import React, {useState} from 'react';
 import Row from 'react-bootstrap/Row';
 import Table from 'react-bootstrap/Table';
@@ -14,6 +13,7 @@ import Toast from 'react-bootstrap/Toast';
 import ActionRuleFormColumns from '../../components/settings/ActionRuleFormColumns';
 import ActionRulesTableRow from '../../components/settings/ActionRulesTableRow';
 import '../../styles/_settings.scss';
+import FixedWidthCenterAlignedLayout from '../layouts/FixedWidthCenterAlignedLayout';
 
 const mockedActionRules = [
   {
@@ -138,102 +138,99 @@ export default function ActionRuleSettingsTab() {
   ));
 
   return (
-    <>
-      <Container>
-        <Row className="mt-3">
-          <Col>
-            <h1>Action Rules</h1>
-            <p>
-              Each rule indicates an action to be taken based on labels (e.g.,
-              classification labels of a matching signal)
-            </p>
-          </Col>
-        </Row>
-        <Row>
-          <Col>
-            <Table bordered>
-              <thead>
-                <tr>
-                  <th>
-                    <Button
-                      className="table-action-button"
-                      onClick={() => setAdding(true)}>
-                      <ion-icon name="add" size="large" />
-                    </Button>
-                  </th>
-                  <th>Name</th>
-                  <th>Labeled As</th>
-                  <th>Not Labeled As</th>
-                  <th>Action</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr hidden={!adding}>
-                  <td>
-                    <Button
-                      variant="outline-primary"
-                      className="mb-2 table-action-button"
-                      onClick={() => {
-                        setShowErrors(false);
-                        if (actionRuleIsValid(newActionRule, actionRules)) {
-                          addActionRule(newActionRule);
-                          resetForm();
-                          setAdding(false);
-                          displayToast(
-                            'A new action rule was added successfully.',
-                          );
-                        } else {
-                          setShowErrors(true);
-                        }
-                      }}>
-                      <ion-icon
-                        name="checkmark"
-                        size="large"
-                        className="ion-icon-white"
-                      />
-                    </Button>{' '}
-                    <Button
-                      variant="outline-secondary"
-                      className="table-action-button"
-                      onClick={() => {
-                        setShowErrors(false);
+    <FixedWidthCenterAlignedLayout title="Action Rules">
+      <Row className="mt-3">
+        <Col>
+          <p>
+            Each rule indicates an action to be taken based on labels (e.g.,
+            classification labels of a matching signal)
+          </p>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <Table bordered>
+            <thead>
+              <tr>
+                <th>
+                  <Button
+                    className="table-action-button"
+                    onClick={() => setAdding(true)}>
+                    <ion-icon name="add" size="large" />
+                  </Button>
+                </th>
+                <th>Name</th>
+                <th>Labeled As</th>
+                <th>Not Labeled As</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr hidden={!adding}>
+                <td>
+                  <Button
+                    variant="outline-primary"
+                    className="mb-2 table-action-button"
+                    onClick={() => {
+                      setShowErrors(false);
+                      if (actionRuleIsValid(newActionRule, actionRules)) {
+                        addActionRule(newActionRule);
                         resetForm();
                         setAdding(false);
-                      }}>
-                      <ion-icon
-                        name="close"
-                        size="large"
-                        className="ion-icon-white"
-                      />
-                    </Button>
-                  </td>
-                  <ActionRuleFormColumns
-                    actions={actions}
-                    name={newActionRule.name}
-                    mustHaveLabels={newActionRule.must_have_labels}
-                    mustNotHaveLabels={newActionRule.must_not_have_labels}
-                    actionId={newActionRule.action_id}
-                    showErrors={showErrors}
-                    nameIsUnique={nameIsUnique}
-                    oldName={undefined}
-                    onChange={onNewActionRuleChange}
-                  />
-                </tr>
-                {actionRulesTableRows}
-              </tbody>
-            </Table>
-          </Col>
-        </Row>
-        <div className="feedback-toast-container">
-          <Toast
-            onClose={() => setShowToast(false)}
-            show={showToast}
-            delay={5000}
-            autohide>
-            <Toast.Body>{toastMessage}</Toast.Body>
-          </Toast>
-        </div>
-      </Container>
-    </>
+                        displayToast(
+                          'A new action rule was added successfully.',
+                        );
+                      } else {
+                        setShowErrors(true);
+                      }
+                    }}>
+                    <ion-icon
+                      name="checkmark"
+                      size="large"
+                      className="ion-icon-white"
+                    />
+                  </Button>{' '}
+                  <Button
+                    variant="outline-secondary"
+                    className="table-action-button"
+                    onClick={() => {
+                      setShowErrors(false);
+                      resetForm();
+                      setAdding(false);
+                    }}>
+                    <ion-icon
+                      name="close"
+                      size="large"
+                      className="ion-icon-white"
+                    />
+                  </Button>
+                </td>
+                <ActionRuleFormColumns
+                  actions={actions}
+                  name={newActionRule.name}
+                  mustHaveLabels={newActionRule.must_have_labels}
+                  mustNotHaveLabels={newActionRule.must_not_have_labels}
+                  actionId={newActionRule.action_id}
+                  showErrors={showErrors}
+                  nameIsUnique={nameIsUnique}
+                  oldName={undefined}
+                  onChange={onNewActionRuleChange}
+                />
+              </tr>
+              {actionRulesTableRows}
+            </tbody>
+          </Table>
+        </Col>
+      </Row>
+      <div className="feedback-toast-container">
+        <Toast
+          onClose={() => setShowToast(false)}
+          show={showToast}
+          delay={5000}
+          autohide>
+          <Toast.Body>{toastMessage}</Toast.Body>
+        </Toast>
+      </div>
+    </FixedWidthCenterAlignedLayout>
   );
 }


### PR DESCRIPTION
Summary
---------
@eriksendc had called out in #558 that some pages are not using bootstrap the right way. This PR adds a new Layout component which makes it easy for folks to get on with the program and use one common way for laying out a page.

Other than the matches page which has a multi-pane design, all other pages can potentially be migrated. As part of this, few have been and more will be added if this is accepted. For practical purposes, this fixes #558.

I feel the settings pages could do with their own layout because of their tabbed nature. If this appeals to folks, I'll take a stab at that.

Test Plan
---------
Screenshots for the updated pages are shown below.

## Dashboard
<img width="1792" alt="Screen Shot 2021-05-12 at 19 54 43" src="https://user-images.githubusercontent.com/217056/118058393-21c73a80-b35c-11eb-86e7-614850e652fc.png">

## Content Details / Summary
<img width="1792" alt="Screen Shot 2021-05-12 at 19 54 58" src="https://user-images.githubusercontent.com/217056/118058395-225fd100-b35c-11eb-9e51-91b37b874a1f.png">

## Signals
<img width="1790" alt="Screen Shot 2021-05-12 at 19 55 05" src="https://user-images.githubusercontent.com/217056/118058396-225fd100-b35c-11eb-9a7e-efff7e8c3cbe.png">

## Upload
<img width="1792" alt="Screen Shot 2021-05-12 at 19 55 12" src="https://user-images.githubusercontent.com/217056/118058397-225fd100-b35c-11eb-8d38-4ded63851b35.png">

## Submit Content
<img width="1792" alt="Screen Shot 2021-05-12 at 19 55 21" src="https://user-images.githubusercontent.com/217056/118058398-22f86780-b35c-11eb-98d7-a077243cc8d4.png">
