### PR TITLE
[hma][scripts] add semi-hacky latency command to soak test

### DIFF
--- a/hasher-matcher-actioner/scripts/listener.py
+++ b/hasher-matcher-actioner/scripts/listener.py
@@ -3,7 +3,7 @@
 
 import os
 import json
-import time
+import datetime
 import threading
 import requests
 import typing as t
@@ -18,6 +18,9 @@ class _Handler(BaseHTTPRequestHandler):
 
     count_lock: threading.Lock = threading.Lock()
     post_counter: int = 0
+    latency_lock: threading.Lock = threading.Lock()
+    # ToDo do we want this to grow without bound or be limted to x most recent items?
+    submission_latencies: t.List[float] = []
 
     def _set_response(self):
         self.send_response(200)
@@ -53,6 +56,18 @@ class _Handler(BaseHTTPRequestHandler):
             _Handler.post_counter += 1
         self._set_response()
         self.wfile.write(json.dumps(payload).encode("utf-8"))
+
+        present = datetime.datetime.now()
+        if content_id := json.loads(post_data).get("content_key"):
+            try:
+                submit_time = datetime.datetime.fromisoformat(
+                    content_id.split("-time-")[0]
+                )
+                latency = present - submit_time
+                with self.latency_lock:
+                    self.submission_latencies.append(latency.total_seconds())
+            except ValueError:
+                pass
 
 
 class Listener:
@@ -93,6 +108,10 @@ class Listener:
             return 0
         with _Handler.count_lock:
             return _Handler.post_counter
+
+    def get_submission_latencies(self) -> t.List[float]:
+        with _Handler.latency_lock:
+            return _Handler.submission_latencies.copy()
 
 
 if __name__ == "__main__":

--- a/hasher-matcher-actioner/scripts/soak_test_system
+++ b/hasher-matcher-actioner/scripts/soak_test_system
@@ -42,6 +42,7 @@ import time
 import threading
 import uuid
 import datetime
+import numpy as np
 import typing as t
 from submit_content_test import DeployedInstanceTestHelper
 from listener import Listener
@@ -50,8 +51,6 @@ from listener import Listener
 API_URL = ""
 REFRESH_TOKEN = ""
 CLIENT_ID = ""
-
-ID_SEPARATOR = "-"
 
 
 class SubmittingThread(threading.Thread):
@@ -85,9 +84,11 @@ class SubmittingThread(threading.Thread):
                 self._lock.release()
                 return
             try:
-                batch_prefix = f"soak_test{ID_SEPARATOR}{datetime.date.today().isoformat()}{ID_SEPARATOR}{str(uuid.uuid4())}"
+                batch_prefix = f"soak-test-{str(uuid.uuid4())}"
                 for i in range(self.batch_size):
-                    content_id = f"{batch_prefix}-{i}"
+                    content_id = (
+                        f"{datetime.datetime.now().isoformat()}-time-{batch_prefix}-{i}"
+                    )
                     if self.filepaths:
                         self.helper.submit_test_content(
                             content_id, filepath=self.filepaths[i % len(self.filepaths)]
@@ -145,6 +146,20 @@ class SoakShell(cmd.Cmd):
             print(
                 f"TOTAL POST requests received: {self.listener.get_post_request_count()}"
             )
+
+    def do_latency(self, arg):
+        "Get the latency of submissions: latency"
+        if self.listener:
+            latencies = np.array(self.listener.get_submission_latencies())
+            if latencies.size:
+                print("Rough delay between submit to action request received")
+                print(f"p90: {np.percentile(latencies, 90)} seconds")
+                print(f"p50: {np.percentile(latencies, 50)} seconds")
+                print(f"avg: {latencies.mean()} seconds")
+            else:
+                print("No requests received yet.")
+        else:
+            print("No listener found.")
 
     def do_start(self, arg):
         "Start submitting thread: start"


### PR DESCRIPTION
Summary
---------

Fastest way I had to get a latency calculation.
Put the current time in the `content_id`

Have the listener measure the difference upon receipt.

initial findings of interest:
high batch size reduces delay at least at first (likely due not having to wait the sqs timeout window) 

Test Plan
---------

```
Submitter Settings: 5 items every 5 seconds.
TOTAL SUBMITTED: 65
TOTAL POST requests received: 21
> latency
Rough delay between submit to action request received
p90: 108.347026 seconds
p50: 96.819337 seconds
avg: 97.74182985714285 seconds
```