### PR TITLE
Add user-pool name to terraform outputs

### DIFF
--- a/hasher-matcher-actioner/terraform/authentication/outputs.tf
+++ b/hasher-matcher-actioner/terraform/authentication/outputs.tf
@@ -4,6 +4,10 @@ output "webapp_and_api_user_pool_id" {
   value = var.use_shared_user_pool ? var.webapp_and_api_shared_user_pool_id : aws_cognito_user_pool.webapp_and_api_user_pool[0].id
 }
 
+output "webapp_and_api_user_pool_name" {
+  value = aws_cognito_user_pool.webapp_and_api_user_pool[0].name
+}
+
 output "webapp_and_api_user_pool_client_id" {
   value = var.use_shared_user_pool ? var.webapp_and_api_shared_user_pool_client_id : aws_cognito_user_pool_client.webapp_and_api_user_pool_client[0].id
 }

--- a/hasher-matcher-actioner/terraform/outputs.tf
+++ b/hasher-matcher-actioner/terraform/outputs.tf
@@ -25,3 +25,7 @@ output "prefix" {
 output "api_url" {
   value = module.api.invoke_url
 }
+
+output "cognito_user_pool_name" {
+  value = module.authentication.webapp_and_api_user_pool_name
+}


### PR DESCRIPTION
Summary
---------
Output user pool name. This is required to make the 'Grant users access to HMA' wiki entry smoother.

Test Plan
---------
Ran `terraform output`

<img width="567" alt="Screen Shot 2021-05-31 at 19 22 00" src="https://user-images.githubusercontent.com/217056/120248564-ba5b2700-c245-11eb-870a-df072f651d5f.png">
