### PR TITLE
Increase requests version to >=2.26.0

### DIFF
--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -56,7 +56,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         "python-Levenshtein",
-        "requests",
+        "requests>=2.26.0",
         "dataclasses",
         "python-dateutil",
     ],


### PR DESCRIPTION
Summary
---------

## Partner request: Make version of `requests` package more explicit


Test Plan
---------

Partner mentioned version `2.26.0` explicitly. Confirmed that I had been running this version locally as well:

```
jeberl@1f611a8224ba:/workspaces/ThreatExchange/hasher-matcher-actioner$ pip show requests
Name: requests
Version: 2.26.0
Summary: Python HTTP for Humans.
Home-page: https://requests.readthedocs.io
Author: Kenneth Reitz
Author-email: me@kennethreitz.org
License: Apache 2.0
Location: /home/jeberl/.local/lib/python3.8/site-packages
Requires: idna, charset-normalizer, certifi, urllib3
Required-by: threatexchange, responses, moto
```

Wasn't sure how to test the setup.py changes explicitly and looks like we haven't been doing this in the past (#347) but this change should be pretty naive