### PR TITLE
[hma][api] Split submit API into different paths for each submission type.

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -1,12 +1,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import functools
-from hmalib.common.image_sources import S3BucketImageSource
 import bottle
 import boto3
 import base64
 import json
 import datetime
+import dataclasses
 
 from enum import Enum
 from dataclasses import dataclass, asdict
@@ -15,13 +15,12 @@ from botocore.exceptions import ClientError
 import typing as t
 
 from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
+from hmalib.common.image_sources import S3BucketImageSource
 from hmalib.common.content_models import ContentObject, ContentRefType, ContentType
 from hmalib.common.logging import get_logger
 from hmalib.common.message_models import URLImageSubmissionMessage
 
 logger = get_logger(__name__)
-s3_client = boto3.client("s3")
-dynamodb = boto3.resource("dynamodb")
 
 
 @functools.lru_cache(maxsize=None)
@@ -59,8 +58,59 @@ def create_presigned_url(bucket_name, key, file_type, expiration, client_method)
     return response
 
 
+# Request Objects
 @dataclass
-class InitUploadResponse(JSONifiable):
+class SubmitRequestBodyBase(DictParseable):
+    content_id: str
+    content_type: str  # TODO: change to content_type enum from TE
+    additional_fields: t.Optional[t.List]
+
+    def get_content_ref_details(self) -> t.Tuple[str, ContentRefType]:
+        raise NotImplementedError
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(**{f.name: d.get(f.name, None) for f in dataclasses.fields(cls)})
+
+
+@dataclass
+class SubmitContentViaURLRequestBody(SubmitRequestBodyBase):
+    content_url: str
+
+    def get_content_ref_details(self) -> t.Tuple[str, ContentRefType]:
+        return (self.content_url, ContentRefType.URL)
+
+
+@dataclass
+class SubmitContentBytesRequestBody(SubmitRequestBodyBase):
+    content_bytes: bytes
+
+    def get_content_ref_details(self) -> t.Tuple[str, ContentRefType]:
+        return (self.content_id, ContentRefType.DEFAULT_S3_BUCKET)
+
+
+@dataclass
+class SubmitContentViaPostURLUploadRequestBody(SubmitRequestBodyBase):
+    file_type: str
+
+    def get_content_ref_details(self) -> t.Tuple[str, ContentRefType]:
+        # Treat this as an S3 submission because
+        # we expect the client to upload it there directly
+        return (self.content_id, ContentRefType.DEFAULT_S3_BUCKET)
+
+
+# Response Objects
+@dataclass
+class SubmitResponse(JSONifiable):
+    content_id: str
+    submit_successful: bool
+
+    def to_json(self) -> t.Dict:
+        return asdict(self)
+
+
+@dataclass
+class SubmitViaUploadUrlResponse(JSONifiable):
     content_id: str
     file_type: str
     presigned_url: str
@@ -70,52 +120,7 @@ class InitUploadResponse(JSONifiable):
 
 
 @dataclass
-class InitUploadRequestBody(DictParseable):
-    content_id: str
-    file_type: str
-
-    @classmethod
-    def from_dict(cls, d):
-        return cls(d["content_id"], d["file_type"])
-
-
-class SubmissionType(Enum):
-    POST_URL_UPLOAD = "Upload"
-    DIRECT_UPLOAD = "Direct Upload (~faster but only works for images < 3.5MB)"
-    FROM_URL = "From URL"
-
-
-@dataclass
-class SubmitContentRequestBody(DictParseable):
-    submission_type: str  # Enum SubmissionType names
-    content_id: str
-    content_type: str  # Only PHOTO supported. TODO: @schatten change to content_type enum
-    content_bytes_url_or_file_type: t.Union[str, bytes]
-    additional_fields: t.Optional[t.List]
-
-    @classmethod
-    def from_dict(cls, d):
-        # ToDo Cleaner error handling
-        return cls(
-            d["submission_type"],
-            d["content_id"],
-            d["content_type"],
-            d["content_bytes_url_or_file_type"],
-            d["additional_fields"],
-        )
-
-
-@dataclass
-class SubmitContentResponse(JSONifiable):
-    content_id: str
-    submit_successful: bool
-
-    def to_json(self) -> t.Dict:
-        return asdict(self)
-
-
-@dataclass
-class SubmitContentError(JSONifiable):
+class SubmitError(JSONifiable):
     """
     Warning: by default this will still return 200
     you need to update bottle.response.status
@@ -130,59 +135,59 @@ class SubmitContentError(JSONifiable):
         return asdict(self)
 
 
-def record_content_submission(dynamodb_table: Table, request: SubmitContentRequestBody):
+def record_content_submission(
+    dynamodb_table: Table,
+    content_id: str,
+    content_type: ContentType,
+    content_ref: str,
+    content_ref_type: ContentRefType,
+    additional_fields: t.Set = set(),
+):
+    """
+    Write a content object that is submitted to the dynamodb_table.
+
+    Note: this method does not store the data of the content itself
+    If we want to store the media itself that is done either:
+    - by a client using a presign url we give them
+    - direct s3 put call in the case of raw bytes
+    - not at all in the case of CDN-URL submission
+        - (WIP: possibly done after a match is found)
+
+    This function is also called directly by api_root when handling s3 uploads to partner
+    banks. If editing, ensure the logic in api_root.process_s3_event is still correct
+    """
     # TODO add a confirm overwrite path for this
     submit_time = datetime.datetime.now()
-    if request.submission_type in (
-        SubmissionType.FROM_URL,
-        SubmissionType.FROM_URL.name,
-    ):
-        # ^ Someday we'll have type inference between enum and enum values,
-        # until then, this is how it is.
-        content_ref_type = ContentRefType.URL
-        content_ref = t.cast(str, request.content_bytes_url_or_file_type)
-    else:
-        # defaults to DEFAULT_S3_BUCKET
-        content_ref_type = ContentRefType.DEFAULT_S3_BUCKET
-        content_ref = request.content_id
-
     ContentObject(
-        content_id=request.content_id,
-        content_type=ContentType(request.content_type or ContentType.PHOTO),
+        content_id=content_id,
+        content_type=content_type,
         content_ref=content_ref,
         content_ref_type=content_ref_type,
-        additional_fields=set(request.additional_fields)
-        if request.additional_fields
-        else set(),
+        additional_fields=additional_fields,
         submission_times=[submit_time],  # Note: custom write_to_table impl appends.
         created_at=submit_time,
         updated_at=submit_time,
     ).write_to_table(dynamodb_table)
 
 
-def submit_from_url(
-    request: SubmitContentRequestBody, dynamodb_table: Table, images_topic_arn: str
-) -> SubmitContentResponse:
+def send_submission_to_url_queue(
+    dynamodb_table: Table,
+    images_topic_arn: str,
+    content_id: str,
+    url: str,
+):
     """
-    Submission via a url to content. This does not store a copy of the content in s3
+    Send a submitted url of content to the hasher. This does not store a copy of the content in s3
 
     This function is also called directly by api_root when handling s3 uploads to partner
     banks. If editing, ensure the logic in api_root.process_s3_event is still correct
     """
-    content_id = request.content_id
-    url = request.content_bytes_url_or_file_type
-
-    # Again, We want to record the submission before triggering and processing on
-    # the content itself therefore we write to dynamo before s3
-    record_content_submission(dynamodb_table, request)
 
     url_submission_message = URLImageSubmissionMessage(content_id, t.cast(str, url))
     _get_sns_client().publish(
         TopicArn=images_topic_arn,
         Message=json.dumps(url_submission_message.to_sqs_message()),
     )
-
-    return SubmitContentResponse(content_id=request.content_id, submit_successful=True)
 
 
 def get_submit_api(
@@ -202,85 +207,102 @@ def get_submit_api(
     submit_api = bottle.Bottle()
     s3_bucket_image_source = S3BucketImageSource(image_bucket, image_prefix)
 
-    # Set of helpers that could be split into there own submit endpoints depending on longterm design choices
+    def _record_content_submission_from_request(
+        request: SubmitRequestBodyBase,
+    ):
+        """
+        Given a request object submission record the content object to the table passed to
+        the API using 'record_content_submission'
+        Note: this method does not store the content media itself.
+        """
 
-    def direct_upload(
-        request: SubmitContentRequestBody,
-    ) -> t.Union[SubmitContentResponse, SubmitContentError]:
+        content_ref, content_ref_type = request.get_content_ref_details()
+
+        record_content_submission(
+            dynamodb_table,
+            content_id=request.content_id,
+            content_type=ContentType(request.content_type or ContentType.PHOTO),
+            content_ref=content_ref,
+            content_ref_type=content_ref_type,
+            additional_fields=set(request.additional_fields)
+            if request.additional_fields
+            else set(),
+        )
+
+    @submit_api.post("/", apply=[jsoninator])
+    def submit() -> SubmitError:
+        """
+        Root for the general submission of content to the system.
+        Currently just provides 400 error code (todo delete, leaving now for debug help)
+        """
+
+        logger.info(f"Submit attempted on root submit endpoint.")
+
+        bottle.response.status = 400
+        return SubmitError(
+            content_id="",
+            message="Submission not supported from just /submit/.",
+        )
+
+    @submit_api.post("/url/", apply=[jsoninator(SubmitContentViaURLRequestBody)])
+    def submit_url(
+        request: SubmitContentViaURLRequestBody,
+    ) -> t.Union[SubmitResponse, SubmitError]:
+        """
+        Submission via a url to content. This does not store a copy of the content in s3
+        """
+        _record_content_submission_from_request(request)
+        send_submission_to_url_queue(
+            dynamodb_table, images_topic_arn, request.content_id, request.content_url
+        )
+
+        return SubmitResponse(content_id=request.content_id, submit_successful=True)
+
+    @submit_api.post("/bytes/", apply=[jsoninator(SubmitContentBytesRequestBody)])
+    def submit_bytes(
+        request: SubmitContentBytesRequestBody,
+    ) -> t.Union[SubmitResponse, SubmitError]:
         """
         Direct transfer of bits to system's s3 bucket
         """
         content_id = request.content_id
-        file_contents = base64.b64decode(request.content_bytes_url_or_file_type)
+        file_contents = base64.b64decode(request.content_bytes)
 
         # We want to record the submission before triggering and processing on
-        # the content itself therefore we write to dynamo before s3
-        record_content_submission(dynamodb_table, request)
+        # the content itself therefore we write to dynamodb before s3
+        _record_content_submission_from_request(request)
 
-        # TODO a whole bunch more validation and error checking...
         s3_bucket_image_source.put_image_bytes(content_id, file_contents)
 
-        return SubmitContentResponse(
-            content_id=request.content_id, submit_successful=True
-        )
+        return SubmitResponse(content_id=request.content_id, submit_successful=True)
 
-    def post_url_upload(
-        request: SubmitContentRequestBody,
-    ) -> t.Union[InitUploadResponse, SubmitContentError]:
+    @submit_api.post(
+        "/post_url/", apply=[jsoninator(SubmitContentViaPostURLUploadRequestBody)]
+    )
+    def submit_post_url(
+        request: SubmitContentViaPostURLUploadRequestBody,
+    ) -> t.Union[SubmitViaUploadUrlResponse, SubmitError]:
         """
         Submission of content to the system's s3 bucket by providing a post url to client
         """
         presigned_url = create_presigned_put_url(
             bucket_name=image_bucket,
             key=s3_bucket_image_source.get_s3_key(request.content_id),
-            file_type=request.content_bytes_url_or_file_type,
+            file_type=request.file_type,
         )
 
         if presigned_url:
-            record_content_submission(dynamodb_table, request)
-            return InitUploadResponse(
+            _record_content_submission_from_request(request)
+            return SubmitViaUploadUrlResponse(
                 content_id=request.content_id,
-                file_type=str(request.content_bytes_url_or_file_type),
+                file_type=str(request.file_type),
                 presigned_url=presigned_url,
             )
 
         bottle.response.status = 400
-        return SubmitContentError(
+        return SubmitError(
             content_id=request.content_id,
-            message="not yet supported",
+            message="Failed to generate upload url",
         )
-
-    def from_url(
-        request: SubmitContentRequestBody,
-    ) -> t.Union[SubmitContentResponse, SubmitContentError]:
-        """
-        Submission via a url to content. This does not store a copy of the content in s3
-        """
-        return submit_from_url(request, dynamodb_table, images_topic_arn)
-
-    @submit_api.post("/", apply=[jsoninator(SubmitContentRequestBody)])
-    def submit(
-        request: SubmitContentRequestBody,
-    ) -> t.Union[SubmitContentResponse, InitUploadResponse, SubmitContentError]:
-        """
-        Endpoint to allow for the general submission of content to the system
-        """
-
-        assert isinstance(request, SubmitContentRequestBody)
-        logger.debug(f"Content Submit Request Received {request.content_id}")
-
-        if request.submission_type == SubmissionType.DIRECT_UPLOAD.name:
-            return direct_upload(request)
-        elif request.submission_type == SubmissionType.POST_URL_UPLOAD.name:
-            return post_url_upload(request)
-        elif request.submission_type == SubmissionType.FROM_URL.name:
-            return from_url(request)
-        else:
-            # Other possible submission types are not supported so just echo content_id for testing
-            bottle.response.status = 422
-            return SubmitContentError(
-                content_id=request.content_id,
-                message="submission_type not yet supported",
-            )
 
     return submit_api

--- a/hasher-matcher-actioner/scripts/get_auth_token
+++ b/hasher-matcher-actioner/scripts/get_auth_token
@@ -103,7 +103,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--username",
         help="username of user in pool",
-        default=f'{os.environ.get("HMA_PREFIX","")}TestUser',
+        default=f'{os.environ.get("HMA_PREFIX","")}testuser',
     )
     parser.add_argument(
         "--pwd",

--- a/hasher-matcher-actioner/scripts/script_utils.py
+++ b/hasher-matcher-actioner/scripts/script_utils.py
@@ -83,15 +83,14 @@ class HasherMatcherActionerAPI:
         content_id: str,
         b64_file_contents: str,
         additional_fields: t.List[str] = [],
-        api_path: str = "/submit/",
     ):
         payload = {
-            "submission_type": "DIRECT_UPLOAD",
             "content_id": content_id,
             "content_type": "PHOTO",
-            "content_bytes_url_or_file_type": b64_file_contents,
             "additional_fields": additional_fields,
+            "content_bytes": b64_file_contents,
         }
+        api_path: str = "/submit/bytes/"
         response = self.session.post(
             self._get_request_url(api_path),
             data=json.dumps(payload).encode("utf-8"),
@@ -103,15 +102,14 @@ class HasherMatcherActionerAPI:
         content_id: str,
         file: t.BinaryIO,
         additional_fields: t.List[str] = [],
-        api_path: str = "/submit/",
     ):
         payload = {
-            "submission_type": "POST_URL_UPLOAD",
             "content_id": content_id,
             "content_type": "PHOTO",
-            "content_bytes_url_or_file_type": "image/jpeg",
             "additional_fields": additional_fields,
+            "file_type": "image/jpeg",
         }
+        api_path: str = "/submit/post_url/"
         response = self.session.post(
             self._get_request_url(api_path),
             data=json.dumps(payload).encode(),
@@ -138,13 +136,12 @@ class HasherMatcherActionerAPI:
         and bypasses s3 completely.
         """
         payload = {
-            "submission_type": "FROM_URL",
             "content_id": content_id,
             "content_type": "PHOTO",
-            "content_bytes_url_or_file_type": url,
             "additional_fields": additional_fields,
+            "content_url": url,
         }
-        api_path: str = "/submit/"
+        api_path: str = "/submit/url/"
         response = self.session.post(
             self._get_request_url(api_path),
             data=json.dumps(payload).encode(),

--- a/hasher-matcher-actioner/scripts/submit_s3_bucket
+++ b/hasher-matcher-actioner/scripts/submit_s3_bucket
@@ -6,6 +6,11 @@ Given an S3 bucket, and enough permissions on the credentials, iterates through
 all items and submits them as presigned URLs to HMA.
 
 Run without arguments for help.
+
+Requires you have AWS credentials to 'get_object' from the bucket passed to the script.    
+Example usage:
+$ ./scripts/submit_s3_bucket --token `cat .authtoken` --prefix "<redacted/s3-object/prefix/>" --api_url https://<redacted>.execute-api.us-east-1.amazonaws.com/ --storm <redacted_bucketname> 
+
 """
 
 import uuid

--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -3,7 +3,6 @@
  */
 
 import {Auth, API} from 'aws-amplify';
-import {encode} from 'base64-arraybuffer';
 
 async function getAuthorizationToken() {
   const currentSession = await Auth.currentSession();
@@ -116,35 +115,31 @@ export async function requestSignalOpinionChange(
   );
 }
 
-export async function submitContent(
-  submissionType,
+export async function submitContentViaURL(
   contentId,
   contentType,
-  content,
   additionalFields,
+  content,
 ) {
-  return apiPost('/submit/', {
-    submission_type: submissionType,
+  return apiPost('/submit/url/', {
     content_id: contentId,
     content_type: contentType,
-    content_bytes_url_or_file_type: content,
     additional_fields: additionalFields,
+    content_url: content,
   });
 }
 
-export async function submitContentPostURLUpload(
-  submissionType,
+export async function submitContentViaPostURLUpload(
   contentId,
   contentType,
-  content,
   additionalFields,
+  content,
 ) {
-  const submitResponse = await apiPost('/submit/', {
-    submission_type: submissionType,
+  const submitResponse = await apiPost('/submit/post_url/', {
     content_id: contentId,
     content_type: contentType,
-    content_bytes_url_or_file_type: content.type,
     additional_fields: additionalFields,
+    file_type: content.type,
   });
 
   const requestOptions = {

--- a/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
@@ -14,7 +14,7 @@ import {
 } from 'react-bootstrap';
 import {Link} from 'react-router-dom';
 
-import {submitContent, submitContentPostURLUpload} from '../Api';
+import {submitContentViaURL, submitContentViaPostURLUpload} from '../Api';
 import {SUBMISSION_TYPE} from '../utils/constants';
 
 import {
@@ -76,23 +76,21 @@ export default function SubmitContent() {
     event.preventDefault();
     setSubmitting(true);
     if (inputs.submissionType === 'POST_URL_UPLOAD') {
-      submitContentPostURLUpload(
-        inputs.submissionType,
+      submitContentViaPostURLUpload(
         inputs.contentId,
         inputs.contentType,
-        inputs.content.raw,
         packageAdditionalFields(),
+        inputs.content.raw,
       ).then(() => {
         setSubmitting(false);
         setSubmittedId(inputs.contentId);
       });
     } else {
-      submitContent(
-        inputs.submissionType,
+      submitContentViaURL(
         inputs.contentId,
         inputs.contentType,
-        inputs.content,
         packageAdditionalFields(),
+        inputs.content,
       ).then(() => {
         setSubmitting(false);
         setSubmittedId(inputs.contentId);
@@ -174,11 +172,7 @@ export default function SubmitContent() {
                   style={{maxHeight: 38}}
                   className="ml-3"
                   variant="primary"
-                  disabled={
-                    submitting ||
-                    submissionType === SUBMISSION_TYPE.RAW ||
-                    submissionType === SUBMISSION_TYPE.S3_OBJECT
-                  }
+                  disabled={submitting}
                   type="submit">
                   Submit
                 </Button>

--- a/hasher-matcher-actioner/webapp/src/utils/constants.jsx
+++ b/hasher-matcher-actioner/webapp/src/utils/constants.jsx
@@ -21,7 +21,6 @@ export const PENDING_OPINION_CHANGE = Object.freeze({
 // Corseponds  SubmissionType in hmalib/api/submit.py
 export const SUBMISSION_TYPE = Object.freeze({
   POST_URL_UPLOAD: 'Upload',
-  // DIRECT_UPLOAD: 'Direct Upload (~faster but only works for images < 3.5MB)', todo delete this and remove class SubmissionType(Enum): from submit.py
   FROM_URL: 'From URL',
 });
 


### PR DESCRIPTION
Summary
---------

Note: Reviewing commit by commit or as one should both work. RC and ask for commit level details as desired. 

The Submit API as it exists right now [wiki](https://github.com/facebook/ThreatExchange/wiki/Content-Submissions-API) (to be updated post merge), is really 3 different APIs on the same path using an enum so the server can tell requests apart (this isn't great. my bad).

This PR removes 'just make it work' `/submit/` Swiss army endpoint and creates the following three endpoints:
- /submit/url/ - (formerly `SubmissionType.FROM_URL`)
- /submit/bytes/ - (formerly `SubmissionType.DIRECT_UPLOAD`)
- /submit/post_url/ - (formerly `SubmissionType.POST_URL_UPLOAD`)

Luckily due to good client library abstraction, the [UI](https://github.com/facebook/ThreatExchange/commit/d0ca18e1b9ab07121e908de9a4e783c11e7638d1) and [python script](https://github.com/facebook/ThreatExchange/commit/7b08e08a332b3437a0b4cefd15eeac0471c0fd79) changes were very straight forward.

The largest commit where the breakup actually occurs is [here](https://github.com/facebook/ThreatExchange/commit/546168c0cb278845507eac3205948d5c0193326a)

Also in this PR: I didn't like the root_api.py used a request object like `SubmitContentRequestBody` so since I had to change that anyway I broke up the impl it was using into two methods called in both flows instead (see `record_content_submission` and `send_submission_to_url_queue` in submit.py for details).

Test Plan
---------

Tested the following submit flows to ensure they still worked (to my surprise they did):
- Manual submission on the UI (both Upload and URL)
- `make dev_test_instance` which is (`scripts/submit_content_test.py`)
- `scripts/submit_s3_bucket` which I updated the doc-string of as well.
- `scripts/storm_submissions_api` (to test bytes submissions) 
- more testing ongoing as part of this + future PRs

