### PR TITLE
[hma][hotfix] fix broken override of call in WebhookActionPerformer subclass

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -67,7 +67,7 @@ class WebhookPostActionPerformer(WebhookActionPerformer):
 class WebhookGetActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a GET"""
 
-    def call(self, _data: str) -> Response:
+    def call(self, data: str) -> Response:
         return get(self.url, headers=json.loads(self.headers))
 
 
@@ -83,5 +83,5 @@ class WebhookPutActionPerformer(WebhookActionPerformer):
 class WebhookDeleteActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a DELETE"""
 
-    def call(self, _data: str) -> Response:
+    def call(self, data: str) -> Response:
         return delete(self.url, headers=json.loads(self.headers))


### PR DESCRIPTION

Summary
---------

When writing tests I discovered that  `WebhookGetActionPerformer` and `WebhookDeleteActionPerformer` don't override`WebhookActionPerformer.call()` correctly. This results in an key arg error for all calls to `WebhookActionPerformer.perform_action()`

Meaning Get and Delete Actions won't trigger correctly. 

Test Plan
---------

two line class override fix.
