### PR TITLE
git ignore react file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pdq/java/bazel-out/
 pdq/java/bazel-testlogs/
 .mypy_cache/
 .vscode/
+*q.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ pdq/java/bazel-out/
 pdq/java/bazel-testlogs/
 .mypy_cache/
 .vscode/
-*q.d.ts
+*.d.ts

--- a/hasher-matcher-actioner/webapp/src/react-app-env.d.ts
+++ b/hasher-matcher-actioner/webapp/src/react-app-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="react-scripts" />


### PR DESCRIPTION
Summary
---------

This file seems to be necessary for Typescript compilation but not needed. Standard practice is to add to .gitignore.

More context: https://github.com/facebook/create-react-app/issues/6560

Test Plan
---------

npm still compiles