### PR TITLE
Filter Partner Bucket Uploads to files in specific folders or with specific extensions

### DIFF
--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -333,11 +333,19 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
     lambda_function_arn = aws_lambda_function.api_root.arn
     events              = ["s3:ObjectCreated:*"]
 
-    # TODO: Allow filtering to enable hashing to only certain f
-    # olders and file types. eg...
-    #
-    # filter_prefix       = "images/"
-    # filter_suffix       = ".jpg"
+    # Check if a prefix filter (or the aliases folder, path) was specified
+    # Otherwise no prefix constraint
+    filter_prefix = lookup(var.partner_image_buckets[count.index].params, "prefix", 
+                      lookup(var.partner_image_buckets[count.index].params, "folder", 
+                        lookup(var.partner_image_buckets[count.index].params, "path", "")
+                      )
+                    )
+
+    # Check if a suffix filter (or the alias extension) was specified
+    # Otherwise no suffix constraint
+    filter_suffix = lookup(var.partner_image_buckets[count.index].params, "suffix", 
+                      lookup(var.partner_image_buckets[count.index].params, "extension", "")
+                    ) 
   }
 
   depends_on = [aws_lambda_permission.allow_bucket]

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -114,6 +114,7 @@ variable "partner_image_buckets" {
   type        = list(object({
     name = string
     arn  = string
+    params = map(string)
   }))
 }
 

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -93,6 +93,26 @@ variable "partner_image_buckets" {
   type        = list(object({
     name = string
     arn  = string
+    params = map(string)
   }))
   default     = []
+
+  # Ensure only correct params are used
+  validation {
+    condition = alltrue(
+      [
+        for partner_bucket in var.partner_image_buckets: 
+        alltrue(
+          [
+            for param_key in keys(partner_bucket.params):
+            # 'prefix' is the prefered term but we also accept 'folder' or 'path'. All these options are processed in the same way
+            # similarly, 'suffix' is the prefered term but we also accept 'extension'
+            param_key == "prefix" || param_key == "folder" || param_key == "path" || param_key == "suffix" || param_key == "extension"
+          ]
+        )
+      ]
+    )
+
+    error_message = "The only accepted params are 'prefix' to specify a prefix/folder/path string where only uploads with that prefix should be sent to HMA and 'suffix' to restrict uploads to only files with a specific extension."
+  }
 }


### PR DESCRIPTION
!!! This is a stacked PR. Only review c32ff57aef541878eac17a5bcece4c4a5edf7a1b "Add params to Partner Local Buckets terraform arg" !!!


Summary
---------

Partners who want to upload their banks to HMA will likely only want to send specific file types and specific folders within buckets to HMA. This PR enables this through prefix filtering and suffix filtering in terraform

Test Plan
---------

Ran the following tests by editing my tfvars file, running `terraform plan`, and looking at what would change in AWS as a result.

## Test 1
Change: `params:{"prefix" : "test/folder/path/"}`

Result:
```
## module.api.aws_s3_bucket_notification.bucket_notification[0] will be updated in-place
  ~ resource "aws_s3_bucket_notification" "bucket_notification" {
        id     = "jesses-separate-aws-bucket"
        # (1 unchanged attribute hidden)

      ~ lambda_function {
          + filter_prefix       = "test/folder/path/"
            id                  = "tf-s3-lambda-20210721194532010900000001"
            # (2 unchanged attributes hidden)
        }
    }
```

## Test 2 - Same result as Test 1
Change: `params:{"folder" : "test/folder/path/"}`

## Test 3 - Same result as Test 1
Change: `params:{"path" : "test/folder/path/"}`

## Test 4
Change: `params:{"suffix" : ".jpg"}`

Result:
```
## module.api.aws_s3_bucket_notification.bucket_notification[0] will be updated in-place
  ~ resource "aws_s3_bucket_notification" "bucket_notification" {
        id     = "jesses-separate-aws-bucket"
        # (1 unchanged attribute hidden)

      ~ lambda_function {
          + filter_suffix       = ".jpg"
            id                  = "tf-s3-lambda-20210721194532010900000001"
            # (2 unchanged attributes hidden)
        }
    }
```

## Test 5 - Same result as Test 4
Change: `params:{"extension" : ".jpg"}`

## Test 6
Change: `params:{"extension" : ".jpg", "folder" : "test/folder/path/"}`

Result:
```
## module.api.aws_s3_bucket_notification.bucket_notification[0] will be updated in-place
  ~ resource "aws_s3_bucket_notification" "bucket_notification" {
        id     = "jesses-separate-aws-bucket"
        # (1 unchanged attribute hidden)

      ~ lambda_function {
          + filter_suffix       = ".jpg"
          + filter_prefix       = "test/folder/path/"
            id                  = "tf-s3-lambda-20210721194532010900000001"
            # (2 unchanged attributes hidden)
        }
    }
```

## Test 7
Change: `params:{"not-a-key" : ".jpg", "folder" : "test/folder/path/"}`

Result:
```
Error: Invalid value for variable
│
│   on variables.tf line 91:
│   91: variable "partner_image_buckets" {
│
│ The only accepted params are 'prefix' to specify a prefix/folder/path string where only uploads with that prefix should be sent to HMA and 'extension' to restrict uploads to only files with a specific extension.
│
│ This was checked by the validation rule at variables.tf:101,3-13.
```