### PR TITLE
[hma] Fix typing in storm script and create method to get dev token from cli

### DIFF
--- a/hasher-matcher-actioner/scripts/get_auth_token
+++ b/hasher-matcher-actioner/scripts/get_auth_token
@@ -1,0 +1,72 @@
+#! /usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Helper script for a developer to get an API token from cognito based on args
+See 
+https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow.html#amazon-cognito-user-pools-admin-authentication-flow
+
+Sample Usage:
+```
+$ export TMP_TOKEN=$(./scripts/get_auth_token) #if you elect to set values in the file
+"""
+
+import argparse
+import json
+import tempfile
+import subprocess
+import boto3
+
+client = boto3.client("cognito-idp")
+
+
+# Defaults (often it is easier to edit the script than provide the args)
+USERNAME = ""
+PWD = "-"
+POOL_ID = ""
+CLIENT_ID = ""
+
+
+def get_token(
+    username: str,
+    pwd: str,
+    pool_id: str,
+    client_id: str,
+) -> str:
+    resp = client.admin_initiate_auth(
+        AuthFlow="ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters={"USERNAME": username, "PASSWORD": pwd},
+        UserPoolId=pool_id,
+        ClientId=client_id,
+    )
+    return resp["AuthenticationResult"]["IdToken"]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Request a token for the storm scripts or other tests of the API. Rquires AWS account credentials be present locally. Additionally the UserPoolId must allow 'ADMIN_USER_PASSWORD_AUTH'"
+    )
+    parser.add_argument(
+        "--username",
+        help="username of user in pool",
+        default=USERNAME,
+    )
+    parser.add_argument(
+        "--pwd",
+        help="password of user in pool",
+        default=PWD,
+    )
+    parser.add_argument(
+        "--pool_id",
+        help="id of the user pool",
+        default=POOL_ID,
+    )
+    parser.add_argument(
+        "--client_id",
+        help="id of app client for the pool",
+        default=CLIENT_ID,
+    )
+
+    args = parser.parse_args()
+
+    print(get_token(args.username, args.pwd, args.pool_id, args.client_id))

--- a/hasher-matcher-actioner/scripts/storm_submissions_api
+++ b/hasher-matcher-actioner/scripts/storm_submissions_api
@@ -31,14 +31,16 @@ from urllib import request
 import concurrent.futures
 from time import perf_counter
 
-STOLEN_JWT_TOKEN = "<STOLEN_JWT_TOKEN>"
+TOKEN = "<STOLEN_JWT_TOKEN>"
 
 # "/" does not work with react router preventing the content submission details from rendering.
 # However it can be used here for easier clean up between storms that do not need the UI.
 SUBMISSION_SEPARATOR = "-"
 
 
-def _send_single_submission_url(api_url: str, filepath: str, metadata: t.Dict) -> int:
+def _send_single_submission_url(
+    api_url: str, filepath: str, token: str, metadata: t.Dict
+) -> int:
     """
     Submit a single file by requesting a presigned url and return the time it took in ms.
     TODO: remove repeated code between this and _send_single_submission_b64
@@ -58,18 +60,12 @@ def _send_single_submission_url(api_url: str, filepath: str, metadata: t.Dict) -
             "additional_fields": [],
         }
 
-        payload = {
-            "content_id": submission_content_id,
-            "file_type": "image/jpeg",
-        }
-
         get_signed_url_req = request.Request(submission_path, method="POST")
         get_signed_url_req.add_header("Content-Type", "application/json")
-        get_signed_url_req.add_header("Authorization", STOLEN_JWT_TOKEN)
-        payload = json.dumps(payload)
-        payload = payload.encode()
+        get_signed_url_req.add_header("Authorization", token)
+        payload_bytes = json.dumps(payload).encode()
 
-        response = request.urlopen(get_signed_url_req, data=payload)
+        response = request.urlopen(get_signed_url_req, data=payload_bytes)
         response = json.loads(response.read().decode("utf-8"))
         put_response = requests.put(
             response["presigned_url"], data=f, headers={"content-type": "image/jpeg"}
@@ -79,7 +75,9 @@ def _send_single_submission_url(api_url: str, filepath: str, metadata: t.Dict) -
     return int((perf_counter() - start_time) * 1000)
 
 
-def _send_single_submission_b64(api_url: str, filepath: str, metadata: t.Dict) -> int:
+def _send_single_submission_b64(
+    api_url: str, filepath: str, token: str, metadata: t.Dict
+) -> int:
     """
     Submit a single file and return the time it took in ms.
     """
@@ -98,11 +96,10 @@ def _send_single_submission_b64(api_url: str, filepath: str, metadata: t.Dict) -
 
         req = request.Request(submission_path, method="POST")
         req.add_header("Content-Type", "application/json")
-        req.add_header("Authorization", STOLEN_JWT_TOKEN)
-        payload = json.dumps(payload)
-        payload = payload.encode()
+        req.add_header("Authorization", token)
+        payload_bytes = json.dumps(payload).encode()
 
-        r = request.urlopen(req, data=payload)
+        response = request.urlopen(req, data=payload_bytes)
 
     # convert seconds to miliseconds.
     return int((perf_counter() - start_time) * 1000)
@@ -112,6 +109,7 @@ def unleash_storm(
     api_url: str,
     filepath: str,
     msg_count: int,
+    token: str,
     url_mode: bool,
 ):
     sent_message_count = 0
@@ -126,7 +124,9 @@ def unleash_storm(
     with concurrent.futures.ThreadPoolExecutor(max_workers=50) as executor:
         while sent_message_count < msg_count:
             jobs.append(
-                executor.submit(send_single_submission_func, api_url, filepath, {})
+                executor.submit(
+                    send_single_submission_func, api_url, filepath, token, {}
+                )
             )
 
             sent_message_count += 1
@@ -164,13 +164,16 @@ if __name__ == "__main__":
         help="Approximately how many times do we want to send this photo?",
     )
     parser.add_argument(
+        "--token",
+        help="token required to access the API",
+        default=TOKEN,
+    )
+    parser.add_argument(
         "--url_mode",
         action="store_true",
         help="Submit using presign putObject urls instead of base64 encoding json",
     )
 
     args = parser.parse_args()
-
-    api_url = args.api_url
-    file = args.file
-    unleash_storm(args.api_url, args.file, args.count, args.url_mode)
+    print(args.token)
+    # unleash_storm(args.api_url, args.file, args.count, args.token, args.url_mode)

--- a/hasher-matcher-actioner/terraform/authentication-shared/main.tf
+++ b/hasher-matcher-actioner/terraform/authentication-shared/main.tf
@@ -72,7 +72,7 @@ resource "aws_cognito_user_pool_client" "webapp_and_api_shared_user_pool_client"
   user_pool_id                         = aws_cognito_user_pool.webapp_and_api_shared_user_pool.id
   generate_secret                      = false
   allowed_oauth_flows_user_pool_client = true
-  explicit_auth_flows                  = ["ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+  explicit_auth_flows                  = ["ADMIN_USER_PASSWORD_AUTH", "ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
   allowed_oauth_scopes                 = ["openid"]
   allowed_oauth_flows                  = ["code"]
   callback_urls                        = ["https://localhost:3000"] # a shared user pool and its app client is for developers only


### PR DESCRIPTION
Summary
---------

mypy wasn't happy with the variable reuse within `scripts/storm_submissions_api.` This address that and allows the user to pass in the token to the script from the command line. 

This PR also adds a script that can request a token if you have AWS developer credentials in your environment which when combined with the changes above makes the test plan command possible.


Test Plan
---------

```
# update USERNAME, PWD, POOL_ID, CLIENT_ID in script (future version could also create a test user)
scripts/storm_submissions_api https://<id>.execute-api.us-east-1.amazonaws.com/ '/dev/200000.jpg' 2 --token $(scripts/get_auth_token) --url_mode
```