### PR TITLE
[hma][ui] Update additional fields in submit form to reflect API backend.

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/SubmitContentFields.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/SubmitContentFields.jsx
@@ -149,21 +149,7 @@ export function OptionalAdditionalFields({
           <Form.Group as={Col}>
             <InputGroup>
               <InputGroup.Prepend>
-                <InputGroup.Text>Key</InputGroup.Text>
-              </InputGroup.Prepend>
-              <Form.Control
-                onChange={e => {
-                  const copy = {...additionalFields};
-                  copy[entry].key = e.target.value;
-                  setAdditionalFields(copy);
-                }}
-              />
-            </InputGroup>
-          </Form.Group>
-          <Form.Group as={Col}>
-            <InputGroup>
-              <InputGroup.Prepend>
-                <InputGroup.Text>Value</InputGroup.Text>
+                <InputGroup.Text>Field</InputGroup.Text>
               </InputGroup.Prepend>
               <Form.Control
                 onChange={e => {

--- a/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
@@ -70,9 +70,8 @@ export default function SubmitContent() {
   const packageAdditionalFields = () => {
     const entries = [];
     Object.values(additionalFields).forEach(entry =>
-      // store key:value for now to avoid collisions/overwrite of repeats
-      // exact extra additional fields spec should be established in documentation
-      entries.push(`${entry.key}:${entry.value}`),
+      // TODO extra additional fields spec should be established in documentation
+      entries.push(`${entry.value}`),
     );
     return entries;
   };


### PR DESCRIPTION
Summary
---------

Additional fields on content objects are currently a set of strings. If we want to make them a key-value pair in the future we can however the UI should match the current backend as it exists now to avoid confusion. 
  
Test Plan
---------
Did a full submit to verify functionality. 
Old form: 
<img width="1234" alt="Screen Shot 2021-08-04 at 2 16 33 PM" src="https://user-images.githubusercontent.com/7664526/128233341-cf23a5ed-2823-4fce-9937-f7bce033cb3d.png">

Form now looks like this:
<img width="1173" alt="Screen Shot 2021-08-04 at 2 12 07 PM" src="https://user-images.githubusercontent.com/7664526/128233128-20e89811-0c03-45d2-9354-e08d841221a9.png">
