### PR TITLE
Add UI URL to terraform outputs

### DIFF
--- a/hasher-matcher-actioner/terraform/outputs.tf
+++ b/hasher-matcher-actioner/terraform/outputs.tf
@@ -34,3 +34,7 @@ output "cognito_user_pool_client_id" {
   value = module.authentication.webapp_and_api_user_pool_client_id
 }
 
+output "ui_url" {
+  value = module.webapp.ui_url
+}
+

--- a/hasher-matcher-actioner/terraform/webapp/outputs.tf
+++ b/hasher-matcher-actioner/terraform/webapp/outputs.tf
@@ -7,3 +7,7 @@ output "s3_bucket_name" {
 output "cloudfront_distribution_domain_name" {
   value = var.include_cloudfront_distribution ? aws_cloudfront_distribution.webapp[0].domain_name : "no-cloudfront-distribution"
 }
+
+output "ui_url" {
+  value = aws_s3_bucket.webapp.website_endpoint
+}


### PR DESCRIPTION
Summary
---------

To make the [Installation of HMA](https://github.com/facebook/ThreatExchange/wiki/Installation) easier, include in the terraform outputs the link to view the UI at

Test Plan
---------

```
$ terraform -chdir=terraform apply
...
Terraform will perform the following actions:

Plan: 0 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + ui_url = "jesses-org-jeberl-hma-webapp.s3-website-us-east-1.amazonaws.com"

...
```

Go to jesses-org-jeberl-hma-webapp.s3-website-us-east-1.amazonaws.com and confirm it leads to the HMA UI