### PR TITLE
Can't switch directly from TP <-> FP

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/OpinionTableCell.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/OpinionTableCell.jsx
@@ -45,7 +45,8 @@ export default function OpinionTableCell({
         <Dropdown.Item
           size="sm"
           disabled={
-            OPINION_STRING.FALSE_POSITIVE === opinion ||
+            opinion === OPINION_STRING.FALSE_POSITIVE ||
+            opinion === OPINION_STRING.TRUE_POSITIVE ||
             (updatePending &&
               pendingOpinionChange !==
                 PENDING_OPINION_CHANGE.MARK_FALSE_POSITIVE)
@@ -69,7 +70,8 @@ export default function OpinionTableCell({
         <Dropdown.Item
           size="sm"
           disabled={
-            OPINION_STRING.TRUE_POSITIVE === opinion ||
+            opinion === OPINION_STRING.FALSE_POSITIVE ||
+            opinion === OPINION_STRING.TRUE_POSITIVE ||
             (updatePending &&
               pendingOpinionChange !==
                 PENDING_OPINION_CHANGE.MARK_TRUE_POSITIVE)


### PR DESCRIPTION
Summary
---------

Writebacks can't currently handle switching directly from True Positive to False Positive. The quickest v0 solution is to disable this and require users to first remove a previous opinion before adding a new opinion. We could potentially change this in the future but for v0 this should work

Decided that a tool tip wasn't really necessary here as having only one enabled action "Remove Opinion" seems to make it clear how to change an opinion. if anyone feels particularly strongly I can add one but already a lot of text/explanations on this page

Test Plan
---------

![Screen Shot 2021-05-19 at 5 30 06 PM](https://user-images.githubusercontent.com/24800630/118887093-db2b9000-b8c7-11eb-8a21-99be1cdef5b6.png)

