### PR TITLE
Update dataset command to show more stats

### DIFF
--- a/python-threatexchange/threatexchange/cli/dataset_cmd.py
+++ b/python-threatexchange/threatexchange/cli/dataset_cmd.py
@@ -107,9 +107,15 @@ class DatasetCommand(command_base.Command):
                 k: v
                 for k, v in indicators.items()
                 if v.indicator_type == self.only_type
-                or (signal_types
-                and any(sig_type.indicator_applies(v.indicator_type, v.rollup.labels) for sig_type in signal_types))
+                or (
+                    signal_types
+                    and any(
+                        sig_type.indicator_applies(v.indicator_type, v.rollup.labels)
+                        for sig_type in signal_types
+                    )
+                )
             }
+
         if self.rebuild_indices:
             generate_cli_indices(dataset, stores)
         if self.print_records:

--- a/python-threatexchange/threatexchange/cli/dataset_cmd.py
+++ b/python-threatexchange/threatexchange/cli/dataset_cmd.py
@@ -91,6 +91,7 @@ class DatasetCommand(command_base.Command):
         indicators = {}
         for store in stores:
             indicators.update(store.load_state())
+
         if self.only_type:
             signal_types = []
             s_type = meta.get_signal_types_by_name().get(self.only_type)
@@ -114,6 +115,12 @@ class DatasetCommand(command_base.Command):
                         for sig_type in signal_types
                     )
                 )
+            }
+
+        if self.only_tag:
+            self.signal_summary = True
+            indicators = {
+                k: v for k, v in indicators.items() if self.only_tag in v.rollup.labels
             }
 
         if self.rebuild_indices:

--- a/python-threatexchange/threatexchange/cli/dataset_cmd.py
+++ b/python-threatexchange/threatexchange/cli/dataset_cmd.py
@@ -43,7 +43,14 @@ class DatasetCommand(command_base.Command):
             "-t",
             dest="only_type",
             metavar="STR",
-            help="only process one type of indicators (or signals)",
+            help="only process one type of indicator (eg HASH_MD5), signal (eg photo_md5), or content (eg photo); specifying a signal or content type implies '--signal-summary'",
+        )
+        ap.add_argument(
+            "--tag",
+            "-g",
+            dest="only_tag",
+            metavar="STR",
+            help="only process a single tag; implies '--signal-summary'",
         )
         ap.add_argument(
             "--indicator-only", "-i", action="store_true", help="only print indicators"
@@ -59,12 +66,14 @@ class DatasetCommand(command_base.Command):
         self,
         rebuild_indices: bool,
         only_type: t.Optional[str],
+        only_tag: t.Optional[str],
         indicator_only: bool,
         signal_summary: bool,
         print_records: bool,
     ) -> None:
         self.rebuild_indices = rebuild_indices
         self.only_type = only_type
+        self.only_tag = only_tag
         self.indicator_only = indicator_only
         self.signal_summary = signal_summary
         self.print_records = print_records
@@ -83,16 +92,23 @@ class DatasetCommand(command_base.Command):
         for store in stores:
             indicators.update(store.load_state())
         if self.only_type:
+            signal_types = []
             s_type = meta.get_signal_types_by_name().get(self.only_type)
             if s_type:
+                signal_types.append(s_type)
+                self.signal_summary = True
+
+            content_type = meta.get_content_types_by_name().get(self.only_type)
+            if content_type:
+                signal_types.extend(content_type.get_signal_types())
                 self.signal_summary = True
 
             indicators = {
                 k: v
                 for k, v in indicators.items()
                 if v.indicator_type == self.only_type
-                or s_type
-                and s_type.indicator_applies(v.indicator_type, v.rollup.labels)
+                or (signal_types
+                and any(sig_type.indicator_applies(v.indicator_type, v.rollup.labels) for sig_type in signal_types))
             }
         if self.rebuild_indices:
             generate_cli_indices(dataset, stores)

--- a/python-threatexchange/threatexchange/content_type/meta.py
+++ b/python-threatexchange/threatexchange/content_type/meta.py
@@ -17,9 +17,11 @@ def get_all_content_types() -> t.List[t.Type[content_base.ContentType]]:
     """Returns all content_type implementations for commands"""
     return [text.TextContent, video.VideoContent, photo.PhotoContent]
 
+
 @functools.lru_cache(1)
 def get_content_types_by_name() -> t.Dict[str, content_base.ContentType]:
     return {c.get_name(): c for c in get_all_content_types()}
+
 
 @functools.lru_cache(1)
 def get_all_signal_types() -> t.Set[t.Type[signal_base.SignalType]]:

--- a/python-threatexchange/threatexchange/content_type/meta.py
+++ b/python-threatexchange/threatexchange/content_type/meta.py
@@ -17,6 +17,9 @@ def get_all_content_types() -> t.List[t.Type[content_base.ContentType]]:
     """Returns all content_type implementations for commands"""
     return [text.TextContent, video.VideoContent, photo.PhotoContent]
 
+@functools.lru_cache(1)
+def get_content_types_by_name() -> t.Dict[str, content_base.ContentType]:
+    return {c.get_name(): c for c in get_all_content_types()}
 
 @functools.lru_cache(1)
 def get_all_signal_types() -> t.Set[t.Type[signal_base.SignalType]]:


### PR DESCRIPTION
Summary
---------

Add functionality to the existing `dataset` command to display stats about downloaded data. My proposed changes to the command:
`threatexchange dataset --type <content type>`:
```
 % threatexchange --config config.json dataset --type photo
pdq: 14023
photo_md5: 160
video_md5: 23
```

`threatexchange dataset --type <signal type>` (existing functionality):
```
% threatexchange --config config.json dataset --type video_md5
video_md5: 161124
photo_md5: 23
```

`threatexchange dataset --tag <tag name>`:
```
% threatexchange --config config.json dataset --tag media_priority_s1
video_md5: 14529
pdq: 657
photo_md5: 109
```

Test Plan
---------

See above for sample commands run to show filtering on a subset of the data for privacy group <>, app id <>. These commands demonstrate content type, indicator type, and tag filtering applied to the base data set; for reference, here are the stats for the full data set I have locally:
```
% threatexchange --config config.json dataset -s
video_md5: 161124
pdq: 14023
photo_md5: 160
```

To validate the actual counts, I used grep against the raw data to compare to the output from the dataset commands

For example:
```
% grep media_priority_s1 simple.HASH_MD5.te | wc -l
   14618
% threatexchange --config config.json dataset -t HASH_MD5 -g media_priority_s1
video_md5: 14529
photo_md5: 109
```
The total from `dataset` is 14,638, but `grep media_priority_s1 simple.HASH_MD5.te | grep media_type_photo | grep media_type_video` shows that there are 20 records tagged as both `media_type_photo` and `media_type_video`, which is why the count from dataset is 20 more than the initial grep search.
