### PR TITLE
Misc design changes to dashboard

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/GraphWithNumberWidget.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/GraphWithNumberWidget.jsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  */
 
-import React from 'react';
+import React, {useState, useCallback} from 'react';
 import PropTypes from 'prop-types';
 
 // import uPlot from 'uplot';
@@ -25,16 +25,28 @@ const opts = {
   series: [
     {},
     {
-      stroke: 'rgba(5, 141, 199, 1)',
-      fill: 'rgba(255, 0, 0, 0.3)',
+      stroke: 'rgba(134, 182, 254, 1)',
+      fill: 'rgba(134, 182, 254, 0.3)',
     },
   ],
 };
 
 export default function GraphWithNumberWidget({graphData}) {
+  // Uses https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node
+  //  to resize the graph on first render and on resizes
+  const [width, setWidth] = useState(0);
+
+  const measuredRef = useCallback(node => {
+    if (node !== null) {
+      setWidth(node.getBoundingClientRect().width);
+    }
+  }, []);
+
+  const myOpts = {...opts, width};
+
   return (
-    <div>
-      <UplotReact options={opts} data={graphData} />
+    <div ref={measuredRef}>
+      <UplotReact options={myOpts} data={graphData} />
     </div>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/pages/Dashboard.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Dashboard.jsx
@@ -192,7 +192,8 @@ function StatCardError({statName}) {
       <Card.Body>
         <Col>
           <h4 className="text-danger font-weight-light">
-            Failed to load stats for {statName}.
+            Failed to load stats for {statName}. This could be because the
+            configuration MEASURE_PERFORMANCE is disabled.
             {/* TODO: This will include a link to the wiki after we add an entry for MEASURE_PERFORMANCE. */}
           </h4>
         </Col>

--- a/hasher-matcher-actioner/webapp/src/pages/Dashboard.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Dashboard.jsx
@@ -8,10 +8,10 @@ import {
   Row,
   Col,
   Card,
-  Spinner,
   ButtonGroup,
   Dropdown,
   DropdownButton,
+  Spinner,
 } from 'react-bootstrap';
 
 import {fetchStats} from '../Api';
@@ -109,19 +109,28 @@ export default function Dashboard() {
 }
 
 function StatCard({statName, timeSpan}) {
+  // Card can be undefined, the card object, or 'failed' string.
+  // Failed string will have a different repr.
   const [card, setCard] = useState(undefined);
 
   useEffect(() => {
-    fetchStats(statName, timeSpan).then(response => {
-      setCard(response.card);
-    });
+    fetchStats(statName, timeSpan)
+      .then(response => {
+        setCard(response.card);
+      })
+      .catch(() => {
+        setCard('failed');
+      });
   }, [timeSpan]);
 
-  return card === undefined ? (
-    <Spinner animation="border" role="status">
-      <span className="sr-only">Loading...</span>
-    </Spinner>
-  ) : (
+  if (card === undefined) {
+    return <StatCardLoading statName={statName} />;
+  }
+  if (card === 'failed') {
+    return <StatCardError statName={statName} />;
+  }
+
+  return (
     <Card key={`stat-card-${statName}`} className="mb-4">
       <Card.Body>
         <Row>
@@ -150,4 +159,48 @@ function StatCard({statName, timeSpan}) {
 StatCard.propTypes = {
   statName: PropTypes.string.isRequired,
   timeSpan: PropTypes.string.isRequired,
+};
+
+function StatCardLoading({statName}) {
+  return (
+    <Card key={`stat-card-${statName}`} className="mb-4">
+      <Card.Body>
+        <Col>
+          <h4 className="text-muted font-weight-light">
+            <Spinner
+              as="span"
+              animation="border"
+              size="lg"
+              role="status"
+              aria-hidden="true"
+            />
+            <span>&nbsp;Loading stats for {statName}...</span>
+          </h4>
+        </Col>
+      </Card.Body>
+    </Card>
+  );
+}
+
+StatCardLoading.propTypes = {
+  statName: PropTypes.string.isRequired,
+};
+
+function StatCardError({statName}) {
+  return (
+    <Card key={`stat-card-${statName}`} className="mb-4">
+      <Card.Body>
+        <Col>
+          <h4 className="text-danger font-weight-light">
+            Failed to load stats for {statName}.
+            {/* TODO: This will include a link to the wiki after we add an entry for MEASURE_PERFORMANCE. */}
+          </h4>
+        </Col>
+      </Card.Body>
+    </Card>
+  );
+}
+
+StatCardError.propTypes = {
+  statName: PropTypes.string.isRequired,
 };

--- a/hasher-matcher-actioner/webapp/src/pages/Dashboard.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Dashboard.jsx
@@ -123,13 +123,10 @@ function StatCard({statName, timeSpan}) {
     </Spinner>
   ) : (
     <Card key={`stat-card-${statName}`} className="mb-4">
-      <Card.Header>
-        <GraphWithNumberWidget graphData={toUFlotFormat(card.graph_data)} />
-      </Card.Header>
       <Card.Body>
         <Row>
           <Col xs={4}>
-            <h3 style={{fontWeight: 300}}>{getDisplayTitle(statName)}</h3>
+            <h2 style={{fontWeight: 300}}>{getDisplayTitle(statName)}</h2>
           </Col>
           <Col xs={4}>
             <h1>{getDisplayNumber(card.time_span_count)}</h1>
@@ -143,6 +140,9 @@ function StatCard({statName, timeSpan}) {
           </Col>
         </Row>
       </Card.Body>
+      <Card.Footer>
+        <GraphWithNumberWidget graphData={toUFlotFormat(card.graph_data)} />
+      </Card.Footer>
     </Card>
   );
 }


### PR DESCRIPTION
Fixes #635 

Summary
---------
* move Graph below header in stat cards
* switch from red to blue for dashboard chart color
* allow graph to expand to fill the space available
* add loading and error state for stat cards

Test Plan
---------
Took screenshots!

### Before
![d3jelb9xcmkers cloudfront net_](https://user-images.githubusercontent.com/217056/120389649-b2a98a00-c2fa-11eb-81de-023e325976a1.png)

### After
![localhost_3000_](https://user-images.githubusercontent.com/217056/120389667-b9d09800-c2fa-11eb-9f66-e5a221b6d71f.png)

### Failed to load stats
<img width="1154" alt="Screen Shot 2021-06-02 at 10 08 42" src="https://user-images.githubusercontent.com/217056/120495563-d2888e80-c38a-11eb-9291-7aca051ed5c6.png">

### Loading gif (manually introduced delays)
![hma-dashboard-loading](https://user-images.githubusercontent.com/217056/120496007-3317cb80-c38b-11eb-8f3d-15f4b1284367.gif)
