### PR TITLE
[hma][hotfix] fix non-url submissions

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/content.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/content.py
@@ -123,9 +123,9 @@ def get_content_api(
         content_object = t.cast(ContentObject, content_object)
 
         if content_object.content_ref_type == ContentRefType.DEFAULT_S3_BUCKET:
-            bytes_: bytes = S3BucketContentSource(
-                image_bucket, image_prefix
-            ).get_image_bytes(content_id)
+            bytes_: bytes = S3BucketContentSource(image_bucket, image_prefix).get_bytes(
+                content_id
+            )
             bottle.response.set_header("Content-type", "image/jpeg")
             return bytes_
         elif content_object.content_ref_type == ContentRefType.URL:

--- a/hasher-matcher-actioner/scripts/script_utils.py
+++ b/hasher-matcher-actioner/scripts/script_utils.py
@@ -87,7 +87,6 @@ class HasherMatcherActionerAPI:
         payload = {
             "content_id": content_id,
             "content_type": "photo",
-            "content_bytes_url_or_file_type": b64_file_contents,
             "additional_fields": additional_fields,
             "content_bytes": b64_file_contents,
         }
@@ -107,7 +106,6 @@ class HasherMatcherActionerAPI:
         payload = {
             "content_id": content_id,
             "content_type": "photo",
-            "content_bytes_url_or_file_type": "image/jpeg",
             "additional_fields": additional_fields,
             "file_type": "image/jpeg",
         }
@@ -140,7 +138,6 @@ class HasherMatcherActionerAPI:
         payload = {
             "content_id": content_id,
             "content_type": "photo",
-            "content_bytes_url_or_file_type": url,
             "additional_fields": additional_fields,
             "content_url": url,
         }

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -46,7 +46,6 @@ resource "aws_lambda_function" "api_root" {
       THREAT_EXCHANGE_API_TOKEN_SECRET_NAME = var.te_api_token_secret.name
       MEASURE_PERFORMANCE                   = var.measure_performance ? "True" : "False"
       WRITEBACKS_QUEUE_URL                  = var.writebacks_queue.url
-      IMAGES_TOPIC_ARN                      = var.images_topic_arn
       SUBMISSIONS_QUEUE_URL                 = var.submissions_queue.url
     }
   }
@@ -103,12 +102,12 @@ data "aws_iam_policy_document" "api_root" {
     ]
     resources = concat(
       [
-      "arn:aws:s3:::${var.threat_exchange_data.bucket_name}/${var.threat_exchange_data.data_folder}*",
-    ],
-    [for partner_bucket in var.partner_image_buckets: "${partner_bucket.arn}/*"]
+        "arn:aws:s3:::${var.threat_exchange_data.bucket_name}/${var.threat_exchange_data.data_folder}*",
+      ],
+      [for partner_bucket in var.partner_image_buckets : "${partner_bucket.arn}/*"]
     )
   }
-  
+
   statement {
     effect = "Allow"
     actions = [
@@ -146,11 +145,6 @@ data "aws_iam_policy_document" "api_root" {
     resources = [var.writebacks_queue.arn, var.submissions_queue.arn]
   }
 
-  statement {
-    effect    = "Allow"
-    actions   = ["SNS:Publish"]
-    resources = [var.images_topic_arn]
-  }
 }
 
 resource "aws_iam_policy" "api_root" {
@@ -332,17 +326,17 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 
     # Check if a prefix filter (or the aliases folder, path) was specified
     # Otherwise no prefix constraint
-    filter_prefix = lookup(var.partner_image_buckets[count.index].params, "prefix", 
-                      lookup(var.partner_image_buckets[count.index].params, "folder", 
-                        lookup(var.partner_image_buckets[count.index].params, "path", "")
-                      )
-                    )
+    filter_prefix = lookup(var.partner_image_buckets[count.index].params, "prefix",
+      lookup(var.partner_image_buckets[count.index].params, "folder",
+        lookup(var.partner_image_buckets[count.index].params, "path", "")
+      )
+    )
 
     # Check if a suffix filter (or the alias extension) was specified
     # Otherwise no suffix constraint
-    filter_suffix = lookup(var.partner_image_buckets[count.index].params, "suffix", 
-                      lookup(var.partner_image_buckets[count.index].params, "extension", "")
-                    ) 
+    filter_suffix = lookup(var.partner_image_buckets[count.index].params, "suffix",
+      lookup(var.partner_image_buckets[count.index].params, "extension", "")
+    )
   }
 
   depends_on = [aws_lambda_permission.allow_bucket]

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -63,11 +63,6 @@ variable "datastore" {
   })
 }
 
-variable "images_topic_arn" {
-  description = "SNS Topic for publishing image submission requests"
-  type        = string
-}
-
 variable "log_retention_in_days" {
   description = "How long to retain cloudwatch logs for lambda functions in days"
   type        = number
@@ -119,9 +114,9 @@ variable "submissions_queue" {
 
 variable "partner_image_buckets" {
   description = "Names and arns of s3 buckets to consider as inputs to HMA. All images uploaded to these buckets will be processed by the hasher"
-  type        = list(object({
-    name = string
-    arn  = string
+  type = list(object({
+    name   = string
+    arn    = string
     params = map(string)
   }))
 }

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -117,7 +117,7 @@ module "pdq_signals" {
       [
         "arn:aws:s3:::${module.hashing_data.image_folder_info.bucket_name}/${module.hashing_data.image_folder_info.key}*"
       ],
-      [for partner_bucket in var.partner_image_buckets: "${partner_bucket.arn}/*"]
+      [for partner_bucket in var.partner_image_buckets : "${partner_bucket.arn}/*"]
     )
     image_folder_key = module.hashing_data.image_folder_info.key
   }
@@ -380,7 +380,6 @@ module "api" {
   te_api_token_secret   = aws_secretsmanager_secret.te_api_token
 
   writebacks_queue = module.actions.writebacks_queue
-  images_topic_arn = module.hashing_data.image_folder_info.notification_topic
 
   submissions_queue = {
     url = aws_sqs_queue.submissions_queue.id,


### PR DESCRIPTION
Summary
---------

#749 made a noble attempt to keep `pdq_hasher` and `pdq_matcher` working while adding the unified versions however a few things were missed/not yet handled.

This PR fixes those errors and migrates recent changes to the submit API that were skipped (likely because #750 merged after the implementation and review of the MD5 additions in 749). 
 
More clean up and migration to the architecture changes that #749 made are needed in follow ups but this should at least get prod/main working e2e again for all submission methods.

Test Plan
---------
Checked that both `upload` and `from url` submit work using `make dev_test_instance` for upload submissions e2e and `./scripts/submit_s3_bucket ...` for url submissions and well as both flows on the UI