### PR TITLE
[hma][scripts] Move submit and listen to threads in soak test

### DIFF
--- a/hasher-matcher-actioner/scripts/listener.py
+++ b/hasher-matcher-actioner/scripts/listener.py
@@ -5,17 +5,18 @@ import os
 import json
 import time
 import threading
+import requests
 import typing as t
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 
-class Handler(BaseHTTPRequestHandler):
+class _Handler(BaseHTTPRequestHandler):
     """
     Request handler that counts the number of post request it receives.
+    Currently multiple instances cannot operating without taking a lock on the class attribute
     """
 
-    # ToDo Currently multiple instances cannot operating without taking a lock on the class attribute
-    threadLock: threading.Lock = threading.Lock()
+    count_lock: threading.Lock = threading.Lock()
     post_counter: int = 0
 
     def _set_response(self):
@@ -23,13 +24,17 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-type", "application/json")
         self.end_headers()
 
+    def log_message(self, format, *args):
+        # Override log method to keep test output clear
+        return
+
     def do_GET(self):
-        with Handler.threadLock:
+        with _Handler.count_lock:
             payload = {
                 "message": "GET Received",
                 "path": str(self.path),
                 "headers": str(self.headers),
-                "post_counter": str(Handler.post_counter),
+                "post_counter": str(_Handler.post_counter),
             }
         self._set_response()
         self.wfile.write(json.dumps(payload).encode("utf-8"))
@@ -44,24 +49,51 @@ class Handler(BaseHTTPRequestHandler):
             "headers": str(self.headers),
             "body": str(post_data.decode("utf-8")),
         }
-        with Handler.threadLock:
-            Handler.post_counter += 1
+        with _Handler.count_lock:
+            _Handler.post_counter += 1
         self._set_response()
         self.wfile.write(json.dumps(payload).encode("utf-8"))
 
 
-def start_listening_web_server(
-    hostname: str = "localhost",
-    port: int = 8080,
-    handler=Handler,
-) -> ThreadingHTTPServer:
-    with Handler.threadLock:
-        Handler.post_counter = 0
-    web_server = ThreadingHTTPServer((hostname, port), handler)
-    server_thread = threading.Thread(target=web_server.serve_forever)
-    server_thread.daemon = True
-    server_thread.start()
-    return web_server
+class Listener:
+    def __init__(self) -> None:
+        self.web_server: t.Optional[ThreadingHTTPServer] = None
+
+    def start_listening(
+        self,
+        hostname: str = "localhost",
+        port: int = 8080,
+    ):
+        if self.web_server:
+            print(
+                "Listener already started\nTo reset counter call `stop_listening` first."
+            )
+
+        with _Handler.count_lock:
+            _Handler.post_counter = 0
+        self.web_server = ThreadingHTTPServer((hostname, port), _Handler)
+        server_thread = threading.Thread(target=self.web_server.serve_forever)
+        server_thread.daemon = True
+        server_thread.start()
+        self.server_url = f"http://{hostname}:{port}"
+        print(f"Listener server started {self.server_url}")
+
+    def stop_listening(self):
+        if self.web_server:
+            self.web_server.shutdown()
+            print("Listener server stopped")
+            self.web_server = None
+        else:
+            print("Listener server not found")
+
+    def get_post_request_count(self) -> int:
+        if not self.web_server:
+            print("Warning: Listener server not found")
+            return -1
+        # Could use a queue instead of a lock+count and use queue.qsize()
+        # to avoid blocking the handler when getting the count
+        with _Handler.count_lock:
+            return _Handler.post_counter
 
 
 if __name__ == "__main__":
@@ -70,14 +102,11 @@ if __name__ == "__main__":
         "EXTERNAL_HOSTNAME",
         "localhost",
     )
-    web_server = start_listening_web_server(hostname)
-    ip, port = web_server.server_address
-
-    print("Server started http://%s:%s" % (hostname, port))
+    listener = Listener()
+    listener.start_listening(hostname, port=8080)
 
     cmd = ""
     while cmd != "q":
         cmd = input("Enter 'q' to shutdown: ")
 
-    web_server.shutdown()
-    print("Server stopped.")
+    listener.stop_listening()

--- a/hasher-matcher-actioner/scripts/listener.py
+++ b/hasher-matcher-actioner/scripts/listener.py
@@ -90,8 +90,6 @@ class Listener:
         if not self.web_server:
             print("Warning: Listener server not found")
             return -1
-        # Could use a queue instead of a lock+count and use queue.qsize()
-        # to avoid blocking the handler when getting the count
         with _Handler.count_lock:
             return _Handler.post_counter
 

--- a/hasher-matcher-actioner/scripts/soak_test_system
+++ b/hasher-matcher-actioner/scripts/soak_test_system
@@ -61,14 +61,14 @@ class SubmittingThread(threading.Thread):
         self,
         helper: DeployedInstanceTestHelper,
         submission_batch_size=10,
-        second_between_batches=10,
+        seconds_between_batches=10,
         **kwargs,
     ):
         super(SubmittingThread, self).__init__(**kwargs)
         self.daemon = True
         self._stop_signal = threading.Event()
         self.submission_batch_size = submission_batch_size
-        self.second_between_batches = second_between_batches
+        self.seconds_between_batches = seconds_between_batches
         self.helper = helper
 
     def stop(self):
@@ -89,7 +89,7 @@ class SubmittingThread(threading.Thread):
                 self.helper.submit_test_content(content_id)
                 total_submitted += 1
             print(f"Submitter: total submission count {total_submitted}")
-            time.sleep(self.second_between_batches)
+            time.sleep(self.seconds_between_batches)
             self.helper.refresh_api_token()
 
 
@@ -99,13 +99,13 @@ class ListeningThread(threading.Thread):
         helper: DeployedInstanceTestHelper,
         hostname,
         port,
-        second_between_checks=5,
+        seconds_between_checks=5,
         **kwargs,
     ):
         super(ListeningThread, self).__init__(**kwargs)
         self.daemon = True
         self._stop_signal = threading.Event()
-        self.second_between_checks = second_between_checks
+        self.seconds_between_checks = seconds_between_checks
         self.helper = helper
         self.hostname = hostname
         self.port = port
@@ -129,7 +129,7 @@ class ListeningThread(threading.Thread):
             if prev != request_count:
                 print(f"Listener: total POST requests received {request_count}")
                 prev = request_count
-            time.sleep(self.second_between_checks)
+            time.sleep(self.seconds_between_checks)
 
 
 def start_soak(
@@ -139,14 +139,14 @@ def start_soak(
     hostname: str,
     port: int,
     submission_batch_size: int,
-    second_between_batches: int,
+    seconds_between_batches: int,
 ):
     helper = DeployedInstanceTestHelper(api_url, "", client_id, refresh_token)
     helper.refresh_api_token()
     helper.set_up_test(hostname, port)
 
     submitting_thread = SubmittingThread(
-        helper, submission_batch_size, second_between_batches
+        helper, submission_batch_size, seconds_between_batches
     )
     listening_thread = ListeningThread(helper, hostname, port)
 
@@ -183,7 +183,7 @@ def start_soak(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Start a soak test on a delployed HMA instance and submit until cancelled"
+        description="Start a soak test on a deployed HMA instance and submit until cancelled"
     )
     parser.add_argument(
         "--api_url",
@@ -216,7 +216,7 @@ if __name__ == "__main__":
         default=10,
     )
     parser.add_argument(
-        "--second_between_batches",
+        "--seconds_between_batches",
         help="number of seconds between completed submission batches",
         default=10,
     )
@@ -230,5 +230,5 @@ if __name__ == "__main__":
         args.hostname,
         int(args.port),
         int(args.submission_batch_size),
-        int(args.second_between_batches),
+        int(args.seconds_between_batches),
     )

--- a/hasher-matcher-actioner/scripts/soak_test_system
+++ b/hasher-matcher-actioner/scripts/soak_test_system
@@ -29,14 +29,21 @@ ToDo Missing more involed checks (between submit and webhook):
   - wait: match record was created (if expected) and maps to correct signal values
   - longer wait: action record was created and maps to correct action label
 
+
+```
+python3 scripts/soak_test_system --api_url "https://abcd1234.execute-api.us-east-1.amazonaws.com/" --submission_batch_size 5 --second_between_batches 5
+```
+
 """
 
 
 import argparse
 import time
+import threading
+import uuid
+import datetime
 
 from submit_content_test import DeployedInstanceTestHelper
-
 
 # Defaults (often it is easier to edit the script than provide the args)
 API_URL = ""
@@ -46,6 +53,84 @@ CLIENT_ID = ""
 LISTENER_EXTERNAL_HOSTNAME = ""
 LISTENER_PORT = 8080
 
+ID_SEPARATOR = "-"
+
+
+class SubmittingThread(threading.Thread):
+    def __init__(
+        self,
+        helper: DeployedInstanceTestHelper,
+        submission_batch_size=10,
+        second_between_batches=10,
+        **kwargs,
+    ):
+        super(SubmittingThread, self).__init__(**kwargs)
+        self.daemon = True
+        self._stop_signal = threading.Event()
+        self.submission_batch_size = submission_batch_size
+        self.second_between_batches = second_between_batches
+        self.helper = helper
+
+    def stop(self):
+        self._stop_signal.set()
+
+    def stopped(self):
+        return self._stop_signal.is_set()
+
+    def run(self):
+        total_submitted = 0
+        while True:
+            if self.stopped():
+                print(f"Submissions stopped. TOTAL SUBMITTED: {total_submitted}")
+                return
+            batch_prefix = f"soak_test{ID_SEPARATOR}{datetime.date.today().isoformat()}{ID_SEPARATOR}{str(uuid.uuid4())}"
+            for i in range(self.submission_batch_size):
+                content_id = f"{batch_prefix}-{i}"
+                self.helper.submit_test_content(content_id)
+                total_submitted += 1
+            print(f"Submitter: total submission count {total_submitted}")
+            time.sleep(self.second_between_batches)
+            self.helper.refresh_api_token()
+
+
+class ListeningThread(threading.Thread):
+    def __init__(
+        self,
+        helper: DeployedInstanceTestHelper,
+        hostname,
+        port,
+        second_between_checks=5,
+        **kwargs,
+    ):
+        super(ListeningThread, self).__init__(**kwargs)
+        self.daemon = True
+        self._stop_signal = threading.Event()
+        self.second_between_checks = second_between_checks
+        self.helper = helper
+        self.hostname = hostname
+        self.port = port
+
+    def stop(self):
+        self._stop_signal.set()
+
+    def stopped(self):
+        return self._stop_signal.is_set()
+
+    def run(self):
+        self.helper.start_listening_for_action_post_requests(self.hostname, self.port)
+        time.sleep(5)
+        prev = 0
+        while True:
+            if self.stopped():
+                self.helper.stop_listening_for_action_post_requests()
+                print(f"Listener stopped. TOTAL RECEIVED: ~{prev}")
+                return
+            request_count = self.helper.get_post_count_so_far_requests()
+            if prev != request_count:
+                print(f"Listener: total POST requests received {request_count}")
+                prev = request_count
+            time.sleep(self.second_between_checks)
+
 
 def start_soak(
     api_url: str,
@@ -53,20 +138,47 @@ def start_soak(
     client_id: str,
     hostname: str,
     port: int,
-    interval: int,
+    submission_batch_size: int,
+    second_between_batches: int,
 ):
     helper = DeployedInstanceTestHelper(api_url, "", client_id, refresh_token)
     helper.refresh_api_token()
-    helper.set_up_basic_test(hostname, port)
-    counter = 0
-    while True:
-        print(f"Beginning Submit Test:{counter}")
-        # ToDo we should we decouple the 'submission' from the 'counting' (I.e. break up this function at make it async)
-        helper.run_basic_test_with_webhook_listener(hostname, port)
-        print(f"Completed Submit Test:{counter}")
-        counter += 1
-        time.sleep(interval)
-        helper.refresh_api_token()
+    helper.set_up_test(hostname, port)
+
+    submitting_thread = SubmittingThread(
+        helper, submission_batch_size, second_between_batches
+    )
+    listening_thread = ListeningThread(helper, hostname, port)
+
+    print(
+        f"Beginning Soak Test: enter 'q' to stop submissions and again to stop listening."
+    )
+    listening_thread.start()
+    time.sleep(3)
+    submitting_thread.start()
+
+    cmd = ""
+    try:
+        while cmd != "q":
+            cmd = input("Enter 'q' to stop submitter: ")
+    except KeyboardInterrupt:
+        pass
+
+    submitting_thread.stop()
+    print("Submissions stopping")
+    cmd = ""
+    try:
+        while cmd != "q":
+            cmd = input("Enter 'q' to stop listener: ")
+    except KeyboardInterrupt:
+        pass
+
+    # ToDo helper.clean_up_test(hostname, port)
+    listening_thread.stop()
+
+    submitting_thread.join()
+    listening_thread.join()
+    print(f"Soak Test Stopped")
 
 
 if __name__ == "__main__":
@@ -99,9 +211,14 @@ if __name__ == "__main__":
         default=LISTENER_PORT,
     )
     parser.add_argument(
-        "--interal",
-        help="number of seconds between completed submit tests",
-        default=60,
+        "--submission_batch_size",
+        help="How many images to submit in each batch",
+        default=10,
+    )
+    parser.add_argument(
+        "--second_between_batches",
+        help="number of seconds between completed submission batches",
+        default=10,
     )
 
     args = parser.parse_args()
@@ -111,6 +228,7 @@ if __name__ == "__main__":
         args.refresh_token,
         args.client_id,
         args.hostname,
-        args.port,
-        args.interal,
+        int(args.port),
+        int(args.submission_batch_size),
+        int(args.second_between_batches),
     )

--- a/hasher-matcher-actioner/scripts/storm_submissions_api
+++ b/hasher-matcher-actioner/scripts/storm_submissions_api
@@ -63,16 +63,14 @@ def _send_single_submission_url(
                 file,
                 additional_fields,
             )  # api method calls raise_for_status to check for error
-        except urllib3.exceptions.MaxRetryError as errmr:
-            print("MaxRetry Error:", errmr)
-        except requests.exceptions.HTTPError as errh:
-            print("Http Error:", errh)
-        except requests.exceptions.ConnectionError as errc:
-            print("Error Connecting:", errc)
-        except requests.exceptions.Timeout as errt:
-            print("Timeout Error:", errt)
-        except requests.exceptions.RequestException as err:
-            print("OOps: Something Else", err)
+        except (
+            urllib3.exceptions.MaxRetryError,
+            requests.exceptions.HTTPError,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.RequestException,
+        ) as err:
+            print("Error:", err)
 
     # convert seconds to miliseconds.
     return int((perf_counter() - start_time) * 1000)
@@ -99,16 +97,14 @@ def _send_single_submission_b64(
         api.send_single_submission_b64(
             content_id, _get_b64_contents(filepath), additional_fields
         )  # api method calls raise_for_status to check for error
-    except urllib3.exceptions.MaxRetryError as errmr:
-        print("MaxRetry Error:", errmr)
-    except requests.exceptions.HTTPError as errh:
-        print("Http Error:", errh)
-    except requests.exceptions.ConnectionError as errc:
-        print("Error Connecting:", errc)
-    except requests.exceptions.Timeout as errt:
-        print("Timeout Error:", errt)
-    except requests.exceptions.RequestException as err:
-        print("OOps: Something Else", err)
+    except (
+        urllib3.exceptions.MaxRetryError,
+        requests.exceptions.HTTPError,
+        requests.exceptions.ConnectionError,
+        requests.exceptions.Timeout,
+        requests.exceptions.RequestException,
+    ) as err:
+        print("Error:", err)
 
     # convert seconds to miliseconds.
     return int((perf_counter() - start_time) * 1000)

--- a/hasher-matcher-actioner/scripts/submit_content_test.py
+++ b/hasher-matcher-actioner/scripts/submit_content_test.py
@@ -162,16 +162,14 @@ class DeployedInstanceTestHelper:
                     file,
                     additional_fields,
                 )
-        except urllib3.exceptions.MaxRetryError as errmr:
-            print("MaxRetry Error:", errmr)
-        except requests.exceptions.HTTPError as errh:
-            print("Http Error:", errh)
-        except requests.exceptions.ConnectionError as errc:
-            print("Error Connecting:", errc)
-        except requests.exceptions.Timeout as errt:
-            print("Timeout Error:", errt)
-        except requests.exceptions.RequestException as err:
-            print("OOps: Something Else", err)
+        except (
+            urllib3.exceptions.MaxRetryError,
+            requests.exceptions.HTTPError,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.RequestException,
+        ) as err:
+            print("Error:", err)
 
     def start_listening_for_action_post_requests(self, hostname: str, port: int):
         self.listener.start_listening(hostname, port)

--- a/hasher-matcher-actioner/scripts/submit_content_test.py
+++ b/hasher-matcher-actioner/scripts/submit_content_test.py
@@ -5,12 +5,14 @@ import os
 import json
 import base64
 import requests
+import urllib3
 import time
 import dataclasses
 import typing as t
 from urllib.parse import urljoin
+
 from script_utils import HasherMatcherActionerAPI
-from listener import start_listening_web_server
+from listener import Listener
 
 from hmalib.common.evaluator_models import ActionRule
 from hmalib.common.classification_models import ActionLabel, ClassificationLabel
@@ -40,6 +42,7 @@ class DeployedInstanceTestHelper:
         self.api = HasherMatcherActionerAPI(
             api_url, api_token, client_id, refresh_token
         )
+        self.listener = Listener()
 
     def refresh_api_token(self):
         """
@@ -93,7 +96,7 @@ class DeployedInstanceTestHelper:
 
     ### Start Basic Test Methods  ####
 
-    def set_up_basic_test(self, hostname: str, port: int):
+    def set_up_test(self, hostname: str, port: int):
         """
         Set up/Create the following:
         - Dataset (Privacy Group Config)
@@ -104,13 +107,16 @@ class DeployedInstanceTestHelper:
         to create configs that already exist.
 
         """
+
+        # Possible it already exists which is fine.
         self.create_dataset_config(
             privacy_group_id="inria-holidays-test",
             privacy_group_name="Holiday Sample Set",
         )
 
+        # ToDo These actions should be cleaned up with clean_up_basic_test
         action_performer = WebhookPostActionPerformer(
-            name="TestActionWebhookPost",
+            name="SubmitContentTestActionWebhookPost",
             url=f"http://{hostname}:{port}",
             headers='{"this-is-a":"test-header"}',
         )
@@ -120,8 +126,8 @@ class DeployedInstanceTestHelper:
         )
 
         action_rule = ActionRule(
-            name="Trigger for holidays_jpg1_dataset tag",
-            action_label=ActionLabel("TestActionWebhookPost"),
+            name="trigger-on-tag-holidays_jpg1_dataset",
+            action_label=ActionLabel("SubmitContentTestActionWebhookPost"),
             must_have_labels=set(
                 [
                     ClassificationLabel("holidays_jpg1_dataset"),
@@ -134,16 +140,47 @@ class DeployedInstanceTestHelper:
             action_rule=action_rule,
         )
 
-    def _submit_for_basic_test(self):
-        content_id = "submit_content_test_id_1"
-        filepath = "sample_data/b.jpg"
-        additional_fields = ["i-am:a-bridge", "this-is:a-test"]
-        with open(filepath, "rb") as file:
-            self.api.send_single_submission_b64(
-                content_id,
-                str(base64.b64encode(file.read()), "utf-8"),
-                additional_fields,
-            )
+    def clean_up_test(self, hostname: str, port: int):
+        """
+        Deletes specific action and action rules
+        """
+        raise NotImplementedError
+
+    def submit_test_content(
+        self,
+        content_id="submit_content_test_id_1",
+        filepath="sample_data/b.jpg",
+        additional_fields=[
+            "this-is:a-test",
+            "submitted-from:submit_content_test.py",
+        ],
+    ):
+        try:
+            with open(filepath, "rb") as file:
+                self.api.send_single_submission_url(
+                    content_id,
+                    file,
+                    additional_fields,
+                )
+        except urllib3.exceptions.MaxRetryError as errmr:
+            print("MaxRetry Error:", errmr)
+        except requests.exceptions.HTTPError as errh:
+            print("Http Error:", errh)
+        except requests.exceptions.ConnectionError as errc:
+            print("Error Connecting:", errc)
+        except requests.exceptions.Timeout as errt:
+            print("Timeout Error:", errt)
+        except requests.exceptions.RequestException as err:
+            print("OOps: Something Else", err)
+
+    def start_listening_for_action_post_requests(self, hostname: str, port: int):
+        self.listener.start_listening(hostname, port)
+
+    def stop_listening_for_action_post_requests(self):
+        self.listener.stop_listening()
+
+    def get_post_count_so_far_requests(self) -> int:
+        return self.listener.get_post_request_count()
 
     def run_basic_test_with_webhook_listener(self, hostname: str, port: int):
         """
@@ -156,35 +193,24 @@ class DeployedInstanceTestHelper:
         Test needs to be run from a computer (likely ec2), that can bind and then receive request at
         (external) 'hostname' and 'port'
         """
-        web_server = start_listening_web_server(hostname, port)
-        server_url = f"http://{hostname}:{port}"
-        print(f"Server started {server_url}")
+        self.start_listening_for_action_post_requests(hostname, port)
 
-        self._submit_for_basic_test()
+        self.submit_test_content()
 
         post_counter = 0
         while post_counter < 1:
             time.sleep(10)
-            r = requests.get(server_url)
-            post_counter = int(r.json().get("post_counter", 0))
+            post_counter = self.get_post_count_so_far_requests()
 
         time.sleep(5)
-        web_server.shutdown()
-        print("Server stopped.")
-
-
-def clean_up_basic_test(self, hostname: str, port: int):
-    """
-    ToDo Delete (at least a subset of) what was created in set_up_basic_test
-    """
-    raise NotImplementedError
+        self.stop_listening_for_action_post_requests()
 
 
 ### End Basic Test Methods  ####
 
 
 if __name__ == "__main__":
-    # If you want hard code tests, you can do so here:
+    # If you want manually test the lib, you can do so here:
 
     # i.e. "https://<app-id>.execute-api.<region>.amazonaws.com/"
     api_url = os.environ.get(
@@ -226,6 +252,6 @@ if __name__ == "__main__":
     if refresh_token and client_id:
         helper.refresh_api_token()
 
-    helper.set_up_basic_test(hostname, port)
+    helper.set_up_test(hostname, port)
 
     helper.run_basic_test_with_webhook_listener(hostname, port)


### PR DESCRIPTION
Summary
---------

Clean up the submit_content_test and listener modules to allow for a cleaner soak_test run structure and interface.
 
Test Plan
---------
```
ubuntu@ip-<ip>:~/hma-dir$ python3 scripts/soak_test_system --help
usage: soak_test_system [-h] [--api_url API_URL] [--refresh_token REFRESH_TOKEN] [--client_id CLIENT_ID] [--hostname HOSTNAME] [--port PORT] [--submission_batch_size SUBMISSION_BATCH_SIZE] [--second_between_batches SECOND_BETWEEN_BATCHES]

Start a soak test on a deployed HMA instance and submit until cancelled

optional arguments:
  -h, --help            show this help message and exit
  --api_url API_URL     HMA's API URL
  --refresh_token REFRESH_TOKEN
                        refresh token to be used throughout a long running test
  --client_id CLIENT_ID
                        id of app client for the pool of the refresh token
  --hostname HOSTNAME   external hostname used to listen for the actioner
  --port PORT           port used to listen for the actioner
  --submission_batch_size SUBMISSION_BATCH_SIZE
                        How many images to submit in each batch
  --seconds_between_batches SECONDS_BETWEEN_BATCHES
                        number of seconds between completed submission batches
```
```
ubuntu@ip-<ip>:~/hma-dir$ python3 scripts/soak_test_system --api_url "https://<api_id>.execute-api.us-east-1.amazonaws.com/" --submission_batch_size 5 --seconds_between_batches 5
Beginning Soak Test: enter 'q' to stop submissions and again to stop listening.
Listener server started http://ec2-<ip>.compute-1.amazonaws.com:8080
Enter 'q' to stop submitter: Submitter: total submission count 5
Submitter: total submission count 10
Submitter: total submission count 15
Submitter: total submission count 20
Submitter: total submission count 25
Submitter: total submission count 30
Submitter: total submission count 35
Submitter: total submission count 40
Submitter: total submission count 45
Submitter: total submission count 50
Submitter: total submission count 55
Submitter: total submission count 60
Submitter: total submission count 65
Submitter: total submission count 70
Submitter: total submission count 75
Submitter: total submission count 80
Listener: total POST requests received 16
Submitter: total submission count 85
Listener: total POST requests received 28
Submitter: total submission count 90
Submitter: total submission count 95
Submitter: total submission count 100
Submitter: total submission count 105
Submitter: total submission count 110
Listener: total POST requests received 57
q
Submissions stopping
Enter 'q' to stop listener: Submissions stopped. TOTAL SUBMITTED: 110
Listener: total POST requests received 61
Listener: total POST requests received 78
Listener: total POST requests received 85
Listener: total POST requests received 110
q
Listener server stopped
Listener stopped. TOTAL RECEIVED: ~110
Soak Test Stopped
```