### PR TITLE
Make ActionRule Labels understandable

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
@@ -8,6 +8,20 @@ import Form from 'react-bootstrap/Form';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 
+const classificationOptions = [
+  <option key="Dataset Source" value="BankSourceClassification">
+    Dataset Source
+  </option>,
+  <option key="Dataset ID" value="BankIDClassification">
+    Dataset ID
+  </option>,
+  <option key="MatchedContent ID" value="BankedContentIDClassification">
+    MatchedContent ID
+  </option>,
+  <option key="MatchedContent Classification" value="Classification">
+    MatchedContent Classification
+  </option>,
+];
 export default function ActionRuleFormColumns({
   actions,
   name,
@@ -18,62 +32,12 @@ export default function ActionRuleFormColumns({
   oldName,
   onChange,
 }) {
-  const classificationOptions = [
-    <option key="Dataset Source" value="BankSourceClassification">
-      Dataset Source
-    </option>,
-    <option key="Dataset ID" value="BankIDClassification">
-      Dataset ID
-    </option>,
-    <option key="Matched Content ID" value="BankedContentIDClassification">
-      Matched Content ID
-    </option>,
-    <option key="Matched Content Tag" value="Classification">
-      Matched Content Tag
-    </option>,
-  ];
-
-  // const classificationOptionValues = {
-  //   BankSourceClassification: {
-  //     form_type: 'select',
-  //     options: [
-  //       <option key="te" value="te">
-  //         ThreatExchange
-  //       </option>,
-  //     ],
-  //   },
-  //   BankIDClassification: {
-  //     form_type: 'select',
-  //     options: [
-  //       <option key="1" value="1">
-  //         DS 1
-  //       </option>,
-  //       <option key="2" value="2">
-  //         DS 2
-  //       </option>,
-  //     ],
-  //   },
-  //   BankedContentIDClassification: {
-  //     form_type: 'text',
-  //   },
-  //   Classification: {
-  //     form_type: 'select',
-  //     options: [
-  //       <option key="1a" value="1">
-  //         Tag 1
-  //       </option>,
-  //       <option key="2a" value="2">
-  //         DS 2
-  //       </option>,
-  //     ],
-  //   },
-  // };
-
-  const renderClassificationRow = (classification, onClassificationChange) => (
-    <Row
-      key={
-        classification.classification_type + classification.classification_value
-      }>
+  const renderClassificationRow = (
+    classification,
+    onClassificationChange,
+    index,
+  ) => (
+    <Row key={index}>
       <Col key="select-classification-type">
         <Form.Control
           as="select"
@@ -94,13 +58,13 @@ export default function ActionRuleFormColumns({
           value={classification.equals}
           onChange={e => {
             const newClassification = classification;
-            newClassification.equals = e.target.value;
+            newClassification.equals = e.target.value === 'true';
             onClassificationChange(newClassification);
           }}>
-          <option key="Equal" value>
+          <option key="Equal" value="true">
             =
           </option>
-          <option key="NotEqual" value={false}>
+          <option key="NotEqual" value="false">
             ≠
           </option>
         </Form.Control>
@@ -115,6 +79,8 @@ export default function ActionRuleFormColumns({
             newClassification.classification_value = e.target.value;
             onClassificationChange(newClassification);
           }}
+          selected
+          isInvalid={showErrors && !classification.classification_value}
         />
       </Col>
     </Row>
@@ -162,14 +128,12 @@ export default function ActionRuleFormColumns({
                 const onClassificationChange = newClassification => {
                   const newClassifications = classifications;
                   newClassifications[index] = newClassification;
-                  console.log('onChange called');
-                  console.log(newClassifications);
-
                   onChange({classifications: newClassifications});
                 };
                 return renderClassificationRow(
                   classification,
                   onClassificationChange,
+                  index,
                 );
               })
             : []}
@@ -210,9 +174,7 @@ ActionRuleFormColumns.propTypes = {
       equals: PropTypes.bool.isRequired,
       classification_value: PropTypes.string.isRequired,
     }),
-  ).isRequired,
-  // mustHaveLabels: PropTypes.string.isRequired,
-  // mustNotHaveLabels: PropTypes.string,
+  ),
   actionId: PropTypes.string.isRequired,
   showErrors: PropTypes.bool.isRequired,
   nameIsUnique: PropTypes.func.isRequired,
@@ -222,4 +184,5 @@ ActionRuleFormColumns.propTypes = {
 
 ActionRuleFormColumns.defaultProps = {
   oldName: undefined,
+  classifications: [],
 };

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
@@ -5,6 +5,8 @@
 import React from 'react';
 import {PropTypes} from 'prop-types';
 import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
 
 export default function ActionRuleFormColumns({
   actions,
@@ -17,6 +19,128 @@ export default function ActionRuleFormColumns({
   oldName,
   onChange,
 }) {
+  const classifications = [
+    {
+      classification_type: 'BankSourceClassification',
+      equals: true,
+      classification_value: mustHaveLabels + mustNotHaveLabels,
+    },
+  ];
+
+  const classificationOptions = [
+    <option key="Dataset Source" value="BankSourceClassification">
+      Dataset Source
+    </option>,
+    <option key="Dataset ID" value="BankIDClassification">
+      Dataset ID
+    </option>,
+    <option key="Matched Content ID" value="BankedContentIDClassification">
+      Matched Content ID
+    </option>,
+    <option key="Matched Content Tag" value="Classification">
+      Matched Content Tag
+    </option>,
+  ];
+
+  const classificationOptionValues = {
+    BankSourceClassification: {
+      form_type: 'select',
+      options: [
+        <option key="te" value="te">
+          ThreatExchange
+        </option>,
+      ],
+    },
+    BankIDClassification: {
+      form_type: 'select',
+      options: [
+        <option key="1" value="1">
+          DS 1
+        </option>,
+        <option key="2" value="2">
+          DS 2
+        </option>,
+      ],
+    },
+    BankedContentIDClassification: {
+      form_type: 'text',
+    },
+    Classification: {
+      form_type: 'select',
+      options: [
+        <option key="1a" value="1">
+          Tag 1
+        </option>,
+        <option key="2a" value="2">
+          DS 2
+        </option>,
+      ],
+    },
+  };
+
+  const renderClassificationRow = (classification, index) => {
+    const onClassificationChange = newClassification => {
+      const newClassifications = classifications;
+      newClassifications[index] = newClassification;
+      onChange({must_have_labels: newClassifications});
+    };
+
+    return (
+      <Row key={index}>
+        <Col key="select-classification-type">
+          <Form.Control
+            as="select"
+            required
+            onChange={e => {
+              const newClassification = classification;
+              newClassification.classification_type = e.target.value;
+              onClassificationChange(newClassification);
+            }}
+            isInvalid={showErrors && classifications.length > 0}>
+            {classificationOptions}
+          </Form.Control>
+        </Col>
+        <Col xs="auto" key="select-classification-equals">
+          <Form.Control
+            as="select"
+            required
+            onChange={e => {
+              const newClassification = classification;
+              newClassification.equals = e.target.value;
+              onClassificationChange(newClassification);
+            }}>
+            <option key="Equal" value>
+              =
+            </option>
+            <option key="NotEqual" value={false}>
+              ≠
+            </option>
+          </Form.Control>
+        </Col>
+        <Col key="select-classification-value">
+          <Form.Control
+            // as={
+            //   classificationOptionValues[
+            //     classifications[0].classification_type
+            //   ].form_type
+            // }
+            as="select"
+            required
+            onChange={e => {
+              const newClassification = classification;
+              newClassification.classification_value = e.target.value;
+              onClassificationChange(newClassification);
+            }}>
+            {
+              classificationOptionValues[classifications[0].classification_type]
+                .options
+            }
+          </Form.Control>
+        </Col>
+      </Row>
+    );
+  };
+
   const actionOptions = actions
     ? actions.map(action => (
         <option key={action.id} value={action.id}>
@@ -46,18 +170,20 @@ export default function ActionRuleFormColumns({
         </Form.Text>
       </td>
       <td>
-        <Form.Label>
-          Labeled As
-          <span hidden={!showErrors || mustHaveLabels}> (required)</span>
-        </Form.Label>
-        <Form.Control
-          as="textarea"
-          rows={4}
-          required
-          value={mustHaveLabels}
-          onChange={e => onChange({must_have_labels: e.target.value})}
-          isInvalid={showErrors && !mustNotHaveLabels}
-        />
+        <Form>
+          <Form.Label>
+            Classifications
+            <span hidden={!showErrors || classifications.length === 0}>
+              {' '}
+              (required)
+            </span>
+          </Form.Label>
+          {classifications
+            ? classifications.map((classification, index) =>
+                renderClassificationRow(classification, index),
+              )
+            : []}
+        </Form>
       </td>
       <td>
         <Form.Label>

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
@@ -56,16 +56,7 @@ export default function ActionRuleFormColumns({
           required
           value={mustHaveLabels}
           onChange={e => onChange({must_have_labels: e.target.value})}
-          isInvalid={showErrors && !mustHaveLabels}
-        />
-      </td>
-      <td>
-        <Form.Label>Not Labeled As</Form.Label>
-        <Form.Control
-          as="textarea"
-          rows={4}
-          value={mustNotHaveLabels}
-          onChange={e => onChange({must_not_have_labels: e.target.value})}
+          isInvalid={showErrors && !mustNotHaveLabels}
         />
       </td>
       <td>

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
@@ -18,14 +18,6 @@ export default function ActionRuleFormColumns({
   oldName,
   onChange,
 }) {
-  // const classifications = [
-  //   {
-  //     classification_type: 'BankSourceClassification',
-  //     equals: true,
-  //     classification_value: mustHaveLabels + mustNotHaveLabels,
-  //   },
-  // ];
-
   const classificationOptions = [
     <option key="Dataset Source" value="BankSourceClassification">
       Dataset Source
@@ -41,104 +33,92 @@ export default function ActionRuleFormColumns({
     </option>,
   ];
 
-  const classificationOptionValues = {
-    BankSourceClassification: {
-      form_type: 'select',
-      options: [
-        <option key="te" value="te">
-          ThreatExchange
-        </option>,
-      ],
-    },
-    BankIDClassification: {
-      form_type: 'select',
-      options: [
-        <option key="1" value="1">
-          DS 1
-        </option>,
-        <option key="2" value="2">
-          DS 2
-        </option>,
-      ],
-    },
-    BankedContentIDClassification: {
-      form_type: 'text',
-    },
-    Classification: {
-      form_type: 'select',
-      options: [
-        <option key="1a" value="1">
-          Tag 1
-        </option>,
-        <option key="2a" value="2">
-          DS 2
-        </option>,
-      ],
-    },
-  };
+  // const classificationOptionValues = {
+  //   BankSourceClassification: {
+  //     form_type: 'select',
+  //     options: [
+  //       <option key="te" value="te">
+  //         ThreatExchange
+  //       </option>,
+  //     ],
+  //   },
+  //   BankIDClassification: {
+  //     form_type: 'select',
+  //     options: [
+  //       <option key="1" value="1">
+  //         DS 1
+  //       </option>,
+  //       <option key="2" value="2">
+  //         DS 2
+  //       </option>,
+  //     ],
+  //   },
+  //   BankedContentIDClassification: {
+  //     form_type: 'text',
+  //   },
+  //   Classification: {
+  //     form_type: 'select',
+  //     options: [
+  //       <option key="1a" value="1">
+  //         Tag 1
+  //       </option>,
+  //       <option key="2a" value="2">
+  //         DS 2
+  //       </option>,
+  //     ],
+  //   },
+  // };
 
-  const renderClassificationRow = (classification, index) => {
-    const onClassificationChange = newClassification => {
-      const newClassifications = classifications;
-      newClassifications[index] = newClassification;
-      onChange({must_have_labels: newClassifications});
-    };
-
-    return (
-      <Row key={index}>
-        <Col key="select-classification-type">
-          <Form.Control
-            as="select"
-            required
-            onChange={e => {
-              const newClassification = classification;
-              newClassification.classification_type = e.target.value;
-              onClassificationChange(newClassification);
-            }}
-            isInvalid={showErrors && classifications.length > 0}>
-            {classificationOptions}
-          </Form.Control>
-        </Col>
-        <Col xs="auto" key="select-classification-equals">
-          <Form.Control
-            as="select"
-            required
-            onChange={e => {
-              const newClassification = classification;
-              newClassification.equals = e.target.value;
-              onClassificationChange(newClassification);
-            }}>
-            <option key="Equal" value>
-              =
-            </option>
-            <option key="NotEqual" value={false}>
-              ≠
-            </option>
-          </Form.Control>
-        </Col>
-        <Col key="select-classification-value">
-          <Form.Control
-            // as={
-            //   classificationOptionValues[
-            //     classifications[0].classification_type
-            //   ].form_type
-            // }
-            as="select"
-            required
-            onChange={e => {
-              const newClassification = classification;
-              newClassification.classification_value = e.target.value;
-              onClassificationChange(newClassification);
-            }}>
-            {
-              classificationOptionValues[classifications[0].classification_type]
-                .options
-            }
-          </Form.Control>
-        </Col>
-      </Row>
-    );
-  };
+  const renderClassificationRow = (classification, onClassificationChange) => (
+    <Row
+      key={
+        classification.classification_type + classification.classification_value
+      }>
+      <Col key="select-classification-type">
+        <Form.Control
+          as="select"
+          required
+          value={classification.classification_type}
+          onChange={e => {
+            const newClassification = classification;
+            newClassification.classification_type = e.target.value;
+            onClassificationChange(newClassification);
+          }}>
+          {classificationOptions}
+        </Form.Control>
+      </Col>
+      <Col xs="auto" key="select-classification-equals">
+        <Form.Control
+          as="select"
+          required
+          value={classification.equals}
+          onChange={e => {
+            const newClassification = classification;
+            newClassification.equals = e.target.value;
+            onClassificationChange(newClassification);
+          }}>
+          <option key="Equal" value>
+            =
+          </option>
+          <option key="NotEqual" value={false}>
+            ≠
+          </option>
+        </Form.Control>
+      </Col>
+      <Col key="select-classification-value">
+        <Form.Control
+          type="text"
+          value={classification.classification_value}
+          required
+          onChange={e => {
+            const newClassification = classification;
+            newClassification.classification_value = e.target.value;
+            onClassificationChange(newClassification);
+          }}
+        />
+      </Col>
+    </Row>
+  );
 
   const actionOptions = actions
     ? actions.map(action => (
@@ -178,9 +158,20 @@ export default function ActionRuleFormColumns({
             </span>
           </Form.Label>
           {classifications
-            ? classifications.map((classification, index) =>
-                renderClassificationRow(classification, index),
-              )
+            ? classifications.map((classification, index) => {
+                const onClassificationChange = newClassification => {
+                  const newClassifications = classifications;
+                  newClassifications[index] = newClassification;
+                  console.log('onChange called');
+                  console.log(newClassifications);
+
+                  onChange({classifications: newClassifications});
+                };
+                return renderClassificationRow(
+                  classification,
+                  onClassificationChange,
+                );
+              })
             : []}
         </Form>
       </td>
@@ -220,6 +211,8 @@ ActionRuleFormColumns.propTypes = {
       classification_value: PropTypes.string.isRequired,
     }),
   ).isRequired,
+  // mustHaveLabels: PropTypes.string.isRequired,
+  // mustNotHaveLabels: PropTypes.string,
   actionId: PropTypes.string.isRequired,
   showErrors: PropTypes.bool.isRequired,
   nameIsUnique: PropTypes.func.isRequired,

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
@@ -8,20 +8,6 @@ import Form from 'react-bootstrap/Form';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 
-const classificationOptions = [
-  <option key="Dataset Source" value="BankSourceClassification">
-    Dataset Source
-  </option>,
-  <option key="Dataset ID" value="BankIDClassification">
-    Dataset ID
-  </option>,
-  <option key="MatchedContent ID" value="BankedContentIDClassification">
-    MatchedContent ID
-  </option>,
-  <option key="MatchedContent Classification" value="Classification">
-    MatchedContent Classification
-  </option>,
-];
 export default function ActionRuleFormColumns({
   actions,
   name,
@@ -37,8 +23,8 @@ export default function ActionRuleFormColumns({
     onClassificationChange,
     index,
   ) => (
-    <Row key={index}>
-      <Col key="select-classification-type">
+    <Row key={index} style={{marginBottom: 3, marginLeft: 3}}>
+      <Col>
         <Form.Control
           as="select"
           required
@@ -48,10 +34,15 @@ export default function ActionRuleFormColumns({
             newClassification.classification_type = e.target.value;
             onClassificationChange(newClassification);
           }}>
-          {classificationOptions}
+          <option value="BankSourceClassification">Dataset Source</option>
+          <option value="BankIDClassification">Dataset ID</option>
+          <option value="BankedContentIDClassification">
+            MatchedSignal ID
+          </option>
+          <option value="Classification">MatchedSignal</option>
         </Form.Control>
       </Col>
-      <Col xs="auto" key="select-classification-equals">
+      <Col>
         <Form.Control
           as="select"
           required
@@ -61,15 +52,19 @@ export default function ActionRuleFormColumns({
             newClassification.equals = e.target.value === 'true';
             onClassificationChange(newClassification);
           }}>
-          <option key="Equal" value="true">
-            =
+          <option value="true">
+            {classification.classification_type === 'Classification'
+              ? 'Classified As'
+              : '='}
           </option>
-          <option key="NotEqual" value="false">
-            ≠
+          <option value="false">
+            {classification.classification_type === 'Classification'
+              ? 'Not Classified As'
+              : '≠'}
           </option>
         </Form.Control>
       </Col>
-      <Col key="select-classification-value">
+      <Col>
         <Form.Control
           type="text"
           value={classification.classification_value}
@@ -115,29 +110,24 @@ export default function ActionRuleFormColumns({
         </Form.Text>
       </td>
       <td>
-        <Form>
-          <Form.Label>
-            Classifications
-            <span hidden={!showErrors || classifications.length === 0}>
-              {' '}
-              (required)
-            </span>
-          </Form.Label>
-          {classifications
-            ? classifications.map((classification, index) => {
-                const onClassificationChange = newClassification => {
-                  const newClassifications = classifications;
-                  newClassifications[index] = newClassification;
-                  onChange({classifications: newClassifications});
-                };
-                return renderClassificationRow(
-                  classification,
-                  onClassificationChange,
-                  index,
-                );
-              })
-            : []}
-        </Form>
+        <Form.Label>
+          Classifications
+          <span hidden={!showErrors || classifications}> (required)</span>
+        </Form.Label>
+        {classifications
+          ? classifications.map((classification, index) => {
+              const onClassificationChange = newClassification => {
+                const newClassifications = classifications;
+                newClassifications[index] = newClassification;
+                onChange({classifications: newClassifications});
+              };
+              return renderClassificationRow(
+                classification,
+                onClassificationChange,
+                index,
+              );
+            })
+          : []}
       </td>
       <td>
         <Form.Label>

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
@@ -42,7 +42,7 @@ export default function ActionRuleFormColumns({
           <option value="Classification">MatchedSignal</option>
         </Form.Control>
       </Col>
-      <Col>
+      <Col xs={2}>
         <Form.Control
           as="select"
           required
@@ -52,16 +52,8 @@ export default function ActionRuleFormColumns({
             newClassification.equals = e.target.value === 'true';
             onClassificationChange(newClassification);
           }}>
-          <option value="true">
-            {classification.classification_type === 'Classification'
-              ? 'Classified As'
-              : '='}
-          </option>
-          <option value="false">
-            {classification.classification_type === 'Classification'
-              ? 'Not Classified As'
-              : '≠'}
-          </option>
+          <option value="true">=</option>
+          <option value="false">≠</option>
         </Form.Control>
       </Col>
       <Col>

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.jsx
@@ -11,21 +11,20 @@ import Col from 'react-bootstrap/Col';
 export default function ActionRuleFormColumns({
   actions,
   name,
-  mustHaveLabels,
-  mustNotHaveLabels,
+  classifications,
   actionId,
   showErrors,
   nameIsUnique,
   oldName,
   onChange,
 }) {
-  const classifications = [
-    {
-      classification_type: 'BankSourceClassification',
-      equals: true,
-      classification_value: mustHaveLabels + mustNotHaveLabels,
-    },
-  ];
+  // const classifications = [
+  //   {
+  //     classification_type: 'BankSourceClassification',
+  //     equals: true,
+  //     classification_value: mustHaveLabels + mustNotHaveLabels,
+  //   },
+  // ];
 
   const classificationOptions = [
     <option key="Dataset Source" value="BankSourceClassification">
@@ -214,8 +213,13 @@ ActionRuleFormColumns.propTypes = {
     }),
   ).isRequired,
   name: PropTypes.string.isRequired,
-  mustHaveLabels: PropTypes.string.isRequired,
-  mustNotHaveLabels: PropTypes.string.isRequired,
+  classifications: PropTypes.arrayOf(
+    PropTypes.shape({
+      classification_type: PropTypes.string.isRequired,
+      equals: PropTypes.bool.isRequired,
+      classification_value: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
   actionId: PropTypes.string.isRequired,
   showErrors: PropTypes.bool.isRequired,
   nameIsUnique: PropTypes.func.isRequired,

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.jsx
@@ -9,6 +9,20 @@ import Modal from 'react-bootstrap/Modal';
 import ActionRuleFormColumns from './ActionRuleFormColumns';
 import '../../styles/_settings.scss';
 
+const classificationsFromLabels = (mustHaveLabels, mustNotHaveLabels) =>
+  mustHaveLabels
+    .map(mustHaveLabel => ({
+      classification_type: mustHaveLabel.key,
+      equals: true,
+      classification_value: mustHaveLabel.value,
+    }))
+    .concat(
+      mustNotHaveLabels.map(mustNotHaveLabel => ({
+        classification_type: mustNotHaveLabel.key,
+        equals: false,
+        classification_value: mustNotHaveLabel.value,
+      })),
+    );
 export default function ActionRulesTableRow({
   actions,
   name,
@@ -25,23 +39,13 @@ export default function ActionRulesTableRow({
     showDeleteActionRuleConfirmation,
     setShowDeleteActionRuleConfirmation,
   ] = useState(false);
+
   const [updatedActionRule, setUpdatedActionRule] = useState({
     name,
-    // must_have_labels: mustHaveLabels,
-    // must_not_have_labels: mustNotHaveLabels,
-    classifications: JSON.parse(mustHaveLabels)
-      .map(mustHaveLabel => ({
-        classification_type: mustHaveLabel.key,
-        equals: true,
-        classification_value: mustHaveLabel.value,
-      }))
-      .concat(
-        JSON.parse(mustNotHaveLabels).map(mustHaveLabel => ({
-          classification_type: mustHaveLabel.key,
-          equals: false,
-          classification_value: mustHaveLabel.value,
-        })),
-      ),
+    classifications: classificationsFromLabels(
+      mustHaveLabels,
+      mustNotHaveLabels,
+    ),
     action_id: actionId,
   });
   const [showErrors, setShowErrors] = useState(false);
@@ -53,19 +57,10 @@ export default function ActionRulesTableRow({
   const resetForm = () => {
     setUpdatedActionRule({
       name,
-      classifications: JSON.parse(mustHaveLabels)
-        .map(mustHaveLabel => ({
-          classification_type: mustHaveLabel.key,
-          equals: true,
-          classification_value: mustHaveLabel.value,
-        }))
-        .concat(
-          JSON.parse(mustNotHaveLabels).map(mustHaveLabel => ({
-            classification_type: mustHaveLabel.key,
-            equals: false,
-            classification_value: mustHaveLabel.value,
-          })),
-        ),
+      classifications: classificationsFromLabels(
+        mustHaveLabels,
+        mustNotHaveLabels,
+      ),
       action_id: actionId,
     });
   };
@@ -186,30 +181,27 @@ export default function ActionRulesTableRow({
             className="mb-2 table-action-button"
             onClick={() => {
               setShowErrors(false);
-              if (ruleIsValid(updatedActionRule, name)) {
-                const updatedMustHaveLabels = updatedActionRule.classifications
-                  .filter(classification => classification.equals)
-                  .map(classification => ({
-                    key: classification.classification_type,
-                    value: classification.classification_value,
-                  }));
-                const updatedMustNotHaveLabels = updatedActionRule.classifications
-                  .filter(classification => !classification.equals)
-                  .map(classification => ({
-                    key: classification.classification_type,
-                    value: classification.classification_value,
-                  }));
 
-                updatedActionRule.must_have_labels = JSON.stringify(
-                  updatedMustHaveLabels,
-                );
-                updatedActionRule.must_not_have_labels = JSON.stringify(
-                  updatedMustNotHaveLabels,
-                );
+              // Convert classifications into Label sets which the backend understands
+              const updatedMustHaveLabels = updatedActionRule.classifications
+                .filter(classification => classification.equals)
+                .map(classification => ({
+                  key: classification.classification_type,
+                  value: classification.classification_value,
+                }));
+              const updatedMustNotHaveLabels = updatedActionRule.classifications
+                .filter(classification => !classification.equals)
+                .map(classification => ({
+                  key: classification.classification_type,
+                  value: classification.classification_value,
+                }));
+
+              updatedActionRule.must_have_labels = updatedMustHaveLabels;
+              updatedActionRule.must_not_have_labels = updatedMustNotHaveLabels;
+              if (ruleIsValid(updatedActionRule, name)) {
                 onUpdateActionRule(name, updatedActionRule);
                 setEditing(false);
               } else {
-                console.log('showing errors');
                 setShowErrors(true);
               }
             }}>
@@ -233,8 +225,6 @@ export default function ActionRulesTableRow({
         <ActionRuleFormColumns
           actions={actions}
           name={updatedActionRule.name}
-          // mustHaveLabels={updatedActionRule.must_have_labels}
-          // mustNotHaveLabels={updatedActionRule.must_not_have_labels}
           classifications={updatedActionRule.classifications}
           actionId={updatedActionRule.action_id}
           showErrors={showErrors}
@@ -255,8 +245,18 @@ ActionRulesTableRow.propTypes = {
     }),
   ).isRequired,
   name: PropTypes.string.isRequired,
-  mustHaveLabels: PropTypes.string.isRequired,
-  mustNotHaveLabels: PropTypes.string,
+  mustHaveLabels: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  mustNotHaveLabels: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+    }),
+  ),
   actionId: PropTypes.string.isRequired,
   onDeleteActionRule: PropTypes.func.isRequired,
   onUpdateActionRule: PropTypes.func.isRequired,

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.jsx
@@ -99,22 +99,22 @@ export default function ActionRulesTableRow({
 
           case 'Classification':
             ret += ' MatchedContent';
-            if (classification.equals) {
-              ret += ' has been';
-            } else {
-              ret += ' has not been';
-            }
-            ret += ` classified ${classification.classification_value}`;
-            return ret;
+            break;
           default:
             ret += ` ${classification.classification_type}`;
             break;
         }
 
         if (classification.equals) {
-          ret += ' is';
+          ret +=
+            classification.classification_type === 'Classification'
+              ? ' has been classified'
+              : ' is';
         } else {
-          ret += ' is not';
+          ret +=
+            classification.classification_type === 'Classification'
+              ? ' has not been classified'
+              : ' is not';
         }
         ret += ` ${classification.classification_value}`;
         return ret;

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.jsx
@@ -109,13 +109,6 @@ export default function ActionRulesTableRow({
         </td>
         <td>{name}</td>
         <td className="action-rule-classification-column">{mustHaveLabels}</td>
-        <td className="action-rule-classification-column">
-          {mustNotHaveLabels.length > 0 ? (
-            mustNotHaveLabels
-          ) : (
-            <span>&mdash;</span>
-          )}
-        </td>
         <td>{getAction()}</td>
       </tr>
       <tr hidden={!editing}>

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.jsx
@@ -33,6 +33,24 @@ export default function ActionRulesTableRow({
   });
   const [showErrors, setShowErrors] = useState(false);
 
+  console.log('logging');
+  console.log(mustHaveLabels);
+  console.log(mustNotHaveLabels);
+  const classifications = JSON.parse(mustHaveLabels)
+    .map(mustHaveLabel => ({
+      classification_type: mustHaveLabel.key,
+      equals: true,
+      classification_value: mustHaveLabel.value,
+    }))
+    .concat(
+      JSON.parse(mustNotHaveLabels).map(mustHaveLabel => ({
+        classification_type: mustHaveLabel.key,
+        equals: false,
+        classification_value: mustHaveLabel.value,
+      })),
+    );
+  console.log(classifications);
+
   const onUpdatedActionRuleChange = updatedField => {
     setUpdatedActionRule({...updatedActionRule, ...updatedField});
   };

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ActionRuleSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ActionRuleSettingsTab.jsx
@@ -183,8 +183,7 @@ export default function ActionRuleSettingsTab() {
                   </Button>
                 </th>
                 <th>Name</th>
-                <th>Labeled As</th>
-                <th>Not Labeled As</th>
+                <th>Classifications</th>
                 <th>Action</th>
               </tr>
             </thead>

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ActionRuleSettingsTab.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ActionRuleSettingsTab.jsx
@@ -43,8 +43,8 @@ export default function ActionRuleSettingsTab() {
       if (response && response.error_message === '') {
         const mappedActionRules = response.action_rules.map(actionRule => ({
           name: actionRule.name,
-          must_have_labels: JSON.stringify(actionRule.must_have_labels),
-          must_not_have_labels: JSON.stringify(actionRule.must_not_have_labels),
+          must_have_labels: actionRule.must_have_labels,
+          must_not_have_labels: actionRule.must_not_have_labels,
           action_id: actionRule.action_label.value,
         }));
         setActionRules(mappedActionRules);
@@ -104,8 +104,8 @@ export default function ActionRuleSettingsTab() {
 
   const getAPIActionRule = actionRule => ({
     name: actionRule.name,
-    must_have_labels: JSON.parse(actionRule.must_have_labels),
-    must_not_have_labels: JSON.parse(actionRule.must_not_have_labels),
+    must_have_labels: actionRule.must_have_labels,
+    must_not_have_labels: actionRule.must_not_have_labels,
     action_label: {
       key: 'Action',
       value: actionRule.action_id,


### PR DESCRIPTION
Summary
---------
An ActionRule consists of two sets of Classifications (formerly called Labels): `mustHaveLabels` an `mustNotHaveLabels`. The action rule is run if all the `mustHaveLabels` are present AND none of the `mustNotHaveLabels` are present on the Match. Formerly, the only way to edit these sets ActionRules was via raw JSON. This PR makes editing, viewing, and understanding the Classifications easier.

There are 4 types of Classifications: 
1. `BankIDClassification` which maps to a Dataset ID
2. `BankSourceClassification` which maps to a Dataset Source
3. `BankedContentIDClassification` which maps to the MatchedSignal ID
4. `Classification` which maps to an arbitrary Classification on the Match. For ThreatExchange, this corresponds to Tags on indicators

To edit Classifications, you can now select one of these types from a drop down menu, select `=` or `=/=` operator accordingly, and input the value free form. This prevent user errors and provide greater understanding for what the Classifications are used for.

Additionally, when you now view the Classifications for a rule, an english description of what the classifications mean for the ActionRule is provided rather than a JSON blob. This will increase the understandability of the system as well

Next steps: 
1. Allow Classifications to be added and remove
2. Update Documentation
3. [Maybe] Make values drop down instead of free form for `BankSourceClassification` (only `te`)
4. [Maybe] Make values drop down instead of free form for `BankIDClassification` (only IDs in your system)
5. [Maybe] Make values drop down instead of free form for `Classification` (might be a way to query for tags present?)
6. [Maybe] Add validation for `BankedContentIDClassification` (or any other classification that can be validated until we implement as a dropdown)



Test Plan
---------

https://user-images.githubusercontent.com/24800630/122480295-92382b80-cf9a-11eb-96cf-39570b81f327.mov

Edit: new margins and operator text
<img width="1260" alt="Screen Shot 2021-06-21 at 2 04 58 PM" src="https://user-images.githubusercontent.com/24800630/122807511-ab422480-d299-11eb-879f-21692bae86f2.png">


