### PR TITLE
[hma] Prompt the user if terraform/backend.tf doesn't exist

### DIFF
--- a/hasher-matcher-actioner/Makefile
+++ b/hasher-matcher-actioner/Makefile
@@ -11,7 +11,6 @@ REPOSITORY_NAME = hma-lambda-dev
 DOCKER_TAG ?= ${USER}# todo - change to ${USER}-latest?
 DOCKER_URI = $(call shell-or-die,docker images --filter=reference='*/${REPOSITORY_NAME}:${DOCKER_TAG}' --format='{{.Repository}}')
 
-
 all:
 	@echo >&2 "Must specify target. ${FAIL}"
 
@@ -26,7 +25,9 @@ terraform/terraform.tfvars:
 	echo 'hma_lambda_docker_uri = "${DOCKER_URI}:${DOCKER_TAG}"' > terraform/terraform.tfvars
 
 terraform/backend.tf:
-	./scripts/write_backend_config.sh > terraform/backend.tf
+	@echo terraform state will be stored locally unless a backend.tf file is configured. 
+	@echo Create a backend.tf? to use custom s3 bucket run: export TF_STATE_S3_BUCKET=bucket_name [y/N]
+	@read ans; if [ $$ans = "y" ]; then ./scripts/write_backend_config.sh > terraform/backend.tf; fi
 
 dev_create_configs: terraform/terraform.tfvars terraform/backend.tf
 


### PR DESCRIPTION
Summary
---------

closes #698 
Which flagged that our [install instructions](https://github.com/facebook/ThreatExchange/wiki/Installation) did not provide context around `backend.tf` and defaulted to using a bucket that only ThreatExchange Eng have access to.

To address this I have updated the Makefile's `make dev_create_instance` (more specifically it's dependency `terraform/backend.tf`) to prompt the user if a backend.tf is not found to give more context and asks before creating the file.

I have already updated the instructions/wiki with more context that also reflects this change. 

Test Plan
---------

```
# delete backend.tf if exist
$ make dev_create_instance                                                                                                                                                                                                                                                                            
terraform state will be stored locally unless a backend.tf file is configured.
Create a backend.tf? to use custom s3 bucket run: export TF_STATE_S3_BUCKET=bucket_name [y/N]
N
# deployment continues without a backend.tf
...
```

```
# delete backend.tf if exist
$ make dev_create_instance                                                                                                                                                                                                                                                                            
terraform state will be stored locally unless a backend.tf file is configured.
Create a backend.tf? to use custom s3 bucket run: export TF_STATE_S3_BUCKET=bucket_name [y/N]
y
# creates backend.tf file with default values and continues deployment
...
```

```
# delete backend.tf if exist
$ export TF_STATE_S3_BUCKET="different_s3_state_bucket_name"  
$ make dev_create_instance                                                                                                                                                                                                                                                                            
terraform state will be stored locally unless a backend.tf file is configured.
Create a backend.tf? to use custom s3 bucket run: export TF_STATE_S3_BUCKET=bucket_name [y/N]
y
# creates backend.tf file  w/ bucket = "different_s3_state_bucket_name" and continues deployment
...
```
