### PR TITLE
change information icon background color if privacy group is not in use

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.jsx
@@ -71,7 +71,7 @@ export default function ThreatExchangePrivacyGroupCard({
                     </Popover.Content>
                   </Popover>
                 }>
-                <Button className="btn btn-primary btn-circle">
+                <Button variant={inUse ? 'primary' : 'secondary'}>
                   <ion-icon name="information-circle-outline" size="large" />
                 </Button>
               </OverlayTrigger>


### PR DESCRIPTION
Summary
---------

In ThreatExchange tab, if a privacy group is not in use, the header background will be gray, but the information icon stays blue. 

Test Plan
---------

test changes locally
  before:
![Screen Shot 2021-06-03 at 5 49 02 PM](https://user-images.githubusercontent.com/81996660/120716991-d3a5e280-c494-11eb-95ed-779915a66590.png)
  after:
![Screen Shot 2021-06-03 at 5 49 44 PM](https://user-images.githubusercontent.com/81996660/120717000-d86a9680-c494-11eb-98c7-21e3cc54be4f.png)
