### PR TITLE
[hma] have dash use var.measure_performance and set time period to 1 minute

### DIFF
--- a/hasher-matcher-actioner/terraform/dashboard/lambda_widget.tpl
+++ b/hasher-matcher-actioner/terraform/dashboard/lambda_widget.tpl
@@ -1,10 +1,10 @@
 ${jsonencode({
   width  = 6
   type   = "metric"
-  period = 60
   properties = {
     title  = "${lambda_title} λ Invocations & Duration"
     region = "${region}"
+    period = 60
     stat   = "Sum"
     metrics = [
       [

--- a/hasher-matcher-actioner/terraform/dashboard/main.tf
+++ b/hasher-matcher-actioner/terraform/dashboard/main.tf
@@ -9,12 +9,12 @@ locals {
   )]
 
   queues_to_monitor_items = [for queue in var.queues_to_monitor : jsonencode({
-    width  = 6
-    type   = "metric"
-    period = 60
+    width = 6
+    type  = "metric"
     properties = {
       title  = "${queue[0]}: Age of Oldest Item"
       region = "${var.region}"
+      period = 60
       stat   = "Maximum"
       metrics = [
         [
@@ -32,14 +32,14 @@ locals {
   ])
 
   total_concurrent_lambda = jsonencode({
-    width  = 6
-    type   = "metric"
-    period = 60
+    width = 6
+    type  = "metric"
     properties = {
       title   = "Total Concurrent λ Executions"
       region  = "${var.region}"
       stacked = true
       stat    = "Maximum"
+      period  = 60
       metrics = [for lambda in local.all_lambda_names : ["AWS/Lambda", "ConcurrentExecutions", "FunctionName", "${lambda}"]]
     }
   })
@@ -47,12 +47,12 @@ locals {
   api_lambda_widget = templatefile("${path.module}/lambda_widget.tpl", { region = var.region, lambda_name = var.api_lambda_name, lambda_title = "API" })
 
   api_gateway_widget = jsonencode({
-    width  = 6
-    type   = "metric"
-    period = 60
+    width = 6
+    type  = "metric"
     properties = {
       title  = "API Gateway (${var.api_gateway_id})"
       region = "${var.region}"
+      period = 60
       stat   = "Sum"
       metrics = [
         ["AWS/ApiGateway", "4xx", "Stage", "$default", "ApiId", "${var.api_gateway_id}"],
@@ -70,6 +70,7 @@ locals {
     properties = {
       title  = "DynamoDB R/W Units (WIP: Consult ${var.datastore.name} for actual numbers)",
       region = "${var.region}",
+      period = 60
       stat   = "Average",
       metrics = [
         ["AWS/DynamoDB", "ConsumedReadCapacityUnits", "TableName", "${var.datastore.name}", { yAxis = "right" }],
@@ -83,12 +84,12 @@ locals {
   })
 
   datastore_widgets_errors = jsonencode({
-    width  = 6
-    type   = "metric"
-    period = 60
+    width = 6
+    type  = "metric"
     properties = {
       title  = "DynamoDB Errors, Throttles, & Conflicts",
       region = "${var.region}",
+      period = 60
       stat   = "Sum",
       metrics = [
         ["AWS/DynamoDB", "ThrottledRequests", "TableName", "${var.datastore.name}", "Operation", "TransactWriteItems"],
@@ -116,7 +117,7 @@ JSON
 }
 
 resource "aws_cloudwatch_dashboard" "basic_dashboard" {
-  dashboard_name = "${var.prefix}-dashboard"
+  dashboard_name = var.name
   // tf converts numbers to strings when putting them in a list.
   // this strip quotes around numbers, so that {"value": "123"} turns into {"value": 123}
   dashboard_body = replace(local.dashboard_body, "/\"([0-9]+)\"/", "$1")

--- a/hasher-matcher-actioner/terraform/dashboard/outputs.tf
+++ b/hasher-matcher-actioner/terraform/dashboard/outputs.tf
@@ -1,5 +1,1 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-
-output "dashboard_name" {
-  value = aws_cloudwatch_dashboard.basic_dashboard.dashboard_name
-}

--- a/hasher-matcher-actioner/terraform/dashboard/variables.tf
+++ b/hasher-matcher-actioner/terraform/dashboard/variables.tf
@@ -11,6 +11,11 @@ variable "prefix" {
   type        = string
 }
 
+variable "name" {
+  description = "Name of generated dashboard"
+  type        = string
+}
+
 variable "datastore" {
   description = "DynamoDB Table to store hash and match information into"
   type = object({

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -260,7 +260,8 @@ module "api" {
 # Build and deploy webapp
 
 locals {
-  aws_dashboard_url = "https://console.aws.amazon.com/cloudwatch/home?region=${data.aws_region.default.name}#dashboards:name=${module.dashboard.dashboard_name}"
+  dashboard_name    = "${var.prefix}-dashboard"
+  aws_dashboard_url = var.measure_performance ? "https://console.aws.amazon.com/cloudwatch/home?region=${data.aws_region.default.name}#dashboards:name=${local.dashboard_name}" : ""
 }
 
 resource "local_file" "webapp_env" {
@@ -332,10 +333,12 @@ resource "aws_secretsmanager_secret_version" "te_api_token" {
 
 ### Basic Dashboard ###
 module "dashboard" {
+  count = var.measure_performance ? 1 : 0
   depends_on = [
     module.api.api_root_function_name,
     module.datastore.primary_datastore,
   ]
+  name      = local.dashboard_name
   source    = "./dashboard"
   prefix    = var.prefix
   datastore = module.datastore.primary_datastore

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -23,7 +23,7 @@ variable "log_retention_in_days" {
 }
 
 variable "measure_performance" {
-  description = "Send metrics to cloudwatch. Useful for benchmarking, but can incur costs. Set to string True for this to work."
+  description = "Send metrics to cloudwatch and build a dashboard. Useful for benchmarking, but can incur costs. Set to string True for this to work."
   type        = bool
   default     = false
 }

--- a/hasher-matcher-actioner/webapp/src/pages/Dashboard.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Dashboard.jsx
@@ -106,17 +106,23 @@ export default function Dashboard() {
       </Row>
       <Row>
         <Col>
-          <Alert variant="secondary">
-            Additional metrics for the system&apos;s underlying implementation
-            can be found{' '}
-            <a
-              href={process.env.REACT_APP_AWS_DASHBOARD_URL}
-              target="_blank"
-              rel="noreferrer">
-              here.
-            </a>{' '}
-            (AWS Console authentication required)
-          </Alert>
+          {process.env.REACT_APP_AWS_DASHBOARD_URL ? (
+            <Alert variant="secondary">
+              Additional metrics for the system&apos;s underlying implementation
+              can be found{' '}
+              <a
+                href={process.env.REACT_APP_AWS_DASHBOARD_URL}
+                target="_blank"
+                rel="noreferrer">
+                here.
+              </a>{' '}
+              (AWS Console authentication required)
+            </Alert>
+          ) : (
+            <Alert variant="secondary">
+              Detailed metrics need to be enabled during deployment.
+            </Alert>
+          )}
         </Col>
       </Row>
     </FixedWidthCenterAlignedLayout>


### PR DESCRIPTION
Summary
---------

Because the dashboard is an added expense, I decided to only create it if the var.measure_performance is true. 
- Also updated the HMA UI Dash to match.

This also fixes the period of the dashboard to actually default to 1 min as intended 

Test Plan
---------

Viewed dashboard to confirm period 5min -> 1min

<img width="1199" alt="Screen Shot 2021-06-25 at 8 41 55 AM" src="https://user-images.githubusercontent.com/7664526/123427285-6ddbe080-d592-11eb-9179-17504a539257.png">