### PR TITLE
Improve Install flow

### DIFF
--- a/hasher-matcher-actioner/Makefile
+++ b/hasher-matcher-actioner/Makefile
@@ -24,7 +24,6 @@ upload_docker:
 
 terraform/terraform.tfvars:
 	echo 'hma_lambda_docker_uri = "${DOCKER_URI}:${DOCKER_TAG}"' > terraform/terraform.tfvars
-	echo 'organization = "${USER}-org"' >> terraform/terraform.tfvars
 
 terraform/backend.tf:
 	./scripts/write_backend_config.sh > terraform/backend.tf

--- a/hasher-matcher-actioner/Makefile
+++ b/hasher-matcher-actioner/Makefile
@@ -8,7 +8,7 @@ shell-or-die = $\
 
 USER ?= $(call shell-or-die,whoami)
 REPOSITORY_NAME = hma-lambda-dev
-DOCKER_TAG ?= ${USER} # todo - change to ${USER}-latest?
+DOCKER_TAG ?= ${USER}# todo - change to ${USER}-latest?
 DOCKER_URI = $(call shell-or-die,docker images --filter=reference='*/${REPOSITORY_NAME}:${DOCKER_TAG}' --format='{{.Repository}}')
 
 
@@ -24,6 +24,7 @@ upload_docker:
 
 terraform/terraform.tfvars:
 	echo 'hma_lambda_docker_uri = "${DOCKER_URI}:${DOCKER_TAG}"' > terraform/terraform.tfvars
+	echo 'organization = "${USER}-org"' >> terraform/terraform.tfvars
 
 terraform/backend.tf:
 	./scripts/write_backend_config.sh > terraform/backend.tf


### PR DESCRIPTION
Summary
---------

Some improvement to make the [install flow](https://github.com/facebook/ThreatExchange/wiki/Installation) easier/work.

1. Make `org` a default variable for terraform
2. Fix bug where user name prefix had trailing whitespace which was causing issues with Docker urls

Test Plan
---------

Followed the steps in the install guide: https://github.com/facebook/ThreatExchange/wiki/Installation