### PR TITLE
fix matcher_active

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
@@ -109,7 +109,9 @@ def lambda_handler(event, context):
                 metadata["privacy_groups"] = list(
                     filter(
                         lambda x: get_privacy_group_matcher_active(
-                            str(x), time.time() // CACHED_TIME
+                            str(x),
+                            time.time() // CACHED_TIME,
+                            # CACHED_TIME default to 300 seconds, this will convert time.time() to an int parameter which changes every 300 seconds
                         ),
                         privacy_group_list,
                     )

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
@@ -25,6 +25,7 @@ s3_client = boto3.client("s3")
 sns_client: SNSClient = boto3.client("sns")
 dynamodb = boto3.resource("dynamodb")
 
+CACHED_TIME = 300
 THRESHOLD = 31
 LOCAL_INDEX_FILENAME = "/tmp/hashes.index"
 
@@ -107,7 +108,7 @@ def lambda_handler(event, context):
                 privacy_group_list = metadata.get("privacy_groups", [])
                 metadata["privacy_groups"] = filter(
                     lambda x: get_privacy_group_matcher_active(
-                        str(x), time.time() // 300
+                        str(x), time.time() // CACHED_TIME
                     ),
                     privacy_group_list,
                 )


### PR DESCRIPTION
Summary
---------
previous PR : https://github.com/facebook/ThreatExchange/pull/561
this PR is to fix the issue with matcher_active:
1. fix the issue when disable matcher_active, it will still write the matching record to DynamoDB and publish to SQS queue
2. add lru cache(5 mins) for getting the matcher_active config from dynamoDB

Test Plan
---------
1. black hmalib
2. mypy hmalib
3. python -m py.test to pass all tests
5. make docker
6. make upload_docker 
7.  terraform apply
Test changes in localhost:
1. disable matcher_active, upload an image, no matching records should be written to dynamoDB

https://user-images.githubusercontent.com/81996660/118562991-c3bf9c00-b73b-11eb-81d2-0f973a30315a.mov

