### PR TITLE
Fix Content ID Bug In Partner Bucket Submissions

### DIFF
--- a/hasher-matcher-actioner/Makefile
+++ b/hasher-matcher-actioner/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all docker upload_docker dev_create_configs dev_create_instance dev_test_instance dev_upload_test_signal dev_upload_test_content dev_upload_test_data dev_destroy_instance dev_clear_configs clean
+.PHONY: all docker upload_docker dev_create_configs dev_create_instance dev_test_instance dev_destroy_instance dev_clear_configs clean
 
 shell-or-die = $\
 	$(eval sod_out := $(shell $(1); echo $$?))$\
@@ -37,6 +37,9 @@ dev_create_instance: dev_create_configs upload_docker
 
 dev_destroy_instance:
 	cd terraform/ && terraform destroy -var "prefix=${USER}"
+
+dev_test_instance:
+	python3 scripts/submit_content_test.py
 
 dev_clear_configs:
 	-rm terraform/terraform.tfvars terraform/backend.tf

--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -4,10 +4,9 @@ import hmalib.common.config as config
 import json
 import typing as t
 
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass
 from hmalib.common.logging import get_logger
 from hmalib.common.message_models import MatchMessage
-from hmalib.common.classification_models import ActionLabel, Label
 from hmalib.common.aws_dataclass import HasAWSSerialization
 from requests import get, post, put, delete, Response
 

--- a/hasher-matcher-actioner/hmalib/common/classification_models.py
+++ b/hasher-matcher-actioner/hmalib/common/classification_models.py
@@ -1,13 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from hmalib.common.signal_models import PendingOpinionChange
-import hmalib.common.config as config
-import json
-import typing as t
-
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, field
 from hmalib.common.logging import get_logger
-from requests import get, post, put, delete, Response
 
 logger = get_logger(__name__)
 
@@ -48,6 +42,11 @@ class BankIDClassificationLabel(ClassificationLabel):
 class BankedContentIDClassificationLabel(ClassificationLabel):
     # TODO name confusing. Should probably be SignalID...
     key: str = field(default="BankedContentIDClassification", init=False)
+
+
+@dataclass(unsafe_hash=True)
+class SubmittedContentClassificationLabel(ClassificationLabel):
+    key: str = field(default="SubmittedContent", init=False)
 
 
 @dataclass(unsafe_hash=True)

--- a/hasher-matcher-actioner/hmalib/common/message_models.py
+++ b/hasher-matcher-actioner/hmalib/common/message_models.py
@@ -13,10 +13,9 @@ from hmalib.common.classification_models import (
     ClassificationLabel,
     Label,
     WritebackTypes,
-    PendingOpinionChange,
 )
+from hmalib.common.signal_models import PendingOpinionChange
 from hmalib.common.evaluator_models import ActionLabel, ActionRule
-from hmalib.common.content_models import ContentObject
 from hmalib.common.aws_dataclass import HasAWSSerialization
 from hmalib.common.image_sources import S3BucketImageSource
 from hmalib.common.logging import get_logger

--- a/hasher-matcher-actioner/hmalib/common/message_models.py
+++ b/hasher-matcher-actioner/hmalib/common/message_models.py
@@ -16,6 +16,7 @@ from hmalib.common.classification_models import (
     PendingOpinionChange,
 )
 from hmalib.common.evaluator_models import ActionLabel, ActionRule
+from hmalib.common.content_models import ContentObject
 from hmalib.common.aws_dataclass import HasAWSSerialization
 from hmalib.common.image_sources import S3BucketImageSource
 from hmalib.common.logging import get_logger
@@ -84,12 +85,16 @@ class ActionMessage(MatchMessage):
     action_label: ActionLabel = ActionLabel("UnspecifiedAction")
     action_rules: t.List[ActionRule] = field(default_factory=list)
 
+    # from content
+    additional_fields: t.List[str] = field(default_factory=list)
+
     @classmethod
-    def from_match_message_action_label_and_action_rules(
+    def from_match_message_action_label_action_rules_and_additional_fields(
         cls,
         match_message: MatchMessage,
         action_label: ActionLabel,
         action_rules: t.List[ActionRule],
+        additional_fields=t.List[str],
     ) -> "ActionMessage":
         return cls(
             match_message.content_key,
@@ -97,6 +102,7 @@ class ActionMessage(MatchMessage):
             match_message.matching_banked_signals,
             action_label,
             action_rules,
+            additional_fields,
         )
 
 

--- a/hasher-matcher-actioner/hmalib/common/message_models.py
+++ b/hasher-matcher-actioner/hmalib/common/message_models.py
@@ -16,6 +16,7 @@ from hmalib.common.classification_models import (
 )
 from hmalib.common.signal_models import PendingOpinionChange
 from hmalib.common.evaluator_models import ActionLabel, ActionRule
+from hmalib.common.content_models import ContentObject
 from hmalib.common.aws_dataclass import HasAWSSerialization
 from hmalib.common.image_sources import S3BucketImageSource
 from hmalib.common.logging import get_logger

--- a/hasher-matcher-actioner/hmalib/common/message_models.py
+++ b/hasher-matcher-actioner/hmalib/common/message_models.py
@@ -16,7 +16,6 @@ from hmalib.common.classification_models import (
 )
 from hmalib.common.signal_models import PendingOpinionChange
 from hmalib.common.evaluator_models import ActionLabel, ActionRule
-from hmalib.common.content_models import ContentObject
 from hmalib.common.aws_dataclass import HasAWSSerialization
 from hmalib.common.image_sources import S3BucketImageSource
 from hmalib.common.logging import get_logger

--- a/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
@@ -48,7 +48,7 @@ class ActionRuleEvaluationTestCase(unittest.TestCase):
 
         action_label_to_action_rules: t.Dict[
             ActionLabel, t.List[ActionRule]
-        ] = get_actions_to_take(match_message_without_foo, action_rules)
+        ] = get_actions_to_take(match_message_without_foo, action_rules, set())
 
         assert len(action_label_to_action_rules) == 1
         self.assertIn(
@@ -58,7 +58,7 @@ class ActionRuleEvaluationTestCase(unittest.TestCase):
         )
 
         action_label_to_action_rules = get_actions_to_take(
-            match_message_with_foo, action_rules
+            match_message_with_foo, action_rules, set()
         )
 
         assert len(action_label_to_action_rules) == 0
@@ -125,7 +125,7 @@ class ActionRuleEvaluationTestCase(unittest.TestCase):
         )
 
         action_label_to_action_rules = get_actions_to_take(
-            mini_castle_match_message, action_rules
+            mini_castle_match_message, action_rules, set()
         )
 
         assert len(action_label_to_action_rules) == 1
@@ -136,7 +136,7 @@ class ActionRuleEvaluationTestCase(unittest.TestCase):
         )
 
         action_label_to_action_rules = get_actions_to_take(
-            sailboat_match_message, action_rules
+            sailboat_match_message, action_rules, set()
         )
 
         assert len(action_label_to_action_rules) == 1

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -9,12 +9,16 @@ from dataclasses import dataclass
 from functools import lru_cache
 from hmalib.common.logging import get_logger
 from hmalib.common.classification_models import (
+    BankIDClassificationLabel,
+    BankSourceClassificationLabel,
+    BankedContentIDClassificationLabel,
+    ClassificationLabel,
+    SubmittedContentClassificationLabel,
     WritebackTypes,
     Label,
 )
 from hmalib.common.config import HMAConfig
 from hmalib.common.evaluator_models import (
-    Action,
     ActionLabel,
     ActionRule,
 )
@@ -91,10 +95,10 @@ def lambda_handler(event, context):
             match_message.content_key,
         )
 
-        # TODO: Convert AdditionalFields to ActionRules for determining if rule should be processed
         action_label_to_action_rules = get_actions_to_take(
             match_message,
             action_rules,
+            submitted_content.additional_fields,
         )
         action_labels = list(action_label_to_action_rules.keys())
         for action_label in action_labels:
@@ -122,16 +126,27 @@ def lambda_handler(event, context):
 def get_actions_to_take(
     match_message: MatchMessage,
     action_rules: t.List[ActionRule],
+    additional_fields_on_content: t.Set[str],
 ) -> t.Dict[ActionLabel, t.List[ActionRule]]:
     """
     Returns action labels for each action rule that applies to a match message.
     """
     action_label_to_action_rules: t.Dict[ActionLabel, t.List[ActionRule]] = dict()
 
+    content_classifications = {
+        SubmittedContentClassificationLabel(field)
+        for field in additional_fields_on_content
+    }
+
+    logger.info(
+        "Adding SubmittedContentClassificationLabel(s): %s", content_classifications
+    )
+
     for banked_signal in match_message.matching_banked_signals:
         for action_rule in action_rules:
             if action_rule_applies_to_classifications(
-                action_rule, banked_signal.classifications
+                action_rule,
+                banked_signal.classifications.union(content_classifications),
             ):
                 if action_rule.action_label in action_label_to_action_rules:
                     action_label_to_action_rules[action_rule.action_label].append(
@@ -185,7 +200,7 @@ if __name__ == "__main__":
     HMAConfig.initialize(os.environ["CONFIG_TABLE_NAME"])
     action_rules = get_action_rules()
     match_message = MatchMessage(
-        content_key="c6",
+        content_key="m2",
         content_hash="361da9e6cf1b72f5cea0344e5bb6e70939f4c70328ace762529cac704297354a",
         matching_banked_signals=[
             BankedSignal(
@@ -193,12 +208,10 @@ if __name__ == "__main__":
                 bank_id="258601789084078",
                 bank_source="te",
                 classifications={
-                    Label(key="BankIDClassification", value="258601789084078"),
-                    Label(key="Classification", value="true_positive"),
-                    Label(key="BankSourceClassification", value="te"),
-                    Label(
-                        key="BankedContentIDClassification", value="3534976909868947"
-                    ),
+                    BankedContentIDClassificationLabel(value="258601789084078"),
+                    ClassificationLabel(value="true_positive"),
+                    BankSourceClassificationLabel(value="te"),
+                    BankIDClassificationLabel(value="3534976909868947"),
                 },
             )
         ],

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -34,6 +34,7 @@ from mypy_boto3_dynamodb.service_resource import Table, DynamoDBServiceResource
 
 
 logger = get_logger(__name__)
+dynamodb: DynamoDBServiceResource = boto3.resource("dynamodb")
 
 
 @dataclass
@@ -57,8 +58,8 @@ class ActionEvaluatorConfig:
             os.environ["DYNAMODB_TABLE"],
         )
         HMAConfig.initialize(os.environ["CONFIG_TABLE_NAME"])
-        dynamo_db_table_name = os.environ["DYNAMODB_TABLE"]
 
+        dynamo_db_table_name = os.environ["DYNAMODB_TABLE"]
         dynamodb: DynamoDBServiceResource = boto3.resource("dynamodb")
 
         return cls(
@@ -102,11 +103,13 @@ def lambda_handler(event, context):
         )
         action_labels = list(action_label_to_action_rules.keys())
         for action_label in action_labels:
-            action_message = ActionMessage.from_match_message_action_label_action_rules_and_additional_fields(
-                match_message,
-                action_label,
-                action_label_to_action_rules[action_label],
-                list(submitted_content.additional_fields),
+            action_message = (
+                ActionMessage.from_match_message_action_label_and_action_rules(
+                    match_message,
+                    action_label,
+                    action_label_to_action_rules[action_label],
+                    submitted_content.additional_fields,
+                )
             )
 
             logger.info("Sending Action message: %s", action_message)

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -103,13 +103,11 @@ def lambda_handler(event, context):
         )
         action_labels = list(action_label_to_action_rules.keys())
         for action_label in action_labels:
-            action_message = (
-                ActionMessage.from_match_message_action_label_and_action_rules(
-                    match_message,
-                    action_label,
-                    action_label_to_action_rules[action_label],
-                    submitted_content.additional_fields,
-                )
+            action_message = ActionMessage.from_match_message_action_label_action_rules_and_additional_fields(
+                match_message,
+                action_label,
+                action_label_to_action_rules[action_label],
+                list(submitted_content.additional_fields),
             )
 
             logger.info("Sending Action message: %s", action_message)

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
@@ -1,19 +1,15 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-import json
 import os
 import boto3
-import typing as t
 import datetime
 from functools import lru_cache
 from mypy_boto3_dynamodb import DynamoDBServiceResource
 
-from hmalib.common.message_models import BankedSignal, ActionMessage, MatchMessage
+from hmalib.common.message_models import ActionMessage
 from hmalib.common.actioner_models import (
     ActionPerformer,
-    WebhookPostActionPerformer,
 )
-from hmalib.common.evaluator_models import ActionLabel
 from hmalib.common.content_models import ActionEvent
 from hmalib.common.logging import get_logger
 from hmalib.common import config

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -122,9 +122,10 @@ def submit_content_request_from_s3_event_record(
     For partner bucket uploads the content IDs are unique and human understandable but
     not reversable
       * uniqueness is provided by uuid4 which has a collision rate of 2^-36
-      * human understandbility is provided by including the (slightly modified key)
+      * human understandbility is provided by including the (slightly modified) key
+        in the content id
       * modifications to the key mean that the original content bucket and key are
-        not derivable from the content ID alon
+        not derivable from the content ID alone
 
     The original contnet (bucket and key) is stored in the reference url which is passed
     to the webhook via additional_fields

--- a/hasher-matcher-actioner/hmalib/models.py
+++ b/hasher-matcher-actioner/hmalib/models.py
@@ -1,14 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import datetime
-from enum import Enum
 import typing as t
-import json
-from dataclasses import dataclass, field
-from decimal import Decimal
-from boto3 import client
+from dataclasses import dataclass
 from mypy_boto3_dynamodb.service_resource import Table
-from boto3.dynamodb.conditions import Attr, Key, And
+from boto3.dynamodb.conditions import Attr, Key
 from botocore.exceptions import ClientError
 
 """

--- a/hasher-matcher-actioner/scripts/set_tf_outputs_in_local_env.sh
+++ b/hasher-matcher-actioner/scripts/set_tf_outputs_in_local_env.sh
@@ -5,7 +5,7 @@
 # usage:
 #    $ source scripts/set_tf_outputs_in_local_env.sh 
 
-echo "Reminder: only works if you 'source' the file"
+[[ $_ != $0 ]] && echo "Error: this script needs to be 'source'd not run." && exit
 for s in $(terraform -chdir=terraform output -json | jq -r "to_entries|map(\"HMA_\(.key|ascii_upcase)=\(.value.value|tostring)\")|.[]"); do
     export $s
 done 

--- a/hasher-matcher-actioner/scripts/submit_content_test.py
+++ b/hasher-matcher-actioner/scripts/submit_content_test.py
@@ -256,6 +256,37 @@ if __name__ == "__main__":
         "",
     )
 
+    print(
+        "Attempting to run submit_content_test,gs you may need to run additional commands first."
+    )
+    print(
+        "This simple tests should take a little over 2 minutes to complete (due to sqs timeout).\n"
+    )
+
+    if not api_url:
+        print("Error: Failed to find HMA_API_URL in environ.")
+        print(
+            "Easiest way to add this to your environment is `source scripts/set_tf_outputs_in_local_env.sh`"
+        )
+        exit()
+
+    if refresh_token and not client_id:
+        print(
+            "Error: Failed to find HMA_COGNITO_USER_POOL_CLIENT_ID in environ. (Required to use HMA_REFRESH_TOKEN)"
+        )
+        print(
+            "Easiest way to add this to your environment is `source scripts/set_tf_outputs_in_local_env.sh`"
+        )
+        exit()
+
+    if not token and not refresh_token:
+        print("Error: Failed to find HMA_TOKEN or HMA_REFRESH_TOKEN in environ.")
+        print(
+            "Easiest way to add either to your environment is to export the result `scripts/get_auth_token`"
+        )
+        print("See script (get_auth_token) for usage.")
+        exit()
+
     helper = DeployedInstanceTestHelper(api_url, token, client_id, refresh_token)
 
     if refresh_token and client_id:

--- a/hasher-matcher-actioner/terraform/actions/main.tf
+++ b/hasher-matcher-actioner/terraform/actions/main.tf
@@ -103,6 +103,7 @@ resource "aws_lambda_function" "action_evaluator" {
       ACTIONS_QUEUE_URL    = aws_sqs_queue.actions_queue.id,
       WRITEBACKS_QUEUE_URL = aws_sqs_queue.writebacks_queue.id,
       CONFIG_TABLE_NAME    = var.config_table.name,
+      DYNAMODB_TABLE       = var.datastore.name
     }
   }
 }
@@ -244,6 +245,14 @@ data "aws_iam_policy_document" "action_evaluator" {
     effect    = "Allow"
     actions   = ["cloudwatch:PutMetricData"]
     resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:Get*",
+    ]
+    resources = [var.datastore.arn]
   }
 }
 

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -100,18 +100,14 @@ data "aws_iam_policy_document" "api_root" {
     actions = [
       "s3:GetObject",
     ]
-    resources = [
+    resources = concat(
+      [
       "arn:aws:s3:::${var.threat_exchange_data.bucket_name}/${var.threat_exchange_data.data_folder}*",
-    ]
+    ],
+    [for partner_bucket in var.partner_image_buckets: "${partner_bucket.arn}/*"]
+    )
   }
-
-    statement {
-    effect = "Allow"
-    actions = [
-      "s3:GetObject",
-    ]
-    resources = [for partner_bucket in var.partner_image_buckets: "${partner_bucket.arn}/*"]
-  }
+  
   statement {
     effect = "Allow"
     actions = [

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -333,11 +333,19 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
     lambda_function_arn = aws_lambda_function.api_root.arn
     events              = ["s3:ObjectCreated:*"]
 
-    # TODO: Allow filtering to enable hashing to only certain f
-    # olders and file types. eg...
-    #
-    # filter_prefix       = "images/"
-    # filter_suffix       = ".jpg"
+    # Check if a prefix filter (or the aliases folder, path) was specified
+    # Otherwise no prefix constraint
+    filter_prefix = lookup(var.partner_image_buckets[count.index].params, "prefix", 
+                      lookup(var.partner_image_buckets[count.index].params, "folder", 
+                        lookup(var.partner_image_buckets[count.index].params, "path", "")
+                      )
+                    )
+
+    # Check if a suffix filter (or the alias extension) was specified
+    # Otherwise no suffix constraint
+    filter_suffix = lookup(var.partner_image_buckets[count.index].params, "suffix", 
+                      lookup(var.partner_image_buckets[count.index].params, "extension", "")
+                    ) 
   }
 
   depends_on = [aws_lambda_permission.allow_bucket]

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -114,6 +114,7 @@ variable "partner_image_buckets" {
   type        = list(object({
     name = string
     arn  = string
+    params = map(string)
   }))
 }
 

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -93,6 +93,26 @@ variable "partner_image_buckets" {
   type        = list(object({
     name = string
     arn  = string
+    params = map(string)
   }))
   default     = []
+
+  # Ensure only correct params are used
+  validation {
+    condition = alltrue(
+      [
+        for partner_bucket in var.partner_image_buckets: 
+        alltrue(
+          [
+            for param_key in keys(partner_bucket.params):
+            # 'prefix' is the prefered term but we also accept 'folder' or 'path'. All these options are processed in the same way
+            # similarly, 'suffix' is the prefered term but we also accept 'extension'
+            param_key == "prefix" || param_key == "folder" || param_key == "path" || param_key == "suffix" || param_key == "extension"
+          ]
+        )
+      ]
+    )
+
+    error_message = "The only accepted params are 'prefix' to specify a prefix/folder/path string where only uploads with that prefix should be sent to HMA and 'suffix' to restrict uploads to only files with a specific extension."
+  }
 }

--- a/hasher-matcher-actioner/webapp/src/components/SubmitContentFields.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/SubmitContentFields.jsx
@@ -149,21 +149,7 @@ export function OptionalAdditionalFields({
           <Form.Group as={Col}>
             <InputGroup>
               <InputGroup.Prepend>
-                <InputGroup.Text>Key</InputGroup.Text>
-              </InputGroup.Prepend>
-              <Form.Control
-                onChange={e => {
-                  const copy = {...additionalFields};
-                  copy[entry].key = e.target.value;
-                  setAdditionalFields(copy);
-                }}
-              />
-            </InputGroup>
-          </Form.Group>
-          <Form.Group as={Col}>
-            <InputGroup>
-              <InputGroup.Prepend>
-                <InputGroup.Text>Value</InputGroup.Text>
+                <InputGroup.Text>Field</InputGroup.Text>
               </InputGroup.Prepend>
               <Form.Control
                 onChange={e => {

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.tsx
@@ -67,6 +67,7 @@ export default function ActionRuleFormColumns({
             MatchedSignal ID
           </option>
           <option value="Classification">MatchedSignal</option>
+          <option value="SubmittedContent">SubmittedContent Label</option>
         </Form.Control>
       </Col>
       <Col xs={2}>

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.tsx
@@ -94,6 +94,9 @@ export default function ActionRulesTableRow({
           case 'Classification':
             ret += ' MatchedContent';
             break;
+          case 'SubmittedContent':
+            ret += ' SubmittedContent';
+            break;
           default:
             ret += ` ${classification.classificationType}`;
             break;
@@ -101,12 +104,14 @@ export default function ActionRulesTableRow({
 
         if (classification.equalTo) {
           ret +=
-            classification.classificationType === 'Classification'
+            classification.classificationType === 'Classification' ||
+            classification.classificationType === 'SubmittedContent'
               ? ' has been classified'
               : ' is';
         } else {
           ret +=
-            classification.classificationType === 'Classification'
+            classification.classificationType === 'Classification' ||
+            classification.classificationType === 'SubmittedContent'
               ? ' has not been classified'
               : ' is not';
         }

--- a/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
@@ -70,9 +70,8 @@ export default function SubmitContent() {
   const packageAdditionalFields = () => {
     const entries = [];
     Object.values(additionalFields).forEach(entry =>
-      // store key:value for now to avoid collisions/overwrite of repeats
-      // exact extra additional fields spec should be established in documentation
-      entries.push(`${entry.key}:${entry.value}`),
+      // TODO extra additional fields spec should be established in documentation
+      entries.push(`${entry.value}`),
     );
     return entries;
   };

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -56,7 +56,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         "python-Levenshtein",
-        "requests",
+        "requests>=2.26.0",
         "dataclasses",
         "python-dateutil",
     ],


### PR DESCRIPTION
Summary
---------

Partner Bucket uploads formerly created content IDs as `bucket-name/path/to/content/key.extension`. This led to two issues:

1. The matches Page in the API doesn't work correctly if content ID has `/` in it
2. The path could potentially lead to collisions with other submission methods if the same string was used

This diff changes the content IDs to a string like `bucket-name:path.to.content.key.extension` which adresses problem 1 and mitigates problem 2 since the second string is less likely to be random. We also decided to tell partners that should not use Partner Bucket Submissions in conjunction with another submission method.


I have also updated the documentation here to reflect this change:

>If you upload content from s3 buckets in this manner, ContentIDs will be generated automatically from the bucket and key. Specifically, if you upload a photo with file name `xkcd.jpg` to the `images/important/` directory of bucket `my-separate-aws-bucket`, the content ID will be:

>`my-separate-aws-bucket:images.important.xkcd.jpg`

>Because ContentIDs are unique across HMA, and the above string could be submitted as a ContentID for submissions via the UI or API, if you are using partner bucket uploads in prod we recommend only submitting content via this method unless you are absolutely confident you wont cause collisions.

Test Plan
---------

Upload photo to bucket in folder. Show that the new ContentID is correct (jesses-separate-aws-bucket:folder.200600.jpg) and that the matches page work:


<br class="Apple-interchange-newline">
<img width="1680" alt="Screen Shot 2021-07-29 at 12 57 50 PM" src="https://user-images.githubusercontent.com/24800630/127533701-40fed5b5-450a-45c8-a616-be3f02c9bdf7.png">
