### PR TITLE
For match metrics, add and use correct metric

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/stats.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/stats.py
@@ -60,7 +60,7 @@ def get_stats_api(dynamodb_table: Table) -> bottle.Bottle:
 
     stat_name_to_metric = {
         "hashes": metrics.names.pdq_hasher_lambda.hash,
-        "matches": metrics.names.pdq_matcher_lambda.search_index,
+        "matches": metrics.names.pdq_matcher_lambda.write_match_record,
     }
 
     # DynamoDBItem class is used to get total counts

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
@@ -119,15 +119,18 @@ def lambda_handler(event, context):
                 if metadata["privacy_groups"]:
                     signal_id = metadata["id"]
 
-                    # TODO: Add source (threatexchange) tags to match record
-                    PDQMatchRecord(
-                        key,
-                        hash_str,
-                        current_datetime,
-                        signal_id,
-                        metadata["source"],
-                        metadata["hash"],
-                    ).write_to_table(records_table)
+                    with metrics.timer(
+                        metrics.names.pdq_matcher_lambda.write_match_record
+                    ):
+                        # TODO: Add source (threatexchange) tags to match record
+                        PDQMatchRecord(
+                            key,
+                            hash_str,
+                            current_datetime,
+                            signal_id,
+                            metadata["source"],
+                            metadata["hash"],
+                        ).write_to_table(records_table)
 
                     for pg in metadata.get("privacy_groups", []):
                         # TODO: we might be able to get away with some 'if exists/upsert' here

--- a/hasher-matcher-actioner/hmalib/metrics/__init__.py
+++ b/hasher-matcher-actioner/hmalib/metrics/__init__.py
@@ -74,6 +74,7 @@ class names:
         download_index = f"{_prefix}.download_index"
         parse_index = f"{_prefix}.parse_index"
         search_index = f"{_prefix}.search_index"
+        write_match_record = f"{_prefix}.write_match_record"
 
     class api_hash_count(lambda_with_datafiles):
         _prefix = "api.hashcount"


### PR DESCRIPTION
Summary
---------
So far, we were using the number of times the index was searched as a number of matches metric. This is patently false. The number of matches is actually the number of times match records were written.

This adds a new metric, measures it, and uses it to report back stats.

Test Plan
---------
Deployed to prod and saw the number of matches (as viewed in the dashboard graphs) drop.

Note: There is still some work to be done to ensure things are accurate. I'm not sure they are at this point.