### PR TITLE
[HMA] Replace Upload page and refresh Submit Page

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/content.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/content.py
@@ -62,7 +62,9 @@ def get_content_api(
         see hmalib/commom/content_models.ContentObject for specific fields
         """
         if content_id := bottle.request.query.content_id or None:
-            return ContentObject.get_from_content_id(dynamodb_table, content_id)
+            return ContentObject.get_from_content_id(
+                dynamodb_table, f"{image_folder_key}{content_id}"
+            )
         return None
 
     @content_api.get("/action-history/", apply=[jsoninator])
@@ -73,7 +75,9 @@ def get_content_api(
         """
         if content_id := bottle.request.query.content_id or None:
             return ActionHistoryResponse(
-                ActionEvent.get_from_content_id(dynamodb_table, content_id)
+                ActionEvent.get_from_content_id(
+                    dynamodb_table, f"{image_folder_key}{content_id}"
+                )
             )
         return ActionHistoryResponse()
 

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -64,21 +64,19 @@ class InitUploadRequestBody(DictParseable):
         return cls(d["content_id"], d["file_type"])
 
 
-# TODO use enum in storage class
 class SubmissionType(Enum):
-    UPLOAD = "Direct Upload"
-    URL = "URL"
-    RAW = "Raw Value (example only)"
-    S3_OBJECT = "S3 Object (example only)"
+    POST_URL_UPLOAD = "Upload"
+    DIRECT_UPLOAD = "Direct Upload (~faster but only works for images < 3.5MB)"
+    FROM_URL = "From URL"
 
 
 @dataclass
 class SubmitContentRequestBody(DictParseable):
-    submission_type: str  # TODO Enum
+    submission_type: str  # Enum SubmissionType names
     content_id: str
-    content_type: str  # TODO Enum
-    content_ref: t.Union[str, bytes]
-    metadata: t.Optional[t.List]
+    content_type: str  # Only photo supported
+    content_bytes_url_or_file_type: t.Union[str, bytes]
+    additional_fields: t.Optional[t.List]
 
     @classmethod
     def from_dict(cls, d):
@@ -87,8 +85,8 @@ class SubmitContentRequestBody(DictParseable):
             d["submission_type"],
             d["content_id"],
             d["content_type"],
-            d["content_ref"],
-            d["metadata"],
+            d["content_bytes_url_or_file_type"],
+            d["additional_fields"],
         )
 
 
@@ -124,10 +122,12 @@ def record_content_submission(
     submit_time = datetime.datetime.now()
     ContentObject(
         content_id=request.content_id,
-        content_type="PHOTO",
+        content_type=request.content_type or "PHOTO",
         content_ref=f"{image_folder_key}{request.content_id}",  # raw bytes + tmp urls are a bad idea atm, assume s3 object for now
         content_ref_type=request.submission_type,
-        additional_fields=set(request.metadata) if request.metadata else set(),
+        additional_fields=set(request.additional_fields)
+        if request.additional_fields
+        else set(),
         submission_times=[submit_time],  # Note: custom write_to_table impl appends.
         created_at=submit_time,
         updated_at=submit_time,
@@ -147,28 +147,82 @@ def get_submit_api(
     # The documentation below expects prefix to be '/submit/'
     submit_api = bottle.Bottle()
 
-    @submit_api.post("/", apply=[jsoninator(SubmitContentRequestBody)])
-    def submit(
+    # Set of helpers that could be split into there own submit endpoints depending on longterm design choices
+
+    def direct_upload(
         request: SubmitContentRequestBody,
     ) -> t.Union[SubmitContentResponse, SubmitContentError]:
         """
-        Endpoint to allow for the general submission of content to the system
+        Direct transfer of bits to system's s3 bucket
         """
+        fileName = request.content_id
+        fileContents = base64.b64decode(request.content_bytes_url_or_file_type)
 
-        assert isinstance(request, SubmitContentRequestBody)
-        logger.debug(f"Content Submit Request Received {request.content_id}")
+        # We want to record the submission before triggering and processing on
+        # the content itself therefore we write to dynamo before s3
+        record_content_submission(dynamodb_table, image_folder_key, request)
 
-        if request.submission_type == SubmissionType.UPLOAD.name:
-            fileName = request.content_id
-            fileContents = base64.b64decode(request.content_ref)
+        # TODO a whole bunch more validation and error checking...
+        s3_client.put_object(
+            Body=fileContents,
+            Bucket=image_bucket_key,
+            Key=f"{image_folder_key}{fileName}",
+        )
 
-            # We want to record the submission before triggering and processing on
+        return SubmitContentResponse(
+            content_id=request.content_id, submit_successful=True
+        )
+
+    def post_url_upload(
+        request: SubmitContentRequestBody,
+    ) -> t.Union[InitUploadResponse, SubmitContentError]:
+        """
+        Submission of content to the system's s3 bucket by providing a post url to client
+        """
+        # TODO error checking on if key already exist etc.
+        presigned_url = create_presigned_put_url(
+            bucket_name=image_bucket_key,
+            object_name=f"{image_folder_key}{request.content_id}",
+            file_type=request.content_bytes_url_or_file_type,
+        )
+
+        record_content_submission(dynamodb_table, image_folder_key, request)
+
+        if presigned_url:
+            return InitUploadResponse(
+                content_id=request.content_id,
+                file_type=str(request.content_bytes_url_or_file_type),
+                presigned_url=presigned_url,
+            )
+
+        bottle.response.status = 400
+        return SubmitContentError(
+            content_id=request.content_id,
+            message="not yet supported",
+        )
+
+    def from_url(
+        request: SubmitContentRequestBody,
+    ) -> t.Union[SubmitContentResponse, SubmitContentError]:
+        """
+        TODO xyz doctring
+        """
+        fileName = request.content_id
+        url = request.content_bytes_url_or_file_type
+        response = requests.get(url)
+        # TODO better checks that the URL actually worked...
+        if response and response.content:
+            # TODO a whole bunch more validation and error checking...
+
+            # Again, We want to record the submission before triggering and processing on
             # the content itself therefore we write to dynamo before s3
             record_content_submission(dynamodb_table, image_folder_key, request)
 
-            # TODO a whole bunch more validation and error checking...
+            # Right now this makes a local copy in s3 but future changes to
+            # pdq_hasher should allow us to avoid storing to our own s3 bucket
+            # (or possibly give the api/user the option)
             s3_client.put_object(
-                Body=fileContents,
+                Body=response.content,
                 Bucket=image_bucket_key,
                 Key=f"{image_folder_key}{fileName}",
             )
@@ -176,36 +230,30 @@ def get_submit_api(
             return SubmitContentResponse(
                 content_id=request.content_id, submit_successful=True
             )
-        elif request.submission_type == SubmissionType.URL.name:
-            fileName = request.content_id
-            url = request.content_ref
-            response = requests.get(url)
-            # TODO better checks that the URL actually worked...
-            if response and response.content:
-                # TODO a whole bunch more validation and error checking...
+        else:
+            bottle.response.status = 400
+            return SubmitContentError(
+                content_id=request.content_id,
+                message="url submitted could not be read from",
+            )
 
-                # Again, We want to record the submission before triggering and processing on
-                # the content itself therefore we write to dynamo before s3
-                record_content_submission(dynamodb_table, image_folder_key, request)
+    @submit_api.post("/", apply=[jsoninator(SubmitContentRequestBody)])
+    def submit(
+        request: SubmitContentRequestBody,
+    ) -> t.Union[SubmitContentResponse, InitUploadResponse, SubmitContentError]:
+        """
+        Endpoint to allow for the general submission of content to the system
+        """
 
-                # Right now this makes a local copy in s3 but future changes to
-                # pdq_hasher should allow us to avoid storing to our own s3 bucket
-                # (or possibly give the api/user the option)
-                s3_client.put_object(
-                    Body=response.content,
-                    Bucket=image_bucket_key,
-                    Key=f"{image_folder_key}{fileName}",
-                )
+        assert isinstance(request, SubmitContentRequestBody)
+        logger.debug(f"Content Submit Request Received {request.content_id}")
 
-                return SubmitContentResponse(
-                    content_id=request.content_id, submit_successful=True
-                )
-            else:
-                bottle.response.status = 400
-                return SubmitContentError(
-                    content_id=request.content_id,
-                    message="url submitted could not be read from",
-                )
+        if request.submission_type == SubmissionType.DIRECT_UPLOAD.name:
+            return direct_upload(request)
+        elif request.submission_type == SubmissionType.POST_URL_UPLOAD.name:
+            return post_url_upload(request)
+        elif request.submission_type == SubmissionType.FROM_URL.name:
+            return from_url(request)
         else:
             # Other possible submission types are not supported so just echo content_id for testing
             bottle.response.status = 422
@@ -219,7 +267,7 @@ def get_submit_api(
         request: InitUploadRequestBody,
     ) -> t.Union[InitUploadResponse, SubmitContentError]:
         """
-        TODO Endpoint to provide requester with presigned url to upload a photo
+        Endpoint to provide requester with presigned url to upload a photo
         """
 
         # TODO error checking on if key already exist etc.

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -204,7 +204,7 @@ def get_submit_api(
         request: SubmitContentRequestBody,
     ) -> t.Union[SubmitContentResponse, SubmitContentError]:
         """
-        TODO xyz doctring
+        Submission via a url to content. Current behavior copies content into the system's s3 bucket.
         """
         fileName = request.content_id
         url = request.content_bytes_url_or_file_type

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -121,7 +121,7 @@ def record_content_submission(
     # TODO add a confirm overwrite path for this
     submit_time = datetime.datetime.now()
     ContentObject(
-        content_id=request.content_id,
+        content_id=f"{image_folder_key}{request.content_id}",
         content_type=request.content_type or "PHOTO",
         content_ref=f"{image_folder_key}{request.content_id}",  # raw bytes + tmp urls are a bad idea atm, assume s3 object for now
         content_ref_type=request.submission_type,
@@ -186,9 +186,8 @@ def get_submit_api(
             file_type=request.content_bytes_url_or_file_type,
         )
 
-        record_content_submission(dynamodb_table, image_folder_key, request)
-
         if presigned_url:
+            record_content_submission(dynamodb_table, image_folder_key, request)
             return InitUploadResponse(
                 content_id=request.content_id,
                 file_type=str(request.content_bytes_url_or_file_type),

--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -158,7 +158,7 @@ export async function submitContentPostURLUpload(
   content,
   additionalFields,
 ) {
-  const postURL = await apiPost('/submit/', {
+  const submitResponse = await apiPost('/submit/', {
     submission_type: submissionType,
     content_id: contentId,
     content_type: contentType,
@@ -171,7 +171,9 @@ export async function submitContentPostURLUpload(
     body: content,
   };
 
-  const result = await fetch(postURL.presigned_url, requestOptions);
+  // Content object was created. Now the content itself needs to be uploaded to s3
+  // using the post url in the response.
+  const result = await fetch(submitResponse.presigned_url, requestOptions);
   return result;
 }
 

--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -139,24 +139,48 @@ export async function submitContent(
   submissionType,
   contentId,
   contentType,
-  contentRef,
-  metadata,
+  content,
+  additionalFields,
 ) {
   return apiPost('/submit/', {
     submission_type: submissionType,
     content_id: contentId,
     content_type: contentType,
-    content_ref: contentRef,
-    metadata,
+    content_bytes_url_or_file_type: content,
+    additional_fields: additionalFields,
   });
 }
 
-export async function submitContentUpload(
+export async function submitContentPostURLUpload(
   submissionType,
   contentId,
   contentType,
-  contentRef,
-  metadata,
+  content,
+  additionalFields,
+) {
+  const postURL = await apiPost('/submit/', {
+    submission_type: submissionType,
+    content_id: contentId,
+    content_type: contentType,
+    content_bytes_url_or_file_type: content.type,
+    additional_fields: additionalFields,
+  });
+
+  const requestOptions = {
+    method: 'PUT',
+    body: content,
+  };
+
+  const result = await fetch(postURL.presigned_url, requestOptions);
+  return result;
+}
+
+export async function submitContentDirectUpload(
+  submissionType,
+  contentId,
+  contentType,
+  content,
+  additionalFields,
 ) {
   const fileReader = new FileReader();
   fileReader.onload = () => {
@@ -165,11 +189,11 @@ export async function submitContentUpload(
       submission_type: submissionType,
       content_id: contentId,
       content_type: contentType,
-      content_ref: fileContentsBase64Encoded,
-      metadata,
+      content_bytes_url_or_file_type: fileContentsBase64Encoded,
+      additional_fields: additionalFields,
     });
   };
-  return fileReader.readAsArrayBuffer(contentRef);
+  return fileReader.readAsArrayBuffer(content);
 }
 
 export function fetchAllDatasets() {

--- a/hasher-matcher-actioner/webapp/src/Sidebar.jsx
+++ b/hasher-matcher-actioner/webapp/src/Sidebar.jsx
@@ -37,9 +37,9 @@ export default function Sidebar({className}) {
         <li className="nav-item">
           <NavLink
             activeClassName="text-white bg-secondary rounded"
-            to="/upload"
+            to="/submit"
             className="nav-link px-2">
-            Upload
+            Submit Content
           </NavLink>
         </li>
       </ul>

--- a/hasher-matcher-actioner/webapp/src/Upload.jsx
+++ b/hasher-matcher-actioner/webapp/src/Upload.jsx
@@ -20,11 +20,11 @@ export default function Upload() {
     <FixedWidthCenterAlignedLayout title="Upload">
       <Row className="mt-3" float>
         <Col md={6}>
-          Checkout WIP{' '}
+          The{' '}
           <Link as="Button" to="/submit">
             Submit Page
           </Link>{' '}
-          that will soon replace this one!
+          has replaced this one.
         </Col>
       </Row>
       <Row className="mt-3">

--- a/hasher-matcher-actioner/webapp/src/components/SubmitContentFields.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/SubmitContentFields.jsx
@@ -20,17 +20,17 @@ const inputsShape = {
   submissionType: PropTypes.oneOf(Object.keys(SUBMISSION_TYPE)),
   contentId: PropTypes.string,
   contentType: PropTypes.string,
-  contentRef: PropTypes.oneOfType([
+  content: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.shape({raw: PropTypes.file, preview: PropTypes.string}),
   ]),
 };
 
-export function ContentIdAndTypeField({inputs, handleInputChange}) {
+export function ContentUniqueIdField({inputs, handleInputChange}) {
   return (
     <Form.Group>
       <Form.Row>
-        <Form.Label>Content ID and Type</Form.Label>
+        <Form.Label>Unique ID for Content</Form.Label>
         <InputGroup>
           <Form.Control
             onChange={handleInputChange}
@@ -67,21 +67,19 @@ export function ContentIdAndTypeField({inputs, handleInputChange}) {
   );
 }
 
-ContentIdAndTypeField.propTypes = {
+ContentUniqueIdField.propTypes = {
   inputs: PropTypes.shape(inputsShape),
   handleInputChange: PropTypes.func.isRequired,
 };
 
-ContentIdAndTypeField.defaultProps = {
+ContentUniqueIdField.defaultProps = {
   inputs: undefined,
 };
 
 export function PhotoUploadField({inputs, handleInputChangeUpload}) {
   const fileNameIfExist = () =>
-    inputs.contentRef &&
-    inputs.contentRef.raw &&
-    inputs.contentRef.raw instanceof File
-      ? inputs.contentRef.raw.name
+    inputs.content && inputs.content.raw && inputs.content.raw instanceof File
+      ? inputs.content.raw.name
       : undefined;
 
   return (
@@ -91,7 +89,7 @@ export function PhotoUploadField({inputs, handleInputChangeUpload}) {
         <Form.File.Label>
           {fileNameIfExist() ?? 'Submitted file will be stored by HMA System'}
         </Form.File.Label>
-        <Form.File.Input onChange={handleInputChangeUpload} name="contentRef" />
+        <Form.File.Input onChange={handleInputChangeUpload} name="content" />
       </Form.File>
       <Form.Group>
         {fileNameIfExist() ? (
@@ -114,7 +112,7 @@ export function PhotoUploadField({inputs, handleInputChangeUpload}) {
                       maxHeight: '400px',
                       maxWidth: '400px',
                     }}
-                    src={fileNameIfExist() ? inputs.contentRef.preview : ''}
+                    src={fileNameIfExist() ? inputs.content.preview : ''}
                     fluid
                     rounded
                   />
@@ -137,28 +135,16 @@ PhotoUploadField.defaultProps = {
   inputs: undefined,
 };
 
-export function OptionalMetadataField({
-  submissionMetadata,
-  setSubmissionMetadata,
+export function OptionalAdditionalFields({
+  additionalFields,
+  setAdditionalFields,
 }) {
   return (
     <Form.Group>
       <Form.Row>
-        <Form.Label as={Col}>Optional Metadata (not recorded yet)</Form.Label>
-        <Form.Group>
-          <Button
-            variant="success"
-            onClick={() => {
-              setSubmissionMetadata({
-                ...submissionMetadata,
-                [Object.keys(submissionMetadata).length]: {},
-              });
-            }}>
-            +
-          </Button>
-        </Form.Group>
+        <Form.Label as={Col}>Optional Additional Fields</Form.Label>
       </Form.Row>
-      {Object.keys(submissionMetadata).map(entry => (
+      {Object.keys(additionalFields).map(entry => (
         <Form.Row key={entry}>
           <Form.Group as={Col}>
             <InputGroup>
@@ -167,9 +153,9 @@ export function OptionalMetadataField({
               </InputGroup.Prepend>
               <Form.Control
                 onChange={e => {
-                  const metadataCopy = {...submissionMetadata};
-                  metadataCopy[entry].key = e.target.value;
-                  setSubmissionMetadata(metadataCopy);
+                  const copy = {...additionalFields};
+                  copy[entry].key = e.target.value;
+                  setAdditionalFields(copy);
                 }}
               />
             </InputGroup>
@@ -181,9 +167,9 @@ export function OptionalMetadataField({
               </InputGroup.Prepend>
               <Form.Control
                 onChange={e => {
-                  const metadataCopy = {...submissionMetadata};
-                  metadataCopy[entry].value = e.target.value;
-                  setSubmissionMetadata(metadataCopy);
+                  const copy = {...additionalFields};
+                  copy[entry].value = e.target.value;
+                  setAdditionalFields(copy);
                 }}
               />
             </InputGroup>
@@ -193,26 +179,38 @@ export function OptionalMetadataField({
               variant="danger"
               className="float-right"
               onClick={() => {
-                const metadataCopy = {...submissionMetadata};
-                delete metadataCopy[entry];
-                setSubmissionMetadata(metadataCopy);
+                const copy = {...additionalFields};
+                delete copy[entry];
+                setAdditionalFields(copy);
               }}>
               -
             </Button>
           </Form.Group>
         </Form.Row>
       ))}
+      <Form.Group>
+        <Button
+          variant="success"
+          onClick={() => {
+            setAdditionalFields({
+              ...additionalFields,
+              [Object.keys(additionalFields).length]: {},
+            });
+          }}>
+          +
+        </Button>
+      </Form.Group>
     </Form.Group>
   );
 }
 
-OptionalMetadataField.propTypes = {
-  submissionMetadata: PropTypes.objectOf(PropTypes.string),
-  setSubmissionMetadata: PropTypes.func.isRequired,
+OptionalAdditionalFields.propTypes = {
+  additionalFields: PropTypes.objectOf(PropTypes.string),
+  setAdditionalFields: PropTypes.func.isRequired,
 };
 
-OptionalMetadataField.defaultProps = {
-  submissionMetadata: undefined,
+OptionalAdditionalFields.defaultProps = {
+  additionalFields: undefined,
 };
 
 export function NotYetSupportedField({label, handleInputChange}) {
@@ -221,7 +219,7 @@ export function NotYetSupportedField({label, handleInputChange}) {
       <Form.Label>{label}</Form.Label>
       <Form.Control
         onChange={handleInputChange}
-        name="contentRef"
+        name="content"
         placeholder="Not yet supported"
         required
       />

--- a/hasher-matcher-actioner/webapp/src/utils/constants.jsx
+++ b/hasher-matcher-actioner/webapp/src/utils/constants.jsx
@@ -20,10 +20,9 @@ export const PENDING_OPINION_CHANGE = Object.freeze({
 
 // Corseponds  SubmissionType in hmalib/api/submit.py
 export const SUBMISSION_TYPE = Object.freeze({
-  UPLOAD: 'Direct Upload',
-  URL: 'URL',
-  RAW: 'Raw Value (example only)',
-  S3_OBJECT: 'S3 Object (example only)',
+  POST_URL_UPLOAD: 'Upload',
+  DIRECT_UPLOAD: 'Direct Upload (~faster but only works for images < 3.5MB)',
+  FROM_URL: 'From URL',
 });
 
 // Matchtes MetricTimePeriod in hmalib/metrics/query.py


### PR DESCRIPTION
Summary
---------

This PR does a number of small things to unfortunately connected files which made my usually strategy of breaking up at commit level rough/impossible. Still willing to try if this review becomes onerous. 

Largest Changes:
- swaps "Upload" side bar page with "Submit Content"
- Changes `SubmissionType` enum (python & JS) to only the currently supported methods
- Adds new supported method (Post URL Upload)
  - This is what was used and tested on the old upload pages (this allows it to be used on the submit page)
 
Renaming:
- `ContentIdAndTypeField` ->  `ContentUniqueIdField` 
  - done to avoid confusion as the only type we support atm is PHOTO and should be broken up once we support additional
- `metadata` -> `AdditionalFields` (and all associated fields/helpers) 
  - change was already the case at the storage layer this just has the submit layer match
- `content_ref`  -> `content_bytes_url_or_file_type` (in submit request body)
  - don't love the name but the field changes meaning based on  `SubmissionType`
  -  and it NOT match content_ref in the storage layer so it need to be renamed to avoid confusion

Minor:
- some text string on the UI and comments were updated 
- form alignment on submit page
- Add additional field button


Test Plan
---------
This should actually change very little functionality.

https://user-images.githubusercontent.com/7664526/119198938-2ecce380-ba58-11eb-93be-623f250dee84.mov