### PR TITLE
using standard way to naming apis

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/actions_api.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/actions_api.py
@@ -71,7 +71,7 @@ def get_actions_api(hma_config_table: str) -> bottle.Bottle:
             actions_response=[config.__dict__ for config in action_configs]
         )
 
-    @actions_api.post("/update", apply=[jsoninator(CreateUpdateActionRequest)])
+    @actions_api.put("/", apply=[jsoninator(CreateUpdateActionRequest)])
     def update_action(request: CreateUpdateActionRequest) -> UpdateActionResponse:
         """
         Update an action url and headers
@@ -84,7 +84,7 @@ def get_actions_api(hma_config_table: str) -> bottle.Bottle:
         hmaconfig.update_config(config)
         return UpdateActionResponse(response="The action config is updated.")
 
-    @actions_api.post("/create", apply=[jsoninator(CreateUpdateActionRequest)])
+    @actions_api.post("/", apply=[jsoninator(CreateUpdateActionRequest)])
     def create_action(request: CreateUpdateActionRequest) -> CreateActionResponse:
         """
         create an action
@@ -95,7 +95,7 @@ def get_actions_api(hma_config_table: str) -> bottle.Bottle:
         hmaconfig.create_config(config)
         return CreateActionResponse(response="The action config is created.")
 
-    @actions_api.post("/delete/<key>", apply=[jsoninator])
+    @actions_api.delete("/<key>", apply=[jsoninator])
     def delete_action(key=None) -> DeleteActionResponse:
         """
         Delete an action


### PR DESCRIPTION
Summary
---------
Previous PR: https://github.com/facebook/ThreatExchange/pull/573
This PR is to change action apis to use the standard way of naming an api
 

Test Plan
---------

1. black hmalib
2. mypy hmalib
3. python -m py.test to pass all tests
4. python -m hmalib.lambdas.api.api_root
5. test all apis in postman

https://user-images.githubusercontent.com/81996660/118333896-8c9e8000-b4da-11eb-8c89-3866bd3f3698.mov

