### PR TITLE
Send additional fields in Action responses

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/actioner_models.py
+++ b/hasher-matcher-actioner/hmalib/common/actioner_models.py
@@ -4,10 +4,9 @@ import hmalib.common.config as config
 import json
 import typing as t
 
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass
 from hmalib.common.logging import get_logger
 from hmalib.common.message_models import MatchMessage
-from hmalib.common.classification_models import ActionLabel, Label
 from hmalib.common.aws_dataclass import HasAWSSerialization
 from requests import get, post, put, delete, Response
 

--- a/hasher-matcher-actioner/hmalib/common/message_models.py
+++ b/hasher-matcher-actioner/hmalib/common/message_models.py
@@ -16,6 +16,7 @@ from hmalib.common.classification_models import (
     PendingOpinionChange,
 )
 from hmalib.common.evaluator_models import ActionLabel, ActionRule
+from hmalib.common.content_models import ContentObject
 from hmalib.common.aws_dataclass import HasAWSSerialization
 from hmalib.common.image_sources import S3BucketImageSource
 from hmalib.common.logging import get_logger
@@ -84,12 +85,16 @@ class ActionMessage(MatchMessage):
     action_label: ActionLabel = ActionLabel("UnspecifiedAction")
     action_rules: t.List[ActionRule] = field(default_factory=list)
 
+    # from content
+    additional_fields: t.List[str] = field(default_factory=list)
+
     @classmethod
     def from_match_message_action_label_and_action_rules(
         cls,
         match_message: MatchMessage,
         action_label: ActionLabel,
         action_rules: t.List[ActionRule],
+        additional_fileds=t.List[str],
     ) -> "ActionMessage":
         return cls(
             match_message.content_key,
@@ -97,6 +102,7 @@ class ActionMessage(MatchMessage):
             match_message.matching_banked_signals,
             action_label,
             action_rules,
+            additional_fileds,
         )
 
 

--- a/hasher-matcher-actioner/hmalib/common/message_models.py
+++ b/hasher-matcher-actioner/hmalib/common/message_models.py
@@ -86,7 +86,7 @@ class ActionMessage(MatchMessage):
     action_rules: t.List[ActionRule] = field(default_factory=list)
 
     # from content
-    additional_fields: t.Dict[str, str] = field(default_factory=dict)
+    additional_fields: t.List[str] = field(default_factory=list)
 
     @classmethod
     def from_match_message_action_label_action_rules_and_additional_fields(
@@ -94,7 +94,7 @@ class ActionMessage(MatchMessage):
         match_message: MatchMessage,
         action_label: ActionLabel,
         action_rules: t.List[ActionRule],
-        additional_fields=t.Dict[str, str],
+        additional_fields=t.List[str],
     ) -> "ActionMessage":
         return cls(
             match_message.content_key,

--- a/hasher-matcher-actioner/hmalib/common/message_models.py
+++ b/hasher-matcher-actioner/hmalib/common/message_models.py
@@ -86,15 +86,15 @@ class ActionMessage(MatchMessage):
     action_rules: t.List[ActionRule] = field(default_factory=list)
 
     # from content
-    additional_fields: t.List[str] = field(default_factory=list)
+    additional_fields: t.Dict[str, str] = field(default_factory=dict)
 
     @classmethod
-    def from_match_message_action_label_and_action_rules(
+    def from_match_message_action_label_action_rules_and_additional_fields(
         cls,
         match_message: MatchMessage,
         action_label: ActionLabel,
         action_rules: t.List[ActionRule],
-        additional_fileds=t.List[str],
+        additional_fields=t.Dict[str, str],
     ) -> "ActionMessage":
         return cls(
             match_message.content_key,
@@ -102,7 +102,7 @@ class ActionMessage(MatchMessage):
             match_message.matching_banked_signals,
             action_label,
             action_rules,
-            additional_fileds,
+            additional_fields,
         )
 
 

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -90,20 +90,24 @@ def lambda_handler(event, context):
             match_message.content_key,
         )
 
+        # Convert to dict becuase JSON can't serialize Sets for Action Message
+        # plus we think of these fields as key: value anyways
+        additional_fields: t.Dict[str, str] = dict(
+            field.split(":", 1) for field in submitted_content.additional_fields
+        )
+
+        # TODO: Convert AdditionalFields to ActionRules for determining if rule should be processed
         action_label_to_action_rules = get_actions_to_take(
             match_message,
             action_rules,
-            submitted_content.additional_fields,
         )
         action_labels = list(action_label_to_action_rules.keys())
         for action_label in action_labels:
-            action_message = (
-                ActionMessage.from_match_message_action_label_and_action_rules(
-                    match_message,
-                    action_label,
-                    action_label_to_action_rules[action_label],
-                    submitted_content.additional_fields,
-                )
+            action_message = ActionMessage.from_match_message_action_label_action_rules_and_additional_fields(
+                match_message,
+                action_label,
+                action_label_to_action_rules[action_label],
+                additional_fields,
             )
 
             logger.info("Sending Action message: %s", action_message)
@@ -123,22 +127,16 @@ def lambda_handler(event, context):
 def get_actions_to_take(
     match_message: MatchMessage,
     action_rules: t.List[ActionRule],
-    additional_fields_on_content: t.Dict[str, str],
 ) -> t.Dict[ActionLabel, t.List[ActionRule]]:
     """
     Returns action labels for each action rule that applies to a match message.
     """
     action_label_to_action_rules: t.Dict[ActionLabel, t.List[ActionRule]] = dict()
 
-    # Content Classifications are derived from additional_fields
-    content_classifications = {
-        Label(*field) for field in additional_fields_on_content.items()
-    }
-
     for banked_signal in match_message.matching_banked_signals:
         for action_rule in action_rules:
             if action_rule_applies_to_classifications(
-                action_rule, banked_signal.classifications | content_classifications
+                action_rule, banked_signal.classifications
             ):
                 if action_rule.action_label in action_label_to_action_rules:
                     action_label_to_action_rules[action_rule.action_label].append(
@@ -175,22 +173,6 @@ def action_rule_applies_to_classifications(
     ) and action_rule.must_not_have_labels.isdisjoint(classifications)
 
 
-def get_actions() -> t.List[Action]:
-    """
-    TODO implement
-    Returns the Action objects stored in the config repository. Each Action will have
-    the following attributes: ActionLabel, Priority, SupersededByActionLabel (Priority
-    and SupersededByActionLabel are used by remove_superseded_actions).
-    """
-    return [
-        Action(
-            ActionLabel("EnqueueForReview"),
-            1,
-            [ActionLabel("A_MORE_IMPORTANT_ACTION")],
-        )
-    ]
-
-
 def remove_superseded_actions(
     action_label_to_action_rules: t.Dict[ActionLabel, t.List[ActionRule]],
 ) -> t.Dict[ActionLabel, t.List[ActionRule]]:
@@ -208,15 +190,15 @@ if __name__ == "__main__":
     HMAConfig.initialize(os.environ["CONFIG_TABLE_NAME"])
     action_rules = get_action_rules()
     match_message = MatchMessage(
-        content_key="images/200200.jpg",
-        content_hash="20f66f3a2e6eff06d895a8f421c045e1c76f0bf87652d72ce7249412d8d52acc",
+        content_key="c6",
+        content_hash="361da9e6cf1b72f5cea0344e5bb6e70939f4c70328ace762529cac704297354a",
         matching_banked_signals=[
             BankedSignal(
-                banked_content_id="3534976909868947",
-                bank_id="303636684709969",
+                banked_content_id="3070359009741438",
+                bank_id="258601789084078",
                 bank_source="te",
                 classifications={
-                    Label(key="BankIDClassification", value="303636684709969"),
+                    Label(key="BankIDClassification", value="258601789084078"),
                     Label(key="Classification", value="true_positive"),
                     Label(key="BankSourceClassification", value="te"),
                     Label(
@@ -226,7 +208,8 @@ if __name__ == "__main__":
             )
         ],
     )
-    action_label_to_action_rules = get_actions_to_take(
-        match_message, action_rules, {"Added": "field"}
-    )
-    action_labels = list(action_label_to_action_rules.keys())
+
+    event = {
+        "Records": [{"body": json.dumps({"Message": match_message.to_aws_json()})}]
+    }
+    lambda_handler(event, None)

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -30,7 +30,6 @@ from mypy_boto3_dynamodb.service_resource import Table, DynamoDBServiceResource
 
 
 logger = get_logger(__name__)
-dynamodb: DynamoDBServiceResource = boto3.resource("dynamodb")
 
 
 @dataclass
@@ -55,6 +54,8 @@ class ActionEvaluatorConfig:
         )
         HMAConfig.initialize(os.environ["CONFIG_TABLE_NAME"])
         dynamo_db_table_name = os.environ["DYNAMODB_TABLE"]
+
+        dynamodb: DynamoDBServiceResource = boto3.resource("dynamodb")
 
         return cls(
             actions_queue_url=os.environ["ACTIONS_QUEUE_URL"],

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -91,12 +91,6 @@ def lambda_handler(event, context):
             match_message.content_key,
         )
 
-        # Convert to dict becuase JSON can't serialize Sets for Action Message
-        # plus we think of these fields as key: value anyways
-        additional_fields: t.Dict[str, str] = dict(
-            field.split(":", 1) for field in submitted_content.additional_fields
-        )
-
         # TODO: Convert AdditionalFields to ActionRules for determining if rule should be processed
         action_label_to_action_rules = get_actions_to_take(
             match_message,
@@ -108,7 +102,7 @@ def lambda_handler(event, context):
                 match_message,
                 action_label,
                 action_label_to_action_rules[action_label],
-                additional_fields,
+                list(submitted_content.additional_fields),
             )
 
             logger.info("Sending Action message: %s", action_message)

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_performer.py
@@ -1,19 +1,15 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-import json
 import os
 import boto3
-import typing as t
 import datetime
 from functools import lru_cache
 from mypy_boto3_dynamodb import DynamoDBServiceResource
 
-from hmalib.common.message_models import BankedSignal, ActionMessage, MatchMessage
+from hmalib.common.message_models import ActionMessage
 from hmalib.common.actioner_models import (
     ActionPerformer,
-    WebhookPostActionPerformer,
 )
-from hmalib.common.evaluator_models import ActionLabel
 from hmalib.common.content_models import ActionEvent
 from hmalib.common.logging import get_logger
 from hmalib.common import config

--- a/hasher-matcher-actioner/hmalib/models.py
+++ b/hasher-matcher-actioner/hmalib/models.py
@@ -1,14 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import datetime
-from enum import Enum
 import typing as t
-import json
-from dataclasses import dataclass, field
-from decimal import Decimal
-from boto3 import client
+from dataclasses import dataclass
 from mypy_boto3_dynamodb.service_resource import Table
-from boto3.dynamodb.conditions import Attr, Key, And
+from boto3.dynamodb.conditions import Attr, Key
 from botocore.exceptions import ClientError
 
 """

--- a/hasher-matcher-actioner/terraform/actions/main.tf
+++ b/hasher-matcher-actioner/terraform/actions/main.tf
@@ -103,6 +103,7 @@ resource "aws_lambda_function" "action_evaluator" {
       ACTIONS_QUEUE_URL    = aws_sqs_queue.actions_queue.id,
       WRITEBACKS_QUEUE_URL = aws_sqs_queue.writebacks_queue.id,
       CONFIG_TABLE_NAME    = var.config_table.name,
+      DYNAMODB_TABLE       = var.datastore.name
     }
   }
 }
@@ -244,6 +245,14 @@ data "aws_iam_policy_document" "action_evaluator" {
     effect    = "Allow"
     actions   = ["cloudwatch:PutMetricData"]
     resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:Get*",
+    ]
+    resources = [var.datastore.arn]
   }
 }
 


### PR DESCRIPTION
Summary
---------

We currently accept "AdditionalFields" when partners submit content but don't do anything with the fields they provide. This PR includes additional_fields in Webhooks when sent.

A future PR will add the ability to filter by additional_fields in actionRules 

Note: Also did some clean up of imports in files I touched

Test Plan
---------

1. Create Action and ActionRule that sends all TE matches to webhook https://webhook.site/81bf390d-d2e3-4757-989d-9822a81d85dd/4abcd206-e1cd-40f2-8514-1eb5511abe4f/1
1.  Submit matching Content to HMA with 2 additional_fields set 
2. Confirm that additional fields are included in Webhook response here: https://webhook.site/#!/81bf390d-d2e3-4757-989d-9822a81d85dd/4abcd206-e1cd-40f2-8514-1eb5511abe4f/1

![Screen Shot 2021-08-03 at 3 54 04 PM](https://user-images.githubusercontent.com/24800630/128077561-38da8c0c-404a-4963-8878-ba1a246fc5dd.png)
![Screen Shot 2021-08-03 at 3 54 16 PM](https://user-images.githubusercontent.com/24800630/128077595-b4ce7902-89ee-4903-8a56-157a9001935d.png)

