### PR TITLE
Matches page design feedback

### DIFF
--- a/hasher-matcher-actioner/webapp/src/Sidebar.jsx
+++ b/hasher-matcher-actioner/webapp/src/Sidebar.jsx
@@ -7,13 +7,10 @@ import PropTypes from 'prop-types';
 import {NavLink} from 'react-router-dom';
 import {Auth} from 'aws-amplify';
 import './styles/_sidebar.scss';
-import {SeparatorBorder} from './utils/constants';
 
 export default function Sidebar({className}) {
   return (
-    <div
-      className={`${className} d-flex flex-column`}
-      style={{borderRight: SeparatorBorder}}>
+    <div className={`${className} d-flex flex-column`}>
       <div className="px-2 pt-2 pb-4Right">
         <a className="navbar-brand alert-link" href="/">
           HMA

--- a/hasher-matcher-actioner/webapp/src/Sidebar.jsx
+++ b/hasher-matcher-actioner/webapp/src/Sidebar.jsx
@@ -10,8 +10,10 @@ import './styles/_sidebar.scss';
 
 export default function Sidebar({className}) {
   return (
-    <div className={`${className} d-flex flex-column`}>
-      <div className="px-2 pt-2 pb-4">
+    <div
+      className={`${className} d-flex flex-column`}
+      style={{borderRight: '1px solid #ececec'}}>
+      <div className="px-2 pt-2 pb-4Right">
         <a className="navbar-brand alert-link" href="/">
           HMA
         </a>

--- a/hasher-matcher-actioner/webapp/src/Sidebar.jsx
+++ b/hasher-matcher-actioner/webapp/src/Sidebar.jsx
@@ -7,12 +7,13 @@ import PropTypes from 'prop-types';
 import {NavLink} from 'react-router-dom';
 import {Auth} from 'aws-amplify';
 import './styles/_sidebar.scss';
+import {SeparatorBorder} from './utils/constants';
 
 export default function Sidebar({className}) {
   return (
     <div
       className={`${className} d-flex flex-column`}
-      style={{borderRight: '1px solid #ececec'}}>
+      style={{borderRight: SeparatorBorder}}>
       <div className="px-2 pt-2 pb-4Right">
         <a className="navbar-brand alert-link" href="/">
           HMA

--- a/hasher-matcher-actioner/webapp/src/Sidebar.jsx
+++ b/hasher-matcher-actioner/webapp/src/Sidebar.jsx
@@ -53,7 +53,6 @@ export default function Sidebar({className}) {
             activeClassName="text-white bg-secondary rounded"
             to="/settings"
             className="nav-link px-2">
-            <span className="glyphicon glyphicon-cog" />
             Settings
           </NavLink>
         </li>

--- a/hasher-matcher-actioner/webapp/src/components/ContentMatchPane.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/ContentMatchPane.jsx
@@ -78,10 +78,12 @@ export default function ContentMatchPane({contentId, signalId, signalSource}) {
             )}
 
             <p className="mt-4">
-              <Link to={`/matches/${contentId}`}>See all details</Link>
+              <Link to={`/matches/${contentId}`}>
+                Open the details page for content
+              </Link>
             </p>
 
-            <h4 className="mt-4">Filter search results</h4>
+            <h4 className="mt-4">Filter results on this page</h4>
             <li>
               <Link to={`?signalId=${signalSource}|${signalId}`}>
                 Show matches for this signal

--- a/hasher-matcher-actioner/webapp/src/components/ContentMatchPane.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/ContentMatchPane.jsx
@@ -6,8 +6,9 @@ import React, {useEffect, useState} from 'react';
 import {Link} from 'react-router-dom';
 import PropTypes from 'prop-types';
 import {Container, Row, Col} from 'react-bootstrap';
-import {fetchHash, fetchImage} from '../Api';
+import {fetchHash, fetchImage, fetchContentDetails} from '../Api';
 import {BlurUntilHoverImage} from '../utils/ImageUtils';
+import {formatTimestamp} from '../utils/DateTimeUtils';
 
 /**
  * For a content key that matched a signal, show a summary and link to other
@@ -15,6 +16,7 @@ import {BlurUntilHoverImage} from '../utils/ImageUtils';
  */
 export default function ContentMatchPane({contentId, signalId, signalSource}) {
   const [hashDetails, setHashDetails] = useState(null);
+  const [contentDetails, setContentDetails] = useState(null);
   const [img, setImage] = useState(null);
 
   useEffect(() => {
@@ -36,43 +38,61 @@ export default function ContentMatchPane({contentId, signalId, signalSource}) {
       });
   }, [contentId]);
 
+  useEffect(() => {
+    fetchContentDetails(contentId).then(result => {
+      // Ensure placeholders don't get displayed. TODO: Move this to the API.
+      const additionalFields = result.additional_fields.filter(
+        x => x !== 'Placeholder',
+      );
+
+      setContentDetails({...result, additional_fields: additionalFields});
+    });
+  }, [contentId]);
+
   return (
     (hashDetails === null && <p>Loading...</p>) || (
       <Container>
         <Row>
           {/* Avoid explicit padding if possible when re-doing this page. */}
-          <Col className="p-4">
+          <Col className="p-4 text-center" style={{minHeight: '200px'}}>
             <BlurUntilHoverImage src={img} />
           </Col>
         </Row>
         <Row>
-          <Col md={3} className="p-4">
-            Details
-          </Col>
           <Col className="p-4">
-            <Link to={`/matches/${contentId}`}>
-              View Details for this matched content.
-            </Link>
-          </Col>
-        </Row>
-        <Row>
-          <Col md={3} className="p-4">
-            Signal
-          </Col>
-          <Col className="p-4">
-            <Link to={`?signalId=${signalSource}|${signalId}`}>
-              View Matches for Signal
-            </Link>
-          </Col>
-        </Row>
-        <Row>
-          <Col md={3} className="p-4">
-            Content
-          </Col>
-          <Col className="p-4">
-            <Link to={`?contentId=images/${contentId}`}>
-              View Matches of this Content
-            </Link>
+            <h4 className="mt-4">Content Details</h4>
+            <p>
+              Last Submitted to HMA:{' '}
+              <b>
+                {contentDetails && contentDetails.updated_at
+                  ? formatTimestamp(contentDetails.updated_at)
+                  : 'Unknown'}
+              </b>
+            </p>
+
+            <h4 className="mt-4">Additional Fields</h4>
+            {contentDetails && contentDetails.additional_fields.length !== 0 ? (
+              contentDetails.additional_fields.map(field => <li>{field}</li>)
+            ) : (
+              <p>No additional fields provided</p>
+            )}
+
+            <p className="mt-4">
+              <Link to={`/matches/${contentId}`}>See all details</Link>
+            </p>
+
+            <h4 className="mt-4">Filter search results</h4>
+            <li>
+              <Link to={`?signalId=${signalSource}|${signalId}`}>
+                Show matches for this signal
+              </Link>
+            </li>
+
+            <li>
+              <Link to={`?contentId=images/${contentId}`}>
+                Show all matches for this content
+              </Link>
+            </li>
           </Col>
         </Row>
       </Container>

--- a/hasher-matcher-actioner/webapp/src/pages/Matches.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Matches.jsx
@@ -31,12 +31,12 @@ import {SeparatorBorder} from '../utils/constants';
 
 export default function Matches() {
   const query = useQuery();
-  const searchQuery = query.get('contentId') || query.get('signalId');
-  let searchInAttribute;
+  const filterString = query.get('contentId') || query.get('signalId');
+  let filterAttribute;
 
   ['contentId', 'signalId'].forEach(attribute => {
     if (query.has(attribute)) {
-      searchInAttribute = attribute;
+      filterAttribute = attribute;
     }
   });
 
@@ -59,24 +59,24 @@ export default function Matches() {
             md={6}
             className="d-flex flex-column justify-content-start h-100 px-0"
             style={{borderRight: SeparatorBorder}}>
-            {/* This column is vertically split into the search bar and the table of search results. */}
+            {/* This column is vertically split into the filter input box and the table of filtered results. */}
             <div
               className="flex-grow-0 bg-light px-2"
               style={{borderBottom: SeparatorBorder}}>
               <MatchListFilters
-                searchInAttribute={searchInAttribute}
-                searchQuery={searchQuery}
+                filterAttribute={filterAttribute}
+                filterString={filterString}
               />
             </div>
             <div
               className="flex-grow-1 px-3"
-              // Padding to align with search bar in match filters
+              // Padding to align with input box in match filters
               style={{overflowY: 'auto', overflowX: 'hidden'}}>
               <MatchList
                 selection={selectedContentAndSignalIds}
                 onSelect={setSelectedContentAndSignalIds}
-                searchInAttribute={searchInAttribute}
-                searchQuery={searchQuery}
+                filterAttribute={filterAttribute}
+                filterString={filterString}
               />
             </div>
           </Col>
@@ -111,47 +111,47 @@ function EmptyContentMatchPane() {
 /**
  * A box of filters for the list of matches that appear on the match filters page.
  */
-function MatchListFilters({searchInAttribute, searchQuery}) {
-  const [localSearchInAttribute, setLocalSearchInAttribute] = useState(
-    searchInAttribute,
+function MatchListFilters({filterAttribute, filterString}) {
+  const [localFilterAttribute, setLocalFilterAttribute] = useState(
+    filterAttribute,
   );
-  const [localSearchQuery, setLocalSearchQuery] = useState(searchQuery);
+  const [localFilterString, setLocalFilterString] = useState(filterString);
 
   useEffect(() => {
     /** Update state when props changed. */
-    setLocalSearchInAttribute(searchInAttribute);
-    setLocalSearchQuery(searchQuery);
-  }, [searchInAttribute, searchQuery]);
+    setLocalFilterAttribute(filterAttribute);
+    setLocalFilterString(filterString);
+  }, [filterAttribute, filterString]);
 
   const history = useHistory();
-  const loadSearchPage = e => {
-    history.push(`?${localSearchInAttribute}=${localSearchQuery}`);
+  const loadResults = e => {
+    history.push(`?${localFilterAttribute}=${localFilterString}`);
     e.preventDefault(); // Prevent form submit
   };
 
   const inputRef = React.createRef();
 
   return (
-    <Form className="mx-4" onSubmit={loadSearchPage}>
+    <Form className="mx-4" onSubmit={loadResults}>
       <Form.Group className="mb-0">
         <Row className="my-2">
           <InputGroup>
             <InputGroup.Prepend>
               <Form.Control
                 as="select"
-                value={localSearchInAttribute}
-                onChange={e => setLocalSearchInAttribute(e.target.value)}>
+                value={localFilterAttribute}
+                onChange={e => setLocalFilterAttribute(e.target.value)}>
                 <option value="contentId">Content ID</option>
                 <option value="signalId">Signal ID</option>
               </Form.Control>
             </InputGroup.Prepend>
             <FormControl
               ref={inputRef}
-              onChange={e => setLocalSearchQuery(e.target.value)}
-              value={localSearchQuery || ''}
+              onChange={e => setLocalFilterString(e.target.value)}
+              value={localFilterString || ''}
             />
             <InputGroup.Append>
-              <Button onClick={loadSearchPage}>Filter</Button>
+              <Button onClick={loadResults}>Filter</Button>
             </InputGroup.Append>
           </InputGroup>
         </Row>
@@ -161,27 +161,27 @@ function MatchListFilters({searchInAttribute, searchQuery}) {
 }
 
 MatchListFilters.propTypes = {
-  searchInAttribute: PropTypes.oneOf(['contentId', 'signalId']),
-  searchQuery: PropTypes.string,
+  filterAttribute: PropTypes.oneOf(['contentId', 'signalId']),
+  filterString: PropTypes.string,
 };
 
 MatchListFilters.defaultProps = {
-  searchInAttribute: 'contentId',
-  searchQuery: undefined,
+  filterAttribute: 'contentId',
+  filterString: undefined,
 };
 
-function MatchList({selection, onSelect, searchInAttribute, searchQuery}) {
+function MatchList({selection, onSelect, filterAttribute, filterString}) {
   const [matchesData, setMatchesData] = useState(null);
 
   useEffect(() => {
     let apiPromise;
-    if (searchInAttribute === 'contentId') {
-      apiPromise = fetchMatchesFromContent(searchQuery);
-    } else if (searchInAttribute === 'signalId') {
+    if (filterAttribute === 'contentId') {
+      apiPromise = fetchMatchesFromContent(filterString);
+    } else if (filterAttribute === 'signalId') {
       /** Hack alert. This expects strings like
-       * "facebook/threatexchange|12312121" to be the searchQuery. A pipe
+       * "facebook/threatexchange|12312121" to be the filterString. A pipe
        * separates the source from the signal id */
-      const parts = searchQuery.split('|');
+      const parts = filterString.split('|');
       apiPromise = fetchMatchesFromSignal(parts[0], parts[1]);
     } else {
       apiPromise = fetchAllMatches();
@@ -189,7 +189,7 @@ function MatchList({selection, onSelect, searchInAttribute, searchQuery}) {
 
     apiPromise.then(matches => setMatchesData(matches.match_summaries));
     // .catch(err => console.log(err));
-  }, [searchInAttribute, searchQuery]);
+  }, [filterAttribute, filterString]);
 
   return (
     <>
@@ -256,12 +256,12 @@ MatchList.propTypes = {
   onSelect: PropTypes.func.isRequired,
 
   // Filter matches list
-  searchInAttribute: PropTypes.oneOf(['contentId', 'signalId']),
-  searchQuery: PropTypes.string,
+  filterAttribute: PropTypes.oneOf(['contentId', 'signalId']),
+  filterString: PropTypes.string,
 };
 
 MatchList.defaultProps = {
   selection: {contentId: undefined, signalId: undefined},
-  searchInAttribute: 'contentId',
-  searchQuery: undefined,
+  filterAttribute: 'contentId',
+  filterString: undefined,
 };

--- a/hasher-matcher-actioner/webapp/src/pages/Matches.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Matches.jsx
@@ -26,6 +26,7 @@ import {
 import {timeAgo} from '../utils/DateTimeUtils';
 import ContentMatchPane from '../components/ContentMatchPane';
 import {useQuery} from '../utils/QueryParams';
+import FullWidthLocalScrollingLeftAlignedLayout from './layouts/FullWidthLocalScrollingLeftAlignedLayout';
 
 export default function Matches() {
   const query = useQuery();
@@ -48,49 +49,43 @@ export default function Matches() {
   });
 
   return (
-    <div className="d-flex flex-column justify-content-start align-items-stretch h-100 w-100">
-      <div className="flex-grow-0">
-        <Container className="bg-dark text-light" fluid>
-          <Row className="d-flex flex-row justify-content-between align-items-end">
-            <div className="px-4 py-2">
-              <h1>Matches</h1>
-              <p>View content that has been flagged by the HMA system.</p>
-            </div>
-            <div className="px-4 py-2">
+    <FullWidthLocalScrollingLeftAlignedLayout title="Matches">
+      <Container className="h-100 v-100" fluid>
+        {/* ^ This container is everything below the header */}
+        <Row className="d-flex align-items-stretch h-100">
+          {/* Each child of this row spans half the available space dividing into left and right pane. */}
+          <Col
+            md={6}
+            className="d-flex flex-column justify-content-start h-100 px-0">
+            {/* This column is vertically split into the search bar and the table of search results. */}
               <MatchListFilters
                 searchInAttribute={searchInAttribute}
                 searchQuery={searchQuery}
               />
             </div>
-          </Row>
-        </Container>
-      </div>
-      <div className="flex-grow-1" style={{overflowY: 'hidden'}}>
-        <Container className="h-100 v-100" fluid>
-          <Row className="d-flex align-items-stretch h-100">
-            <Col className="h-100" style={{overflowY: 'auto'}} md={6}>
+            <div className="flex-grow-1" style={{overflowY: 'auto'}}>
               <MatchList
                 selection={selectedContentAndSignalIds}
                 onSelect={setSelectedContentAndSignalIds}
                 searchInAttribute={searchInAttribute}
                 searchQuery={searchQuery}
               />
-            </Col>
-            <Col md={6}>
-              {(selectedContentAndSignalIds.contentId === undefined && (
-                <p>Select a match to see its details.</p>
-              )) || (
-                <ContentMatchPane
-                  contentId={selectedContentAndSignalIds.contentId}
-                  signalId={selectedContentAndSignalIds.signalId}
-                  signalSource={selectedContentAndSignalIds.signalSource}
-                />
-              )}
-            </Col>
-          </Row>
-        </Container>
-      </div>
-    </div>
+            </div>
+          </Col>
+          <Col md={6}>
+            {(selectedContentAndSignalIds.contentId === undefined && (
+              <p>Select a match to see its details.</p>
+            )) || (
+              <ContentMatchPane
+                contentId={selectedContentAndSignalIds.contentId}
+                signalId={selectedContentAndSignalIds.signalId}
+                signalSource={selectedContentAndSignalIds.signalSource}
+              />
+            )}
+          </Col>
+        </Row>
+      </Container>
+    </FullWidthLocalScrollingLeftAlignedLayout>
   );
 }
 
@@ -208,7 +203,7 @@ function MatchList({selection, onSelect, searchInAttribute, searchQuery}) {
         <span className="sr-only">Loading...</span>
       </Spinner>
       <Collapse in={matchesData !== null}>
-        <Row className="mt-3">
+        <Row>
           <Col>
             <table className="table table-hover small">
               <thead>

--- a/hasher-matcher-actioner/webapp/src/pages/Matches.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Matches.jsx
@@ -82,7 +82,7 @@ export default function Matches() {
           </Col>
           <Col md={6}>
             {(selectedContentAndSignalIds.contentId === undefined && (
-              <p>Select a match to see its details.</p>
+              <EmptyContentMatchPane />
             )) || (
               <ContentMatchPane
                 contentId={selectedContentAndSignalIds.contentId}
@@ -94,6 +94,17 @@ export default function Matches() {
         </Row>
       </Container>
     </FullWidthLocalScrollingLeftAlignedLayout>
+  );
+}
+
+function EmptyContentMatchPane() {
+  return (
+    <div className="h-100" style={{textAlign: 'center', paddingTop: '40%'}}>
+      <h1 className="display-4 text-secondary">Nothing Selected!</h1>
+      <p className="lead">
+        Select a match on the left pane to see its details.
+      </p>
+    </div>
   );
 }
 

--- a/hasher-matcher-actioner/webapp/src/pages/Matches.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Matches.jsx
@@ -27,6 +27,7 @@ import {timeAgo} from '../utils/DateTimeUtils';
 import ContentMatchPane from '../components/ContentMatchPane';
 import {useQuery} from '../utils/QueryParams';
 import FullWidthLocalScrollingLeftAlignedLayout from './layouts/FullWidthLocalScrollingLeftAlignedLayout';
+import {SeparatorBorder} from '../utils/constants';
 
 export default function Matches() {
   const query = useQuery();
@@ -56,14 +57,21 @@ export default function Matches() {
           {/* Each child of this row spans half the available space dividing into left and right pane. */}
           <Col
             md={6}
-            className="d-flex flex-column justify-content-start h-100 px-0">
+            className="d-flex flex-column justify-content-start h-100 px-0"
+            style={{borderRight: SeparatorBorder}}>
             {/* This column is vertically split into the search bar and the table of search results. */}
+            <div
+              className="flex-grow-0 bg-light px-2"
+              style={{borderBottom: SeparatorBorder}}>
               <MatchListFilters
                 searchInAttribute={searchInAttribute}
                 searchQuery={searchQuery}
               />
             </div>
-            <div className="flex-grow-1" style={{overflowY: 'auto'}}>
+            <div
+              className="flex-grow-1 px-3"
+              // Padding to align with search bar in match filters
+              style={{overflowY: 'auto', overflowX: 'hidden'}}>
               <MatchList
                 selection={selectedContentAndSignalIds}
                 onSelect={setSelectedContentAndSignalIds}
@@ -113,53 +121,28 @@ function MatchListFilters({searchInAttribute, searchQuery}) {
   const inputRef = React.createRef();
 
   return (
-    <Form onSubmit={loadSearchPage}>
-      <Form.Group>
-        <Row className="mt-1">
+    <Form className="mx-4" onSubmit={loadSearchPage}>
+      <Form.Group className="mb-0">
+        <Row className="my-2">
           <InputGroup>
+            <InputGroup.Prepend>
+              <Form.Control
+                as="select"
+                value={localSearchInAttribute}
+                onChange={e => setLocalSearchInAttribute(e.target.value)}>
+                <option value="contentId">Content ID</option>
+                <option value="signalId">Signal ID</option>
+              </Form.Control>
+            </InputGroup.Prepend>
             <FormControl
               ref={inputRef}
               onChange={e => setLocalSearchQuery(e.target.value)}
               value={localSearchQuery || ''}
-              htmlSize="40"
             />
             <InputGroup.Append>
-              <Button onClick={loadSearchPage}>Search</Button>
+              <Button onClick={loadSearchPage}>Filter</Button>
             </InputGroup.Append>
           </InputGroup>
-        </Row>
-        <Row className="justify-content-between mt-3">
-          <Col md="5">
-            <Form.Check
-              id="match-list-filter-radio-contentid"
-              type="radio"
-              value="contentId"
-              label="Content ID"
-              checked={localSearchInAttribute === 'contentId'}
-              onChange={e => setLocalSearchInAttribute(e.target.value)}
-            />
-          </Col>
-          <Col md="4">
-            <Form.Check
-              id="match-list-filter-radio-signalid"
-              type="radio"
-              value="signalId"
-              label="Signal ID"
-              checked={localSearchInAttribute === 'signalId'}
-              onChange={e => setLocalSearchInAttribute(e.target.value)}
-            />
-          </Col>
-          <Col md="3" className="push-right">
-            <Button
-              variant="light"
-              size="sm"
-              onClick={() => {
-                setLocalSearchQuery('');
-                inputRef.current.focus();
-              }}>
-              Clear
-            </Button>
-          </Col>
         </Row>
       </Form.Group>
     </Form>

--- a/hasher-matcher-actioner/webapp/src/pages/Matches.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Matches.jsx
@@ -205,7 +205,7 @@ function MatchList({selection, onSelect, searchInAttribute, searchQuery}) {
                 <tr>
                   <th>Content Id</th>
                   <th>Matched in Dataset</th>
-                  <th>Seen</th>
+                  <th>Submitted</th>
                 </tr>
               </thead>
               <tbody>

--- a/hasher-matcher-actioner/webapp/src/pages/Matches.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Matches.jsx
@@ -27,7 +27,7 @@ import {timeAgo} from '../utils/DateTimeUtils';
 import ContentMatchPane from '../components/ContentMatchPane';
 import {useQuery} from '../utils/QueryParams';
 import FullWidthLocalScrollingLeftAlignedLayout from './layouts/FullWidthLocalScrollingLeftAlignedLayout';
-import {SeparatorBorder} from '../utils/constants';
+import '../styles/_matches.scss';
 
 export default function Matches() {
   const query = useQuery();
@@ -57,12 +57,9 @@ export default function Matches() {
           {/* Each child of this row spans half the available space dividing into left and right pane. */}
           <Col
             md={6}
-            className="d-flex flex-column justify-content-start h-100 px-0"
-            style={{borderRight: SeparatorBorder}}>
+            className="left-pane d-flex flex-column justify-content-start h-100 px-0">
             {/* This column is vertically split into the filter input box and the table of filtered results. */}
-            <div
-              className="flex-grow-0 bg-light px-2"
-              style={{borderBottom: SeparatorBorder}}>
+            <div className="match-filter-box flex-grow-0 bg-light px-2">
               <MatchListFilters
                 filterAttribute={filterAttribute}
                 filterString={filterString}

--- a/hasher-matcher-actioner/webapp/src/pages/layouts/FullWidthLocalScrollingLeftAlignedLayout.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/layouts/FullWidthLocalScrollingLeftAlignedLayout.jsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Container, Row, Col} from 'react-bootstrap';
-import {SeparatorBorder} from '../../utils/constants';
 
 /**
  * Usage is exactly the same as FixedWidthCenterAlignedLayout. Might be worth it
@@ -23,16 +22,12 @@ export default function FullWidthLocalScrollingLeftAlignedLayout({
     <Container
       fluid
       className="d-flex flex-column justify-content-start align-items-stretch h-100 w-100 py-0">
-      <Row className="flex-grow-0">
+      <Row className="full-width-header flex-grow-0">
         <Col className="mt-4">
           <h1>{title}</h1>
         </Col>
       </Row>
-      <Row
-        className="flex-grow-1"
-        style={{overflowY: 'hidden', borderTop: SeparatorBorder}}>
-        {children}
-      </Row>
+      <Row className="flex-grow-1">{children}</Row>
     </Container>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/pages/layouts/FullWidthLocalScrollingLeftAlignedLayout.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/layouts/FullWidthLocalScrollingLeftAlignedLayout.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Container, Row, Col} from 'react-bootstrap';
+import {SeparatorBorder} from '../../utils/constants';
 
 /**
  * Usage is exactly the same as FixedWidthCenterAlignedLayout. Might be worth it
@@ -27,7 +28,9 @@ export default function FullWidthLocalScrollingLeftAlignedLayout({
           <h1>{title}</h1>
         </Col>
       </Row>
-      <Row className="flex-grow-1" style={{overflowY: 'hidden'}}>
+      <Row
+        className="flex-grow-1"
+        style={{overflowY: 'hidden', borderTop: SeparatorBorder}}>
         {children}
       </Row>
     </Container>

--- a/hasher-matcher-actioner/webapp/src/pages/layouts/FullWidthLocalScrollingLeftAlignedLayout.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/layouts/FullWidthLocalScrollingLeftAlignedLayout.jsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Container, Row, Col} from 'react-bootstrap';
+
+/**
+ * Usage is exactly the same as FixedWidthCenterAlignedLayout. Might be worth it
+ * to abstract out common pieces at some point.
+ *
+ * Salient features:
+ * - Full width beyond the sidebar
+ * - The layout by itself does not do any scrolling, left for children to implement
+ */
+export default function FullWidthLocalScrollingLeftAlignedLayout({
+  title,
+  children,
+}) {
+  return (
+    <Container
+      fluid
+      className="d-flex flex-column justify-content-start align-items-stretch h-100 w-100 py-0">
+      <Row className="flex-grow-0">
+        <Col className="mt-4">
+          <h1>{title}</h1>
+        </Col>
+      </Row>
+      <Row className="flex-grow-1" style={{overflowY: 'hidden'}}>
+        {children}
+      </Row>
+    </Container>
+  );
+}
+
+FullWidthLocalScrollingLeftAlignedLayout.propTypes = {
+  title: PropTypes.string.isRequired,
+  children: PropTypes.arrayOf(PropTypes.node),
+};
+
+FullWidthLocalScrollingLeftAlignedLayout.defaultProps = {
+  children: [],
+};

--- a/hasher-matcher-actioner/webapp/src/styles/_app.scss
+++ b/hasher-matcher-actioner/webapp/src/styles/_app.scss
@@ -2,6 +2,8 @@
  * Copyright (c) Facebook, Inc. and its affiliates.All Rights Reserved
  */
 
+@import '_variables';
+
 div#root {
   display: flex;
   flex-wrap: nowrap;
@@ -18,6 +20,10 @@ div#root {
 .main {
   height: 100vh;
   overflow-y: auto;
+}
+
+.full-width-header {
+  border-bottom: $pane-separator-border;
 }
 
 .ion-icon-white {

--- a/hasher-matcher-actioner/webapp/src/styles/_matches.scss
+++ b/hasher-matcher-actioner/webapp/src/styles/_matches.scss
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.All Rights Reserved
+ */
+@import 'variables';
+
+.left-pane {
+  border-right: $pane-separator-border;
+}
+
+.match-filter-box {
+  border-bottom: $pane-separator-border;
+}

--- a/hasher-matcher-actioner/webapp/src/styles/_sidebar.scss
+++ b/hasher-matcher-actioner/webapp/src/styles/_sidebar.scss
@@ -5,9 +5,13 @@
 @import 'node_modules/bootstrap/scss/functions';
 @import 'node_modules/bootstrap/scss/variables';
 
+@import 'variables';
+
 .sidebar {
   height: 100vh;
   width: 248px;
+
+  border-right: $pane-separator-border;
 
   .navbar-brand {
     font-weight: bold;

--- a/hasher-matcher-actioner/webapp/src/styles/_variables.scss
+++ b/hasher-matcher-actioner/webapp/src/styles/_variables.scss
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.All Rights Reserved
+ */
+
+@import 'node_modules/bootstrap/scss/functions';
+@import 'node_modules/bootstrap/scss/variables';
+
+$pane-separator-border: 1px solid $gray-200;

--- a/hasher-matcher-actioner/webapp/src/utils/constants.jsx
+++ b/hasher-matcher-actioner/webapp/src/utils/constants.jsx
@@ -37,3 +37,5 @@ export const StatNames = Object.freeze({
   HASHES: 'hashes',
   MATCHES: 'matches',
 });
+
+export const SeparatorBorder = '1px solid #ececec';

--- a/hasher-matcher-actioner/webapp/src/utils/constants.jsx
+++ b/hasher-matcher-actioner/webapp/src/utils/constants.jsx
@@ -37,5 +37,3 @@ export const StatNames = Object.freeze({
   HASHES: 'hashes',
   MATCHES: 'matches',
 });
-
-export const SeparatorBorder = '1px solid #ececec';


### PR DESCRIPTION
Fixes #630. Can review commit by commit or all at once.

Summary
---------
Changes are mostly visual.
* Added border to sidebar
* Wrote a new layout for full width pages, made matches page use that layout
* Moved the content / signal search bar to the table header
* Added more content to the content details page
* Fancier empty state for no match selected

Test Plan
---------
Clicked around on prod data.

Screenshots attached.

### Empty state for matches
![localhost_3000_matches (1)](https://user-images.githubusercontent.com/217056/120383589-0fa14200-c2f3-11eb-8a90-2524bf365543.png)

### When additional fields are not available
![localhost_3000_matches](https://user-images.githubusercontent.com/217056/120383687-2fd10100-c2f3-11eb-8726-fe75898ff89d.png)

### When additional fields are available
![localhost_3000_matches](https://user-images.githubusercontent.com/217056/120383436-df59a380-c2f2-11eb-890a-b66acbe1b92d.png)

