### PR TITLE
[hma] Add ActionHistoryTable to Details page

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/ActionHistoryTable.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/ActionHistoryTable.jsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React, {useState, useEffect} from 'react';
+import {Col, Collapse, Row, Table, Button} from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import Spinner from 'react-bootstrap/Spinner';
+
+import {fetchContentActionHistory} from '../Api';
+import {CopyableTextField} from '../utils/TextFieldsUtils';
+import {formatTimestamp} from '../utils/DateTimeUtils';
+
+const DEFAULT_NUM_ROWS = 2;
+
+export default function ActionHistoryTable({contentKey}) {
+  const [actionHistory, setActionHistory] = useState(null);
+  const [showAll, setShowAll] = useState(false);
+
+  useEffect(() => {
+    fetchContentActionHistory(contentKey).then(result => {
+      if (result && result.action_history) {
+        result.action_history.sort(
+          (event1, event2) =>
+            new Date(event2.performed_at).getTime() -
+            new Date(event1.performed_at).getTime(),
+        );
+        setActionHistory(result.action_history);
+      }
+    });
+  }, [contentKey]);
+
+  return (
+    <>
+      <Spinner hidden={actionHistory !== null} animation="border" role="status">
+        <span className="sr-only">Loading...</span>
+      </Spinner>
+      <Collapse in={actionHistory !== null}>
+        <Row>
+          <Col md={12}>
+            <h3>Action History</h3>
+
+            <Table responsive className="mt-2" title="Action History">
+              {actionHistory !== null && actionHistory.length ? (
+                <>
+                  <thead>
+                    <tr>
+                      <th>Action Label</th>
+                      <th>Performed At</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {actionHistory.map((actionEvent, index) => {
+                      if (index < DEFAULT_NUM_ROWS || showAll) {
+                        return (
+                          <tr key={actionEvent.performed_at}>
+                            <td>
+                              <CopyableTextField
+                                text={actionEvent.action_label}
+                              />
+                            </td>
+                            <td>{formatTimestamp(actionEvent.performed_at)}</td>
+                          </tr>
+                        );
+                      }
+                      return null;
+                    })}
+                    <tr>
+                      <td colSpan={2}>
+                        {`Total Action Events ${actionHistory.length}`}
+                        {actionHistory.length > DEFAULT_NUM_ROWS ? (
+                          <Button
+                            variant="link"
+                            className="float-right"
+                            href="#"
+                            onClick={() => setShowAll(!showAll)}>
+                            {showAll ? 'hide' : '...see all'}
+                          </Button>
+                        ) : null}
+                      </td>
+                    </tr>
+                  </tbody>
+                </>
+              ) : (
+                <tbody>
+                  <tr>
+                    <td colSpan={2}>No action history found for content.</td>
+                  </tr>
+                </tbody>
+              )}
+            </Table>
+          </Col>
+        </Row>
+      </Collapse>
+    </>
+  );
+}
+
+ActionHistoryTable.propTypes = {
+  contentKey: PropTypes.string,
+};
+
+ActionHistoryTable.defaultProps = {
+  contentKey: undefined,
+};

--- a/hasher-matcher-actioner/webapp/src/components/ContentMatchTable.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/ContentMatchTable.jsx
@@ -27,28 +27,26 @@ export default function ContentMatchTable({contentKey}) {
       <Spinner hidden={matchDetails !== null} animation="border" role="status">
         <span className="sr-only">Loading...</span>
       </Spinner>
-      <Toast
-        onClose={() => setShowToast(false)}
-        show={showToast}
-        delay={5000}
-        autohide
-        style={{
-          position: 'absolute',
-          top: 300,
-        }}>
-        <Toast.Header>
-          <strong className="mr-auto">Submitted</strong>
-          <small>Thanks!</small>
-        </Toast.Header>
-        <Toast.Body>
-          Please wait for the requested change to propagate
-        </Toast.Body>
-      </Toast>
+      <div className="feedback-toast-container">
+        <Toast
+          onClose={() => setShowToast(false)}
+          show={showToast}
+          delay={5000}
+          autohide>
+          <Toast.Header>
+            <strong className="mr-auto">Submitted</strong>
+            <small>Thanks!</small>
+          </Toast.Header>
+          <Toast.Body>
+            Please wait for the requested change to propagate
+          </Toast.Body>
+        </Toast>
+      </div>
       <Collapse in={matchDetails !== null}>
         <Row>
           <Col md={12}>
             <h3>Matches</h3>
-            <Table responsive className="mt-4" title="Matches">
+            <Table responsive className="mt-2" title="Matches">
               <thead>
                 <tr>
                   <th>ID</th>

--- a/hasher-matcher-actioner/webapp/src/pages/ContentDetails.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/ContentDetails.jsx
@@ -6,23 +6,18 @@ import React, {useState, useEffect} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 import {Col, Row, Table, Button} from 'react-bootstrap';
 
-import {
-  fetchHash,
-  fetchImage,
-  fetchContentActionHistory,
-  fetchContentDetails,
-} from '../Api';
+import {fetchHash, fetchImage, fetchContentDetails} from '../Api';
 import {CopyableHashField} from '../utils/TextFieldsUtils';
 import {formatTimestamp} from '../utils/DateTimeUtils';
 import {BlurUntilHoverImage} from '../utils/ImageUtils';
 import ContentMatchTable from '../components/ContentMatchTable';
+import ActionHistoryTable from '../components/ActionHistoryTable';
 import FixedWidthCenterAlignedLayout from './layouts/FixedWidthCenterAlignedLayout';
 
 export default function ContentDetails() {
   const history = useHistory();
   const {id} = useParams();
   const [contentDetails, setContentDetails] = useState(null);
-  const [actionHistory, setActionHistory] = useState([]);
   const [hashDetails, setHashDetails] = useState(null);
   const [img, setImage] = useState(null);
 
@@ -35,15 +30,6 @@ export default function ContentDetails() {
   useEffect(() => {
     fetchImage(id).then(result => {
       setImage(URL.createObjectURL(result));
-    });
-  }, []);
-
-  // TODO fetch actions once endpoint exists
-  useEffect(() => {
-    fetchContentActionHistory(id).then(result => {
-      if (result && result.action_history) {
-        setActionHistory(result.action_history);
-      }
     });
   }, []);
 
@@ -90,20 +76,6 @@ export default function ContentDetails() {
                     : 'No additional fields provided'}
                 </td>
               </tr>
-              <td className="pb-0" colSpan={2}>
-                <h4>Action History</h4>
-              </td>
-              <tr>
-                <td>Record:</td>
-                <td>
-                  {actionHistory.length
-                    ? actionHistory[0].action_label
-                    : 'No actions performed'}
-                </td>
-              </tr>
-              <td className="pb-0" colSpan={2}>
-                <h4>Hash Details</h4>
-              </td>
               <tr>
                 <td>Content Hash:</td>
                 <CopyableHashField
@@ -124,6 +96,7 @@ export default function ContentDetails() {
               </tr>
             </tbody>
           </Table>
+          <ActionHistoryTable contentKey={id} />
         </Col>
         <Col className="pt-4" md={6}>
           <BlurUntilHoverImage src={img} />


### PR DESCRIPTION
Summary
---------

Makes ActionHistory its own component for the details page. The table shows all actions for a piece of content giving action label and the time it was performed  (most recent first) by default it only displays the two most recent actions but users can see the total count and hit "...see all" to show the rest.

PR also moves opinion change submitted toast to the top right.

Test Plan
---------

<img width="1294" alt="Screen Shot 2021-05-24 at 5 30 45 PM" src="https://user-images.githubusercontent.com/7664526/119411879-1f98a080-bcb9-11eb-8832-4a584ce5a190.png">
<img width="1185" alt="Screen Shot 2021-05-24 at 5 31 01 PM" src="https://user-images.githubusercontent.com/7664526/119411881-20313700-bcb9-11eb-90db-c3b514a175d6.png">
<img width="1199" alt="Screen Shot 2021-05-24 at 5 31 11 PM" src="https://user-images.githubusercontent.com/7664526/119411885-20313700-bcb9-11eb-8de5-8497d3cc74ae.png">
<img width="1224" alt="Screen Shot 2021-05-24 at 5 31 28 PM" src="https://user-images.githubusercontent.com/7664526/119411886-20c9cd80-bcb9-11eb-8483-3a167293030b.png">
<img width="1205" alt="Screen Shot 2021-05-24 at 5 31 42 PM" src="https://user-images.githubusercontent.com/7664526/119411889-20c9cd80-bcb9-11eb-905c-c7fb217e011b.png">

