### PR TITLE
convert action settings related files to typescript files

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerColumns.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerColumns.tsx
@@ -4,10 +4,28 @@
 
 import React from 'react';
 import Form from 'react-bootstrap/Form';
-import {PropTypes} from 'prop-types';
+import PropTypes from 'prop-types';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
-import WebhookActioner from './WebhookActioner';
+import WebhookActioner, {Map} from './WebhookActioner';
+
+export type Params = {
+  url: string;
+  headers: string;
+};
+
+type ActionPerformerColumn = {
+  name: string;
+  type: string;
+  params: Params;
+  editing: boolean;
+  onChange: (arg0: string, arg1: Map) => void;
+  canNotDeleteOrUpdateName: boolean;
+};
+
+interface ActionerMap {
+  [key: string]: typeof WebhookActioner;
+}
 
 export default function ActionPerformerColumns({
   name,
@@ -16,8 +34,8 @@ export default function ActionPerformerColumns({
   editing,
   onChange,
   canNotDeleteOrUpdateName,
-}) {
-  const Actioners = {
+}: ActionPerformerColumn) {
+  const Actioners: ActionerMap = {
     WebhookPostActionPerformer: WebhookActioner,
     WebhookGetActionPerformer: WebhookActioner,
     WebhookDeleteActionPerformer: WebhookActioner,

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerColumns.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerColumns.tsx
@@ -9,7 +9,7 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
 import WebhookActioner, {Map} from './WebhookActioner';
 
-export type Params = {
+export type WebhookActionPerformerParams = {
   url: string;
   headers: string;
 };
@@ -17,9 +17,9 @@ export type Params = {
 type ActionPerformerColumn = {
   name: string;
   type: string;
-  params: Params;
+  params: WebhookActionPerformerParams;
   editing: boolean;
-  onChange: (arg0: string, arg1: Map) => void;
+  onChange: (key: string, keyValueMap: Map) => void;
   canNotDeleteOrUpdateName: boolean;
 };
 

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.tsx
@@ -11,12 +11,19 @@ export interface Map {
   [key: string]: string;
 }
 
+interface WebhookType extends Record<string, any> {
+  WebhookPostActionPerformer: string;
+  WebhookGetActionPerformer: string;
+  WebhookDeleteActionPerformer: string;
+  WebhookPutActionPerformer: string;
+}
+
 type WebhookActioner = {
   url: string;
   headers: string;
   webhookType: string;
   editing: boolean;
-  onChange: (arg0: string, arg1: Map) => void;
+  onChange: (key: string, keyValueMap: Map) => void;
 };
 
 export default function WebhookActioner({
@@ -43,7 +50,7 @@ export default function WebhookActioner({
         'When a match occurs, a webhook will be sent to the specified url with data describing the match',
     },
   };
-  const WebhookType: Map = {
+  const WebhookType: WebhookType = {
     WebhookPostActionPerformer: 'POST',
     WebhookGetActionPerformer: 'GET',
     WebhookDeleteActionPerformer: 'DELETE',

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.tsx
@@ -5,7 +5,19 @@
 import React from 'react';
 import Card from 'react-bootstrap/Card';
 import Form from 'react-bootstrap/Form';
-import {PropTypes} from 'prop-types';
+import PropTypes from 'prop-types';
+
+export interface Map {
+  [key: string]: string;
+}
+
+type WebhookActioner = {
+  url: string;
+  headers: string;
+  webhookType: string;
+  editing: boolean;
+  onChange: (arg0: string, arg1: Map) => void;
+};
 
 export default function WebhookActioner({
   url,
@@ -13,7 +25,7 @@ export default function WebhookActioner({
   webhookType,
   editing,
   onChange,
-}) {
+}: WebhookActioner) {
   const ActionerTypes = {
     WebhookActioner: {
       args: {
@@ -31,7 +43,7 @@ export default function WebhookActioner({
         'When a match occurs, a webhook will be sent to the specified url with data describing the match',
     },
   };
-  const WebhookType = {
+  const WebhookType: Map = {
     WebhookPostActionPerformer: 'POST',
     WebhookGetActionPerformer: 'GET',
     WebhookDeleteActionPerformer: 'DELETE',

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.tsx
@@ -11,7 +11,7 @@ export interface Map {
   [key: string]: string;
 }
 
-interface WebhookType extends Record<string, any> {
+interface WebhookTypeInterface extends Record<string, any> {
   WebhookPostActionPerformer: string;
   WebhookGetActionPerformer: string;
   WebhookDeleteActionPerformer: string;
@@ -50,7 +50,7 @@ export default function WebhookActioner({
         'When a match occurs, a webhook will be sent to the specified url with data describing the match',
     },
   };
-  const WebhookType: WebhookType = {
+  const WebhookType: WebhookTypeInterface = {
     WebhookPostActionPerformer: 'POST',
     WebhookGetActionPerformer: 'GET',
     WebhookDeleteActionPerformer: 'DELETE',


### PR DESCRIPTION
Summary
---------

This PR is to convert WebhookActioner, ActionPerformerColumns files to tsx files and fix type errors

Future Action
---------
Need to also convert ActionPerformerRows and ActionSettingsTab to tsx file, but there is a known issue with ion-icon package and typescript, will spend little more time to look into this issue

Test Plan
---------
test localhost for all test cases on Action setting tab

https://user-images.githubusercontent.com/81996660/125141707-c7d8bc00-e0e3-11eb-9094-50f2290a5130.mov

