### PR TITLE
Fix Content ID Bug In Partner Bucket Uploads

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -57,8 +57,8 @@ class ActionEvaluatorConfig:
             os.environ["DYNAMODB_TABLE"],
         )
         HMAConfig.initialize(os.environ["CONFIG_TABLE_NAME"])
-        dynamo_db_table_name = os.environ["DYNAMODB_TABLE"]
 
+        dynamo_db_table_name = os.environ["DYNAMODB_TABLE"]
         dynamodb: DynamoDBServiceResource = boto3.resource("dynamodb")
 
         return cls(

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -7,6 +7,7 @@ import json
 import typing as t
 from apig_wsgi import make_lambda_handler
 from bottle import response, error
+from uuid import uuid4
 
 from hmalib.common.logging import get_logger
 
@@ -117,21 +118,33 @@ def submit_content_request_from_s3_event_record(
 ) -> SubmitContentRequestBody:
     """
     Converts s3 event into a SubmitContentRequestBody object with a URL to the content
-    """
-    # For partner buckets we use the full bucket name and key as the content ID to avoid collisions with
-    # existing objects
-    bucket = record["bucket"]["name"]
-    key = record["object"]["key"]
-    content_id = bucket + "/" + key
 
-    url = create_presigned_url(bucket, key, None, 3600, "get_object")
+    For partner bucket uploads the content IDs are unique and human understandable but
+    not reversable
+      * uniqueness is provided by uuid4 which has a collision rate of 2^-36
+      * human understandbility is provided by including the (slightly modified) key
+        in the content id
+      * modifications to the key mean that the original content bucket and key are
+        not derivable from the content ID alone
+
+    The original contnet (bucket and key) is stored in the reference url which is passed
+    to the webhook via additional_fields
+    """
+    bucket: str = record["bucket"]["name"]
+    key: str = record["object"]["key"]
+
+    readable_key = key.replace("/", ".").replace("?", ".").replace("&", ".")
+    content_id = f"{uuid4()}-{readable_key}"
+
+    presigned_url = create_presigned_url(bucket, key, None, 3600, "get_object")
+    reference_url = f"https://{bucket}.s3.amazonaws.com/{key}"
 
     return SubmitContentRequestBody(
         submission_type="FROM_URL",
         content_id=content_id,
         content_type="PHOTO",
-        content_bytes_url_or_file_type=url,
-        additional_fields=None,
+        content_bytes_url_or_file_type=presigned_url,
+        additional_fields=[f"partner_s3_reference_url:{reference_url}"],
     )
 
 

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -119,21 +119,23 @@ def submit_content_request_from_s3_event_record(
     """
     Converts s3 event into a SubmitContentRequestBody object with a URL to the content
 
-    For partner bucket uploads the content IDs are unique and human understandable but
+    For partner bucket uploads, the content IDs are unique and (somewhat) readable but
     not reversable
       * uniqueness is provided by uuid4 which has a collision rate of 2^-36
-      * human understandbility is provided by including the (slightly modified) key
-        in the content id
+      * readability is provided by including part of the key in the content id
       * modifications to the key mean that the original content bucket and key are
         not derivable from the content ID alone
 
     The original contnet (bucket and key) is stored in the reference url which is passed
     to the webhook via additional_fields
+
+    Q: Why not include full key and bucket in content_id?
+    A: Bucket keys often have "/" which dont work well with ContentDetails UI page
     """
     bucket: str = record["bucket"]["name"]
     key: str = record["object"]["key"]
 
-    readable_key = key.replace("/", ".").replace("?", ".").replace("&", ".")
+    readable_key = key.split("/")[-1].replace("?", ".").replace("&", ".")
     content_id = f"{uuid4()}-{readable_key}"
 
     presigned_url = create_presigned_url(bucket, key, None, 3600, "get_object")


### PR DESCRIPTION
See #738 for context and test plan. Will be easier to review with a new PR and rebase



Test Plan
---------

1. Create a new bucket `jesses-separate-aws-bucket` in the UI that is not controlled by terraform to simulate a separate bucket owned by a partner
2. Add the following line to my `terraform.tfvars` file:
```
local_image_buckets = [{"name": "jesses-separate-aws-bucket", "arn" : "arn:aws:s3:::jesses-separate-aws-bucket"}]
```
3. `make upload_docker && terraform -chdir=terraform apply`
4. using the AWS UI upload images to the bucket
5. Through logs watch them be processed by the api_root lambda, added to the sqs queue, and then loaded and hashed by the pdq_hasher: ![image](https://user-images.githubusercontent.com/24800630/128760967-ea23b9b7-dcfb-4c8b-8e62-4205573820ca.png)