### PR TITLE
Stop counting totals in DDB transactions

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/stats.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/stats.py
@@ -8,7 +8,7 @@ import typing as t
 from mypy_boto3_dynamodb.service_resource import Table
 
 from hmalib.common.logging import get_logger
-from hmalib import metrics, models
+from hmalib import metrics
 from hmalib.metrics import query as metrics_query
 from hmalib.metrics.query import is_publishing_metrics
 
@@ -22,7 +22,6 @@ class StatsCard(JSONifiable):
     time_span_count: int
     time_span: metrics_query.MetricTimePeriod
     graph_data: t.List[t.Tuple[datetime.datetime, t.Optional[int]]]
-    total_count: int
     last_updated: datetime.datetime = field(default_factory=datetime.datetime.now)
 
     def to_json(self) -> t.Dict:
@@ -63,12 +62,6 @@ def get_stats_api(dynamodb_table: Table) -> bottle.Bottle:
         "matches": metrics.names.pdq_matcher_lambda.write_match_record,
     }
 
-    # DynamoDBItem class is used to get total counts
-    stat_name_to_count = {
-        "hashes": lambda: models.PipelinePDQHashRecord.get_total_count(dynamodb_table),
-        "matches": lambda: models.PDQMatchRecord.get_total_count(dynamodb_table),
-    }
-
     @stats_api.get("/", apply=[jsoninator])
     def default_stats() -> StatResponse:
         """
@@ -105,14 +98,11 @@ def get_stats_api(dynamodb_table: Table) -> bottle.Bottle:
             metric_time_period,
         )
 
-        total_count = stat_name_to_count[bottle.request.query.stat_name]()
-
         return StatResponse(
             StatsCard(
                 count_with_graphs[metric].count,
                 metric_time_period,
                 count_with_graphs[metric].graph_data,
-                total_count or 0,
             )
         )
 

--- a/hasher-matcher-actioner/hmalib/models.py
+++ b/hasher-matcher-actioner/hmalib/models.py
@@ -6,9 +6,8 @@ import typing as t
 import json
 from dataclasses import dataclass, field
 from decimal import Decimal
+from boto3 import client
 from mypy_boto3_dynamodb.service_resource import Table
-from mypy_boto3_dynamodb import Client
-from mypy_boto3_dynamodb.type_defs import TransactWriteItemTypeDef
 from boto3.dynamodb.conditions import Attr, Key, And
 from botocore.exceptions import ClientError
 
@@ -19,123 +18,32 @@ Classes in this module should implement methods `to_dynamodb_item(self)` and
 """
 
 
-class DynamoDBCountMixin:
-    """
-    This is a mixin for the base class (DynamoDBItem). It is not required to be
-    mixed in to the concrete classes. Use this just to group common
-    functionality together.
-
-    Most methods defined are class methods and not static methods. Static
-    methods are unbounded which makes it impossible to override and refer to in
-    sub classes.
-    """
-
-    @classmethod
-    def is_total_countable(cls):
-        """
-        To be declared by sub classes. If true, a counter record is maintained
-        in the same table. Be advised, that the counter is incremented with
-        every 'write' be it a create or update.
-        """
-        return False
-
-    @classmethod
-    def get_total_count_keyname(cls):
-        """
-        Is used to store and retrieve count values. To be implemented by
-        concrete classes alone. Unless is_total_countable() is True, this method
-        need not be implemented.
-        """
-        raise NotImplementedError
-
-    @classmethod
-    def get_total_count(cls, table: Table) -> t.Optional[int]:
-        """
-        See `is_total_countable`. If self.is_total_countable is False, return
-        None. Else return the number of writes this table has seen.
-        """
-        if cls.is_total_countable():
-            response = table.get_item(
-                Key={"PK": cls._get_count_pkey(), "SK": cls._get_count_skey()}
-            )
-            return (
-                "Item" in response
-                and int(t.cast(Decimal, response["Item"]["WriteCount"]))
-                or 0
-            )
-        else:
-            return None
-
-    @classmethod
-    def _get_count_pkey(cls) -> str:
-        return "counts"
-
-    @classmethod
-    def _get_count_skey(cls) -> str:
-        return f"count#{cls.get_total_count_keyname()}"
-
-
-class DynamoDBItem(DynamoDBCountMixin):
+class DynamoDBItem:
 
     CONTENT_KEY_PREFIX = "c#"
     SIGNAL_KEY_PREFIX = "s#"
     TYPE_PREFIX = "type#"
 
-    def _get_count_update_transact_item(self, table: Table):
-        return {
-            "Update": {
-                "Key": {
-                    "PK": self._get_count_pkey(),
-                    "SK": self._get_count_skey(),
-                },
-                # if_not_exists takes care of initializing the count if it hasn't been done yet.
-                "UpdateExpression": "SET WriteCount = if_not_exists(WriteCount, :zero) + :one",
-                "TableName": table.table_name,
-                "ExpressionAttributeValues": {":one": 1, ":zero": 0},
-            },
-        }
-
     def write_to_table(self, table: Table):
-        client: Client = table.meta.client
-        transact_items: t.List[TransactWriteItemTypeDef] = [
-            {
-                "Put": {
-                    "Item": self.to_dynamodb_item(),
-                    "TableName": table.table_name,
-                },
-            },
-        ]
-
-        if self.__class__.is_total_countable():
-            transact_items.append(self._get_count_update_transact_item(table))
-
-        client.transact_write_items(TransactItems=transact_items)
+        table.put_item(Item=self.to_dynamodb_item())
 
     def write_to_table_if_not_found(self, table: Table) -> bool:
-        client: Client = table.meta.client
-        transact_items: t.List[TransactWriteItemTypeDef] = [
-            {
-                "Put": {
-                    "Item": self.to_dynamodb_item(),
-                    "TableName": table.table_name,
-                    "ConditionExpression": "attribute_not_exists(PK) AND attribute_not_exists(SK)",
-                },
-            },
-        ]
-
-        if self.__class__.is_total_countable():
-            transact_items.append(self._get_count_update_transact_item(table))
-
         try:
-            client.transact_write_items(TransactItems=transact_items)
-        except ClientError as e:
+            table.put_item(
+                Item=self.to_dynamodb_item(),
+                ConditionExpression="attribute_not_exists(PK) AND attribute_not_exists(SK)",
+            )
+        except ClientError as client_error:
+            # boto3 exception handling https://imgflip.com/i/5f5zfj
             if (
-                e.response["Error"]["Code"] != "TransactionCanceledException"
-                and e.response["CancellationReasons"][0]["Code"]
-                != "ConditionalCheckFailed"
+                client_error.response.get("Error", {"Code", "Unknown"}).get(
+                    "Code", "Unknown"
+                )
+                == "ConditionalCheckFailedException"
             ):
-                raise e
-            return False
+                return False
+            else:
+                raise client_error
         return True
 
     def to_dynamodb_item(self) -> t.Dict:
@@ -222,14 +130,6 @@ class PipelinePDQHashRecord(PDQRecordBase):
         }
 
     @classmethod
-    def is_total_countable(cls):
-        return True
-
-    @classmethod
-    def get_total_count_keyname(cls):
-        return "PipelinePDQHashRecord"
-
-    @classmethod
     def get_from_content_id(
         cls, table: Table, content_key: str
     ) -> t.Optional["PipelinePDQHashRecord"]:
@@ -293,14 +193,6 @@ class PDQMatchRecord(PDQRecordBase):
     def to_sqs_message(self) -> dict:
         # TODO add method for when matches are added to a sqs
         raise NotImplementedError
-
-    @classmethod
-    def is_total_countable(self):
-        return True
-
-    @classmethod
-    def get_total_count_keyname(self):
-        return "PDQMatchRecord"
 
     @classmethod
     def get_from_content_id(

--- a/hasher-matcher-actioner/hmalib/tests/test_pdq_models.py
+++ b/hasher-matcher-actioner/hmalib/tests/test_pdq_models.py
@@ -343,7 +343,14 @@ class TestPDQModels(unittest.TestCase):
         )
 
 
-class CountersTest(TestPDQModels):
+class MatchByPrivacyGroupCounterTestCase(TestPDQModels):
+    """
+    Better placed inside common, but unfortunately has to be here.
+
+    To be able to re-use the ddb schema definitions, must place things here.
+    tests are module free so can't be cross-referenced.
+    """
+
     @contextmanager
     def fresh_dynamodb(self):
         # Code to acquire resource, e.g.:
@@ -352,51 +359,6 @@ class CountersTest(TestPDQModels):
             yield
         finally:
             self.__class__.tearDownClass()
-
-    def test_writes_init_counters(self):
-        """
-        Test that the first write creates a counter.
-        """
-        with self.fresh_dynamodb():
-            record = self.get_example_pdq_hash_record()
-            record.write_to_table(self.table)
-
-            assert 1 == models.PipelinePDQHashRecord.get_total_count(self.table)
-
-    def test_writes_inc_counters(self):
-        """
-        Test that subsequent writes increment counters.
-        """
-        with self.fresh_dynamodb():
-            record = self.get_example_pdq_hash_record()
-            record.write_to_table(self.table)
-            record.write_to_table(self.table)
-            record.write_to_table(self.table)
-            record.write_to_table(self.table)
-
-            assert 4 == models.PipelinePDQHashRecord.get_total_count(self.table)
-
-    def test_writes_inc_counters_only_for_the_updated_class(self):
-        """
-        Test that the writes do not increment counters for other classes.
-        """
-        with self.fresh_dynamodb():
-            record = self.get_example_pdq_hash_record()
-            record.write_to_table(self.table)
-            record.write_to_table(self.table)
-            record.write_to_table(self.table)
-            record.write_to_table(self.table)
-
-            assert 0 == models.PDQMatchRecord.get_total_count(self.table)
-
-
-class MatchByPrivacyGroupCounterTestCase(CountersTest):
-    """
-    Better placed inside common, but unfortunately has to be here.
-
-    To be able to re-use the ddb schema definitions, must place things here.
-    tests are module free so can't be cross-referenced.
-    """
 
     def test_full_flow(self):
         with self.fresh_dynamodb():

--- a/hasher-matcher-actioner/webapp/src/pages/Dashboard.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Dashboard.jsx
@@ -144,18 +144,14 @@ function StatCard({statName, timeSpan}) {
     <Card key={`stat-card-${statName}`} className="mb-4">
       <Card.Body>
         <Row>
-          <Col xs={4}>
+          <Col xs={8}>
             <h2 style={{fontWeight: 300}}>{getDisplayTitle(statName)}</h2>
           </Col>
-          <Col xs={4}>
+          <Col xs={4} className="text-right">
             <h1>{getDisplayNumber(card.time_span_count)}</h1>
             <small className="text-muted">
               in the last {getDisplayTimeSpan(card.time_span)}.
             </small>
-          </Col>
-          <Col xs={4}>
-            <h1>{getDisplayNumber(card.total_count)}</h1>
-            <small className="text-muted">since HMA is online.</small>
           </Col>
         </Row>
       </Card.Body>


### PR DESCRIPTION
Summary
---------
DDB does not block writes when a transaction is in conflict. It errors out. So, we can't do transactions for every write. Will figure something out later, but until them, remove all vestiges of using transactions to count things.

Removed from models and from dashboard too.

Test Plan
---------
```shell
$ python
>>> from hmalib.models import PipelinePDQHashRecord
>>> import boto3
>>> table = boto3.resource('dynamodb').Table('dipanjanm-HMADataStore')
>>> x = PipelinePDQHashRecord.get_from_time_range(table, "2020-02-02T00:00:00", "2022-02-02T00:00:00")[0]
>>> x.write_to_table_if_not_found(table)
False
```

<img width="1132" alt="Screen Shot 2021-07-01 at 15 11 53" src="https://user-images.githubusercontent.com/217056/124178722-cc67f980-da7f-11eb-8cf8-680ab9983132.png">


```
$ python -m mypy hmalib
$ python -m black hmalib
$ python -m py.test
```
