### PR TITLE
add validation rules when for update and delete

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerColumns.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerColumns.jsx
@@ -5,6 +5,8 @@
 import React from 'react';
 import Form from 'react-bootstrap/Form';
 import {PropTypes} from 'prop-types';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
 import WebhookActioner from './WebhookActioner';
 
 export default function ActionPerformerColumns({
@@ -13,6 +15,7 @@ export default function ActionPerformerColumns({
   params,
   editing,
   onChange,
+  canNotDeleteOrUpdateName,
 }) {
   const Actioners = {
     WebhookPostActionPerformer: WebhookActioner,
@@ -28,17 +31,31 @@ export default function ActionPerformerColumns({
 
         <div hidden={!editing}>
           <Form>
-            <Form.Group>
-              <Form.Label>Action Name</Form.Label>
-              <Form.Control
-                type="text"
-                placeholder="New Action Name"
-                value={name}
-                onChange={e => {
-                  onChange('name', {name: e.target.value});
-                }}
-              />
-            </Form.Group>
+            {canNotDeleteOrUpdateName ? (
+              <OverlayTrigger
+                overlay={
+                  <Tooltip id={`tooltip-disabled-${name}`}>
+                    The action {name}&apos;s name can not be modified because it
+                    is currently being used by one or more action rules. Please
+                    edit the rule(s) to refer to another action, or delete the
+                    rule(s), then retry.
+                  </Tooltip>
+                }>
+                <Form.Label>{name}</Form.Label>
+              </OverlayTrigger>
+            ) : (
+              <Form.Group>
+                <Form.Label>Action Name</Form.Label>
+                <Form.Control
+                  type="text"
+                  placeholder="New Action Name"
+                  value={name}
+                  onChange={e => {
+                    onChange('name', {name: e.target.value});
+                  }}
+                />
+              </Form.Group>
+            )}
           </Form>
         </div>
       </td>
@@ -63,4 +80,5 @@ ActionPerformerColumns.propTypes = {
     headers: PropTypes.string.isRequired,
   }).isRequired,
   onChange: PropTypes.func.isRequired,
+  canNotDeleteOrUpdateName: PropTypes.bool.isRequired,
 };

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.jsx
@@ -6,6 +6,8 @@ import React, {useState} from 'react';
 import {PropTypes} from 'prop-types';
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
 import ActionPerformerColumns from './ActionPerformerColumns';
 
 export default function ActionPerformerRows({
@@ -15,6 +17,7 @@ export default function ActionPerformerRows({
   edit,
   onSave,
   onDelete,
+  canNotDeleteOrUpdateName,
 }) {
   const [editing, setEditing] = useState(edit);
   const [
@@ -58,10 +61,12 @@ export default function ActionPerformerRows({
             className="mb-2 table-action-button"
             onClick={() => setEditing(true)}>
             <ion-icon name="pencil" size="large" className="ion-icon-white" />
-          </Button>{' '}
+          </Button>
+          <br />
           <Button
             variant="secondary"
             className="table-action-button"
+            disabled={canNotDeleteOrUpdateName}
             onClick={() => setShowDeleteActionConfirmation(true)}>
             <ion-icon
               name="trash-bin"
@@ -69,6 +74,7 @@ export default function ActionPerformerRows({
               className="ion-icon-white"
             />
           </Button>
+          <br />
           <Modal
             show={showDeleteActionConfirmation}
             onHide={() => setShowDeleteActionConfirmation(false)}>
@@ -92,6 +98,25 @@ export default function ActionPerformerRows({
               </Button>
             </Modal.Footer>
           </Modal>
+          {canNotDeleteOrUpdateName ? (
+            <OverlayTrigger
+              overlay={
+                <Tooltip id={`tooltip-${name}`}>
+                  The action {name} can not be deleted because it is currently
+                  being used by one or more action rules. Please edit the
+                  rule(s) to refer to another action, or delete the rule(s),
+                  then retry.
+                </Tooltip>
+              }>
+              <Button variant="secondary" className="table-action-button">
+                <ion-icon
+                  name="help-outline"
+                  size="large"
+                  className="ion-icon-white"
+                />
+              </Button>
+            </OverlayTrigger>
+          ) : null}
         </td>
         <ActionPerformerColumns
           key={updatedAction.name}
@@ -100,6 +125,7 @@ export default function ActionPerformerRows({
           params={updatedAction.fields}
           editing={false}
           onChange={onUpdatedActionChange}
+          canNotDeleteOrUpdateName={canNotDeleteOrUpdateName}
         />
       </tr>
       <tr hidden={!editing}>
@@ -115,7 +141,8 @@ export default function ActionPerformerRows({
               size="large"
               className="ion-icon-white"
             />
-          </Button>{' '}
+          </Button>
+          <br />
           <Button
             variant="outline-secondary"
             className="table-action-button"
@@ -161,6 +188,7 @@ export default function ActionPerformerRows({
           params={updatedAction.fields}
           editing
           onChange={onUpdatedActionChange}
+          canNotDeleteOrUpdateName={canNotDeleteOrUpdateName}
         />
       </tr>
     </>
@@ -177,4 +205,5 @@ ActionPerformerRows.propTypes = {
   }).isRequired,
   onSave: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
+  canNotDeleteOrUpdateName: PropTypes.bool.isRequired,
 };

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ActionSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ActionSettingsTab.jsx
@@ -12,6 +12,7 @@ import {
   updateAction,
   createAction,
   deleteAction,
+  fetchAllActionRules,
 } from '../../Api';
 import ActionPerformerColumns from '../../components/settings/ActionPerformer/ActionPerformerColumns';
 import ActionPerformerRows from '../../components/settings/ActionPerformer/ActionPerformerRows';
@@ -30,6 +31,10 @@ export default function ActionSettingsTab() {
    * someone else is actively working in this space.
    */
   const [performers, setPerformers] = useState([]);
+  const [
+    actionRulesDependentActions,
+    setActionRulesDependentActions,
+  ] = useState([]);
   const [adding, setAdding] = useState(false);
   const [newAction, setNewAction] = useState(defaultAction);
   const [showToast, setShowToast] = useState(false);
@@ -63,6 +68,14 @@ export default function ActionSettingsTab() {
         rename(item),
       );
       setPerformers(actionPerformers);
+    });
+    fetchAllActionRules().then(response => {
+      if (response && response.error_message === '') {
+        const mappedActions = response.action_rules.map(
+          actionRule => actionRule.action_label.value,
+        );
+        setActionRulesDependentActions(mappedActions);
+      }
     });
   };
   const onActionUpdate = updatedAction => {
@@ -104,6 +117,7 @@ export default function ActionSettingsTab() {
   useEffect(() => {
     refreshActions();
   }, []);
+
   return (
     <>
       <Card>
@@ -170,6 +184,7 @@ export default function ActionSettingsTab() {
                   params={newAction.fields}
                   editing
                   onChange={onNewActionChange}
+                  canNotDeleteOrUpdateName={false}
                 />
               </tr>
               {performers.length === 0
@@ -183,6 +198,9 @@ export default function ActionSettingsTab() {
                       edit={false}
                       onSave={onActionUpdate}
                       onDelete={onActionDelete}
+                      canNotDeleteOrUpdateName={
+                        actionRulesDependentActions.indexOf(performer.name) >= 0
+                      }
                     />
                   ))}
             </tbody>


### PR DESCRIPTION
Summary
---------

In previous PR https://github.com/facebook/ThreatExchange/pull/620, I made action's name and type editable. Since action rules are dependent on actions, delete an action or update an action's name may cause issues. In this PR, I made below changes:

- Fetch and save all action rules when refresh the action page
- If an action has one or more action rules
     1. disable the delete button, display a help icon to show the reason why the delete button is disabled
     2. In edit mode, make action name non-editable, display a hover over message to show the reason why it's non-editable

Test Plan
---------
![Screen Shot 2021-06-01 at 5 39 08 PM](https://user-images.githubusercontent.com/81996660/120394049-e5ef1780-c300-11eb-8659-68b3bc814b92.png)
![Screen Shot 2021-06-01 at 5 39 19 PM](https://user-images.githubusercontent.com/81996660/120394073-edaebc00-c300-11eb-9094-3fb3e39c4890.png)
![Screen Shot 2021-06-01 at 5 39 42 PM](https://user-images.githubusercontent.com/81996660/120394093-f69f8d80-c300-11eb-9173-e5b37f6a9577.png)
![Screen Shot 2021-06-01 at 5 39 32 PM](https://user-images.githubusercontent.com/81996660/120394328-40887380-c301-11eb-8ea1-8b1586126b76.png)

