### PR TITLE
[hma][ui] Remove old direct upload option

### DIFF
--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -158,27 +158,6 @@ export async function submitContentPostURLUpload(
   return result;
 }
 
-export async function submitContentDirectUpload(
-  submissionType,
-  contentId,
-  contentType,
-  content,
-  additionalFields,
-) {
-  const fileReader = new FileReader();
-  fileReader.onload = () => {
-    const fileContentsBase64Encoded = encode(fileReader.result);
-    apiPost('/submit/', {
-      submission_type: submissionType,
-      content_id: contentId,
-      content_type: contentType,
-      content_bytes_url_or_file_type: fileContentsBase64Encoded,
-      additional_fields: additionalFields,
-    });
-  };
-  return fileReader.readAsArrayBuffer(content);
-}
-
 export function fetchAllDatasets() {
   return apiGet('/datasets/');
 }

--- a/hasher-matcher-actioner/webapp/src/pages/ContentDetails.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/ContentDetails.jsx
@@ -21,22 +21,38 @@ export default function ContentDetails() {
   const [hashDetails, setHashDetails] = useState(null);
   const [img, setImage] = useState(null);
 
+  // Catch the following promises because it is possible for the endpoint to
+  // return error codes if the content values are not yet populated if users come
+  /// to this page right after submit
   useEffect(() => {
-    fetchHash(id).then(hash => {
-      setHashDetails(hash);
-    });
+    fetchHash(id)
+      .then(hash => {
+        setHashDetails(hash);
+      })
+      .catch(_ => {
+        setHashDetails(null);
+      });
   }, []);
 
   useEffect(() => {
-    fetchImage(id).then(result => {
-      setImage(URL.createObjectURL(result));
-    });
+    fetchImage(id)
+      .then(result => {
+        setImage(URL.createObjectURL(result));
+      })
+      .catch(_ => {
+        // ToDo put a 'not found' image
+        setImage(null);
+      });
   }, []);
 
   useEffect(() => {
-    fetchContentDetails(id).then(result => {
-      setContentDetails(result);
-    });
+    fetchContentDetails(id)
+      .then(result => {
+        setContentDetails(result);
+      })
+      .catch(_ => {
+        setContentDetails(null);
+      });
   }, []);
 
   return (

--- a/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
@@ -14,11 +14,7 @@ import {
 } from 'react-bootstrap';
 import {Link} from 'react-router-dom';
 
-import {
-  submitContent,
-  submitContentDirectUpload,
-  submitContentPostURLUpload,
-} from '../Api';
+import {submitContent, submitContentPostURLUpload} from '../Api';
 import {SUBMISSION_TYPE} from '../utils/constants';
 
 import {
@@ -79,18 +75,7 @@ export default function SubmitContent() {
   const handleSubmit = event => {
     event.preventDefault();
     setSubmitting(true);
-    if (inputs.submissionType === 'DIRECT_UPLOAD') {
-      submitContentDirectUpload(
-        inputs.submissionType,
-        inputs.contentId,
-        inputs.contentType,
-        inputs.content.raw,
-        packageAdditionalFields(),
-      ).then(() => {
-        setSubmitting(false);
-        setSubmittedId(inputs.contentId);
-      });
-    } else if (inputs.submissionType === 'POST_URL_UPLOAD') {
+    if (inputs.submissionType === 'POST_URL_UPLOAD') {
       submitContentPostURLUpload(
         inputs.submissionType,
         inputs.contentId,
@@ -154,13 +139,6 @@ export default function SubmitContent() {
 
             <Form.Group>
               <Form.Row>
-                {submissionType === SUBMISSION_TYPE.DIRECT_UPLOAD && (
-                  <PhotoUploadField
-                    inputs={inputs}
-                    handleInputChangeUpload={handleInputChangeUpload}
-                  />
-                )}
-
                 {submissionType === SUBMISSION_TYPE.FROM_URL && (
                   <Form.Group>
                     <Form.Label>Provide a URL to the content</Form.Label>

--- a/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
@@ -51,7 +51,7 @@ export default function SubmitContent() {
   // - give a preview of the image to user
   // - auto populate the content id if it is currently empty
   const handleInputChangeUpload = event => {
-    const file = event.nativeEvent.path[0].files[0];
+    const file = event.target.files[0];
     const contentId = inputs.contentId ?? file.name;
     setInputs(inputs_ => ({
       ...inputs_,

--- a/hasher-matcher-actioner/webapp/src/utils/constants.jsx
+++ b/hasher-matcher-actioner/webapp/src/utils/constants.jsx
@@ -21,7 +21,7 @@ export const PENDING_OPINION_CHANGE = Object.freeze({
 // Corseponds  SubmissionType in hmalib/api/submit.py
 export const SUBMISSION_TYPE = Object.freeze({
   POST_URL_UPLOAD: 'Upload',
-  DIRECT_UPLOAD: 'Direct Upload (~faster but only works for images < 3.5MB)',
+  // DIRECT_UPLOAD: 'Direct Upload (~faster but only works for images < 3.5MB)', todo delete this and remove class SubmissionType(Enum): from submit.py
   FROM_URL: 'From URL',
 });
 


### PR DESCRIPTION
Summary
---------

Having both an 'upload' and a 'direct upload' option is confusing and unnecessary for the submit UI.  It is still possible the  soon to be renamed 'direct submit' endpoint could be useful outside of the UI context for sending bytes directly in one request, so leaving that for now. It fails for large images anyway...

One of  the reasons I had kept it around up until now was actually because of #598 so folks could still ~demo HMA using Firefox. As a part of this removal I also tried to fix #598.  Which was easier to fix now that we only have one upload flow as I was able to just remove the need to get the path which is not supported the same way in all browsers. 

Test Plan
---------

Made sure the remaining 'upload' flow works for both Firefox and Chrome. If you'd like a demo video and/or screenshots let me know. 
