### PR TITLE
[HMA][Multipart] Content Object and ActionEvent Storage + API 

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/content_models.py
+++ b/hasher-matcher-actioner/hmalib/common/content_models.py
@@ -1,0 +1,222 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import datetime
+from enum import Enum
+import typing as t
+
+from dataclasses import dataclass, field, asdict
+from mypy_boto3_dynamodb.service_resource import Table
+from boto3.dynamodb.conditions import Attr, Key, Or
+from botocore.exceptions import ClientError
+
+from hmalib.lambdas.api.middleware import JSONifiable
+from hmalib.models import DynamoDBItem
+
+
+@dataclass
+class ContentObjectBase(DynamoDBItem):
+    """
+    Base content obeject for ActionRecords and ContentObjects
+    Both of which used content_id as there PK
+    (This is similar to Hash and Match Records
+    but can easily be moved to it's own db table as they do not
+    use the other indexes)
+    """
+
+    content_id: str
+
+
+@dataclass
+class ActionEventRecord(ContentObjectBase, JSONifiable):
+    """
+    Record of action events in the action performer
+    keyed based on action_label and time of event.
+    For the time being the action_rules in the action message
+    being preformed are also stored as a list serialized json blobs
+    """
+
+    ACTION_TIME_PREFIX = "action_time#"
+    DEFAULT_PROJ_EXP = "PK, SK, ActionLabel, ActionRules"
+
+    time_performed: datetime.datetime
+    action_label: str
+    action_rules: t.List
+
+    @staticmethod
+    def get_dynamodb_action_time_key(time_performed: datetime.datetime) -> str:
+        return f"{ActionEventRecord.ACTION_TIME_PREFIX}{time_performed.isoformat()}"
+
+    def to_dynamodb_item(self) -> dict:
+        return {
+            "PK": self.get_dynamodb_content_key(self.content_id),
+            "SK": self.get_dynamodb_action_time_key(self.time_performed),
+            "ActionLabel": self.action_label,
+            "ActionRules": self.action_rules,
+        }
+
+    def to_json(self) -> t.Dict:
+        """
+        Used by '/content/action-history/<content-id>' in lambdas/api/content
+        """
+        result = asdict(self)
+        result.update(time_performed=self.time_performed.isoformat())
+        return result
+
+    @classmethod
+    def get_from_content_id(
+        cls,
+        table: Table,
+        content_id: str,
+    ) -> t.List["ActionEventRecord"]:
+
+        items = table.query(
+            KeyConditionExpression=Key("PK").eq(
+                cls.get_dynamodb_content_key(content_id)
+            )
+            & Key("SK").begins_with(cls.ACTION_TIME_PREFIX),
+            ProjectionExpression=cls.DEFAULT_PROJ_EXP,
+        ).get("Items", [])
+
+        return cls._result_item_to_action_record(items)
+
+    @classmethod
+    def _result_item_to_action_record(
+        cls,
+        items: t.List[t.Dict],
+    ) -> t.List["ActionEventRecord"]:
+        return [
+            ActionEventRecord(
+                content_id=cls.remove_content_key_prefix(
+                    item["PK"],
+                ),
+                time_performed=datetime.datetime.fromisoformat(
+                    item["SK"][len(cls.ACTION_TIME_PREFIX) :]
+                ),
+                action_label=item["ActionLabel"],
+                action_rules=item["ActionRules"],
+            )
+            for item in items
+        ]
+
+
+@dataclass
+class ContentObject(ContentObjectBase, JSONifiable):
+    """
+    Content object that stores the values related to a specific
+    content_id and content_type.
+    Note/TODO: Something like an override flag should be added to the submit API
+    as ContentRef equality check on bytes is impractical so instead
+    something like:
+     "This content_id exists, [x] overwrite? (I know what you're doing)"
+    is likely better.
+    """
+
+    CONTENT_TYPE_PREFIX = "content_type#"
+
+    content_type: str
+    content_ref: str
+    content_ref_type: str
+    additional_fields: t.Optional[t.Set]
+    submissions: t.List
+    created_on: datetime.datetime
+    updated_at: datetime.datetime
+
+    @staticmethod
+    def get_dynamodb_content_type_key(content_type: str) -> str:
+        return f"{ContentObject.CONTENT_TYPE_PREFIX}{content_type}"
+
+    def to_json(self) -> t.Dict:
+        """
+        TODO docstring
+        """
+        result = asdict(self)
+        result.update(
+            additional_fields=list(
+                self.additional_fields if self.additional_fields else set()
+            ),
+            submissions=[s.isoformat() for s in self.submissions],
+            created_on=self.created_on.isoformat(),
+            updated_at=self.updated_at.isoformat(),
+        )
+        return result
+
+    def write_to_table(self, table: Table):
+        """
+        Write operations for this object need to be special cased (to avoid overwritting)
+        Therefore we do not implement `to_dynamodb_item`
+
+        If you're curious it would ~look like this:
+        def to_dynamodb_item(self) -> dict:
+            return {
+                "PK": self.get_dynamodb_content_key(self.content_id),
+                "SK": self.get_dynamodb_content_type_key(self.content_type),
+                "ContentRef": self.content_ref,
+                "ContentRefType": self.content_ref_type,
+                "AdditionalFields": self.additional_fields,
+                "Submissions": [s.isoformat() for s in self.submissions],
+                "CreatedOn": self.created_on.isoformat(),
+                "UpdatedAt": self.updated_at.isoformat(),
+            }
+        """
+        table.update_item(
+            Key={
+                "PK": self.get_dynamodb_content_key(self.content_id),
+                "SK": self.get_dynamodb_content_type_key(self.content_type),
+            },
+            # If ContentRef exists it needs to match or BAD THING(tm) can happen...
+            ConditionExpression=Or(Attr("ContentRef").not_exists(), Attr("ContentRef").eq(self.content_ref)),  # type: ignore
+            # Unfortunately while prod is happy with this on multiple lines pytest breaks...
+            UpdateExpression="""SET ContentRef = :cr, ContentRefType = :crt, Submissions = list_append(if_not_exists(Submissions, :empty_list), :s), CreatedOn = if_not_exists(CreatedOn, :co), UpdatedAt = :u ADD AdditionalFields :af""",
+            ExpressionAttributeValues={
+                ":cr": self.content_ref,
+                ":crt": self.content_ref_type,
+                ":af": self.additional_fields
+                if self.additional_fields
+                else {"Placeholder"},
+                ":s": [s.isoformat() for s in self.submissions],
+                ":co": self.created_on.isoformat(),
+                ":u": self.updated_at.isoformat(),
+                ":empty_list": [],
+            },
+        )
+
+    @classmethod
+    def get_from_content_id(
+        cls,
+        table: Table,
+        content_id: str,
+        content_type: str = "PHOTO",
+    ) -> t.Optional["ContentObject"]:
+        if not content_id:
+            return None
+        item = table.get_item(
+            Key={
+                "PK": cls.get_dynamodb_content_key(content_id),
+                "SK": cls.get_dynamodb_content_type_key(content_type),
+            }
+        ).get("Item", None)
+        if item:
+            return cls._result_item_to_object(item)
+        return None
+
+    @classmethod
+    def _result_item_to_object(
+        cls,
+        item: t.Dict,
+    ) -> "ContentObject":
+        return ContentObject(
+            content_id=cls.remove_content_key_prefix(
+                item["PK"],
+            ),
+            content_type=item["SK"][len(cls.CONTENT_TYPE_PREFIX) :],
+            content_ref=item["ContentRef"],
+            content_ref_type=item["ContentRefType"],
+            additional_fields=item["AdditionalFields"],
+            # Notes careful not using this version to write back to the table...
+            # Will dup previous submissions...
+            submissions=[
+                datetime.datetime.fromisoformat(s) for s in item["Submissions"]
+            ],
+            created_on=datetime.datetime.fromisoformat(item["CreatedOn"]),
+            updated_at=datetime.datetime.fromisoformat(item["UpdatedAt"]),
+        )

--- a/hasher-matcher-actioner/hmalib/common/content_models.py
+++ b/hasher-matcher-actioner/hmalib/common/content_models.py
@@ -158,6 +158,7 @@ class ContentObject(ContentObjectBase, JSONifiable):
                 "UpdatedAt": self.updated_at.isoformat(),
             }
         """
+        # put_item does not support UpdateExpression
         table.update_item(
             Key={
                 "PK": self.get_dynamodb_content_key(self.content_id),

--- a/hasher-matcher-actioner/hmalib/common/content_models.py
+++ b/hasher-matcher-actioner/hmalib/common/content_models.py
@@ -135,7 +135,7 @@ class ContentObject(ContentObjectBase, JSONifiable):
                 self.additional_fields if self.additional_fields else set()
             ),
             submission_times=[s.isoformat() for s in self.submission_times],
-            created_on=self.created_at.isoformat(),
+            created_at=self.created_at.isoformat(),
             updated_at=self.updated_at.isoformat(),
         )
         return result

--- a/hasher-matcher-actioner/hmalib/common/evaluator_models.py
+++ b/hasher-matcher-actioner/hmalib/common/evaluator_models.py
@@ -5,6 +5,7 @@ import typing as t
 from dataclasses import dataclass, field
 from hmalib.common.classification_models import Label, ActionLabel
 from hmalib.common.config import HMAConfig
+from hmalib.common.aws_dataclass import HasAWSSerialization
 
 
 @dataclass
@@ -15,7 +16,7 @@ class Action:
 
 
 @dataclass
-class ActionRule(HMAConfig):
+class ActionRule(HMAConfig, HasAWSSerialization):
     """
     Action rules are config-backed objects that have a set of labels (both
     "must have" and "must not have") which, when evaluated against the

--- a/hasher-matcher-actioner/hmalib/common/tests/test_content_models.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_content_models.py
@@ -1,0 +1,177 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+from contextlib import contextmanager
+from moto import mock_dynamodb2
+from hmalib.common.content_models import ContentObject, ActionEventRecord
+from hmalib.common.evaluator_models import ActionLabel, ActionRule
+from hmalib.common.message_models import BankedSignal, ActionMessage
+from hmalib.common.classification_models import ClassificationLabel
+
+
+import boto3
+import datetime
+import os
+
+
+class TestContentModels(unittest.TestCase):
+    table = None
+    TEST_CONTENT_ID = "test_content_id_1"
+    TEST_TIME = datetime.datetime(2021, 5, 17, 13, 38, 56, 965173)
+    TEST_ACTION_LABEL = "TestEnqueueMiniCastleForReview"
+
+    @staticmethod
+    def mock_aws_credentials():
+        """
+        Mocked AWS Credentials for moto.
+        (likely not needed based on local testing but just incase)
+        """
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_SECURITY_TOKEN"] = "testing"
+        os.environ["AWS_SESSION_TOKEN"] = "testing"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mock_aws_credentials()
+        cls.mock_dynamodb2 = mock_dynamodb2()
+        cls.mock_dynamodb2.start()
+        cls.create_mocked_table()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mock_dynamodb2.stop()
+
+    @classmethod
+    def create_mocked_table(cls):
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table_name = "test-table"
+        cls.table = dynamodb.create_table(
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            TableName=table_name,
+            BillingMode="PAY_PER_REQUEST",
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+        )
+
+    @staticmethod
+    def get_example_content_object():
+        now = TestContentModels.TEST_TIME
+        return ContentObject(
+            content_id=TestContentModels.TEST_CONTENT_ID,
+            content_type="PHOTO",
+            content_ref="key_of_s3_bucket_object_123",
+            content_ref_type="S3",
+            additional_fields={"additional", "ham"},
+            submissions=[now],
+            created_on=now,
+            updated_at=now,
+        )  # .write_to_table(table)
+
+    @staticmethod
+    def get_example_action_event_record():
+        enqueue_mini_castle_for_review_action_label = ActionLabel(
+            TestContentModels.TEST_ACTION_LABEL
+        )
+        action_rules = [
+            ActionRule(
+                name="Enqueue Mini-Castle for Review",
+                action_label=enqueue_mini_castle_for_review_action_label,
+                must_have_labels=set(
+                    [
+                        ClassificationLabel("true_positive"),
+                    ]
+                ),
+                must_not_have_labels=set(),
+            ),
+        ]
+
+        banked_signal = BankedSignal(
+            banked_content_id="4169895076385542",
+            bank_id="303636684709969",
+            bank_source="te",
+        )
+        banked_signal.add_classification("true_positive")
+
+        action_message = ActionMessage(
+            content_key=TestContentModels.TEST_CONTENT_ID,
+            content_hash="361da9e6cf1b72f5cea0344e5bb6e70939f4c70328ace762529cac704297354a",
+            matching_banked_signals=[banked_signal],
+            action_label=enqueue_mini_castle_for_review_action_label,
+            action_rules=action_rules,
+        )
+
+        return ActionEventRecord(
+            content_id=action_message.content_key,
+            time_performed=TestContentModels.TEST_TIME,
+            action_label=action_message.action_label.value,
+            action_rules=[rule.to_aws_json() for rule in action_message.action_rules],
+        )  # .write_to_table(table)
+
+    def test_write_content_object(self):
+        """
+        Test ContentObject's custom write_to_table
+        """
+        obj = self.get_example_content_object()
+        obj.write_to_table(self.table)
+
+        result = self.table.get_item(
+            Key={
+                "PK": f"c#{TestContentModels.TEST_CONTENT_ID}",
+                "SK": "content_type#PHOTO",
+            }
+        )
+        item = result.get("Item")
+        AdditionalFields = item.get("AdditionalFields")
+        CreatedOn = item.get("CreatedOn")
+        assert AdditionalFields == obj.additional_fields
+        assert TestContentModels.TEST_TIME.isoformat() == CreatedOn
+
+    def test_write_action_event_record(self):
+        """
+        Test ActionEventRecord write
+        """
+        record = self.get_example_action_event_record()
+        record.write_to_table(self.table)
+
+        result = self.table.get_item(
+            Key={
+                "PK": f"c#{TestContentModels.TEST_CONTENT_ID}",
+                "SK": f"action_time#{TestContentModels.TEST_TIME.isoformat()}",
+            }
+        )
+        item = result.get("Item")
+        action_label = item.get("ActionLabel")
+        assert TestContentModels.TEST_ACTION_LABEL == action_label
+
+    def test_query_content_object(self):
+        """
+        Test ContentObject write table with get_from_content_id query
+        """
+        obj = self.get_example_content_object()
+        obj.write_to_table(self.table)
+
+        query_record = ContentObject.get_from_content_id(
+            self.table, TestContentModels.TEST_CONTENT_ID
+        )
+
+        assert obj == query_record
+
+    def test_query_action_event_record(self):
+        """
+        Test ActionEventRecord write table with get_from_content_id query
+        """
+
+        record = self.get_example_action_event_record()
+        record.write_to_table(self.table)
+
+        query_record = ActionEventRecord.get_from_content_id(
+            self.table, TestContentModels.TEST_CONTENT_ID
+        )[0]
+
+        assert record == query_record

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -29,7 +29,6 @@ from hmalib.common.message_models import (
     MatchMessage,
     WritebackMessage,
 )
-from hmalib.lambdas.actions.action_performer import perform_label_action
 from mypy_boto3_sqs import SQSClient
 
 logger = get_logger(__name__)

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
@@ -4,19 +4,25 @@ import json
 import os
 import boto3
 import typing as t
+import datetime
 from functools import lru_cache
+from mypy_boto3_dynamodb import DynamoDBServiceResource
+
 from hmalib.common.message_models import BankedSignal, ActionMessage, MatchMessage
 from hmalib.common.actioner_models import (
     ActionPerformer,
     WebhookPostActionPerformer,
 )
 from hmalib.common.evaluator_models import ActionLabel
+from hmalib.common.content_models import ActionEventRecord
 from hmalib.common.logging import get_logger
-
 from hmalib.common import config
 
 
 logger = get_logger(__name__)
+dynamodb: DynamoDBServiceResource = boto3.resource("dynamodb")
+
+DYNAMODB_TABLE = os.environ["DYNAMODB_TABLE"]
 
 
 @lru_cache(maxsize=1)
@@ -52,6 +58,8 @@ def lambda_handler(event, context):
     an action message on the actions queue and here's where they're popped
     off and dealt with.
     """
+    records_table = dynamodb.Table(DYNAMODB_TABLE)
+
     lambda_init_once()
     for sqs_record in event["Records"]:
         # TODO research max # sqs records / lambda_handler invocation
@@ -60,6 +68,15 @@ def lambda_handler(event, context):
         logger.info("Performing action: action_message = %s", action_message)
 
         perform_label_action(action_message, action_message.action_label)
+
+        ActionEventRecord(
+            content_id=action_message.content_key,
+            time_performed=datetime.datetime.now(),
+            action_label=action_message.action_label.value,
+            # Hack: the label rules model is not something I don't fully understand yet...
+            # rn this just says f-it let's make a list of json blobs we can recover and store it.
+            action_rules=[rule.to_aws_json() for rule in action_message.action_rules],
+        ).write_to_table(records_table)
 
     return {"action_performed": "true"}
 

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
@@ -14,7 +14,7 @@ from hmalib.common.actioner_models import (
     WebhookPostActionPerformer,
 )
 from hmalib.common.evaluator_models import ActionLabel
-from hmalib.common.content_models import ActionEventRecord
+from hmalib.common.content_models import ActionEvent
 from hmalib.common.logging import get_logger
 from hmalib.common import config
 
@@ -69,9 +69,11 @@ def lambda_handler(event, context):
 
         perform_label_action(action_message, action_message.action_label)
 
-        ActionEventRecord(
+        ActionEvent(
             content_id=action_message.content_key,
-            time_performed=datetime.datetime.now(),
+            performed_at=datetime.datetime.now(),
+            # TODO this action_label is an indirection for ActionPerformer look up
+            # we probably also want to store its state (or at least it version once one exists)
             action_label=action_message.action_label.value,
             # Hack: the label rules model is not something I don't fully understand yet...
             # rn this just says f-it let's make a list of json blobs we can recover and store it.

--- a/hasher-matcher-actioner/hmalib/lambdas/api/content.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/content.py
@@ -15,7 +15,7 @@ import typing as t
 
 from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
 from hmalib.models import PipelinePDQHashRecord
-from hmalib.common.content_models import ContentObject, ActionEventRecord
+from hmalib.common.content_models import ContentObject, ActionEvent
 from hmalib.common.logging import get_logger
 
 logger = get_logger(__name__)
@@ -35,7 +35,7 @@ class HashResultResponse(JSONifiable):
 
 @dataclass
 class ActionHistoryResponse(JSONifiable):
-    action_records: t.List[ActionEventRecord]
+    action_records: t.List[ActionEvent]
 
     def to_json(self) -> t.Dict:
         return {"action_history": [record.to_json() for record in self.action_records]}
@@ -67,10 +67,10 @@ def get_content_api(
     def action_history(key=None) -> ActionHistoryResponse:
         """
         List of action event records for a given ID
-        see hmalib/common/content_models.ActionEventRecord for specific fields
+        see hmalib/common/content_models.ActionEvent for specific fields
         """
         return ActionHistoryResponse(
-            ActionEventRecord.get_from_content_id(dynamodb_table, key)
+            ActionEvent.get_from_content_id(dynamodb_table, key)
         )
 
     @content_api.get("/hash/<key>", apply=[jsoninator])

--- a/hasher-matcher-actioner/hmalib/lambdas/api/content.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/content.py
@@ -1,0 +1,111 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import bottle
+import boto3
+import base64
+import requests
+import datetime
+
+from enum import Enum
+from dataclasses import dataclass, asdict
+from mypy_boto3_dynamodb.service_resource import Table
+from boto3.dynamodb.conditions import Attr, Key, Or
+from botocore.exceptions import ClientError
+import typing as t
+
+from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
+from hmalib.models import PipelinePDQHashRecord
+from hmalib.common.content_models import ContentObject, ActionEventRecord
+from hmalib.common.logging import get_logger
+
+logger = get_logger(__name__)
+s3_client = boto3.client("s3")
+dynamodb = boto3.resource("dynamodb")
+
+
+@dataclass
+class HashResultResponse(JSONifiable):
+    content_id: str
+    content_hash: str
+    updated_at: str
+
+    def to_json(self) -> t.Dict:
+        return asdict(self)
+
+
+@dataclass
+class ActionHistoryResponse(JSONifiable):
+    action_records: t.List[ActionEventRecord]
+
+    def to_json(self) -> t.Dict:
+        return {"action_history": [record.to_json() for record in self.action_records]}
+
+
+def get_content_api(
+    dynamodb_table: Table, image_bucket_key: str, image_folder_key: str
+) -> bottle.Bottle:
+    """
+    A Closure that includes all dependencies that MUST be provided by the root
+    API that this API plugs into. Declare dependencies here, but initialize in
+    the root API alone.
+    """
+
+    # A prefix to all routes must be provided by the api_root app
+    # The documentation below expects prefix to be '/content/'
+    content_api = bottle.Bottle()
+    image_folder_key_len = len(image_bucket_key)
+
+    @content_api.get("/<key>", apply=[jsoninator])
+    def content(key=None) -> t.Optional[ContentObject]:
+        """
+        Content object for a given ID
+        see hmalib/commom/content_models.ContentObject for specific fields
+        """
+        return ContentObject.get_from_content_id(dynamodb_table, key)
+
+    @content_api.get("/action-history/<key>", apply=[jsoninator])
+    def action_history(key=None) -> ActionHistoryResponse:
+        """
+        List of action event records for a given ID
+        see hmalib/common/content_models.ActionEventRecord for specific fields
+        """
+        return ActionHistoryResponse(
+            ActionEventRecord.get_from_content_id(dynamodb_table, key)
+        )
+
+    @content_api.get("/hash/<key>", apply=[jsoninator])
+    def hashes(key=None) -> t.Optional[HashResultResponse]:
+        """
+        hash details for a given ID:
+        """
+        if not key:
+            return None
+        record = PipelinePDQHashRecord.get_from_content_id(
+            dynamodb_table, f"{image_folder_key}{key}"
+        )
+        if not record:
+            return None
+        return HashResultResponse(
+            content_id=record.content_id[len(image_folder_key) :],
+            content_hash=record.content_hash,
+            updated_at=record.updated_at.isoformat(),
+        )
+
+    @content_api.get("/image/<key>")
+    def image(key=None):
+        """
+        return the bytes of an image in the "image_folder_key" based on key
+        TODO update return url to request directly from s3?
+        """
+        logger.info(key)
+        if not key:
+            return
+        # TODO a whole bunch of validation and error checking...
+        bytes_: bytes = s3_client.get_object(
+            Bucket=image_bucket_key, Key=f"{image_folder_key}{key}"
+        )["Body"].read()
+        # TODO make the content type dynamic
+        bottle.response.set_header("Content-type", "image/jpeg")
+        return bytes_
+
+    return content_api

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -195,13 +195,15 @@ def get_matches_api(
             ]
         )
 
-    @matches_api.get("/match/<key>/", apply=[jsoninator])
-    def match_details(key=None) -> MatchDetailsResponse:
+    @matches_api.get("/match/", apply=[jsoninator])
+    def match_details() -> MatchDetailsResponse:
         """
         match details API endpoint:
         return format: match_details : [MatchDetailsResult]
         """
-        results = get_match_details(dynamodb_table, key, image_folder_key)
+        results = []
+        if content_id := bottle.request.query.content_id or None:
+            results = get_match_details(dynamodb_table, content_id, image_folder_key)
         return MatchDetailsResponse(match_details=results)
 
     @matches_api.post("/request-signal-opinion-change/")

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -4,6 +4,7 @@ import bottle
 import boto3
 import base64
 import requests
+import datetime
 
 from enum import Enum
 from dataclasses import dataclass, asdict
@@ -12,6 +13,7 @@ from botocore.exceptions import ClientError
 import typing as t
 
 from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
+from hmalib.common.content_models import ContentObject
 from hmalib.common.logging import get_logger
 
 logger = get_logger(__name__)
@@ -115,6 +117,23 @@ class SubmitContentError(JSONifiable):
         return asdict(self)
 
 
+def record_content_submission(
+    dynamodb_table: Table, image_folder_key: str, request: SubmitContentRequestBody
+):
+    # TODO add a confirm overwrite path for this
+    submit_time = datetime.datetime.now()
+    ContentObject(
+        content_id=request.content_id,
+        content_type="PHOTO",
+        content_ref=f"{image_folder_key}{request.content_id}",  # raw bytes + tmp urls are a bad idea atm, assume s3 object for now
+        content_ref_type=request.submission_type,
+        additional_fields=set(request.metadata) if request.metadata else set(),
+        submissions=[submit_time],
+        created_on=submit_time,
+        updated_at=submit_time,
+    ).write_to_table(dynamodb_table)
+
+
 def get_submit_api(
     dynamodb_table: Table, image_bucket_key: str, image_folder_key: str
 ) -> bottle.Bottle:
@@ -142,6 +161,9 @@ def get_submit_api(
         if request.submission_type == SubmissionType.UPLOAD.name:
             fileName = request.content_id
             fileContents = base64.b64decode(request.content_ref)
+
+            record_content_submission(dynamodb_table, image_folder_key, request)
+
             # TODO a whole bunch more validation and error checking...
             s3_client.put_object(
                 Body=fileContents,
@@ -159,6 +181,8 @@ def get_submit_api(
             # TODO better checks that the URL actually worked...
             if response and response.content:
                 # TODO a whole bunch more validation and error checking...
+
+                record_content_submission(dynamodb_table, image_folder_key, request)
 
                 # Right now this makes a local copy in s3 but future changes to
                 # pdq_hasher should allow us to avoid storing to our own s3 bucket

--- a/hasher-matcher-actioner/terraform/actions/main.tf
+++ b/hasher-matcher-actioner/terraform/actions/main.tf
@@ -125,6 +125,7 @@ resource "aws_lambda_function" "action_performer" {
   environment {
     variables = {
       CONFIG_TABLE_NAME = var.config_table.name,
+      DYNAMODB_TABLE    = var.datastore.name
     }
   }
 }
@@ -294,8 +295,9 @@ data "aws_iam_policy_document" "action_performer" {
     effect = "Allow"
     actions = [
       "dynamodb:Get*",
+      "dynamodb:PutItem"
     ]
-    resources = [var.config_table.arn]
+    resources = [var.config_table.arn, var.datastore.arn]
   }
 }
 

--- a/hasher-matcher-actioner/terraform/actions/variables.tf
+++ b/hasher-matcher-actioner/terraform/actions/variables.tf
@@ -58,3 +58,11 @@ variable "config_table" {
     name = string
   })
 }
+
+variable "datastore" {
+  description = "DynamoDB Table to store a record of actions"
+  type = object({
+    name = string
+    arn  = string
+  })
+}

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -296,6 +296,10 @@ module "actions" {
     name = aws_dynamodb_table.config_table.name
     arn  = aws_dynamodb_table.config_table.arn
   }
+  datastore = {
+    name = module.hashing_data.hma_datastore.name
+    arn  = module.hashing_data.hma_datastore.arn
+  }
 }
 
 ### ThreatExchange API Token Secret ###

--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -47,24 +47,24 @@ export function fetchMatchesFromContent(contentId) {
   return apiGet('/matches/', {content_q: contentId});
 }
 
-export function fetchMatchDetails(key) {
-  return apiGet(`/matches/match/${key}/`);
+export function fetchMatchDetails(contentId) {
+  return apiGet('/matches/match/', {content_id: contentId});
 }
 
-export function fetchHash(key) {
-  return apiGet(`/content/hash/${key}`);
+export function fetchHash(contentId) {
+  return apiGet('/content/hash/', {content_id: contentId});
 }
 
-export function fetchImage(key) {
-  return apiGet(`/content/image/${key}`, {}, 'blob');
+export function fetchImage(contentId) {
+  return apiGet('/content/image/', {content_id: contentId}, 'blob');
 }
 
-export function fetchContentActionHistory(key) {
-  return apiGet(`/content/action-history/${key}`);
+export function fetchContentActionHistory(contentId) {
+  return apiGet('/content/action-history/', {content_id: contentId});
 }
 
-export function fetchContentDetails(key) {
-  return apiGet(`/content/${key}`);
+export function fetchContentDetails(contentId) {
+  return apiGet('/content/', {content_id: contentId});
 }
 
 export function fetchSignalSummary() {

--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -52,11 +52,19 @@ export function fetchMatchDetails(key) {
 }
 
 export function fetchHash(key) {
-  return apiGet(`/hash/${key}`);
+  return apiGet(`/content/hash/${key}`);
 }
 
 export function fetchImage(key) {
-  return apiGet(`/image/${key}`, {}, 'blob');
+  return apiGet(`/content/image/${key}`, {}, 'blob');
+}
+
+export function fetchContentActionHistory(key) {
+  return apiGet(`/content/action-history/${key}`);
+}
+
+export function fetchContentDetails(key) {
+  return apiGet(`/content/${key}`);
 }
 
 export function fetchSignalSummary() {

--- a/hasher-matcher-actioner/webapp/src/pages/ContentDetails.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/ContentDetails.jsx
@@ -6,7 +6,12 @@ import React, {useState, useEffect} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 import {Col, Row, Table, Button} from 'react-bootstrap';
 
-import {fetchHash, fetchImage} from '../Api';
+import {
+  fetchHash,
+  fetchImage,
+  fetchContentActionHistory,
+  fetchContentDetails,
+} from '../Api';
 import {CopyableHashField} from '../utils/TextFieldsUtils';
 import {formatTimestamp} from '../utils/DateTimeUtils';
 import {BlurUntilHoverImage} from '../utils/ImageUtils';
@@ -16,7 +21,8 @@ import FixedWidthCenterAlignedLayout from './layouts/FixedWidthCenterAlignedLayo
 export default function ContentDetails() {
   const history = useHistory();
   const {id} = useParams();
-  const [actions, setActions] = useState([]);
+  const [contentDetails, setContentDetails] = useState(null);
+  const [actionHistory, setActionHistory] = useState([]);
   const [hashDetails, setHashDetails] = useState(null);
   const [img, setImage] = useState(null);
 
@@ -34,7 +40,17 @@ export default function ContentDetails() {
 
   // TODO fetch actions once endpoint exists
   useEffect(() => {
-    setActions([]);
+    fetchContentActionHistory(id).then(result => {
+      if (result && result.action_history) {
+        setActionHistory(result.action_history);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    fetchContentDetails(id).then(result => {
+      setContentDetails(result);
+    });
   }, []);
 
   return (
@@ -42,7 +58,7 @@ export default function ContentDetails() {
       <Row>
         <Col className="mb-4">
           <Button variant="link" href="#" onClick={() => history.goBack()}>
-            &larr; Back to Matches
+            &larr; Back
           </Button>
         </Col>
       </Row>
@@ -51,12 +67,43 @@ export default function ContentDetails() {
           minHeight: '450px',
         }}>
         <Col md={6}>
+          <h3>Content Details</h3>
           <Table>
             <tbody>
               <tr>
                 <td>Content ID:</td>
                 <td>{id}</td>
               </tr>
+              <tr>
+                <td>Last Submitted:</td>
+                <td>
+                  {contentDetails && contentDetails.updated_at
+                    ? formatTimestamp(contentDetails.updated_at)
+                    : 'Unknown'}
+                </td>
+              </tr>
+              <tr>
+                <td>Additional Fields:</td>
+                <td>
+                  {contentDetails && contentDetails.additional_fields
+                    ? contentDetails.additional_fields.join(', ')
+                    : 'No additional fields provided'}
+                </td>
+              </tr>
+              <td className="pb-0" colSpan={2}>
+                <h4>Action History</h4>
+              </td>
+              <tr>
+                <td>Record:</td>
+                <td>
+                  {actionHistory.length
+                    ? actionHistory[0].action_label
+                    : 'No actions performed'}
+                </td>
+              </tr>
+              <td className="pb-0" colSpan={2}>
+                <h4>Hash Details</h4>
+              </td>
               <tr>
                 <td>Content Hash:</td>
                 <CopyableHashField
@@ -68,25 +115,17 @@ export default function ContentDetails() {
                 />
               </tr>
               <tr>
-                <td>Hashed on:</td>
+                <td>Last Hashed on:</td>
                 <td>
                   {hashDetails
                     ? formatTimestamp(hashDetails.updated_at)
                     : 'loading...'}
                 </td>
               </tr>
-              <tr>
-                <td>Status:</td>
-                <td>
-                  {actions.length
-                    ? 'TODO Render Actions Needs a Component'
-                    : 'No actions performed'}
-                </td>
-              </tr>
             </tbody>
           </Table>
         </Col>
-        <Col md={6}>
+        <Col className="pt-4" md={6}>
           <BlurUntilHoverImage src={img} />
         </Col>
       </Row>

--- a/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
@@ -67,7 +67,9 @@ export default function SubmitContent() {
   const packageMetadata = () => {
     const entries = [];
     Object.values(submissionMetadata).forEach(entry =>
-      entries.push({[entry.key]: entry.value}),
+      // store key:value for now to avoid collisions/overwrite of repeats
+      // exact extra additional fields spec should be established in documentation
+      entries.push(`${entry.key}:${entry.value}`),
     );
     return entries;
   };


### PR DESCRIPTION
How to Review
---------

- [Diff 1/5](https://github.com/facebook/ThreatExchange/pull/583/commits/65d7ae4d3d96fd9003545ce2536ba3589831f407) Creates models for content and action record objects (and unit test)
- [Diff 2/5](https://github.com/facebook/ThreatExchange/pull/583/commits/706fc17de2aa513225186999e2eb4ae58a85f6a7) Begins recording ActionEventRecords in action_performer lambda
- [Diff 3/5](https://github.com/facebook/ThreatExchange/pull/583/commits/e284c33657a9c822cd976eed5df99ebc005da697) Moves existing related endpoints to sub-api `/content/<x>` and expose new models on same sub-api
- [Diff 4/5](https://github.com/facebook/ThreatExchange/pull/583/commits/47cada24ca7bb2fe8c6853a73fb63e075e800ec2) Begins recording content objects in submit API
- [Diff 5/5](https://github.com/facebook/ThreatExchange/pull/583/commits/cc723f21f05a34efbea1fc3c95265132f8c39492) WIP: Surfaces new action records and content details on summary (`/matches/<content_id>`) page

Summary
---------

This PR is my first pass at creating an interface/model for storing (and actually storing):

1) Content Objects (and additional submissions) including metadata/additional fields (Diff 1 & 4)
2) A record of actions taken in action_evaluator (Diff 1 & 2)

It also:

3) Refractors some legacy endpoints outside of `api_root.py` (Diff 3)
4) Exposed this new content and action record endpoints  (Diff 3)

And finally: (slight WIP but happy to merge as is)

5) Adds these new values to the content summary pages (Diff 5)


Test Plan
---------
See test of the e2e in the video below 
Not yet fully tested:
- ActionRecords end to end. (ui works with mocked values however) -> (need ability to config rules)
- Throughput of system with additional storage step -> (need to update store scripts)

https://user-images.githubusercontent.com/7664526/118521121-b50bc180-b708-11eb-98f9-4d74f1ce259b.mov

