### PR TITLE
[HMA] Add count of matches / privacy group to API and to UI

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -1,19 +1,14 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import os
-import traceback
 import bottle
 import boto3
 import json
-import base64
-import datetime
 import typing as t
 from apig_wsgi import make_lambda_handler
 from bottle import response, error
 
-from hmalib import metrics
 from hmalib.common.logging import get_logger
-from hmalib.common.s3_adapters import ThreatExchangeS3PDQAdapter, S3ThreatDataConfig
 
 from .action_rules_api import get_action_rules_api
 from .actions_api import get_actions_api
@@ -79,22 +74,6 @@ def signals():
     return {"signals": get_signals()}
 
 
-@app.get("/hash-counts")
-def hash_count():
-    """
-    how many hashes exist in HMA
-    """
-    results = get_signal_hash_count()
-    logger.debug(results)
-    hash_counts = {
-        name.replace(THREAT_EXCHANGE_PDQ_FILE_EXTENSION, "").replace(
-            THREAT_EXCHANGE_DATA_FOLDER, ""
-        ): value
-        for name, value in results.items()
-    }
-    return hash_counts if hash_counts else {}
-
-
 def lambda_handler(event, context):
     """
     root request handler
@@ -112,46 +91,6 @@ class SignalSourceSummary(t.TypedDict):
     name: str
     signals: t.List[SignalSourceType]
     updated_at: str
-
-
-def get_signals() -> t.List[SignalSourceSummary]:
-    """
-    TODO this should be updated to check ThreatExchangeConfig
-    based on what it finds in the config it should then do a s3 select on the files
-    """
-    signals = []
-    counts = get_signal_hash_count()
-    for dataset, total in counts.items():
-        if dataset.endswith(THREAT_EXCHANGE_PDQ_FILE_EXTENSION):
-            dataset_name = dataset.replace(
-                THREAT_EXCHANGE_PDQ_FILE_EXTENSION, ""
-            ).replace(THREAT_EXCHANGE_DATA_FOLDER, "")
-            signals.append(
-                SignalSourceSummary(
-                    name=dataset_name,
-                    # TODO remove hardcode and config mapping file extention to type
-                    signals=[SignalSourceType(type="HASH_PDQ", count=total[0])],
-                    updated_at="TODO",
-                )
-            )
-    return signals
-
-
-# TODO this method is expensive some cache or memoization method might be a good idea.
-def get_signal_hash_count() -> t.Dict[str, t.Tuple[int, str]]:
-    s3_config = S3ThreatDataConfig(
-        threat_exchange_data_bucket_name=THREAT_EXCHANGE_DATA_BUCKET_NAME,
-        threat_exchange_data_folder=THREAT_EXCHANGE_DATA_FOLDER,
-        threat_exchange_pdq_file_extension=THREAT_EXCHANGE_PDQ_FILE_EXTENSION,
-    )
-    pdq_storage = ThreatExchangeS3PDQAdapter(
-        config=s3_config, metrics_logger=metrics.names.api_hash_count()
-    )
-    pdq_data_files = pdq_storage.load_data()
-    return {
-        file_name: (len(rows), pdq_storage.last_modified[file_name])
-        for file_name, rows in pdq_data_files.items()
-    }
 
 
 app.mount(
@@ -188,7 +127,13 @@ app.mount(
 
 app.mount(
     "/datasets/",
-    get_datasets_api(hma_config_table=HMA_CONFIG_TABLE),
+    get_datasets_api(
+        hma_config_table=HMA_CONFIG_TABLE,
+        datastore_table=dynamodb.Table(DYNAMODB_TABLE),
+        threat_exchange_data_bucket_name=THREAT_EXCHANGE_DATA_BUCKET_NAME,
+        threat_exchange_data_folder=THREAT_EXCHANGE_DATA_FOLDER,
+        threat_exchange_pdq_file_extension=THREAT_EXCHANGE_PDQ_FILE_EXTENSION,
+    ),
 )
 
 app.mount("/stats/", get_stats_api(dynamodb_table=dynamodb.Table(DYNAMODB_TABLE)))

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -66,14 +66,6 @@ def root():
     }
 
 
-@app.get("/signals")
-def signals():
-    """
-    Summary of all signal sources
-    """
-    return {"signals": get_signals()}
-
-
 def lambda_handler(event, context):
     """
     root request handler

--- a/hasher-matcher-actioner/hmalib/lambdas/api/datasets_api.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/datasets_api.py
@@ -1,19 +1,22 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from hmalib.common.count_models import MatchByPrivacyGroupCounter
 import bottle
 import typing as t
 from dataclasses import dataclass, asdict
-from hmalib.aws_secrets import AWSSecrets
-from threatexchange.api import ThreatExchangeAPI
-from hmalib.common.logging import get_logger
-from .middleware import jsoninator, JSONifiable, DictParseable
+from mypy_boto3_dynamodb.service_resource import Table
+
+from hmalib import metrics
 from hmalib.common.config import HMAConfig
 from hmalib.common import config as hmaconfig
+from hmalib.common.s3_adapters import ThreatExchangeS3PDQAdapter, S3ThreatDataConfig
 from hmalib.common.fetcher_models import ThreatExchangeConfig
 from hmalib.common.threatexchange_config import (
     sync_privacy_groups,
     create_privacy_group_if_not_exists,
 )
+
+from .middleware import jsoninator, JSONifiable, DictParseable
 
 
 @dataclass
@@ -128,19 +131,128 @@ class CreateDatasetResponse(JSONifiable):
         return asdict(self)
 
 
-def get_datasets_api(hma_config_table: str) -> bottle.Bottle:
+@dataclass
+class ThreatExchangeDatasetSummary(Dataset):
+    """
+    Factual information about a ThreatExchange dataset. This could be
+    information like the name of the privacy group, the type of content it
+    covers, the number of hashes it has etc.
+
+    At the same time, it is not meant to replace the Dataset type. It will *not*
+    contain configs that the user can edit. Eg. writeback_active,
+    fetcher_active. Those continue to stay in the Dataset super class.
+    """
+
+    hash_count: int
+    match_count: int
+
+    def to_json(self) -> t.Dict:
+        dataset_json = super().to_json()
+        dataset_json.update(hash_count=self.hash_count, match_count=self.match_count)
+
+        return dataset_json
+
+
+@dataclass
+class DatasetSummariesResponse(JSONifiable):
+    threat_exchange_datasets: t.List[ThreatExchangeDatasetSummary]
+    test_datasets: t.List[ThreatExchangeDatasetSummary]  # re-using same class for
+
+    def to_json(self) -> t.Dict:
+        return {
+            "threat_exchange_datasets": [
+                dataset.to_json() for dataset in self.threat_exchange_datasets
+            ]
+        }
+
+
+def _get_signal_hash_count_and_last_modified(
+    threat_exchange_data_bucket_name: str,
+    threat_exchange_data_folder: str,
+    threat_exchange_pdq_file_extension: str,
+) -> t.Dict[str, t.Tuple[int, str]]:
+    # TODO this method is expensive some cache or memoization method might be a good idea.
+
+    s3_config = S3ThreatDataConfig(
+        threat_exchange_data_bucket_name=threat_exchange_data_bucket_name,
+        threat_exchange_data_folder=threat_exchange_data_folder,
+        threat_exchange_pdq_file_extension=threat_exchange_pdq_file_extension,
+    )
+    pdq_storage = ThreatExchangeS3PDQAdapter(
+        config=s3_config, metrics_logger=metrics.names.api_hash_count()
+    )
+    pdq_data_files = pdq_storage.load_data()
+    return {
+        file_name: (len(rows), pdq_storage.last_modified[file_name])
+        for file_name, rows in pdq_data_files.items()
+    }
+
+
+def _get_threat_exchange_datasets(
+    table: Table,
+    threat_exchange_data_bucket_name: str,
+    threat_exchange_data_folder: str,
+    threat_exchange_pdq_file_extension: str,
+) -> t.List[ThreatExchangeDatasetSummary]:
+    collaborations = ThreatExchangeConfig.get_all()
+    hash_counts: t.Dict[
+        str, t.Tuple[int, str]
+    ] = _get_signal_hash_count_and_last_modified(
+        threat_exchange_data_bucket_name,
+        threat_exchange_data_folder,
+        threat_exchange_pdq_file_extension,
+    )
+
+    match_counts: t.Dict[str, int] = MatchByPrivacyGroupCounter.get_all_counts(table)
+
+    return [
+        ThreatExchangeDatasetSummary(
+            collab.privacy_group_id,
+            collab.privacy_group_name,
+            collab.description,
+            collab.fetcher_active,
+            collab.matcher_active,
+            collab.write_back,
+            collab.in_use,
+            hash_count=t.cast(
+                int,
+                hash_counts.get(
+                    f"{threat_exchange_data_folder}{collab.privacy_group_id}{threat_exchange_pdq_file_extension}",
+                    [0, ""],
+                )[0],
+            ),
+            match_count=match_counts.get(collab.privacy_group_id, 0),
+        )
+        for collab in collaborations
+    ]
+
+
+def get_datasets_api(
+    hma_config_table: str,
+    datastore_table: Table,
+    threat_exchange_data_bucket_name: str,
+    threat_exchange_data_folder: str,
+    threat_exchange_pdq_file_extension: str,
+) -> bottle.Bottle:
     # The documentation below expects prefix to be '/datasets/'
     datasets_api = bottle.Bottle()
     HMAConfig.initialize(hma_config_table)
 
     @datasets_api.get("/", apply=[jsoninator])
-    def datasets() -> DatasetsResponse:
+    def get_all_dataset_summaries() -> DatasetSummariesResponse:
         """
-        Returns all datasets.
+        Returns summaries for all datasets. Summary includes all facts that are
+        not configurable. Eg. its name, the number of hashes it has, the
+        number of matches it has caused, etc.
         """
-        collabs = ThreatExchangeConfig.get_all()
-        return DatasetsResponse(
-            datasets_response=[Dataset.from_collab(collab) for collab in collabs]
+        return DatasetSummariesResponse(
+            threat_exchange_datasets=_get_threat_exchange_datasets(
+                datastore_table,
+                threat_exchange_data_bucket_name,
+                threat_exchange_data_folder,
+                threat_exchange_pdq_file_extension,
+            ),
+            test_datasets=[],
         )
 
     @datasets_api.post("/update", apply=[jsoninator(UpdateDatasetRequest)])

--- a/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.jsx
@@ -20,7 +20,7 @@ export default function ThreatExchangePrivacyGroupCard({
   description,
   writeBack,
   hashCount,
-  lastModified,
+  matchCount,
   onSave,
   onDelete,
 }) {
@@ -98,13 +98,13 @@ export default function ThreatExchangePrivacyGroupCard({
                   trigger="focus"
                   placement="bottom"
                   overlay={
-                    <Popover id={`popover-lastModified${privacyGroupId}`}>
-                      <Popover.Title as="h3">Last Modified Time</Popover.Title>
-                      <Popover.Content>{lastModified}</Popover.Content>
+                    <Popover id={`popover-hashCount${privacyGroupId}`}>
+                      <Popover.Title as="h3">Match Count</Popover.Title>
+                      <Popover.Content>{matchCount}</Popover.Content>
                     </Popover>
                   }>
-                  <Button variant="info">Last Modified Time</Button>
-                </OverlayTrigger>
+                  <Button variant="info">Match Count</Button>
+                </OverlayTrigger>{' '}
               </div>
               <Form.Switch
                 onChange={onSwitchFetcherActive}
@@ -179,7 +179,7 @@ ThreatExchangePrivacyGroupCard.propTypes = {
   description: PropTypes.string.isRequired,
   writeBack: PropTypes.bool.isRequired,
   hashCount: PropTypes.number.isRequired,
-  lastModified: PropTypes.string.isRequired,
+  matchCount: PropTypes.number.isRequired,
   onSave: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
 };

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.jsx
@@ -23,12 +23,10 @@ import {
   syncAllDatasets,
   updateDataset,
   deleteDataset,
-  fetchHashCount,
 } from '../../Api';
 
 export default function ThreatExchangeSettingsTab() {
   const [datasets, setDatasets] = useState([]);
-  const [hashCounts, setHashCount] = useState({});
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState(false);
   const [showToast, setShowToast] = useState(false);
@@ -91,15 +89,14 @@ export default function ThreatExchangeSettingsTab() {
         setShowToast(true);
       });
   };
+
   const refreshDatasets = () => {
     fetchAllDatasets(setLoading(false)).then(response => {
-      fetchHashCount().then(counts => {
-        setHashCount(counts);
-        setLoading(true);
-        setDatasets(response.datasets_response);
-      });
+      setLoading(true);
+      setDatasets(response.threat_exchange_datasets);
     });
   };
+
   useEffect(() => {
     refreshDatasets();
   }, []);
@@ -157,16 +154,8 @@ export default function ThreatExchangeSettingsTab() {
                   inUse={dataset.in_use}
                   privacyGroupId={dataset.privacy_group_id}
                   writeBack={dataset.write_back}
-                  hashCount={
-                    hashCounts[dataset.privacy_group_id]
-                      ? hashCounts[dataset.privacy_group_id][0]
-                      : 'Not yet calculated'
-                  }
-                  lastModified={
-                    hashCounts[dataset.privacy_group_id]
-                      ? hashCounts[dataset.privacy_group_id][1]
-                      : 'Unkown'
-                  }
+                  hashCount={dataset.hash_count}
+                  matchCount={dataset.match_count}
                   onSave={onPrivacyGroupSave}
                   onDelete={onPrivacyGroupDelete}
                 />


### PR DESCRIPTION
Summary
---------
Since we had already added hash counts to the ThreatExchange settings tab, it made sense to add the match counts there as well. I have not added Tate's feedback or played around with the UI. Just replaced last modified with match count.

Last modified is getting tricky because the source of information could be from many places. The config itself is updated. The hash and match counts are updated by separate processes. So, just dropped it from the UI.

Also, removed the /hash_counts/ API and added everything to the same /datasets/ call.

It seems more and more likely that the signals page could go away. There is no information on that page that is not anywhere in the ThreatExchange settings page. And showing the same information in two places becomes confusing.

Test Plan
---------
```
$ python -m mypy .
$ python -m black .
$ python -m py.test 
```

<img width="1017" alt="Screen Shot 2021-05-22 at 19 19 27" src="https://user-images.githubusercontent.com/217056/119243204-a5d6aa80-bb32-11eb-92ed-9c6885d0e79b.png">
