### PR TITLE
[hma] add check to handle sample ds privacy_group_id

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -85,7 +85,7 @@ class FetcherConfig:
         )
 
 
-def is_int(int_string):
+def is_int(int_string: str):
     """
     Checks if string is convertible to int.
     """

--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -85,6 +85,17 @@ class FetcherConfig:
         )
 
 
+def is_int(int_string):
+    """
+    Checks if string is convertible to int.
+    """
+    try:
+        int(int_string)
+        return True
+    except ValueError:
+        return False
+
+
 def lambda_handler(event, context):
     lambda_init_once()
     config = FetcherConfig.get()
@@ -110,6 +121,12 @@ def lambda_handler(event, context):
         logger.info(
             "Processing updates for collaboration %s", collab.privacy_group_name
         )
+
+        if not is_int(collab.privacy_group_id):
+            logger.info(
+                f"Fetch skipped because privacy_group_id({collab.privacy_group_id}) is not an int"
+            )
+            continue
 
         indicator_store = ThreatUpdateS3PDQStore(
             int(collab.privacy_group_id),
@@ -151,10 +168,6 @@ def lambda_handler(event, context):
                 )
             else:
                 logging.error("Failed before fetching any records")
-
-    # TODO add TE data to indexer
-
-    return {"statusCode": 200, "body": "Sure Yeah why not"}
 
 
 class ThreatUpdateS3PDQStore(tu.ThreatUpdatesStore):


### PR DESCRIPTION
Summary
---------

"inria-holidays-test" is not an `int` however our fetcher expects one. If someone creates a local pg config and mistakenly enables the fetcher, the fetcher will get stuck in a retry loop. This PR makes things marginally better by at least checking if the ID is an int (so at least we won't fail on our built-in sample hash set).

Test Plan
---------

Before
`[ERROR] ValueError: invalid literal for int() with base 10: 'inria-holidays-test' Traceback (most recent call last):`
...and retry again and again


After
`Fetch skipped because privacy_group_id(inria-holidays-test) is not an int`
