### PR TITLE
Delete descriptor

### DIFF
--- a/python-threatexchange/threatexchange/api.py
+++ b/python-threatexchange/threatexchange/api.py
@@ -544,7 +544,7 @@ class ThreatExchangeAPI:
             self._base_url
             + "/"
             + str(indicator_id)
-            + "?fields=descriptors&access_token="
+            + "?fields=descriptors{privacy_members,indicator,type,owner}&access_token="
             + self.api_token
         )
 

--- a/python-threatexchange/threatexchange/api.py
+++ b/python-threatexchange/threatexchange/api.py
@@ -483,13 +483,39 @@ class ThreatExchangeAPI:
 
         return self.upload_threat_descriptor(postParams, showURLs, dryRun)
 
+    def delete_threat_descriptor(
+        self, descriptor_id, showURLs, dryRun
+    ) -> t.List[t.Any]:
+        url = (
+            self._base_url
+            + "/"
+            + str(descriptor_id)
+            + "?access_token="
+            + self.api_token
+        )
+        if showURLs:
+            print()
+            print("(DELETE) URL:")
+            print(url)
+        if dryRun:
+            print("Not doing DELETE since --dry-run.")
+            return [None, None, ""]
+
+        try:
+            with self._get_session() as session:
+                return [None, None, session.delete(url).json()]
+
+        except urllib.error.HTTPError as e:
+            responseBody = json.loads(e.read().decode("utf-8"))
+            return [None, e, responseBody]
+
     def _postThreatDescriptor(self, url, postParams, showURLs, dryRun):
         """Code-reuse for submit and update"""
         for key, value in postParams.items():
             url += "&%s=%s" % (key, urllib.parse.quote(str(value)))
         if showURLs:
             print()
-            print("URL:")
+            print("(POST) URL:")
             print(url)
         if dryRun:
             print("Not doing POST since --dry-run.")


### PR DESCRIPTION
Summary
---------

Add function to delete a ThreatDescriptor to pytx3. This is necessary for the RemoveOpinion writebacker in HMA as the ThreatDescriptor will be deleted if the user elects to do so.

The same functionality could also be done by setting the item to expired (expired descriptors are automatically deleted) however this seemed cleaner.

Test Plan
---------

Ran function locally and saw that descriptor was deleted.

I checked the code manually to confirm that threat_updates would register the delete and I belive it would in `EntThreatDescriptorCollaborationSyncTrigger::genOnDirectDeletionOnlyChangesets` Will check with end to end test of all writebacks in future diff