### PR TITLE
[hma][tf] fix sqs queue_batch_size inconsistency (null wasn't good enough)

### DIFF
--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -110,8 +110,8 @@ module "pdq_signals" {
   measure_performance   = var.measure_performance
   config_table          = local.config_table
 
-  queue_batch_size        = var.set_sqs_windows_to_min ? 10 : null
-  queue_window_in_seconds = var.set_sqs_windows_to_min ? 0 : null
+  queue_batch_size        = var.set_sqs_windows_to_min ? 10 : 100
+  queue_window_in_seconds = var.set_sqs_windows_to_min ? 0 : 30
 }
 
 module "counters" {
@@ -322,8 +322,8 @@ module "actions" {
   }
   datastore = module.datastore.primary_datastore
 
-  queue_batch_size        = var.set_sqs_windows_to_min ? 10 : null
-  queue_window_in_seconds = var.set_sqs_windows_to_min ? 0 : null
+  queue_batch_size        = var.set_sqs_windows_to_min ? 10 : 100
+  queue_window_in_seconds = var.set_sqs_windows_to_min ? 0 : 30
 }
 
 ### ThreatExchange API Token Secret ###


### PR DESCRIPTION
Summary
---------

the behavior of `null` in a part of a conditional expression is recommended here:  
https://www.terraform.io/docs/language/expressions/types.html 

However it was not behaving consistently so just added the defaults that should have been used automatically instead of `null`

Test Plan
---------

tf apply and checked that the queue values actually changed to the correct values based on `set_sqs_windows_to_min`