### PR TITLE
Suppress new GCC 8 warnings in pdq/cpp

### DIFF
--- a/pdq/cpp/Makefile
+++ b/pdq/cpp/Makefile
@@ -1,8 +1,8 @@
 # ================================================================
 CC=g++ -g -std=c++11
 IFLAGS=-I../.. -I.
-# -Wno-char-subscripts is because of CImg.h
-WFLAGS=-Wall -Wno-char-subscripts -Werror
+# -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess is because of CImg.h
+WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Werror
 LFLAGS=-lm
 
 CCOPT=$(CC) $(CFLAGS) $(IFLAGS) $(WFLAGS) -O3


### PR DESCRIPTION
Summary
---------

GCC 8 added new warnings that cause `make` of `pdq/cpp` to fail due to `-Werror`

I don't think it is worth digging into the example library that is causing the errors so for now I have the Makefile ignore those.


Test Plan
---------

Locally installed gcc 8.5 have saw `make` complete successfully (failing with warnings before) after adding the `-Wno-stringop-truncation -Wno-class-memaccess` flags.