### PR TITLE
[HMA] make pdq_matcher write of metadata be conditional 

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
@@ -133,8 +133,8 @@ def lambda_handler(event, context):
                         ).write_to_table(records_table)
 
                     for pg in metadata.get("privacy_groups", []):
-                        # TODO: we might be able to get away with some 'if exists/upsert' here
-                        # TODO: @BarrettOlson Write if don't exist or only update given fields is now needed!
+                        # Only update the metadata if it is not found in the table
+                        # once intally created it is the fetcher's job to keep the item up to date
                         PDQSignalMetadata(
                             signal_id,
                             pg,
@@ -142,7 +142,7 @@ def lambda_handler(event, context):
                             metadata["source"],
                             metadata["hash"],
                             metadata["tags"].get(pg, []),
-                        ).write_to_table(records_table)
+                        ).write_to_table_if_not_found(records_table)
 
                     match_ids.append(signal_id)
 


### PR DESCRIPTION
Summary
---------

This changes the matcher to only update/create a metadata object  if it is not found in the table. Once initially created it is the fetcher's job to keep the item up to date.

Test Plan
---------
Test of `write_to_table_if_not_found`
```
import boto3
from hmalib.common.signal_models import PDQSignalMetadata

dynamodb = boto3.resource("dynamodb")
table = dynamodb.Table("barrett-HMADataStore")

print(
    PDQSignalMetadata(
        "example_id_1",
        "example_pg_1",
        datetime.datetime.now(),
        "te",
        "hash_val",
        ["tag1"],
    ).write_to_table_if_not_found(table)
)

print(
    PDQSignalMetadata(
        "example_id_1",
        "example_pg_1",
        datetime.datetime.now(),
        "te",
        "hash_val",
        ["tag1"],
    ).write_to_table_if_not_found(table)
)


``` 
output:
```
True
False
```

Tested changes to matcher via the UI by uploading an image twice and checking that UpdatedAt no longer changes in the table (because the values are the same add after create updates should be coming from the UI or the fetcher not the matcher) .  
