### PR TITLE
Devcontainer for python-threatexchange

### DIFF
--- a/python-threatexchange/.devcontainer/Dockerfile
+++ b/python-threatexchange/.devcontainer/Dockerfile
@@ -1,0 +1,60 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.163.1/containers/javascript-node/.devcontainer/base.Dockerfile
+
+# [Install python]
+# TODO: pin version later. Otherwise starting up will be too slow.
+FROM python:3.8-buster
+
+# [Unixname wrestling]
+# Some of our script (docker-related) are dependent on the unixname. Would 
+# need to setup the environment with *your* unixname as the defualt user.
+ARG unixname
+RUN groupadd --gid 1000 developers \
+  && useradd --uid 1000 --gid developers --shell /bin/bash --create-home $unixname \
+  && usermod -aG sudo $unixname
+
+# [Install Tools!]
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+  apt-get -y install --no-install-recommends git make jq sudo \
+  software-properties-common apt-transport-https ca-certificates curl \
+  gnupg lsb-release tmux zsh vim less
+
+# [Allow sudo] Need sudo later in post-create to open up docker socket
+ARG unixname
+RUN echo "$unixname ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# [Install node] Node.js version: 15 only. Stolen from: https://github.com/nodejs/docker-node/blob/main/15/buster/Dockerfile
+RUN groupadd --gid 1001 node \
+  && useradd --uid 1001 --gid node --shell /bin/bash --create-home node
+
+# [Install GitHub CLI]
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0 \
+  && apt-add-repository https://cli.github.com/packages \
+  && apt update \
+  && apt install gh
+
+# [Shell Dotfiles]
+ARG unixname
+COPY --chown=${unixname} zshrc /home/$unixname/.zshrc
+
+ARG unixname
+COPY --chown=${unixname} bashrc /home/$unixname/.bashrc
+
+# [Shell Histories] The volume is mounted in devcontainer.json
+ARG unixname
+RUN BASH_SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  && ZSH_SNIPPET="HISTFILE=/commandhistory/.zsh_history" \
+  && mkdir -p /commandhistory \
+  && touch /commandhistory/.bash_history \
+  && touch /commandhistory/.zsh_history \
+  && chown -R $unixname /commandhistory \
+  && echo $BASH_SNIPPET >> "/home/$unixname/.bashrc" \
+  && echo $ZSH_SNIPPET >> "/home/$unixname/.zshrc" \
+  && echo $ZSH_SNIPPET >> "/home/$unixname/.profile"
+# Also appends ZSH_SNIPPET to ~/.profile in case users want to overwrite zshrc file
+# e.g. https://code.visualstudio.com/docs/remote/containers#_personalizing-with-dotfile-repositories
+
+
+# [Forward Docker requests to host docker engine]
+# Volume is mounted and so is the socket. The socket configuration is within
+# devcontainer.json
+VOLUME [ "/var/lib/docker"]

--- a/python-threatexchange/.devcontainer/bashrc
+++ b/python-threatexchange/.devcontainer/bashrc
@@ -1,0 +1,10 @@
+source /etc/bash.bashrc
+
+# Make path respect local binaries from pip
+export PATH=$PATH:~/.local/bin
+
+# Add directory containing hmalib to PYTHONPATH. This allows vscode
+# testdiscovery to work
+export PYTHONPATH=$PYTHONPATH:/workspaces/ThreatExchange/hasher-matcher-actioner
+
+# Last line must have a newline char!

--- a/python-threatexchange/.devcontainer/bashrc
+++ b/python-threatexchange/.devcontainer/bashrc
@@ -5,6 +5,6 @@ export PATH=$PATH:~/.local/bin
 
 # Add directory containing hmalib to PYTHONPATH. This allows vscode
 # testdiscovery to work
-export PYTHONPATH=$PYTHONPATH:/workspaces/ThreatExchange/hasher-matcher-actioner
+export PYTHONPATH=$PYTHONPATH:/workspaces/ThreatExchange/python-threatexchange
 
 # Last line must have a newline char!

--- a/python-threatexchange/.devcontainer/devcontainer.json
+++ b/python-threatexchange/.devcontainer/devcontainer.json
@@ -45,7 +45,8 @@
     "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws,target=/var/run/aws-config,type=bind,consistency=cached",
     "source=${localEnv:HOME}${localEnv:USERPROFILE}/.pytx-cmdhist,target=/commandhistory,type=bind"
   ],
-  // Use 'portsAttributes' to set default properties for specific forwarded ports.
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "sh .devcontainer/post-create",
   "remoteEnv": {
     "IN_DEVCONTAINER": "true"
   },

--- a/python-threatexchange/.devcontainer/devcontainer.json
+++ b/python-threatexchange/.devcontainer/devcontainer.json
@@ -1,0 +1,53 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+  "name": "python-threatexchange-devserver",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "unixname": "${env:USER}"
+    }
+  },
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.profiles.linux": {
+      "bash": {
+        "path": "/bin/bash",
+        "args": [
+          "-l"
+        ]
+      },
+      "zsh": {
+        "path": "/bin/zsh",
+        "args": [
+          "-l"
+        ]
+      }
+    },
+    "editor.formatOnSave": true,
+    "python.formatting.blackPath": "black",
+    "python.formatting.provider": "black",
+    "python.testing.pytestArgs": [
+      "."
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pytestEnabled": true,
+  },
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "ms-python.python",
+    "ms-azuretools.vscode-docker",
+    "eamodio.gitlens",
+    "stkb.rewrap"
+  ],
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws,target=/var/run/aws-config,type=bind,consistency=cached",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.pytx-cmdhist,target=/commandhistory,type=bind"
+  ],
+  // Use 'portsAttributes' to set default properties for specific forwarded ports.
+  "remoteEnv": {
+    "IN_DEVCONTAINER": "true"
+  },
+  "remoteUser": "${localEnv:USER}"
+}

--- a/python-threatexchange/.devcontainer/post-create
+++ b/python-threatexchange/.devcontainer/post-create
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Install python dependencies, including dev dep
+make local_install

--- a/python-threatexchange/.devcontainer/zshrc
+++ b/python-threatexchange/.devcontainer/zshrc
@@ -1,0 +1,19 @@
+export SAVEHIST=10000000
+
+# Allow history file to be sooper large
+export HISTFILESIZE=1000000000
+
+# Allow zsh to load as much history as it needs 
+export HISTSIZE=1000000000
+
+# Incrementally add to the history file.
+setopt INC_APPEND_HISTORY
+
+# Make path respect local binaries from pip
+export PATH=$PATH:~/.local/bin
+
+# Add directory containing hmalib to PYTHONPATH. This allows vscode
+# testdiscovery to work
+export PYTHONPATH=$PYTHONPATH:/workspaces/ThreatExchange/hasher-matcher-actioner
+
+# Last line must have a newline char!

--- a/python-threatexchange/.devcontainer/zshrc
+++ b/python-threatexchange/.devcontainer/zshrc
@@ -14,6 +14,6 @@ export PATH=$PATH:~/.local/bin
 
 # Add directory containing hmalib to PYTHONPATH. This allows vscode
 # testdiscovery to work
-export PYTHONPATH=$PYTHONPATH:/workspaces/ThreatExchange/hasher-matcher-actioner
+export PYTHONPATH=$PYTHONPATH:/workspaces/ThreatExchange/python-threatexchange
 
 # Last line must have a newline char!


### PR DESCRIPTION
Summary
---------
In some distant future, we might be able to do a single devcontainer for both python-threatexchange and hma, but for now, have a separate one.

Test Plan
---------
Booted the devcontainer using "Cmd+P" -> "Remote Container: Open Folder.."

The necessary extensions were installed. Once I selected the python interpreter, I could cmd-click into library functions.