### PR TITLE
threatexchange: Allow subclasses to build pdq indexes

### DIFF
--- a/python-threatexchange/threatexchange/signal_type/pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_index.py
@@ -55,7 +55,7 @@ class PDQIndex(SignalTypeIndex):
         """
         Build an PDQ index from a set of entries.
         """
-        return PDQIndex(entries)
+        return cls(entries)
 
     def serialize(self, fout: t.BinaryIO) -> None:
         """


### PR DESCRIPTION
Summary
---------
In doing MD5 indexing, I am extending PDQIndex and TrivialSignalTypeIndex and giving them s3 storage. However, I want to retain the build method from the super classes.

This change will allow a building sub class instances.

Test Plan
---------
```
$ python -m black threatexchange
$ python -m py.test .
```