### PR TITLE
make action performer name and webhook type editable

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/actions_api.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/actions_api.py
@@ -4,7 +4,7 @@ import bottle
 import typing as t
 from dataclasses import dataclass, asdict
 from .middleware import jsoninator, JSONifiable, DictParseable
-from hmalib.common.config import HMAConfig, update_config
+from hmalib.common.config import HMAConfig
 from hmalib.common import config as hmaconfig
 from hmalib.common.actioner_models import ActionPerformer
 
@@ -71,17 +71,26 @@ def get_actions_api(hma_config_table: str) -> bottle.Bottle:
             actions_response=[config.__dict__ for config in action_configs]
         )
 
-    @actions_api.put("/", apply=[jsoninator(CreateUpdateActionRequest)])
-    def update_action(request: CreateUpdateActionRequest) -> UpdateActionResponse:
+    @actions_api.put(
+        "/<old_name>/<old_config_sub_stype>",
+        apply=[jsoninator(CreateUpdateActionRequest)],
+    )
+    def update_action(
+        request: CreateUpdateActionRequest, old_name: str, old_config_sub_stype: str
+    ) -> UpdateActionResponse:
         """
         Update an action url and headers
         """
-        config = ActionPerformer._get_subtypes_by_name()[request.config_subtype].getx(
-            request.name
-        )
-        for key, value in request.fields.items():
-            setattr(config, key, value)
-        hmaconfig.update_config(config)
+        if old_name != request.name or old_config_sub_stype != request.config_subtype:
+            delete_action(old_name)
+            create_action(request)
+        else:
+            config = ActionPerformer._get_subtypes_by_name()[
+                request.config_subtype
+            ].getx(request.name)
+            for key, value in request.fields.items():
+                setattr(config, key, value)
+            hmaconfig.update_config(config)
         return UpdateActionResponse(response="The action config is updated.")
 
     @actions_api.post("/", apply=[jsoninator(CreateUpdateActionRequest)])
@@ -95,13 +104,12 @@ def get_actions_api(hma_config_table: str) -> bottle.Bottle:
         hmaconfig.create_config(config)
         return CreateActionResponse(response="The action config is created.")
 
-    @actions_api.delete("/<key>", apply=[jsoninator])
-    def delete_action(key=None) -> DeleteActionResponse:
+    @actions_api.delete("/<name>", apply=[jsoninator])
+    def delete_action(name: str) -> DeleteActionResponse:
         """
         Delete an action
         """
-        config = ActionPerformer.getx(str(key))
-        hmaconfig.delete_config(config)
+        hmaconfig.delete_config_by_type_and_name("ActionPerformer", name)
         return DeleteActionResponse(response="The action config is deleted.")
 
     return actions_api

--- a/hasher-matcher-actioner/hmalib/lambdas/api/actions_api.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/actions_api.py
@@ -82,6 +82,8 @@ def get_actions_api(hma_config_table: str) -> bottle.Bottle:
         Update an action url and headers
         """
         if old_name != request.name or old_config_sub_stype != request.config_subtype:
+            # The name field can't be updated because it is the primary key
+            # The config sub type can't be updated because it is the config class level param
             delete_action(old_name)
             create_action(request)
         else:

--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -227,15 +227,15 @@ export function fetchAllActions() {
 }
 
 export function createAction(newAction) {
-  return apiPost('/actions/', newAction);
+  return apiPost('actions/', newAction);
 }
 
-export function updateAction(updatedAction) {
-  return apiPut('/actions/', updatedAction);
+export function updateAction(name, type, updatedAction) {
+  return apiPut(`actions/${name}/${type}`, updatedAction);
 }
 
-export function deleteAction(key) {
-  return apiDelete(`/actions/${key}`);
+export function deleteAction(name) {
+  return apiDelete(`actions/${name}`);
 }
 
 export function fetchAllActionRules() {

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerColumns.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerColumns.jsx
@@ -28,7 +28,7 @@ export default function ActionPerformerColumns({
 
         <div hidden={!editing}>
           <Form>
-            <Form.Group controlId={name}>
+            <Form.Group>
               <Form.Label>Action Name</Form.Label>
               <Form.Control
                 type="text"

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerColumns.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerColumns.jsx
@@ -11,7 +11,6 @@ export default function ActionPerformerColumns({
   name,
   type,
   params,
-  create,
   editing,
   onChange,
 }) {
@@ -28,30 +27,25 @@ export default function ActionPerformerColumns({
         <div hidden={editing}>{name}</div>
 
         <div hidden={!editing}>
-          {create ? (
-            <Form>
-              <Form.Group controlId={name}>
-                <Form.Label>Action Name</Form.Label>
-                <Form.Control
-                  type="text"
-                  placeholder="New Action Name"
-                  value={name}
-                  onChange={e => {
-                    onChange('name', {name: e.target.value});
-                  }}
-                />
-              </Form.Group>
-            </Form>
-          ) : (
-            <div>{name}</div>
-          )}
+          <Form>
+            <Form.Group controlId={name}>
+              <Form.Label>Action Name</Form.Label>
+              <Form.Control
+                type="text"
+                placeholder="New Action Name"
+                value={name}
+                onChange={e => {
+                  onChange('name', {name: e.target.value});
+                }}
+              />
+            </Form.Group>
+          </Form>
         </div>
       </td>
       <td>
         {Actioners[type]({
           webhookType: type,
           editing,
-          create,
           ...params,
           onChange,
         })}
@@ -64,7 +58,6 @@ ActionPerformerColumns.propTypes = {
   name: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   editing: PropTypes.bool.isRequired,
-  create: PropTypes.bool.isRequired,
   params: PropTypes.shape({
     url: PropTypes.string.isRequired,
     headers: PropTypes.string.isRequired,

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.jsx
@@ -18,8 +18,8 @@ export default function ActionPerformerRows({
 }) {
   const [editing, setEditing] = useState(edit);
   const [
-    showDeleteActionRuleConfirmation,
-    setShowDeleteActionRuleConfirmation,
+    showDeleteActionConfirmation,
+    setShowDeleteActionConfirmation,
   ] = useState(false);
   const [updatedAction, setUpdatedAction] = useState({
     name,
@@ -58,7 +58,7 @@ export default function ActionPerformerRows({
           <Button
             variant="secondary"
             className="table-action-button"
-            onClick={() => setShowDeleteActionRuleConfirmation(true)}>
+            onClick={() => setShowDeleteActionConfirmation(true)}>
             <ion-icon
               name="trash-bin"
               size="large"
@@ -66,8 +66,8 @@ export default function ActionPerformerRows({
             />
           </Button>
           <Modal
-            show={showDeleteActionRuleConfirmation}
-            onHide={() => setShowDeleteActionRuleConfirmation(false)}>
+            show={showDeleteActionConfirmation}
+            onHide={() => setShowDeleteActionConfirmation(false)}>
             <Modal.Header closeButton>
               <Modal.Title>Confirm Action Delete</Modal.Title>
             </Modal.Header>
@@ -80,7 +80,7 @@ export default function ActionPerformerRows({
             <Modal.Footer>
               <Button
                 variant="secondary"
-                onClick={() => setShowDeleteActionRuleConfirmation(false)}>
+                onClick={() => setShowDeleteActionConfirmation(false)}>
                 Cancel
               </Button>
               <Button variant="primary" onClick={() => onDelete(name)}>
@@ -95,7 +95,6 @@ export default function ActionPerformerRows({
           type={updatedAction.config_subtype}
           params={updatedAction.fields}
           editing={false}
-          create={false}
           onChange={onUpdatedActionChange}
         />
       </tr>
@@ -105,7 +104,7 @@ export default function ActionPerformerRows({
             variant="outline-primary"
             className="mb-2 table-action-button"
             onClick={() => {
-              onSave(updatedAction);
+              onSave({name, type, updatedAction});
               setEditing(false);
             }}>
             <ion-icon
@@ -129,7 +128,6 @@ export default function ActionPerformerRows({
           type={updatedAction.config_subtype}
           params={updatedAction.fields}
           editing
-          create={false}
           onChange={onUpdatedActionChange}
         />
       </tr>

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.jsx
@@ -21,6 +21,10 @@ export default function ActionPerformerRows({
     showDeleteActionConfirmation,
     setShowDeleteActionConfirmation,
   ] = useState(false);
+  const [
+    showUpdateActionConfirmation,
+    setShowUpdateActionConfirmation,
+  ] = useState(false);
   const [updatedAction, setUpdatedAction] = useState({
     name,
     config_subtype: type,
@@ -104,8 +108,7 @@ export default function ActionPerformerRows({
             variant="outline-primary"
             className="mb-2 table-action-button"
             onClick={() => {
-              onSave({name, type, updatedAction});
-              setEditing(false);
+              setShowUpdateActionConfirmation(true);
             }}>
             <ion-icon
               name="checkmark"
@@ -122,6 +125,35 @@ export default function ActionPerformerRows({
             }}>
             <ion-icon name="close" size="large" className="ion-icon-white" />
           </Button>
+          <Modal
+            show={showUpdateActionConfirmation}
+            onHide={() => setShowUpdateActionConfirmation(false)}>
+            <Modal.Header closeButton>
+              <Modal.Title>Confirm Action Update</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+              <p>
+                Please confirm you want to update the action named{' '}
+                <strong>{name}</strong>.
+              </p>
+            </Modal.Body>
+            <Modal.Footer>
+              <Button
+                variant="secondary"
+                onClick={() => setShowUpdateActionConfirmation(false)}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => {
+                  setEditing(false);
+                  onSave({name, type, updatedAction});
+                  setShowUpdateActionConfirmation(false);
+                }}>
+                Yes, Update This Action
+              </Button>
+            </Modal.Footer>
+          </Modal>
         </td>
         <ActionPerformerColumns
           name={updatedAction.name}

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.jsx
@@ -12,7 +12,6 @@ export default function WebhookActioner({
   headers,
   webhookType,
   editing,
-  create,
   onChange,
 }) {
   const ActionerTypes = {
@@ -85,32 +84,26 @@ export default function WebhookActioner({
                 }}
               />
               <br />
-              {create ? (
-                <div>
-                  <Form.Label>Webhook Type</Form.Label>
-                  <Form.Text className="text-muted">
-                    {actionerDetails.args.webhookType.description}
-                  </Form.Text>
-                  <Form.Control
-                    as="select"
-                    value={webhookType}
-                    onChange={e => {
-                      onChange('config_subtype', {
-                        config_subtype: e.target.value,
-                      });
-                    }}>
-                    <option value="">Please select one option</option>
-                    <option value="WebhookPostActionPerformer">POST</option>
-                    <option value="WebhookGetActionPerformer">GET</option>
-                    <option value="WebhookPutActionPerformer">PUT</option>
-                    <option value="WebhookDeleteActionPerformer">DELETE</option>
-                  </Form.Control>
-                </div>
-              ) : (
-                <Form.Label>
-                  Webhook Type : {WebhookType[webhookType]}
-                </Form.Label>
-              )}
+              <div>
+                <Form.Label>Webhook Type</Form.Label>
+                <Form.Text className="text-muted">
+                  {actionerDetails.args.webhookType.description}
+                </Form.Text>
+                <Form.Control
+                  as="select"
+                  value={webhookType}
+                  onChange={e => {
+                    onChange('config_subtype', {
+                      config_subtype: e.target.value,
+                    });
+                  }}>
+                  <option value="">Please select one option</option>
+                  <option value="WebhookPostActionPerformer">POST</option>
+                  <option value="WebhookGetActionPerformer">GET</option>
+                  <option value="WebhookPutActionPerformer">PUT</option>
+                  <option value="WebhookDeleteActionPerformer">DELETE</option>
+                </Form.Control>
+              </div>
               <br />
               <Form.Label>Headers</Form.Label>
               <Form.Text className="text-muted">
@@ -135,7 +128,6 @@ WebhookActioner.propTypes = {
   url: PropTypes.string.isRequired,
   headers: PropTypes.string.isRequired,
   editing: PropTypes.bool.isRequired,
-  create: PropTypes.bool.isRequired,
   webhookType: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
 };

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.jsx
@@ -55,7 +55,11 @@ export default function ActionRulesTableRow({
     ) {
       return <span>&mdash;</span>;
     }
-    return actions.find(action => action.id === actionId).name;
+    const actionPerformer = actions.find(action => action.id === actionId);
+    if (actionPerformer) {
+      return actionPerformer.name;
+    }
+    return <span>&mdash;</span>;
   };
 
   return (

--- a/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.jsx
@@ -174,7 +174,7 @@ ThreatExchangePrivacyGroupCard.propTypes = {
   fetcherActive: PropTypes.bool.isRequired,
   matcherActive: PropTypes.bool.isRequired,
   inUse: PropTypes.bool.isRequired,
-  privacyGroupId: PropTypes.number.isRequired,
+  privacyGroupId: PropTypes.string.isRequired,
   privacyGroupName: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   writeBack: PropTypes.bool.isRequired,

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ActionSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ActionSettingsTab.jsx
@@ -66,10 +66,13 @@ export default function ActionSettingsTab() {
     });
   };
   const onActionUpdate = updatedAction => {
-    updateAction(updatedAction)
+    updateAction(
+      updatedAction.name,
+      updatedAction.type,
+      updatedAction.updatedAction,
+    )
       .then(response => {
         displayToast(response.response);
-        deleteActionUI(updateAction.name);
         refreshActions();
       })
       .catch(() => {
@@ -166,7 +169,6 @@ export default function ActionSettingsTab() {
                   type={newAction.config_subtype}
                   params={newAction.fields}
                   editing
-                  create
                   onChange={onNewActionChange}
                 />
               </tr>


### PR DESCRIPTION
Summary
---------

In previous PR [605](https://github.com/facebook/ThreatExchange/pull/605), I've made the field 'Action Name' and 'webhook type' non-editable. 
This PR is to make these two fields editable, the changes involved:
1. Made changes to ```/actions``` api, added two url params ```/actions/<old_name>/<old_config_sub_stype>```
2. Compare old_name with updated name and old_config_sub_stype with updated config sub type, if either one is different then delete the old config and create the new config. Otherwise will update old config
3. Made changes to UI related files to make those two fields editable

Test Plan
---------
1. ```mypy hmalib```
2. ```python -m pytest```
3. ```black hmalib```
4. ```make docker```
5. ```make upload_docker```
6. ```terraform apply```
7. test changes in localhost

https://user-images.githubusercontent.com/81996660/119396801-5c599d00-bca3-11eb-9184-b76e14a5a231.mov


