### PR TITLE
always mark sample test dataset id as in_use

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/threatexchange_config.py
+++ b/hasher-matcher-actioner/hmalib/common/threatexchange_config.py
@@ -19,6 +19,7 @@ logger = get_logger(__name__)
 FETCHER_ACTIVE_DEFAULT = True
 WRITE_BACK_DEFAULT = True
 MATCHER_ACTIVE_DEFAULT = True
+SAMPLE_DATASET_PRIVACY_GROUP_ID = ["inria-holidays-test"]
 
 
 def create_privacy_group_if_not_exists(
@@ -60,14 +61,16 @@ def sync_privacy_groups():
     privacy_group_member_list = api.get_threat_privacy_groups_member()
     privacy_group_owner_list = api.get_threat_privacy_groups_owner()
     unique_privacy_groups = set(privacy_group_member_list + privacy_group_owner_list)
-    priavcy_group_id_in_use = set()
+    priavcy_group_id_in_use = set(
+        SAMPLE_DATASET_PRIVACY_GROUP_ID
+    )  # add sample test dataset id to avoid disable it when syncing from HMA UI
 
     for privacy_group in unique_privacy_groups:
         if privacy_group.threat_updates_enabled:
             # HMA can only read from privacy groups that have threat_updates enabled.
             # # See here for more details:
             # https://developers.facebook.com/docs/threat-exchange/reference/apis/threat-updates/v9.0
-            priavcy_group_id_in_use.add(privacy_group.id)
+            priavcy_group_id_in_use.add(str(privacy_group.id))
             create_privacy_group_if_not_exists(
                 str(privacy_group.id),
                 privacy_group_name=privacy_group.name,


### PR DESCRIPTION
Summary
---------

This PR will not mark sample test dataset as in_active when users click "sync" button in ThreatExchange settings UI.

Test Plan
---------

1. black hmalib
2. mypy hmalib
3. python -m py.test to pass all tests
4. make docker
5. make upload_docker 
6. terraform apply
7. test in localhost

before : 

https://user-images.githubusercontent.com/81996660/125684911-1f9edc31-311d-489a-92fa-6e8129adb164.mov

after:


https://user-images.githubusercontent.com/81996660/125684940-1d4021af-be5a-4dd7-b9c1-cbc5cc12c3c6.mov




If sample test dataset is not created, click sync button will not add it

https://user-images.githubusercontent.com/81996660/125691572-c63b8f94-a453-4f81-85d6-ae0978571a45.mov

