### PR TITLE
[hma][scripts] Create interactive shell and expand functionality of soak test

### DIFF
--- a/hasher-matcher-actioner/scripts/listener.py
+++ b/hasher-matcher-actioner/scripts/listener.py
@@ -90,7 +90,7 @@ class Listener:
     def get_post_request_count(self) -> int:
         if not self.web_server:
             print("Warning: Listener server not found")
-            return -1
+            return 0
         with _Handler.count_lock:
             return _Handler.post_counter
 

--- a/hasher-matcher-actioner/scripts/soak_test_system
+++ b/hasher-matcher-actioner/scripts/soak_test_system
@@ -31,18 +31,18 @@ ToDo Missing more involed checks (between submit and webhook):
 
 
 ```
-python3 scripts/soak_test_system --api_url "https://abcd1234.execute-api.us-east-1.amazonaws.com/" --submission_batch_size 5 --second_between_batches 5
+python3 scripts/soak_test_system --api_url "https://abcd1234.execute-api.us-east-1.amazonaws.com/" --batch_size 5 --second_between_batches 5
 ```
 
 """
-
+import cmd
 import os
 import argparse
 import time
 import threading
 import uuid
 import datetime
-
+import typing as t
 from submit_content_test import DeployedInstanceTestHelper
 from listener import Listener
 
@@ -51,8 +51,6 @@ API_URL = ""
 REFRESH_TOKEN = ""
 CLIENT_ID = ""
 
-EXTERNAL_HOSTNAME = ""
-
 ID_SEPARATOR = "-"
 
 
@@ -60,16 +58,20 @@ class SubmittingThread(threading.Thread):
     def __init__(
         self,
         helper: DeployedInstanceTestHelper,
-        submission_batch_size=10,
-        seconds_between_batches=10,
+        batch_size: int,
+        seconds_between_batches: int,
+        filepaths: t.List[str] = [],
         **kwargs,
     ):
         super(SubmittingThread, self).__init__(**kwargs)
         self.daemon = True
         self._stop_signal = threading.Event()
-        self.submission_batch_size = submission_batch_size
-        self.seconds_between_batches = seconds_between_batches
+        self._lock = threading.Lock()
         self.helper = helper
+        self.batch_size = batch_size
+        self.seconds_between_batches = seconds_between_batches
+        self.filepaths = filepaths
+        self.total_submitted = 0
 
     def stop(self):
         self._stop_signal.set()
@@ -78,55 +80,190 @@ class SubmittingThread(threading.Thread):
         return self._stop_signal.is_set()
 
     def run(self):
-        total_submitted = 0
-        while True:
+        while not self.stopped() and self._lock.acquire():
             if self.stopped():
-                print(f"Submissions stopped. TOTAL SUBMITTED: {total_submitted}")
+                self._lock.release()
                 return
-            batch_prefix = f"soak_test{ID_SEPARATOR}{datetime.date.today().isoformat()}{ID_SEPARATOR}{str(uuid.uuid4())}"
-            for i in range(self.submission_batch_size):
-                content_id = f"{batch_prefix}-{i}"
-                self.helper.submit_test_content(content_id)
-                total_submitted += 1
-            print(f"Submitter: total submission count {total_submitted}")
+            try:
+                batch_prefix = f"soak_test{ID_SEPARATOR}{datetime.date.today().isoformat()}{ID_SEPARATOR}{str(uuid.uuid4())}"
+                for i in range(self.batch_size):
+                    content_id = f"{batch_prefix}-{i}"
+                    if self.filepaths:
+                        self.helper.submit_test_content(
+                            content_id, filepath=self.filepaths[i % len(self.filepath)]
+                        )
+                    else:
+                        self.helper.submit_test_content(content_id)
+                    self.total_submitted += 1
+            finally:
+                self._lock.release()
             time.sleep(self.seconds_between_batches)
             self.helper.refresh_api_token()
 
+    def get_total_submit_count(self) -> int:
+        with self._lock:
+            return self.total_submitted
 
-class ListeningThread(threading.Thread):
-    def __init__(
-        self,
-        hostname,
-        port,
-        seconds_between_checks=5,
-        **kwargs,
-    ):
-        super(ListeningThread, self).__init__(**kwargs)
-        self.daemon = True
-        self._stop_signal = threading.Event()
-        self.seconds_between_checks = seconds_between_checks
-        self.listener = Listener(hostname, port)
+    def get_current_values(self) -> t.Tuple[int, int, int]:
+        with self._lock:
+            return (self.batch_size, self.seconds_between_batches, self.total_submitted)
 
-    def stop(self):
-        self._stop_signal.set()
+    def set_batch_size(self, batch_size: int):
+        with self._lock:
+            self.batch_size = batch_size
 
-    def stopped(self):
-        return self._stop_signal.is_set()
+    def set_seconds_between_batches(self, seconds_between_batches: int):
+        with self._lock:
+            self.seconds_between_batches = seconds_between_batches
 
-    def run(self):
-        self.listener.start_listening()
-        time.sleep(5)
-        prev = 0
-        while True:
-            if self.stopped():
-                self.listener.stop_listening()
-                print(f"Listener stopped. TOTAL RECEIVED: ~{prev}")
-                return
-            request_count = self.listener.get_post_request_count()
-            if prev != request_count:
-                print(f"Listener: total POST requests received {request_count}")
-                prev = request_count
-            time.sleep(self.seconds_between_checks)
+
+class SoakShell(cmd.Cmd):
+    intro = "Welcome! enter 'start' to begin submitting and 'info' to see current counts. Type help or ? to list commands.\n"
+    prompt = "> "
+
+    def __init__(self, submitter=None, listener=None):
+        super(SoakShell, self).__init__()
+        self.submitter = submitter
+        self.listener = listener
+        self.submitter_paused = False
+
+    def do_info(self, arg):
+        "Get status of the test: info"
+        if not self.submitter_paused:
+            (
+                batch_size,
+                seconds_between_batches,
+                total_submitted,
+            ) = self.submitter.get_current_values()
+            print(
+                f"Submitter Settings: {batch_size} items every {seconds_between_batches} seconds."
+            )
+            print(f"TOTAL SUBMITTED: {total_submitted}")
+        else:
+            print("Submitter is Paused. 'resume' or 'stop' for submit details.")
+        if self.listener:
+            print(
+                f"TOTAL POST requests received: {self.listener.get_post_request_count()}"
+            )
+
+    def do_start(self, arg):
+        "Start submitting thread: start"
+        try:
+            self.submitter.start()
+            print("Started Submitter")
+        except RuntimeError:
+            if self.submitter.is_alive():
+                print("Submitter has already started.")
+            else:
+                print(
+                    "Submitter cannot be (re)started. Exit and run the script again to restart submitting."
+                )
+
+    def do_pause(self, arg):
+        "Pause submitting thread: PAUSE"
+        if not self.submitter.is_alive():
+            print("Submitter is not running")
+            return
+        (
+            batch_size,
+            seconds_between_batches,
+            total_submitted,
+        ) = self.submitter.get_current_values()
+        self.submitter._lock.acquire()
+        print("Submitter Paused")
+        print(f"TOTAL SUBMITTED: {total_submitted}")
+
+        self.submitter_paused = True
+
+    def do_resume(self, arg):
+        "Resume submitting thread: resume"
+        if not self.submitter.is_alive():
+            print("Submitter is not running")
+            return
+        if not self.submitter_paused:
+            print("Submitter is not paused")
+            return
+        self.submitter._lock.release()
+        print("Resuming submissions")
+        self.submitter_paused = False
+
+    def do_stop(self, arg):
+        "Stop submitting thread: stop"
+        if not self.submitter.is_alive():
+            print("Submitter is not running")
+            return
+        self.submitter.stop()
+        if self.submitter_paused:
+            self.submitter._lock.release()
+            self.submitter_paused = False
+        print("Stopped Submitter")
+        print(f"TOTAL SUBMITTED: {self.submitter.get_total_submit_count()}")
+
+    def _valid_update(self, arg):
+        if self.submitter_paused:
+            print("Updates currently not supported while paused (keeps locking simple)")
+            return False
+        try:
+            value = int(arg)
+        except:
+            print("value must be an int")
+            return False
+        if value <= 0:
+            print("value must be postive")
+            return False
+        return True
+
+    def do_update_batch_size(self, arg):
+        "Update batch size: update_batch_size 5"
+        if self._valid_update(arg):
+            self.submitter.set_batch_size(int(arg))
+            print(f"Updated batch_size to {int(arg)}")
+
+    def do_update_sec_btw_batch(self, arg):
+        "Update seconds between batch submissions: update_sec_btw_batch 5"
+        if self._valid_update(arg):
+            self.submitter.set_seconds_between_batches(int(arg))
+            print(f"Updated seconds_between_batches to {int(arg)}")
+
+    def _provide_wait_for_listener_option(self):
+        submitted = self.submitter.get_total_submit_count()
+        received = self.listener.get_post_request_count()
+        if submitted - received > 0:
+            cmd = input("Wait for listener to catch up before exiting? (y/N): ")
+            if cmd == "y":
+                submitted = self.submitter.get_total_submit_count()
+                print(f"TOTAL SUBMITTED: {submitted}")
+                received = self.listener.get_post_request_count()
+                prev = -1
+                try:
+                    while submitted - received > 0:
+                        if received > prev:
+                            print(
+                                f"\tWaiting on {submitted-received} more requests\n",
+                                end="\r",
+                            )
+                            prev = received
+                        received = self.listener.get_post_request_count()
+                        time.sleep(3)
+                except KeyboardInterrupt:
+                    print("KeyboardInterrupt: Skipping wait\n")
+            else:
+                print("Not waiting for listener")
+
+    def do_exit(self, arg):
+        "Stop and exit: EXIT"
+        if self.submitter.is_alive():
+            self.submitter.stop()
+            if self.submitter_paused:
+                self.submitter._lock.release()
+                self.submitter_paused = False
+            print("Stopped Submitter")
+
+        if self.listener:
+            self._provide_wait_for_listener_option()
+
+        print("Closing Shell...\n")
+        return True
 
 
 def start_soak(
@@ -135,48 +272,61 @@ def start_soak(
     client_id: str,
     hostname: str,
     port: int,
-    submission_batch_size: int,
+    batch_size: int,
     seconds_between_batches: int,
+    auto_start: bool = False,
+    skip_listener: bool = False,
+    filepaths: t.List[str] = [],
 ):
     helper = DeployedInstanceTestHelper(api_url, "", client_id, refresh_token)
     helper.refresh_api_token()
-    helper.set_up_test(f"http://{hostname}:{port}")
+    if skip_listener:
+        helper.set_up_test("http://httpstat.us/404")
+    else:
+        helper.set_up_test(f"http://{hostname}:{port}")
 
     submitting_thread = SubmittingThread(
-        helper, submission_batch_size, seconds_between_batches
+        helper, batch_size, seconds_between_batches, filepaths
     )
-    listening_thread = ListeningThread(hostname, port)
 
-    print(
-        f"Beginning Soak Test: enter 'q' to stop submissions and again to stop listening."
-    )
-    listening_thread.start()
-    time.sleep(3)
-    submitting_thread.start()
+    if skip_listener:
+        listener = None
+    else:
+        listener = Listener(hostname, port)
+        listener.start_listening()
 
-    cmd = ""
-    try:
-        while cmd != "q":
-            cmd = input("Enter 'q' to stop submitter: ")
-    except KeyboardInterrupt:
-        pass
+    if auto_start:
+        time.sleep(3)
+        submitting_thread.start()
 
-    submitting_thread.stop()
-    print("Submissions stopping")
-    cmd = ""
-    try:
-        while cmd != "q":
-            cmd = input("Enter 'q' to stop listener: ")
-    except KeyboardInterrupt:
-        pass
+    SoakShell(submitting_thread, listener).cmdloop()
 
-    listening_thread.stop()
+    if submitting_thread.is_alive():
+        submitting_thread.stop()
 
-    submitting_thread.join()
-    listening_thread.join()
+    total_submit = submitting_thread.get_total_submit_count()
+    if listener:
+        total_received = listener.get_post_request_count()
+        listener.stop_listening()
+        print("Submitter and listener stopped.")
+        print(f"FINAL TOTAL SUBMITTED: {total_submit}")
+        print(f"FINAL TOTAL POST requests received: {total_received}")
+        difference = total_submit - total_received
+        if difference:
+            print(f"Difference of {difference} found")
+        if difference > 0:
+            print(
+                "If you exited before waiting on the listener, this is expect. (Warning the actioner may keep trying for a bit)"
+            )
+        if difference < 0:
+            print(
+                f"Negative difference means more action request than submissions were received. (likely bug or multiply actions configured)"
+            )
+    else:
+        print(f"FINAL TOTAL SUBMITTED: {total_submit}")
 
     helper.clean_up_test()
-    print(f"Soak Test Stopped")
+    print(f"Test Run Complete. Thanks!")
 
 
 if __name__ == "__main__":
@@ -185,7 +335,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--api_url",
-        help="HMA's API URL",
+        help="The url of the API to be tested",
         default=os.environ.get(
             "HMA_API_URL",
             API_URL,
@@ -193,7 +343,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--refresh_token",
-        help="refresh token to be used throughout a long running test",
+        help="Refresh token to be used throughout a long running test",
         default=os.environ.get(
             "HMA_REFRESH_TOKEN",
             REFRESH_TOKEN,
@@ -201,7 +351,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--client_id",
-        help="id of app client for the pool",
+        help="ID of app client for the pool",
         default=os.environ.get(
             "HMA_COGNITO_USER_POOL_CLIENT_ID",
             CLIENT_ID,
@@ -209,29 +359,53 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--hostname",
-        help="external hostname used to listen for the actioner",
+        help="Hostname used to listen for the actions webhooks.",
         default=os.environ.get(
             "EXTERNAL_HOSTNAME",
-            EXTERNAL_HOSTNAME,
+            "localhost",
         ),
     )
     parser.add_argument(
         "--port",
-        help="port used to listen for the actioner",
+        help="Port used to listen for the actioner.",
         default=8080,
     )
     parser.add_argument(
-        "--submission_batch_size",
-        help="How many images to submit in each batch",
-        default=10,
+        "--batch_size",
+        help="Number of images to submit in each batch.",
+        default=5,
     )
     parser.add_argument(
         "--seconds_between_batches",
-        help="number of seconds between completed submission batches",
-        default=10,
+        help="Number of seconds between completed submission batches.",
+        default=5,
+    )
+    parser.add_argument(
+        "--auto_start",
+        action="store_true",
+        help="Start submitting right away.",
+    )
+    parser.add_argument(
+        "--skip_listener",
+        action="store_true",
+        help="Do not use a listener at all.",
+    )
+    parser.add_argument(
+        "--filepaths",
+        action="extend",
+        nargs="*",
+        type=str,
+        help="List of filepaths for submit use (will start each batch at the start of the list).",
     )
 
     args = parser.parse_args()
+
+    if args.filepaths:
+        for filepath in args.filepaths:
+            if not os.path.isfile(filepath):
+                print(f"Filepath: {filepath} not found.")
+                parser.print_usage()
+                exit()
 
     start_soak(
         args.api_url,
@@ -239,6 +413,9 @@ if __name__ == "__main__":
         args.client_id,
         args.hostname,
         int(args.port),
-        int(args.submission_batch_size),
+        int(args.batch_size),
         int(args.seconds_between_batches),
+        args.auto_start,
+        args.skip_listener,
+        args.filepaths,
     )

--- a/hasher-matcher-actioner/scripts/soak_test_system
+++ b/hasher-matcher-actioner/scripts/soak_test_system
@@ -90,7 +90,7 @@ class SubmittingThread(threading.Thread):
                     content_id = f"{batch_prefix}-{i}"
                     if self.filepaths:
                         self.helper.submit_test_content(
-                            content_id, filepath=self.filepaths[i % len(self.filepath)]
+                            content_id, filepath=self.filepaths[i % len(self.filepaths)]
                         )
                     else:
                         self.helper.submit_test_content(content_id)
@@ -239,7 +239,7 @@ class SoakShell(cmd.Cmd):
                     while submitted - received > 0:
                         if received > prev:
                             print(
-                                f"\tWaiting on {submitted-received} more requests\n",
+                                f"\tWaiting on {submitted-received} more requests",
                                 end="\r",
                             )
                             prev = received


### PR DESCRIPTION
Summary
---------

Soak test is now run from an interactive shell that lets users:
- dynamically increase and decrease the submit volume and rate.
- pause/resume submissions
- stop submitter but automatically wait for listener

Additional support to the soak test script was also added:
- running soak test without listener is now possible
- a list of file paths can be provided for submission instead of the default `sample_data/b.jpg`  file 
- autostart flag added to avoid having to provide input to the shell to begin the soak test


Next:
- Add calculations for latency of each submission by expanding listener
- Stress test: create way to spin up multiple soak test shells deployed across different ec2 instances 
  

Test Plan
---------
```
$ python3 scripts/soak_test_system --api_url "https://<id>.execute-api.us-east-1.amazonaws.com/" --batch_size 10 --seconds_between_batches 5
Listener server started http://<ip>.compute-1.amazonaws.com:8080
Welcome! enter 'start' to begin submitting and 'info' to see current counts. Type help or ? to list commands.

> start
Started Submitter
> info
Submitter Settings: 10 items every 5 seconds.
TOTAL SUBMITTED: 40
TOTAL POST requests received: 37
> info
Submitter Settings: 10 items every 5 seconds.
TOTAL SUBMITTED: 50
TOTAL POST requests received: 47
> info
Submitter Settings: 10 items every 5 seconds.
TOTAL SUBMITTED: 60
TOTAL POST requests received: 57
> info
Submitter Settings: 10 items every 5 seconds.
TOTAL SUBMITTED: 110
TOTAL POST requests received: 93
> info
Submitter Settings: 10 items every 5 seconds.
TOTAL SUBMITTED: 120
TOTAL POST requests received: 108
> ?

Documented commands (type help <topic>):
========================================
exit  info   resume  stop               update_sec_btw_batch
help  pause  start   update_batch_size

> update_batch_size 20
Updated batch_size to 20
> info
Submitter Settings: 20 items every 5 seconds.
TOTAL SUBMITTED: 160
TOTAL POST requests received: 140
> pause
Submitter Paused
TOTAL SUBMITTED: 200
> info
Submitter is Paused. 'resume' or 'stop' for submit details.
TOTAL POST requests received: 178
> info
Submitter is Paused. 'resume' or 'stop' for submit details.
TOTAL POST requests received: 200
> resume
Resuming submissions
> info
Submitter Settings: 20 items every 5 seconds.
TOTAL SUBMITTED: 220
TOTAL POST requests received: 200
> exit
Stopped Submitter
Wait for listener to catch up before exiting? (y/N): y
TOTAL SUBMITTED: 240
        Waiting on 14 more requests
        Waiting on 5 more requests
^CKeyboardInterrupt: Skipping wait

Closing Shell...

Listener server stopped
Submitter and listener stopped.
FINAL TOTAL SUBMITTED: 240
FINAL TOTAL POST requests received: 235
Difference of 5 found
If you exited before waiting on the listener, this is expect. (Warning the actioner may keep trying for a bit)
Test Run Complete. Thanks!
```

