### PR TITLE
[hma][scripts] Move part of storm_submit_api to util file for reuse

### DIFF
--- a/hasher-matcher-actioner/scripts/get_auth_token
+++ b/hasher-matcher-actioner/scripts/get_auth_token
@@ -22,7 +22,7 @@ client = boto3.client("cognito-idp")
 
 # Defaults (often it is easier to edit the script than provide the args)
 USERNAME = ""
-PWD = "-"
+PWD = ""
 POOL_ID = ""
 CLIENT_ID = ""
 
@@ -32,14 +32,14 @@ def get_token(
     pwd: str,
     pool_id: str,
     client_id: str,
-) -> str:
+):
     resp = client.admin_initiate_auth(
         AuthFlow="ADMIN_USER_PASSWORD_AUTH",
         AuthParameters={"USERNAME": username, "PASSWORD": pwd},
         UserPoolId=pool_id,
         ClientId=client_id,
     )
-    return resp["AuthenticationResult"]["IdToken"]
+    return resp
 
 
 if __name__ == "__main__":
@@ -66,7 +66,16 @@ if __name__ == "__main__":
         help="id of app client for the pool",
         default=CLIENT_ID,
     )
+    parser.add_argument(
+        "--refresh_token",
+        action="store_true",
+        help="Instead of the IdToken return the RefreshToken.",
+    )
 
     args = parser.parse_args()
+    resp = get_token(args.username, args.pwd, args.pool_id, args.client_id)
 
-    print(get_token(args.username, args.pwd, args.pool_id, args.client_id))
+    if args.refresh_token:
+        print(resp["AuthenticationResult"]["RefreshToken"])
+    else:
+        print(resp["AuthenticationResult"]["IdToken"])

--- a/hasher-matcher-actioner/scripts/script_utils.py
+++ b/hasher-matcher-actioner/scripts/script_utils.py
@@ -10,8 +10,6 @@ import base64
 import requests
 import typing as t
 
-from hmalib.lambdas.api.submit import SubmissionType
-
 
 def send_single_submission_url(
     url: str,
@@ -22,7 +20,7 @@ def send_single_submission_url(
 ):
 
     payload = {
-        "submission_type": SubmissionType.POST_URL_UPLOAD.name,
+        "submission_type": "POST_URL_UPLOAD",
         "content_id": content_id,
         "content_type": "PHOTO",
         "content_bytes_url_or_file_type": "image/jpeg",
@@ -53,7 +51,7 @@ def send_single_submission_b64(
 ):
 
     payload = {
-        "submission_type": SubmissionType.DIRECT_UPLOAD.name,
+        "submission_type": "DIRECT_UPLOAD",
         "content_id": content_id,
         "content_type": "PHOTO",
         "content_bytes_url_or_file_type": str(base64.b64encode(file.read()), "utf-8"),

--- a/hasher-matcher-actioner/scripts/script_utils.py
+++ b/hasher-matcher-actioner/scripts/script_utils.py
@@ -1,0 +1,69 @@
+#! /usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Utilities for hma script
+"""
+
+import json
+import base64
+import requests
+import typing as t
+
+from hmalib.lambdas.api.submit import SubmissionType
+
+
+def send_single_submission_url(
+    url: str,
+    content_id: str,
+    file: t.BinaryIO,
+    token: str,
+    additional_fields: t.List[str],
+):
+
+    payload = {
+        "submission_type": SubmissionType.POST_URL_UPLOAD.name,
+        "content_id": content_id,
+        "content_type": "PHOTO",
+        "content_bytes_url_or_file_type": "image/jpeg",
+        "additional_fields": [],
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": token,
+    }
+
+    payload_bytes = json.dumps(payload).encode()
+
+    response = requests.post(url, headers=headers, data=payload_bytes)
+    response_json = response.json()
+    put_response = requests.put(
+        response_json["presigned_url"],
+        data=file,
+        headers={"content-type": "image/jpeg"},
+    )
+
+
+def send_single_submission_b64(
+    url: str,
+    content_id: str,
+    file: t.BinaryIO,
+    token: str,
+    additional_fields: t.List[str] = [],
+):
+
+    payload = {
+        "submission_type": SubmissionType.DIRECT_UPLOAD.name,
+        "content_id": content_id,
+        "content_type": "PHOTO",
+        "content_bytes_url_or_file_type": str(base64.b64encode(file.read()), "utf-8"),
+        "additional_fields": additional_fields,
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": token,
+    }
+
+    payload_bytes = json.dumps(payload).encode()
+
+    response = requests.post(url, headers=headers, data=payload_bytes)

--- a/hasher-matcher-actioner/scripts/script_utils.py
+++ b/hasher-matcher-actioner/scripts/script_utils.py
@@ -9,59 +9,84 @@ import json
 import base64
 import requests
 import typing as t
+from urllib.parse import urljoin
 
 
-def send_single_submission_url(
-    url: str,
-    content_id: str,
-    file: t.BinaryIO,
-    token: str,
-    additional_fields: t.List[str],
-):
+class HasherMatcherActionerAPI:
+    def __init__(
+        self,
+        api_url: str,
+        api_token: str,
+    ) -> None:
+        self.api_url = api_url
+        self.api_token = api_token
 
-    payload = {
-        "submission_type": "POST_URL_UPLOAD",
-        "content_id": content_id,
-        "content_type": "PHOTO",
-        "content_bytes_url_or_file_type": "image/jpeg",
-        "additional_fields": [],
-    }
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": token,
-    }
+    def _get_header(self) -> t.Dict[str, str]:
+        return {
+            "Content-Type": "application/json",
+            "Authorization": self.api_token,
+        }
 
-    payload_bytes = json.dumps(payload).encode()
+    def _get_request_url(self, api_path: str) -> str:
+        return urljoin(self.api_url, api_path)
 
-    response = requests.post(url, headers=headers, data=payload_bytes)
-    response_json = response.json()
-    put_response = requests.put(
-        response_json["presigned_url"],
-        data=file,
-        headers={"content-type": "image/jpeg"},
-    )
+    def send_single_submission_b64(
+        self,
+        content_id: str,
+        file: t.BinaryIO,
+        additional_fields: t.List[str] = [],
+        api_path: str = "/submit/",
+    ):
+
+        payload = {
+            "submission_type": "DIRECT_UPLOAD",
+            "content_id": content_id,
+            "content_type": "PHOTO",
+            "content_bytes_url_or_file_type": str(
+                base64.b64encode(file.read()), "utf-8"
+            ),
+            "additional_fields": additional_fields,
+        }
+        payload_bytes = json.dumps(payload).encode()
+
+        response = requests.post(
+            self._get_request_url(api_path),
+            headers=self._get_header(),
+            data=payload_bytes,
+        )
+
+    def send_single_submission_url(
+        self,
+        content_id: str,
+        file: t.BinaryIO,
+        additional_fields: t.List[str],
+        api_path: str = "/submit/",
+    ):
+
+        payload = {
+            "submission_type": "POST_URL_UPLOAD",
+            "content_id": content_id,
+            "content_type": "PHOTO",
+            "content_bytes_url_or_file_type": "image/jpeg",
+            "additional_fields": [],
+        }
+
+        payload_bytes = json.dumps(payload).encode()
+
+        response = requests.post(
+            self._get_request_url(api_path),
+            headers=self._get_header(),
+            data=payload_bytes,
+        )
+
+        response_json = response.json()
+        put_response = requests.put(
+            response_json["presigned_url"],
+            data=file,
+            headers={"content-type": "image/jpeg"},
+        )
 
 
-def send_single_submission_b64(
-    url: str,
-    content_id: str,
-    file: t.BinaryIO,
-    token: str,
-    additional_fields: t.List[str] = [],
-):
-
-    payload = {
-        "submission_type": "DIRECT_UPLOAD",
-        "content_id": content_id,
-        "content_type": "PHOTO",
-        "content_bytes_url_or_file_type": str(base64.b64encode(file.read()), "utf-8"),
-        "additional_fields": additional_fields,
-    }
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": token,
-    }
-
-    payload_bytes = json.dumps(payload).encode()
-
-    response = requests.post(url, headers=headers, data=payload_bytes)
+if __name__ == "__main__":
+    # if you want hard code tests for additonal methods you can do so here
+    pass

--- a/hasher-matcher-actioner/scripts/storm_submissions_api
+++ b/hasher-matcher-actioner/scripts/storm_submissions_api
@@ -31,7 +31,7 @@ from urllib import request
 import concurrent.futures
 from time import perf_counter
 
-from script_utils import send_single_submission_url, send_single_submission_b64
+from script_utils import HasherMatcherActionerAPI
 
 # Token can be found using Postman or with developer credentials using script/get_auth_token
 TOKEN = ""
@@ -42,20 +42,21 @@ ID_SEPARATOR = "-"
 
 
 def _send_single_submission_url(
-    api_url: str, filepath: str, token: str, additional_fields: t.List[str]
+    api: HasherMatcherActionerAPI, filepath: str, additional_fields: t.List[str]
 ) -> int:
     """
     Submit a single file by requesting a presigned url and return the time it took in ms.
     """
-    submission_path = f"{api_url}submit/"
     file_name = os.path.split(filepath)[-1]
     content_id = f"storm_url{ID_SEPARATOR}{datetime.date.today().isoformat()}{ID_SEPARATOR}{str(uuid.uuid4())}-{file_name}"
 
     start_time = perf_counter()
 
     with open(filepath, "rb") as file:
-        send_single_submission_url(
-            submission_path, content_id, file, token, additional_fields
+        api.send_single_submission_url(
+            content_id,
+            file,
+            additional_fields,
         )
 
     # convert seconds to miliseconds.
@@ -63,23 +64,20 @@ def _send_single_submission_url(
 
 
 def _send_single_submission_b64(
-    api_url: str, filepath: str, token: str, additional_fields: t.List[str]
+    api: HasherMatcherActionerAPI, filepath: str, additional_fields: t.List[str]
 ) -> int:
     """
     Submit a single file and return the time it took in ms.
     """
-    submission_path = f"{api_url}submit/"
     file_name = os.path.split(filepath)[-1]
     content_id = f"storm{ID_SEPARATOR}{datetime.date.today().isoformat()}{ID_SEPARATOR}{str(uuid.uuid4())}-{file_name}"
 
     start_time = perf_counter()
 
     with open(filepath, "rb") as file:
-        send_single_submission_b64(
-            submission_path,
+        api.send_single_submission_b64(
             content_id,
             file,
-            token,
             additional_fields,
         )
 
@@ -103,11 +101,16 @@ def unleash_storm(
     if url_mode:
         send_single_submission_func = _send_single_submission_url
 
+    api = HasherMatcherActionerAPI(api_url, token)
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=50) as executor:
         while sent_message_count < msg_count:
             jobs.append(
                 executor.submit(
-                    send_single_submission_func, api_url, filepath, token, []
+                    send_single_submission_func,
+                    api,
+                    filepath,
+                    [],
                 )
             )
 

--- a/hasher-matcher-actioner/scripts/storm_submissions_api
+++ b/hasher-matcher-actioner/scripts/storm_submissions_api
@@ -31,44 +31,31 @@ from urllib import request
 import concurrent.futures
 from time import perf_counter
 
-TOKEN = "<STOLEN_JWT_TOKEN>"
+from script_utils import send_single_submission_url, send_single_submission_b64
+
+# Token can be found using Postman or with developer credentials using script/get_auth_token
+TOKEN = ""
 
 # "/" does not work with react router preventing the content submission details from rendering.
 # However it can be used here for easier clean up between storms that do not need the UI.
-SUBMISSION_SEPARATOR = "-"
+ID_SEPARATOR = "-"
 
 
 def _send_single_submission_url(
-    api_url: str, filepath: str, token: str, metadata: t.Dict
+    api_url: str, filepath: str, token: str, additional_fields: t.List[str]
 ) -> int:
     """
     Submit a single file by requesting a presigned url and return the time it took in ms.
-    TODO: remove repeated code between this and _send_single_submission_b64
     """
     submission_path = f"{api_url}submit/"
     file_name = os.path.split(filepath)[-1]
+    content_id = f"storm_url{ID_SEPARATOR}{datetime.date.today().isoformat()}{ID_SEPARATOR}{str(uuid.uuid4())}-{file_name}"
+
     start_time = perf_counter()
 
-    with open(filepath, "rb") as f:
-        submission_content_id = f"storm_url{SUBMISSION_SEPARATOR}{datetime.date.today().isoformat()}{SUBMISSION_SEPARATOR}{str(uuid.uuid4())}-{file_name}"
-
-        payload = {
-            "submission_type": "POST_URL_UPLOAD",
-            "content_id": submission_content_id,
-            "content_type": "PHOTO",
-            "content_bytes_url_or_file_type": "image/jpeg",
-            "additional_fields": [],
-        }
-
-        get_signed_url_req = request.Request(submission_path, method="POST")
-        get_signed_url_req.add_header("Content-Type", "application/json")
-        get_signed_url_req.add_header("Authorization", token)
-        payload_bytes = json.dumps(payload).encode()
-
-        response = request.urlopen(get_signed_url_req, data=payload_bytes)
-        response = json.loads(response.read().decode("utf-8"))
-        put_response = requests.put(
-            response["presigned_url"], data=f, headers={"content-type": "image/jpeg"}
+    with open(filepath, "rb") as file:
+        send_single_submission_url(
+            submission_path, content_id, file, token, additional_fields
         )
 
     # convert seconds to miliseconds.
@@ -76,30 +63,25 @@ def _send_single_submission_url(
 
 
 def _send_single_submission_b64(
-    api_url: str, filepath: str, token: str, metadata: t.Dict
+    api_url: str, filepath: str, token: str, additional_fields: t.List[str]
 ) -> int:
     """
     Submit a single file and return the time it took in ms.
     """
     submission_path = f"{api_url}submit/"
     file_name = os.path.split(filepath)[-1]
+    content_id = f"storm{ID_SEPARATOR}{datetime.date.today().isoformat()}{ID_SEPARATOR}{str(uuid.uuid4())}-{file_name}"
+
     start_time = perf_counter()
 
-    with open(filepath, "rb") as f:
-        payload = {
-            "submission_type": "DIRECT_UPLOAD",
-            "content_id": f"storm{SUBMISSION_SEPARATOR}{datetime.date.today().isoformat()}{SUBMISSION_SEPARATOR}{str(uuid.uuid4())}-{file_name}",
-            "content_type": "PHOTO",
-            "content_bytes_url_or_file_type": str(base64.b64encode(f.read()), "utf-8"),
-            "additional_fields": [],
-        }
-
-        req = request.Request(submission_path, method="POST")
-        req.add_header("Content-Type", "application/json")
-        req.add_header("Authorization", token)
-        payload_bytes = json.dumps(payload).encode()
-
-        response = request.urlopen(req, data=payload_bytes)
+    with open(filepath, "rb") as file:
+        send_single_submission_b64(
+            submission_path,
+            content_id,
+            file,
+            token,
+            additional_fields,
+        )
 
     # convert seconds to miliseconds.
     return int((perf_counter() - start_time) * 1000)
@@ -125,7 +107,7 @@ def unleash_storm(
         while sent_message_count < msg_count:
             jobs.append(
                 executor.submit(
-                    send_single_submission_func, api_url, filepath, token, {}
+                    send_single_submission_func, api_url, filepath, token, []
                 )
             )
 
@@ -175,5 +157,4 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-    print(args.token)
-    # unleash_storm(args.api_url, args.file, args.count, args.token, args.url_mode)
+    unleash_storm(args.api_url, args.file, args.count, args.token, args.url_mode)

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -309,7 +309,7 @@ module "actions" {
   config_table = {
     name = aws_dynamodb_table.config_table.name
     arn  = aws_dynamodb_table.config_table.arn
-  }  
+  }
   datastore = module.datastore.primary_datastore
 }
 


### PR DESCRIPTION
Summary
---------

- (title)Moves part of storm_submit_api to util file for reuse
- Adds option to get `RefreshToken` instead of `IdToken` to `get_auth_token` (going to be used in soak testing)

Long term this will make the scripts more maintainable but the short term is a little inconvenience when it comes to using ec2 instances. (requires the copying of two files)

Test Plan
---------

Made sure both storm scripts still worked with changes.
