### PR TITLE
Implement True Positive Writebacks

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/mocks.py
+++ b/hasher-matcher-actioner/hmalib/common/mocks.py
@@ -1,0 +1,64 @@
+import typing as t
+
+
+class MockedThreatExchangeAPI:
+
+    app_id = my_app_id = "a1"
+    other_app_id = "a2"
+    third_app_id = "a3"
+
+    indicator_to_desriptors = {
+        "2862392437204724": [
+            {"owner": {"id": my_app_id}, "id": "11"},
+            {"owner": {"id": other_app_id}, "id": "21"},
+            {"owner": {"id": third_app_id}, "id": "31"},
+        ],
+        "4194946153908639": [
+            {"owner": {"id": my_app_id}, "id": "12"},
+            {"owner": {"id": other_app_id}, "id": "22"},
+            {"owner": {"id": third_app_id}, "id": "32"},
+        ],
+        "3027465034605137": [
+            {"owner": {"id": my_app_id}, "id": "13"},
+            {"owner": {"id": other_app_id}, "id": "23"},
+            {"owner": {"id": third_app_id}, "id": "33"},
+        ],
+    }
+
+    def get_threat_descriptors_from_indicator(
+        self, indicator
+    ) -> t.List[t.Dict[str, t.Any]]:
+        return self.indicator_to_desriptors[indicator]
+
+    def react_to_threat_descriptor(self, descriptor, reaction) -> None:
+        # can only react to a descriptor that exists
+        assert descriptor in (
+            descriptor["id"]
+            for descriptor_set in self.indicator_to_desriptors.values()
+            for descriptor in descriptor_set
+        )
+        return None
+
+    def upload_threat_descriptor(self, postParams, *vargs):
+        # Find the indicator for the descriptor we're trying to copy
+        indicator = [
+            descriptor_set
+            for descriptor_set in self.indicator_to_desriptors.values()
+            if postParams["descriptor_id"]
+            in [descriptor["id"] for descriptor in descriptor_set]
+        ][0]
+        return [
+            None,
+            None,
+            {
+                "success": True,
+                "id": [
+                    descriptor["id"]
+                    for descriptor in indicator
+                    if descriptor["owner"]["id"] == str(self.my_app_id)
+                ][0],
+            },
+        ]
+
+    def copy_threat_descriptor(self, postParams, *vargs):
+        return self.upload_threat_descriptor(postParams, *vargs)

--- a/hasher-matcher-actioner/hmalib/common/tests/test_writebacker.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_writebacker.py
@@ -54,8 +54,8 @@ class WritebackerTestCase(unittest.TestCase):
         assert result == {
             "writebacks_performed": {
                 "te": [
-                    "reacted SAW_THIS_TOO to 2 descriptors",
-                    "reacted SAW_THIS_TOO to 2 descriptors",
+                    "reacted SAW_THIS_TOO to 2 descriptors : 21,31",
+                    "reacted SAW_THIS_TOO to 2 descriptors : 22,32",
                     "No writeback performed for banked content id 3027465034605137 becuase writebacks were disabled",
                 ]
             }
@@ -77,8 +77,8 @@ class WritebackerTestCase(unittest.TestCase):
         assert result == {
             "writebacks_performed": {
                 "te": [
-                    "reacted DISAGREE_WITH_TAGS to 2 descriptors",
-                    "reacted DISAGREE_WITH_TAGS to 2 descriptors",
+                    "reacted DISAGREE_WITH_TAGS to 2 descriptors : 21,31",
+                    "reacted DISAGREE_WITH_TAGS to 2 descriptors : 22,32",
                     "No writeback performed for banked content id 3027465034605137 becuase writebacks were disabled",
                 ]
             }
@@ -100,8 +100,8 @@ class WritebackerTestCase(unittest.TestCase):
         assert result == {
             "writebacks_performed": {
                 "te": [
-                    "MOCKED: Wrote back TruePositive for indicator 2862392437204724",
-                    "MOCKED: Wrote back TruePositive for indicator 4194946153908639",
+                    "Wrote back TruePositive for indicator 2862392437204724\n Built/Updated descriptor: 11",
+                    "Wrote back TruePositive for indicator 4194946153908639\n Built/Updated descriptor: 12",
                     "No writeback performed for banked content id 3027465034605137 becuase writebacks were disabled",
                 ]
             }

--- a/hasher-matcher-actioner/hmalib/common/tests/test_writebacker.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_writebacker.py
@@ -3,7 +3,6 @@
 import unittest
 
 import os
-import typing as t
 from hmalib.lambdas.actions.writebacker import lambda_handler
 from hmalib.common.classification_models import WritebackTypes
 from hmalib.common.message_models import MatchMessage, WritebackMessage, BankedSignal
@@ -11,8 +10,6 @@ from hmalib.common.message_models import MatchMessage, WritebackMessage, BankedS
 from hmalib.common.fetcher_models import ThreatExchangeConfig
 
 from hmalib.common import config as hmaconfig
-
-from hmalib.common.writebacker_models import Writebacker
 
 
 class WritebackerTestCase(unittest.TestCase):
@@ -100,8 +97,8 @@ class WritebackerTestCase(unittest.TestCase):
         assert result == {
             "writebacks_performed": {
                 "te": [
-                    "Wrote back TruePositive for indicator 2862392437204724\n Built/Updated descriptor: 11",
-                    "Wrote back TruePositive for indicator 4194946153908639\n Built/Updated descriptor: 12",
+                    "Wrote back TruePositive for indicator 2862392437204724\n Built descriptor 11 with privacy groups pg 4",
+                    "Wrote back TruePositive for indicator 4194946153908639\n Built descriptor 12 with privacy groups pg 4",
                     "No writeback performed for banked content id 3027465034605137 becuase writebacks were disabled",
                 ]
             }

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/writebacker.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/writebacker.py
@@ -1,12 +1,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from hmalib.common.classification_models import WritebackTypes
 import json
 import os
 
 from hmalib.common.config import HMAConfig
 from hmalib.common.logging import get_logger
 from hmalib.common.writebacker_models import Writebacker
-from hmalib.common.message_models import WritebackMessage
+from hmalib.common.message_models import BankedSignal, WritebackMessage
 
 logger = get_logger(__name__)
 
@@ -44,4 +45,14 @@ def lambda_handler(event, context):
 
 
 if __name__ == "__main__":
-    pass
+    # This will react to real descriptors
+    writeback_message = WritebackMessage(
+        [
+            BankedSignal("3744529885563965", "303636684709969", "te"),
+            BankedSignal("3367257116629705", "303636684709969", "te"),
+        ],
+        WritebackTypes.TruePositive,
+    )
+    event = {"Records": [{"body": writeback_message.to_aws_json()}]}
+    result = lambda_handler(event, None)
+    print(result)

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/writebacker.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/writebacker.py
@@ -45,14 +45,16 @@ def lambda_handler(event, context):
 
 
 if __name__ == "__main__":
-    # This will react to real descriptors
-    writeback_message = WritebackMessage(
-        [
-            BankedSignal("3744529885563965", "303636684709969", "te"),
-            BankedSignal("3367257116629705", "303636684709969", "te"),
-        ],
-        WritebackTypes.TruePositive,
-    )
-    event = {"Records": [{"body": writeback_message.to_aws_json()}]}
-    result = lambda_handler(event, None)
-    print(result)
+    # For basic debugging
+    # This will react to real descriptors if WRITEBACK_LOCAL is on
+    if os.environ.get("WRITEBACK_LOCAL"):
+        writeback_message = WritebackMessage(
+            [
+                BankedSignal("3744529885563965", "303636684709969", "te"),
+                BankedSignal("3744529885563965", "258601789084078", "te"),
+            ],
+            WritebackTypes.TruePositive,
+        )
+        event = {"Records": [{"body": writeback_message.to_aws_json()}]}
+        result = lambda_handler(event, None)
+        print(result)

--- a/hasher-matcher-actioner/setup.py
+++ b/hasher-matcher-actioner/setup.py
@@ -10,7 +10,7 @@ setup(
     install_requires=[
         "boto3",
         "boto3-stubs[essential,sns]==1.17.14.0",
-        "threatexchange[faiss,pdq_hasher]>=0.0.19",
+        "threatexchange[faiss,pdq_hasher]>=0.0.20",
         "bottle",
         "apig_wsgi",
     ],


### PR DESCRIPTION
Summary
---------

Implement True positive Writbacks to ThreatExchange. This will upsert a new descriptor for the given indicator with:
1. MALICIOUS
2. The same privacy group
3. MANUALLY REVIEWED

If the descriptor does not already exist, the following feilds will also be set:
1. Description = "A ThreatDescriptor uploaded via HMA"
2. Tags = "uploaded_by_hma"
3. share level = "RED

If the descriptor already exists, those fields will be unchanged

Test Plan
---------

1. Created new test application (HMA test)
2. Uploaded all test data threat descriptors again with the new app
3. Deleted old Threat Descriptors from the old testing app (Jesse's terrorist stopping app)
4. Triggered TruePositive writeback locally
5. Watched new ThreatDescriptor get created in ThreatExchange
