### PR TITLE
Implement RemoveOpinion ThreatExchange Writebacker

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/mocks.py
+++ b/hasher-matcher-actioner/hmalib/common/mocks.py
@@ -53,10 +53,10 @@ class MockedThreatExchangeAPI:
             )
         return descriptors
 
-    def react_to_threat_descriptor(self, descriptor_id, reaction) -> None:
+    def react_to_threat_descriptor(self, descriptor_id, reaction) -> t.List[t.Any]:
         # can only react to a descriptor that exists
         assert descriptor_id in (descriptor["id"] for descriptor in self.descriptors)
-        return None
+        return [None, None, {"success": True}]
 
     def upload_threat_descriptor(self, postParams, *vargs):
         # Find the indicator for the descriptor we're trying to copy

--- a/hasher-matcher-actioner/hmalib/common/mocks.py
+++ b/hasher-matcher-actioner/hmalib/common/mocks.py
@@ -7,41 +7,60 @@ class MockedThreatExchangeAPI:
     other_app_id = "a2"
     third_app_id = "a3"
 
-    indicator_to_desriptors = {
-        "2862392437204724": [
-            {"owner": {"id": my_app_id}, "id": "11"},
-            {"owner": {"id": other_app_id}, "id": "21"},
-            {"owner": {"id": third_app_id}, "id": "31"},
-        ],
-        "4194946153908639": [
-            {"owner": {"id": my_app_id}, "id": "12"},
-            {"owner": {"id": other_app_id}, "id": "22"},
-            {"owner": {"id": third_app_id}, "id": "32"},
-        ],
-        "3027465034605137": [
-            {"owner": {"id": my_app_id}, "id": "13"},
-            {"owner": {"id": other_app_id}, "id": "23"},
-            {"owner": {"id": third_app_id}, "id": "33"},
-        ],
-    }
+    @classmethod
+    def build_descriptors(
+        cls, privacy_members: t.List[str], seed: int
+    ) -> t.List[t.Dict[str, t.Any]]:
+        apps: t.List[str] = [cls.my_app_id, cls.other_app_id, cls.third_app_id]
+        return [
+            {
+                "owner": {"id": app},
+                "id": app + "|" + str(seed),
+                "privacy_type": "HAS_PRIVACY_GROUP",
+                "privacy_members": privacy_members,
+            }
+            for app in apps
+        ]
+
+    @property
+    def indicator_to_desriptors(self) -> t.Dict[str, t.List[t.Dict[str, t.Any]]]:
+        return {
+            "2862392437204724": self.build_descriptors(["pg 4"], 2862392437204724),
+            "4194946153908639": self.build_descriptors(["pg 4"], 4194946153908639),
+            "3027465034605137": self.build_descriptors(["pg 3"], 3027465034605137),
+        }
+
+    # for convenience
+    @property
+    def descriptors(self) -> t.List[t.Dict[str, t.Any]]:
+        return [d for ds in self.indicator_to_desriptors.values() for d in ds]
 
     def get_threat_descriptors_from_indicator(
         self, indicator
     ) -> t.List[t.Dict[str, t.Any]]:
         return self.indicator_to_desriptors[indicator]
 
-    def react_to_threat_descriptor(self, descriptor, reaction) -> None:
+    def get_threat_descriptors(
+        self, descriptor_ids: t.List[int], **kwargs
+    ) -> t.List[t.Dict[str, t.Any]]:
+        descriptors = [d for d in self.descriptors if d["id"] in descriptor_ids]
+        if "privacy_members" in kwargs.get("fields", []):
+            # Can only get privacy_memebers field from apps you own
+            # otherwise GraphAPI will error
+            assert all(
+                descriptor["owner"]["id"] == self.my_app_id
+                for descriptor in descriptors
+            )
+        return descriptors
+
+    def react_to_threat_descriptor(self, descriptor_id, reaction) -> None:
         # can only react to a descriptor that exists
-        assert descriptor in (
-            descriptor["id"]
-            for descriptor_set in self.indicator_to_desriptors.values()
-            for descriptor in descriptor_set
-        )
+        assert descriptor_id in (descriptor["id"] for descriptor in self.descriptors)
         return None
 
     def upload_threat_descriptor(self, postParams, *vargs):
         # Find the indicator for the descriptor we're trying to copy
-        indicator = [
+        descriptor_set = [
             descriptor_set
             for descriptor_set in self.indicator_to_desriptors.values()
             if postParams["descriptor_id"]
@@ -54,7 +73,7 @@ class MockedThreatExchangeAPI:
                 "success": True,
                 "id": [
                     descriptor["id"]
-                    for descriptor in indicator
+                    for descriptor in descriptor_set
                     if descriptor["owner"]["id"] == str(self.my_app_id)
                 ][0],
             },
@@ -62,3 +81,19 @@ class MockedThreatExchangeAPI:
 
     def copy_threat_descriptor(self, postParams, *vargs):
         return self.upload_threat_descriptor(postParams, *vargs)
+
+    def delete_threat_descriptor(self, id: str, *vargs):
+        assert id in (descriptor["id"] for descriptor in self.descriptors)
+        return [
+            None,
+            None,
+            {
+                "success": True,
+                "id": id,
+            },
+        ]
+
+    def remove_reaction_from_threat_descriptor(self, descriptor_id, reaction) -> None:
+        # can only react to a descriptor that exists
+        assert descriptor_id in (descriptor["id"] for descriptor in self.descriptors)
+        return None

--- a/hasher-matcher-actioner/hmalib/common/tests/test_writebacker.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_writebacker.py
@@ -51,8 +51,8 @@ class WritebackerTestCase(unittest.TestCase):
         assert result == {
             "writebacks_performed": {
                 "te": [
-                    "reacted SAW_THIS_TOO to 2 descriptors : 21,31",
-                    "reacted SAW_THIS_TOO to 2 descriptors : 22,32",
+                    "reacted SAW_THIS_TOO to 2 descriptors : a2|2862392437204724,a3|2862392437204724",
+                    "reacted SAW_THIS_TOO to 2 descriptors : a2|4194946153908639,a3|4194946153908639",
                     "No writeback performed for banked content id 3027465034605137 becuase writebacks were disabled",
                 ]
             }
@@ -74,8 +74,8 @@ class WritebackerTestCase(unittest.TestCase):
         assert result == {
             "writebacks_performed": {
                 "te": [
-                    "reacted DISAGREE_WITH_TAGS to 2 descriptors : 21,31",
-                    "reacted DISAGREE_WITH_TAGS to 2 descriptors : 22,32",
+                    "reacted DISAGREE_WITH_TAGS to 2 descriptors : a2|2862392437204724,a3|2862392437204724",
+                    "reacted DISAGREE_WITH_TAGS to 2 descriptors : a2|4194946153908639,a3|4194946153908639",
                     "No writeback performed for banked content id 3027465034605137 becuase writebacks were disabled",
                 ]
             }
@@ -97,8 +97,8 @@ class WritebackerTestCase(unittest.TestCase):
         assert result == {
             "writebacks_performed": {
                 "te": [
-                    "Wrote back TruePositive for indicator 2862392437204724\n Built descriptor 11 with privacy groups pg 4",
-                    "Wrote back TruePositive for indicator 4194946153908639\n Built descriptor 12 with privacy groups pg 4",
+                    "Wrote back TruePositive for indicator 2862392437204724\n Built descriptor a1|2862392437204724 with privacy groups pg 4",
+                    "Wrote back TruePositive for indicator 4194946153908639\n Built descriptor a1|4194946153908639 with privacy groups pg 4",
                     "No writeback performed for banked content id 3027465034605137 becuase writebacks were disabled",
                 ]
             }
@@ -120,8 +120,20 @@ class WritebackerTestCase(unittest.TestCase):
         assert result == {
             "writebacks_performed": {
                 "te": [
-                    "MOCKED: Removed opinion on indicator 2862392437204724",
-                    "MOCKED: Removed opinion on indicator 4194946153908639",
+                    "\n".join(
+                        (
+                            "Deleted decriptor a1|2862392437204724 for indicator 2862392437204724",
+                            "Removed reaction DISAGREE_WITH_TAGS from descriptor a2|2862392437204724",
+                            "Removed reaction DISAGREE_WITH_TAGS from descriptor a3|2862392437204724",
+                        )
+                    ),
+                    "\n".join(
+                        (
+                            "Deleted decriptor a1|4194946153908639 for indicator 4194946153908639",
+                            "Removed reaction DISAGREE_WITH_TAGS from descriptor a2|4194946153908639",
+                            "Removed reaction DISAGREE_WITH_TAGS from descriptor a3|4194946153908639",
+                        )
+                    ),
                     "No writeback performed for banked content id 3027465034605137 becuase writebacks were disabled",
                 ]
             }

--- a/hasher-matcher-actioner/hmalib/common/tests/test_writebacker.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_writebacker.py
@@ -51,8 +51,8 @@ class WritebackerTestCase(unittest.TestCase):
         assert result == {
             "writebacks_performed": {
                 "te": [
-                    "reacted SAW_THIS_TOO to 2 descriptors : a2|2862392437204724,a3|2862392437204724",
-                    "reacted SAW_THIS_TOO to 2 descriptors : a2|4194946153908639,a3|4194946153908639",
+                    "Reacted SAW_THIS_TOO to descriptor a2|2862392437204724\nReacted SAW_THIS_TOO to descriptor a3|2862392437204724",
+                    "Reacted SAW_THIS_TOO to descriptor a2|4194946153908639\nReacted SAW_THIS_TOO to descriptor a3|4194946153908639",
                     "No writeback performed for banked content id 3027465034605137 becuase writebacks were disabled",
                 ]
             }
@@ -74,8 +74,8 @@ class WritebackerTestCase(unittest.TestCase):
         assert result == {
             "writebacks_performed": {
                 "te": [
-                    "reacted DISAGREE_WITH_TAGS to 2 descriptors : a2|2862392437204724,a3|2862392437204724",
-                    "reacted DISAGREE_WITH_TAGS to 2 descriptors : a2|4194946153908639,a3|4194946153908639",
+                    "Reacted DISAGREE_WITH_TAGS to descriptor a2|2862392437204724\nReacted DISAGREE_WITH_TAGS to descriptor a3|2862392437204724",
+                    "Reacted DISAGREE_WITH_TAGS to descriptor a2|4194946153908639\nReacted DISAGREE_WITH_TAGS to descriptor a3|4194946153908639",
                     "No writeback performed for banked content id 3027465034605137 becuase writebacks were disabled",
                 ]
             }
@@ -97,8 +97,8 @@ class WritebackerTestCase(unittest.TestCase):
         assert result == {
             "writebacks_performed": {
                 "te": [
-                    "Wrote back TruePositive for indicator 2862392437204724\n Built descriptor a1|2862392437204724 with privacy groups pg 4",
-                    "Wrote back TruePositive for indicator 4194946153908639\n Built descriptor a1|4194946153908639 with privacy groups pg 4",
+                    "Wrote back TruePositive for indicator 2862392437204724\nBuilt descriptor a1|2862392437204724 with privacy groups pg 4",
+                    "Wrote back TruePositive for indicator 4194946153908639\nBuilt descriptor a1|4194946153908639 with privacy groups pg 4",
                     "No writeback performed for banked content id 3027465034605137 becuase writebacks were disabled",
                 ]
             }

--- a/hasher-matcher-actioner/hmalib/common/writebacker_models.py
+++ b/hasher-matcher-actioner/hmalib/common/writebacker_models.py
@@ -1,3 +1,5 @@
+from requests import api
+from hmalib.common.signal_models import PDQSignalMetadata
 import typing as t
 import os
 
@@ -180,7 +182,6 @@ class ThreatExchangeTruePositiveWritebacker(ThreatExchangeWritebacker):
             "review_status": "REVIEWED_MANUALLY",
             "status": "MALICIOUS",
         }
-        print(descriptors)
 
         if my_descriptor:
             members = {member for member in my_descriptor.get("privacy_members", [])}

--- a/hasher-matcher-actioner/hmalib/common/writebacker_models.py
+++ b/hasher-matcher-actioner/hmalib/common/writebacker_models.py
@@ -1,5 +1,3 @@
-from requests import api
-from hmalib.common.signal_models import PDQSignalMetadata
 import typing as t
 import os
 
@@ -182,6 +180,7 @@ class ThreatExchangeTruePositiveWritebacker(ThreatExchangeWritebacker):
             "review_status": "REVIEWED_MANUALLY",
             "status": "MALICIOUS",
         }
+        print(descriptors)
 
         if my_descriptor:
             members = {member for member in my_descriptor.get("privacy_members", [])}

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/writebacker.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/writebacker.py
@@ -50,10 +50,9 @@ if __name__ == "__main__":
     if os.environ.get("WRITEBACK_LOCAL"):
         writeback_message = WritebackMessage(
             [
-                BankedSignal("3744529885563965", "303636684709969", "te"),
-                BankedSignal("3744529885563965", "258601789084078", "te"),
+                BankedSignal("2915547128556957", "303636684709969", "te"),
             ],
-            WritebackTypes.TruePositive,
+            WritebackTypes.RemoveOpinion,
         )
         event = {"Records": [{"body": writeback_message.to_aws_json()}]}
         result = lambda_handler(event, None)

--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -309,7 +309,7 @@ class ThreatUpdateS3PDQStore(tu.ThreatUpdatesStore):
         to any of the signals in data_store_table and if found update
         their tags.
 
-        Additionally, if writebacks are enabled for this privacy group write back
+        TODO: Additionally, if writebacks are enabled for this privacy group write back
         INGESTED to ThreatExchange
         """
         table = dynamodb.Table(self.data_store_table)
@@ -332,6 +332,8 @@ class ThreatUpdateS3PDQStore(tu.ThreatUpdatesStore):
                     S3ThreatDataConfig.SOURCE_STR,
                     self.privacy_group,
                 )
+
+        # TODO: If writebacks are enabled for this privacy group write back INGESTED to ThreatExchange
 
 
 def read_s3_text(bucket, key: str) -> t.Optional[io.StringIO]:


### PR DESCRIPTION
Summary
---------

Last unimplemented writebacker option RemoveOpinion

Test Plan
---------

1. Added unit tests
2.Tested all writebackers together by trigging them locally (not through UI). 
    a) Find an indicator that exists in HMA but that our app doesnt have a descriptor for 
    b) Ensure that our app has not reacted to any of the other descriptors yet
    c) trigger a FalsePositive writeback and watch as other descriptor is reacted to
    d) trigger a RemoveOpinion writeback and watch as reaction is removed
    e) trigger a TruePositive writeback and watch as a descriptor is created with the right fields and privacy group
    f) trigger a RemoveOpinion writeback and watch as descriptor is deleted
3. Tested that Triggering from UI works as well
