### PR TITLE
Close the loop on Writebacks

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/signal_models.py
+++ b/hasher-matcher-actioner/hmalib/common/signal_models.py
@@ -29,7 +29,7 @@ class SignalMetadataBase(DynamoDBItem):
 
     DATASET_PREFIX = "ds#"
 
-    signal_id: t.Union[str, int]
+    signal_id: str
     ds_id: str
     updated_at: datetime.datetime
     signal_source: str

--- a/hasher-matcher-actioner/hmalib/common/writebacker_models.py
+++ b/hasher-matcher-actioner/hmalib/common/writebacker_models.py
@@ -322,9 +322,9 @@ class ThreatExchangeRemoveOpinionWritebacker(ThreatExchangeWritebacker):
 
     def remove_false_positive_from_descriptors(self, descriptors) -> t.List[str]:
         ret = []
+        reaction = ThreatExchangeFalsePositiveWritebacker.reaction
         for descriptor in descriptors:
             id = descriptor["id"]
-            reaction = ThreatExchangeFalsePositiveWritebacker.reaction
             self.te_api.remove_reaction_from_threat_descriptor(id, reaction)
             ret.append(f"Removed reaction {reaction} from descriptor {id}")
         return ret

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -219,6 +219,7 @@ def get_matches_api(
         if not signal_id or not signal_source or not ds_id or not opinion_change:
             return ChangeSignalOpinionResponse(False)
 
+        signal_id = str(signal_id)
         pending_opinion_change = PendingOpinionChange(opinion_change)
 
         writeback_message = WritebackMessage.from_banked_signal_and_opinion_change(

--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -423,4 +423,14 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     # This will only kinda work for so long - eventually will
     # need to use a proper harness
-    lambda_handler(None, None)
+    # lambda_handler(None, None)
+    table = dynamodb.Table(os.environ["DYNAMODB_DATASTORE_TABLE"])
+    signal_id = "3323528337667513"
+    ds_id = "30363668470996"
+    metadata = PDQSignalMetadata.get_from_signal_and_ds_id(
+        table,
+        signal_id,
+        S3ThreatDataConfig.SOURCE_STR,
+        ds_id,
+    )
+    print(metadata)

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
@@ -117,7 +117,7 @@ def lambda_handler(event, context):
                     )
                 )
                 if metadata["privacy_groups"]:
-                    signal_id = metadata["id"]
+                    signal_id = str(metadata["id"])
 
                     # TODO: Add source (threatexchange) tags to match record
                     PDQMatchRecord(

--- a/hasher-matcher-actioner/hmalib/models.py
+++ b/hasher-matcher-actioner/hmalib/models.py
@@ -244,7 +244,7 @@ class PDQMatchRecord(PDQRecordBase):
     Successful execution at the matcher produces this record.
     """
 
-    signal_id: t.Union[str, int]
+    signal_id: str
     signal_source: str
     signal_hash: str
 

--- a/hasher-matcher-actioner/terraform/fetcher/main.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/main.tf
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "fetcher" {
   }
   statement {
     effect    = "Allow"
-    actions   = ["dynamodb:UpdateItem", "dynamodb:Query"]
+    actions   = ["dynamodb:UpdateItem", "dynamodb:GetItem"]
     resources = [var.datastore.arn]
   }
   statement {

--- a/hasher-matcher-actioner/terraform/fetcher/main.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/main.tf
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "fetcher" {
   }
   statement {
     effect    = "Allow"
-    actions   = ["dynamodb:UpdateItem"]
+    actions   = ["dynamodb:UpdateItem", "dynamodb:Query"]
     resources = [var.datastore.arn]
   }
   statement {


### PR DESCRIPTION
Summary
---------

Ensure that writebacks flow all the way through the system. From changing opinion in UI -> API -> dynamoDB -> Writebacker -> ThreatExchange ->Fetcher -> dynamoDB -> API -> UI.

A few necessary/helpful changes:
1. Edit fetcher to update the PendingOpinionChange property on a fetch. @BarrettOlson determined that the necessary logic would be to see if the opinion has changed and if so remove any pending change.
1. typing in signal_models to ensure signal_id is always a str
2. typing in fetcher to convert privacy group ID to str

Test Plan
---------

From UI do the following and watch changes be propagated through the system. 
1. Upload an image which our test app currently doesnt have a descriptor for but a noter app has a descriptor in the privacy group
2. Watch match and see that opinion is "Unknown"
3. Change opinion to True Positive. Confirm that a new descriptor is created for our app and the opinion changes from Unknown -> Unknown + pending -> TruePositive
4. Remove opinion. Confirm that the descriptor is delete and the opinion changes from TruePositive -> True Positive +  pending -> Unknown
5. Change opinion to False Positive. Confirm that we react DiSAGREE_WITH_TAGS to the other apps descriptor and the opinion changes from Unknown -> Unknown + pending -> FalsePositive
6. Remove opinion. Confirm our reaction is removed and the opinion changes from FalsePositive -> True FalsePositive +  pending -> Unknown

NOTE: Testing this took about 10 minutes because of time taken to flow through the whole system the full system so I didn't make a video.
