### PR TITLE
[hma] allow js to understand python iso strings 

### DIFF
--- a/hasher-matcher-actioner/webapp/src/utils/DateTimeUtils.jsx
+++ b/hasher-matcher-actioner/webapp/src/utils/DateTimeUtils.jsx
@@ -1,11 +1,14 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ * the timestamps passed to this file originate from python however
+ * https://stackoverflow.com/questions/19654578/python-utc-datetime-objects-iso-format-doesnt-include-z-zulu-or-zero-offset
+ *  so we ~hack-ly add a Z to the isoDateStrings
  */
 
 import {formatDistanceToNow, parseISO} from 'date-fns';
 
-export function formatTimestamp(timestamp) {
-  if (!timestamp) {
+export function formatTimestamp(isoDateString) {
+  if (!isoDateString) {
     return 'Unknown';
   }
   return new Intl.DateTimeFormat('default', {
@@ -16,7 +19,8 @@ export function formatTimestamp(timestamp) {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
-  }).format(new Date(timestamp));
+    timeZoneName: 'short',
+  }).format(parseISO(`${isoDateString}Z`));
 }
 
 /**
@@ -27,5 +31,7 @@ export function formatTimestamp(timestamp) {
  * @returns string
  */
 export function timeAgo(isoDateString) {
-  return formatDistanceToNow(parseISO(isoDateString), {addSuffix: true});
+  return formatDistanceToNow(parseISO(`${isoDateString}Z`), {
+    addSuffix: true,
+  });
 }


### PR DESCRIPTION
Summary
---------

python's `isoformat()` doesn't include a 'Z' at the end the way javascript expects. The results is the time of the `isoDateString` from the API is assumes to be local time (which is incorrect).

Lot of ways to tackle this. Picked the fastest but am open to feedback.

Ref: https://stackoverflow.com/questions/19654578/python-utc-datetime-objects-iso-format-doesnt-include-z-zulu-or-zero-offset



Test Plan
---------

Before:
<img width="782" alt="Screen Shot 2021-06-25 at 5 56 10 PM" src="https://user-images.githubusercontent.com/7664526/123489010-1adc4a80-d5df-11eb-9c7e-dd5e1e373578.png">

After:
<img width="791" alt="Screen Shot 2021-06-25 at 5 55 49 PM" src="https://user-images.githubusercontent.com/7664526/123489027-23cd1c00-d5df-11eb-94be-262ffb72df31.png">

