### PR TITLE
[hma][scripts] Add API methods to script utils

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -26,7 +26,6 @@ class MatchSummary(JSONifiable):
     signal_id: t.Union[str, int]
     signal_source: str
     updated_at: str
-    reactions: str
 
     def to_json(self) -> t.Dict:
         return asdict(self)
@@ -189,7 +188,6 @@ def get_matches_api(
                     signal_id=record.signal_id,
                     signal_source=record.signal_source,
                     updated_at=record.updated_at.isoformat(),
-                    reactions="Mocked",
                 )
                 for record in records
             ]
@@ -227,7 +225,7 @@ def get_matches_api(
         )
         writeback_message.send_to_queue()
         logger.info(
-            f"Reaction change enqueued for {signal_source}:{signal_id} in {ds_id} change={opinion_change}"
+            f"Opinion change enqueued for {signal_source}:{signal_id} in {ds_id} change={opinion_change}"
         )
 
         signal = PDQSignalMetadata(

--- a/hasher-matcher-actioner/scripts/script_utils.py
+++ b/hasher-matcher-actioner/scripts/script_utils.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 """
-Utilities for hma script
+Utilities for hma scripts
 """
 
 import json
@@ -13,13 +13,45 @@ from urllib.parse import urljoin
 
 
 class HasherMatcherActionerAPI:
+    """
+    Class for interfacing with a subset HMA API endpoints in python scripts.
+    Supports future and existing storm, soak, and smoke test as well as being
+    useful for debuging outside of the HMA UI and AWS Console.
+
+    See hmalib/lambdas/api/
+    """
+
     def __init__(
         self,
         api_url: str,
         api_token: str,
+        client_id: str = None,
+        refresh_token: str = None,
     ) -> None:
         self.api_url = api_url
         self.api_token = api_token
+        self.client_id = client_id
+        self.refresh_token = refresh_token
+
+    def _refresh_token(self):
+        """
+        IdToken has a default ttl of 60 minutes
+        RefreshToken as a default ttl of 30 days
+        Only works in boto3 is install and optional values are set.
+        """
+        if self.client_id and self.refresh_token:
+            import boto3
+
+            client = boto3.client("cognito-idp")
+
+            resp = client.initiate_auth(
+                AuthFlow="REFRESH_TOKEN_AUTH",
+                AuthParameters={"REFRESH_TOKEN": self.refresh_token},
+                ClientId=self.client_id,
+            )
+            self.api_token = resp["AuthenticationResult"]["IdToken"]
+            return self.api_token
+        return "Refresh Token and/or client ID Missing"
 
     def _get_header(self) -> t.Dict[str, str]:
         return {
@@ -30,6 +62,31 @@ class HasherMatcherActionerAPI:
     def _get_request_url(self, api_path: str) -> str:
         return urljoin(self.api_url, api_path)
 
+    def _get_with_auth(
+        self,
+        api_path: str = "",
+        params: t.Optional[t.Dict[str, str]] = None,
+    ) -> requests.Response:
+        return requests.get(
+            self._get_request_url(api_path),
+            headers=self._get_header(),
+        )
+
+    def _post_with_auth(
+        self,
+        api_path: str = "",
+        data: t.Optional[bytes] = None,
+    ) -> requests.Response:
+        return requests.post(
+            self._get_request_url(api_path),
+            headers=self._get_header(),
+            data=data,
+        )
+
+    def get_all_matches(self, api_path: str = "/matches/"):
+        response = self._get_with_auth(api_path=api_path)
+        return response.json().get("match_summaries", [])
+
     def send_single_submission_b64(
         self,
         content_id: str,
@@ -37,7 +94,6 @@ class HasherMatcherActionerAPI:
         additional_fields: t.List[str] = [],
         api_path: str = "/submit/",
     ):
-
         payload = {
             "submission_type": "DIRECT_UPLOAD",
             "content_id": content_id,
@@ -47,12 +103,9 @@ class HasherMatcherActionerAPI:
             ),
             "additional_fields": additional_fields,
         }
-        payload_bytes = json.dumps(payload).encode()
-
-        response = requests.post(
-            self._get_request_url(api_path),
-            headers=self._get_header(),
-            data=payload_bytes,
+        self._post_with_auth(
+            api_path=api_path,
+            data=json.dumps(payload).encode(),
         )
 
     def send_single_submission_url(
@@ -62,7 +115,6 @@ class HasherMatcherActionerAPI:
         additional_fields: t.List[str],
         api_path: str = "/submit/",
     ):
-
         payload = {
             "submission_type": "POST_URL_UPLOAD",
             "content_id": content_id,
@@ -70,13 +122,9 @@ class HasherMatcherActionerAPI:
             "content_bytes_url_or_file_type": "image/jpeg",
             "additional_fields": [],
         }
-
-        payload_bytes = json.dumps(payload).encode()
-
-        response = requests.post(
-            self._get_request_url(api_path),
-            headers=self._get_header(),
-            data=payload_bytes,
+        response = self._post_with_auth(
+            api_path=api_path,
+            data=json.dumps(payload).encode(),
         )
 
         response_json = response.json()
@@ -86,7 +134,137 @@ class HasherMatcherActionerAPI:
             headers={"content-type": "image/jpeg"},
         )
 
+    def get_content_hash_details(
+        self,
+        content_id: str,
+        api_path: str = "/content/hash/",
+    ):
+        response = self._get_with_auth(
+            api_path=api_path,
+            params={"content_id": content_id},
+        )
+        return response.json()
+
+    def get_content_action_history(
+        self,
+        content_id: str,
+        api_path: str = "/content/action-history/",
+    ):
+        response = self._get_with_auth(
+            api_path=api_path,
+            params={"content_id": content_id},
+        )
+        return response.json().get("action_history", [])
+
+    def get_content_matches(
+        self,
+        content_id: str,
+        api_path: str = "/matches/match/",
+    ):
+        response = self._get_with_auth(
+            api_path=api_path,
+            params={"content_id": content_id},
+        )
+        return response.json().get("match_details", [])
+
+    def get_dataset_configs(
+        self,
+        api_path: str = "/datasets/",
+    ):
+        response = self._get_with_auth(api_path=api_path)
+        return response.json().get("threat_exchange_datasets", [])
+
+    def create_dataset_config(
+        self,
+        privacy_group_id: str,
+        privacy_group_name: str,
+        description: str = "",
+        matcher_active: bool = True,
+        fetcher_active: bool = False,
+        write_back: bool = False,
+        api_path: str = "/datasets/create/",
+    ):
+        payload = {
+            "privacy_group_id": privacy_group_id,
+            "privacy_group_name": privacy_group_name,
+            "description": description,
+            "fetcher_active": fetcher_active,
+            "matcher_active": matcher_active,
+            "write_back": write_back,
+        }
+        self._post_with_auth(
+            api_path=api_path,
+            data=json.dumps(payload).encode(),
+        )
+
+    def get_actions(
+        self,
+        api_path: str = "/actions/",
+    ):
+        response = self._get_with_auth(api_path=api_path)
+        return response.json().get("actions_response", [])
+
+    def create_action(
+        self,
+        action_name: str,
+        config_subtype: str,
+        fields: t.Dict[str, t.Any],
+        api_path: str = "/actions/",
+    ):
+        payload = {
+            "action_name": action_name,
+            "config_subtype": config_subtype,
+            "fields": fields,
+        }
+        self._post_with_auth(
+            api_path=api_path,
+            data=json.dumps(payload).encode(),
+        )
+
+    def get_action_rules(
+        self,
+        api_path: str = "/action-rules/",
+    ):
+        response = self._get_with_auth(api_path=api_path)
+        return response.json().get("action_rules", [])
+
+    def create_action_rule(
+        self,
+        action_rule: t.Any,
+        api_path: str = "/action-rules/",
+    ):
+        payload = {
+            "action_rule": action_rule,
+        }
+        self._post_with_auth(
+            api_path=api_path,
+            data=json.dumps(payload).encode(),
+        )
+
 
 if __name__ == "__main__":
-    # if you want hard code tests for additonal methods you can do so here
-    pass
+    # If you want hard code tests for methods you can do so here:
+
+    # Testing HasherMatcherActionerAPI
+    #   Since the API requries a deployed instance the majority of
+    #   testing needs to be done manually. See below.
+
+    # Add init values for the api:
+
+    TOKEN = ""
+    # i.e. "https://<app-id>.execute-api.<region>.amazonaws.com/"
+    API_URL = ""
+    # See AWS Console: Cognito -> UserPools... -> App clients
+    CLIENT_ID = ""
+    # Can be created with dev certs `$ scripts/get_auth_token --refresh_token`
+    REFRESH_TOKEN = ""
+
+    api = HasherMatcherActionerAPI(API_URL, TOKEN, CLIENT_ID, REFRESH_TOKEN)
+
+    print("Manual Test of API Request Methods:")
+
+    # Space to test api
+    # e.g. if auth is correct the following command should print:
+    # "{'message': 'Hello World, HMA <#>'}"
+
+    print(api._get_with_auth().json())

--- a/hasher-matcher-actioner/terraform/authentication-shared/main.tf
+++ b/hasher-matcher-actioner/terraform/authentication-shared/main.tf
@@ -72,7 +72,7 @@ resource "aws_cognito_user_pool_client" "webapp_and_api_shared_user_pool_client"
   user_pool_id                         = aws_cognito_user_pool.webapp_and_api_shared_user_pool.id
   generate_secret                      = false
   allowed_oauth_flows_user_pool_client = true
-  explicit_auth_flows                  = ["ADMIN_USER_PASSWORD_AUTH", "ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+  explicit_auth_flows                  = ["ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
   allowed_oauth_scopes                 = ["openid"]
   allowed_oauth_flows                  = ["code"]
   callback_urls                        = ["https://localhost:3000"] # a shared user pool and its app client is for developers only

--- a/hasher-matcher-actioner/terraform/authentication/main.tf
+++ b/hasher-matcher-actioner/terraform/authentication/main.tf
@@ -57,7 +57,7 @@ resource "aws_cognito_user_pool_client" "webapp_and_api_user_pool_client" {
   user_pool_id                         = aws_cognito_user_pool.webapp_and_api_user_pool[0].id
   generate_secret                      = false
   allowed_oauth_flows_user_pool_client = true
-  explicit_auth_flows                  = ["ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+  explicit_auth_flows                  = ["ALLOW_ADMIN_USER_PASSWORD_AUTH", "ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
   allowed_oauth_scopes                 = ["openid"]
   allowed_oauth_flows                  = ["code"]
   callback_urls                        = var.use_cloudfront_distribution_url ? [var.cloudfront_distribution_url] : ["https://localhost:3000"]

--- a/hasher-matcher-actioner/terraform/outputs.tf
+++ b/hasher-matcher-actioner/terraform/outputs.tf
@@ -21,11 +21,16 @@ output "image_folder_key" {
 output "prefix" {
   value = var.prefix
 }
-
 output "api_url" {
   value = module.api.invoke_url
 }
-
+output "cognito_user_pool_id" {
+  value = module.authentication.webapp_and_api_user_pool_id
+}
 output "cognito_user_pool_name" {
   value = module.authentication.webapp_and_api_user_pool_name
 }
+output "cognito_user_pool_client_id" {
+  value = module.authentication.webapp_and_api_user_pool_client_id
+}
+


### PR DESCRIPTION
Summary
---------

Expands `HasherMatcherActionerAPI` to support a number of API endpoints useful for testing. 

Sneaky side fixes (can breakout to own PR if requested):
- Remove vestigial `MatchSummary` field
- Fixed an issue in `authentication-shared/main.tf` and adds to `authentication/main.tf` so `get_auth_token` will work for all deployments with the right local aws credentials.

Test Plan
---------

Manually confirmed all new methods work (see bottom of `scripts/script_utils.py`) EXCEPT for `create_action` and `create_action_rule` which I plan to test as part of 'test deployments script' in my next PR. 