### PR TITLE
add last modified time, hash count

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/s3_adapters.py
+++ b/hasher-matcher-actioner/hmalib/common/s3_adapters.py
@@ -7,7 +7,7 @@ import codecs
 
 import typing as t
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from hmalib import metrics
 from hmalib.common.logging import get_logger
 
@@ -39,9 +39,9 @@ class ThreatExchangeS3Adapter:
     """
 
     metrics_logger: metrics.lambda_with_datafiles
-
     S3FileT = t.Dict[str, t.Any]
     config: S3ThreatDataConfig
+    last_modified: t.Dict[str, str] = field(default_factory=dict)
 
     def load_data(self) -> t.Dict[str, t.List[HashRowT]]:
         """
@@ -115,6 +115,7 @@ class ThreatExchangeS3Adapter:
             codecs.getreader("utf-8")(data_file["Body"]),
             fieldnames=self.indicator_type_file_columns,
         )
+        self.last_modified[file_name] = data_file["LastModified"].isoformat()
         privacy_group = file_name.split("/")[-1].split(".")[0]
         return [
             (

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -115,13 +115,13 @@ def hash_count():
     """
     results = get_signal_hash_count()
     logger.debug(results)
-    for name in results.keys():
-        results[
-            name.replace(THREAT_EXCHANGE_PDQ_FILE_EXTENSION, "").replace(
-                THREAT_EXCHANGE_DATA_FOLDER, ""
-            )
-        ] = results.pop(name)
-    return results if results else {}
+    hash_counts = {
+        name.replace(THREAT_EXCHANGE_PDQ_FILE_EXTENSION, "").replace(
+            THREAT_EXCHANGE_DATA_FOLDER, ""
+        ): value
+        for name, value in results.items()
+    }
+    return hash_counts if hash_counts else {}
 
 
 def lambda_handler(event, context):
@@ -191,7 +191,7 @@ def get_signals() -> t.List[SignalSourceSummary]:
 
 
 # TODO this method is expensive some cache or memoization method might be a good idea.
-def get_signal_hash_count() -> t.Dict[str, t.List[t.Any]]:
+def get_signal_hash_count() -> t.Dict[str, t.Tuple[int, str]]:
     s3_config = S3ThreatDataConfig(
         threat_exchange_data_bucket_name=THREAT_EXCHANGE_DATA_BUCKET_NAME,
         threat_exchange_data_folder=THREAT_EXCHANGE_DATA_FOLDER,
@@ -202,7 +202,7 @@ def get_signal_hash_count() -> t.Dict[str, t.List[t.Any]]:
     )
     pdq_data_files = pdq_storage.load_data()
     return {
-        file_name: [len(rows), pdq_storage.last_modified[file_name]]
+        file_name: (len(rows), pdq_storage.last_modified[file_name])
         for file_name, rows in pdq_data_files.items()
     }
 

--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -170,3 +170,7 @@ export function updateDataset(
     matcher_active: matcherActive,
   });
 }
+
+export function fetchHashCount() {
+  return apiGet('/hash-counts');
+}

--- a/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.jsx
@@ -19,6 +19,8 @@ export default function ThreatExchangePrivacyGroupCard({
   privacyGroupName,
   description,
   writeBack,
+  hashCount,
+  lastModified,
   onSave,
   onDelete,
 }) {
@@ -52,6 +54,27 @@ export default function ThreatExchangePrivacyGroupCard({
             }>
             <h4 className="mb-0">
               <CopyableTextField text={privacyGroupName} color="white" />
+              <OverlayTrigger
+                trigger="focus"
+                placement="bottom"
+                overlay={
+                  <Popover id={`popover-basic${privacyGroupId}`}>
+                    <Popover.Title as="h3">Information</Popover.Title>
+                    <Popover.Content>
+                      <div
+                        dangerouslySetInnerHTML={{
+                          __html: DOMPurify.sanitize(`${description}`, {
+                            ADD_ATTR: ['target'],
+                          }),
+                        }}
+                      />
+                    </Popover.Content>
+                  </Popover>
+                }>
+                <Button class="btn btn-primary btn-circle">
+                  <ion-icon name="information-circle-outline" size="large" />
+                </Button>
+              </OverlayTrigger>
             </h4>
           </Card.Header>
           <Card.Subtitle className="mt-2 mb-2 text-muted">
@@ -59,25 +82,28 @@ export default function ThreatExchangePrivacyGroupCard({
           </Card.Subtitle>
           <Card.Body className="text-left">
             <Form>
-              <div style={{display: 'flex', justifyContent: 'flex-end'}}>
+              <div>
                 <OverlayTrigger
                   trigger="focus"
                   placement="bottom"
                   overlay={
-                    <Popover id={`popover-basic${privacyGroupId}`}>
-                      <Popover.Title as="h3">Information</Popover.Title>
-                      <Popover.Content>
-                        <div
-                          dangerouslySetInnerHTML={{
-                            __html: DOMPurify.sanitize(`${description}`, {
-                              ADD_ATTR: ['target'],
-                            }),
-                          }}
-                        />
-                      </Popover.Content>
+                    <Popover id={`popover-hashCount${privacyGroupId}`}>
+                      <Popover.Title as="h3">Hash Count</Popover.Title>
+                      <Popover.Content>{hashCount}</Popover.Content>
                     </Popover>
                   }>
-                  <Button variant="info">more info</Button>
+                  <Button variant="info">Hash Count</Button>
+                </OverlayTrigger>{' '}
+                <OverlayTrigger
+                  trigger="focus"
+                  placement="bottom"
+                  overlay={
+                    <Popover id={`popover-lastModified${privacyGroupId}`}>
+                      <Popover.Title as="h3">Last Modified Time</Popover.Title>
+                      <Popover.Content>{lastModified}</Popover.Content>
+                    </Popover>
+                  }>
+                  <Button variant="info">Last Modified Time</Button>
                 </OverlayTrigger>
               </div>
               <Form.Switch
@@ -152,6 +178,8 @@ ThreatExchangePrivacyGroupCard.propTypes = {
   privacyGroupName: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   writeBack: PropTypes.bool.isRequired,
+  hashCount: PropTypes.number.isRequired,
+  lastModified: PropTypes.string.isRequired,
   onSave: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
 };

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.jsx
@@ -20,10 +20,12 @@ import {
   syncAllDatasets,
   updateDataset,
   deleteDataset,
+  fetchHashCount,
 } from '../../Api';
 
 export default function ThreatExchangeSettingsTab() {
   const [datasets, setDatasets] = useState([]);
+  const [hashCounts, setHashCount] = useState({});
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState(false);
   const [showToast, setShowToast] = useState(false);
@@ -88,8 +90,11 @@ export default function ThreatExchangeSettingsTab() {
   };
   useEffect(() => {
     fetchAllDatasets(setLoading(false)).then(response => {
-      setLoading(true);
-      setDatasets(response.datasets_response);
+      fetchHashCount().then(counts => {
+        setHashCount(counts);
+        setLoading(true);
+        setDatasets(response.datasets_response);
+      });
     });
   }, []);
   return (
@@ -146,13 +151,14 @@ export default function ThreatExchangeSettingsTab() {
                   inUse={dataset.in_use}
                   privacyGroupId={dataset.privacy_group_id}
                   writeBack={dataset.write_back}
+                  hashCount={hashCounts[dataset.privacy_group_id][0]}
+                  lastModified={hashCounts[dataset.privacy_group_id][1]}
                   onSave={onPrivacyGroupSave}
                   onDelete={onPrivacyGroupDelete}
                 />
               ))}
         </Row>
       </Card.Body>
-
       <Col className="mx-1" md="6">
         <HolidaysDatasetInformationBlock />
       </Col>


### PR DESCRIPTION
Summary
---------
This PR is to display last modified time and hash count for each privacy group .pdq.te file in S3 bucket in ThreatExchange Setting page
 

Test Plan
---------

1. black hmalib
2. mypy hmalib
3. python -m py.test to pass all tests
4. make docker
5. make upload_docker
6. terraform apply
7. test the change in localhost UI
shows privacy group description:
![Screen Shot 2021-05-14 at 5 04 23 PM](https://user-images.githubusercontent.com/81996660/118332445-14cf5600-b4d8-11eb-8352-6b09c7270902.png)
shows hash count:
![Screen Shot 2021-05-14 at 5 04 11 PM](https://user-images.githubusercontent.com/81996660/118332468-2284db80-b4d8-11eb-9466-f6a3b5c2021b.png)
shows last modified time:
![Screen Shot 2021-05-14 at 5 04 17 PM](https://user-images.githubusercontent.com/81996660/118332493-2f093400-b4d8-11eb-8bd8-67de7ea31cf7.png)
![Screen Shot 2021-05-14 at 5 17 12 PM](https://user-images.githubusercontent.com/81996660/118332552-447e5e00-b4d8-11eb-9a64-98cee06afa13.png)
matches the timestamp in S3:
![Screen Shot 2021-05-14 at 5 14 19 PM](https://user-images.githubusercontent.com/81996660/118332585-4ea05c80-b4d8-11eb-87b2-cec157826c0b.png)
