### PR TITLE
For 500 errors, log exception at api_root

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import os
+import traceback
 import bottle
 import boto3
 import json
@@ -48,19 +49,22 @@ IMAGE_FOLDER_KEY_LEN = len(IMAGE_FOLDER_KEY)
 
 # Override common errors codes to return json instead of bottle's default html
 @error(404)
-def error404(error):
+def error404(e):
+    logger.error(f"{e}")
     response.content_type = "application/json"
     return json.dumps({"error": "404"})
 
 
 @error(405)
-def error405(error):
+def error405(e):
+    logger.error(f"{e}")
     response.content_type = "application/json"
     return json.dumps({"error": "405"})
 
 
 @error(500)
-def error500(error):
+def error500(e):
+    logger.exception("Exception raised", exc_info=e.exception)
     response.content_type = "application/json"
     return json.dumps({"error": "500"})
 
@@ -128,9 +132,7 @@ def lambda_handler(event, context):
     """
     root request handler
     """
-    logger.info("Received event: " + json.dumps(event, indent=2))
     response = apig_wsgi_handler(event, context)
-    logger.info("Response event: " + json.dumps(response, indent=2))
     return response
 
 


### PR DESCRIPTION
Summary
---------
Prior to this change, two things were wrong:
1. When errors were encountered, they were not logged unless the view function did a log.
2. The request and response bodies were getting logged on cloudwatch which made it incredibly hard to parse them visually.

Test Plan
---------
Deployed the lambdas and made a request to an endpoint that is raising 500s.

**Before**
<img width="1180" alt="Screen Shot 2021-05-19 at 15 51 15" src="https://user-images.githubusercontent.com/217056/118875444-0f984f80-b8ba-11eb-8ef0-7c0943cbbc75.png">


**After**
<img width="1188" alt="Screen Shot 2021-05-19 at 15 50 15" src="https://user-images.githubusercontent.com/217056/118875334-ed9ecd00-b8b9-11eb-8b3e-cc2b996b0da3.png">

