### PR TITLE
`ContentObject` queries no longer require `content_type` #756

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/tests/test_content_models.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_content_models.py
@@ -120,7 +120,7 @@ class TestContentModels(DynamoDBTableTestBase, unittest.TestCase):
         result = self.get_table().get_item(
             Key={
                 "PK": f"c#{TestContentModels.TEST_CONTENT_ID}",
-                "SK": "content_type#photo",
+                "SK": ContentObject.CONTENT_STATIC_SK,
             }
         )
         item = result.get("Item")
@@ -154,7 +154,7 @@ class TestContentModels(DynamoDBTableTestBase, unittest.TestCase):
         obj.write_to_table(self.get_table())
 
         query_obj = ContentObject.get_from_content_id(
-            self.get_table(), TestContentModels.TEST_CONTENT_ID, PhotoContent
+            self.get_table(), TestContentModels.TEST_CONTENT_ID
         )
 
         assert obj == query_obj

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -92,10 +92,8 @@ def lambda_handler(event, context):
 
         logger.info("Evaluating against action_rules: %s", action_rules)
 
-        # TODO: This is hardcoded to photos for now. #756 requires that we
-        # remove the need for content_type for ContentObject queries.
         submitted_content = ContentObject.get_from_content_id(
-            config.dynamo_db_table, match_message.content_key, PhotoContent
+            config.dynamo_db_table, match_message.content_key
         )
 
         action_label_to_action_rules = get_actions_to_take(

--- a/hasher-matcher-actioner/hmalib/lambdas/api/content.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/content.py
@@ -10,7 +10,6 @@ from boto3.dynamodb.conditions import Attr, Key, Or
 from botocore.exceptions import ClientError
 import typing as t
 
-from threatexchange.content_type.photo import PhotoContent
 
 from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
 from hmalib.models import PipelineHashRecord
@@ -18,7 +17,6 @@ from hmalib.common.content_models import (
     ContentObject,
     ActionEvent,
     ContentRefType,
-    ContentType,
 )
 from hmalib.common.content_sources import S3BucketContentSource
 from hmalib.common.logging import get_logger
@@ -64,18 +62,11 @@ def get_content_api(
         """
         Content object for a given ID see
         hmalib/commom/content_models.ContentObject for specific fields
-
-        TODO: Change the data model so that it does not require content_type,
-        uniqueness and references should be maintainable without requiring
-        content_type.
         """
         content_id = bottle.request.query.content_id or None
-        content_type = bottle.request.query.content_type
 
-        if content_id and content_type:
-            return ContentObject.get_from_content_id(
-                dynamodb_table, f"{content_id}", content_type=content_type
-            )
+        if content_id:
+            return ContentObject.get_from_content_id(dynamodb_table, content_id)
         return None
 
     @content_api.get("/action-history/", apply=[jsoninator])
@@ -124,7 +115,7 @@ def get_content_api(
             return bottle.abort(400, "content_id must be provided")
 
         content_object: ContentObject = ContentObject.get_from_content_id(
-            table=dynamodb_table, content_id=content_id, content_type=PhotoContent
+            table=dynamodb_table, content_id=content_id
         )
 
         if not content_object:

--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -3,8 +3,6 @@
  */
 
 import {Auth, API} from 'aws-amplify';
-import {encode} from 'base64-arraybuffer';
-import {ContentType} from './utils/constants';
 
 async function getAuthorizationToken() {
   const currentSession = await Auth.currentSession();
@@ -83,23 +81,9 @@ export function fetchContentActionHistory(contentId) {
   return apiGet('/content/action-history/', {content_id: contentId});
 }
 
-const acceptableContentTypes = Object.values(ContentType);
-
-/**
- * @param {string} contentType [One of utils/constants.jsx:ContentType]
- * @param {string} contentId
- * @returns
- */
-export function fetchContentDetails(contentType, contentId) {
-  if (acceptableContentTypes.indexOf(contentType) === -1) {
-    return Promise.reject(
-      new Error(`contentType must be one of ${acceptableContentTypes}`),
-    );
-  }
-
+export function fetchContentDetails(contentId) {
   return apiGet('/content/', {
     content_id: contentId,
-    content_type: contentType,
   });
 }
 

--- a/hasher-matcher-actioner/webapp/src/components/ContentMatchPane.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/ContentMatchPane.jsx
@@ -40,7 +40,7 @@ export default function ContentMatchPane({contentId, signalId, signalSource}) {
   }, [contentId]);
 
   useEffect(() => {
-    fetchContentDetails(ContentType.PHOTO, contentId).then(result => {
+    fetchContentDetails(contentId).then(result => {
       // Ensure placeholders don't get displayed. TODO: Move this to the API.
       const additionalFields = result.additional_fields.filter(
         x => x !== 'Placeholder',

--- a/hasher-matcher-actioner/webapp/src/pages/ContentDetails.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/ContentDetails.jsx
@@ -47,7 +47,7 @@ export default function ContentDetails() {
   }, []);
 
   useEffect(() => {
-    fetchContentDetails(ContentType.PHOTO, id)
+    fetchContentDetails(id)
       .then(result => {
         setContentDetails(result);
       })


### PR DESCRIPTION
### Fixes #756 

Summary
---------
ContentObject queries used to require content_type. This is problematic because
a) It may be taken to mean `content_type` + `content_id` is unique. But we would like content_id to be globally unique.
b) later pipeline stages (actioning) do not have access to content_type. With additional data now being required in actioning, the content_type was impossible to obtain.

This PR removes the need for content_type in ContentObject.** queries. This will also allow the UI to link to a single page for a content_id and then support different previews based on the content_type returned by the API.

Test Plan
---------
Ran mypy, black and py.test.

Deployed docker image and webapp after tainting.

1. Verified that a URL submission flow works. (including calling webhook)
2. Verified that the content details page show last_submitted at and all APIs return responses (image failed because of a CORS issue, but need to figure that out separately).
