### PR TITLE
fix edit action issue

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.jsx
@@ -90,10 +90,10 @@ export default function ActionPerformerRows({
           </Modal>
         </td>
         <ActionPerformerColumns
-          key={name}
-          name={name}
-          type={type}
-          params={params}
+          key={updatedAction.name}
+          name={updatedAction.name}
+          type={updatedAction.config_subtype}
+          params={updatedAction.fields}
           editing={false}
           create={false}
           onChange={onUpdatedActionChange}
@@ -106,7 +106,6 @@ export default function ActionPerformerRows({
             className="mb-2 table-action-button"
             onClick={() => {
               onSave(updatedAction);
-              resetForm();
               setEditing(false);
             }}>
             <ion-icon


### PR DESCRIPTION
Summary
---------
previoius PR: https://github.com/facebook/ThreatExchange/pull/605
this PR is to resolve issue https://github.com/facebook/ThreatExchange/issues/612
after edit an action, we shouldn't call ```resetForm()```

Test Plan
---------

https://user-images.githubusercontent.com/81996660/119051242-ed253580-b990-11eb-8bd3-758aee2502bf.mov



