### PR TITLE
Accept Empty Partner Buckets variable in terraform.tfvars

### DIFF
--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -100,18 +100,14 @@ data "aws_iam_policy_document" "api_root" {
     actions = [
       "s3:GetObject",
     ]
-    resources = [
+    resources = concat(
+      [
       "arn:aws:s3:::${var.threat_exchange_data.bucket_name}/${var.threat_exchange_data.data_folder}*",
-    ]
+    ],
+    [for partner_bucket in var.partner_image_buckets: "${partner_bucket.arn}/*"]
+    )
   }
-
-    statement {
-    effect = "Allow"
-    actions = [
-      "s3:GetObject",
-    ]
-    resources = [for partner_bucket in var.partner_image_buckets: "${partner_bucket.arn}/*"]
-  }
+  
   statement {
     effect = "Allow"
     actions = [


### PR DESCRIPTION
Summary
---------

Not having a partner_bucket var in terraform.tfvars was throwing the following error:

│ Error: Error updating IAM policy arn:aws:iam::521978645842:policy/jeberl_api_root_role_policy20210615212904550900000005: MalformedPolicyDocument: Policy statement must contain resources.
│ 	status code: 400, request id: 24b32dc9-bf43-4611-afe1-e65246ac187b
│
│   with module.api.aws_iam_policy.api_root,
│   on api/main.tf line 159, in resource "aws_iam_policy" "api_root":
│  159: resource "aws_iam_policy" "api_root" {

combined two statements in policy document so its never empty

Test Plan
---------

1. Remove partner_bucket variable
2. Run `terraform -chdir=terraform apply`
3. Runs correctly