### PR TITLE
[hma][api] Add option to submit  PDQ hashes directly 

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/content_models.py
+++ b/hasher-matcher-actioner/hmalib/common/content_models.py
@@ -121,6 +121,9 @@ class ContentRefType(Enum):
     # bucket.
     S3_BUCKET = "S3_BUCKET"
 
+    # No content ref was provided for the submission
+    NONE = "NONE"
+
 
 @dataclass
 class ContentObject(ContentObjectBase, JSONifiable):

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -49,6 +49,9 @@ IMAGE_FOLDER_KEY = os.environ[
     "IMAGE_FOLDER_KEY"
 ]  # Misnamed, this is a prefix, not a key, if renaming, use IMAGE_PREFIX
 SUBMISSIONS_QUEUE_URL = os.environ["SUBMISSIONS_QUEUE_URL"]
+HASHES_QUEUE_URL = os.environ["HASHES_QUEUE_URL"]
+PDQ_HASHES_QUEUE_URL = os.environ["PDQ_HASHES_QUEUE_URL"]
+
 
 # Override common errors codes to return json instead of bottle's default html
 @error(404)
@@ -201,6 +204,8 @@ app.mount(
         image_bucket=IMAGE_BUCKET_NAME,
         image_prefix=IMAGE_FOLDER_KEY,
         submissions_queue_url=SUBMISSIONS_QUEUE_URL,
+        hash_queue_url=HASHES_QUEUE_URL,
+        pdq_hash_queue_url=PDQ_HASHES_QUEUE_URL,
     ),
 )
 

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -50,7 +50,6 @@ IMAGE_FOLDER_KEY = os.environ[
 ]  # Misnamed, this is a prefix, not a key, if renaming, use IMAGE_PREFIX
 SUBMISSIONS_QUEUE_URL = os.environ["SUBMISSIONS_QUEUE_URL"]
 HASHES_QUEUE_URL = os.environ["HASHES_QUEUE_URL"]
-PDQ_HASHES_QUEUE_URL = os.environ["PDQ_HASHES_QUEUE_URL"]
 
 
 # Override common errors codes to return json instead of bottle's default html
@@ -164,17 +163,6 @@ def submit_content_request_from_s3_event_record(
     )
 
 
-class SignalSourceType(t.TypedDict):
-    type: str
-    count: int
-
-
-class SignalSourceSummary(t.TypedDict):
-    name: str
-    signals: t.List[SignalSourceType]
-    updated_at: str
-
-
 app.mount(
     "/action-rules/",
     get_action_rules_api(hma_config_table=HMA_CONFIG_TABLE),
@@ -205,7 +193,6 @@ app.mount(
         image_prefix=IMAGE_FOLDER_KEY,
         submissions_queue_url=SUBMISSIONS_QUEUE_URL,
         hash_queue_url=HASHES_QUEUE_URL,
-        pdq_hash_queue_url=PDQ_HASHES_QUEUE_URL,
     ),
 )
 

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -12,12 +12,14 @@ from enum import Enum
 from dataclasses import dataclass, asdict
 from mypy_boto3_dynamodb.service_resource import Table
 from mypy_boto3_sqs import SQSClient
+from mypy_boto3_sns import SNSClient
 from botocore.exceptions import ClientError
 import typing as t
 
 from threatexchange.content_type.content_base import ContentType
 from threatexchange.content_type.photo import PhotoContent
 from threatexchange.content_type.meta import get_content_type_for_name
+from threatexchange.signal_type.pdq import PdqSignal
 
 
 from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
@@ -25,6 +27,7 @@ from hmalib.common.content_sources import S3BucketContentSource
 from hmalib.common.content_models import ContentObject, ContentRefType
 from hmalib.common.logging import get_logger
 from hmalib.common.message_models import URLSubmissionMessage
+from hmalib.models import PipelineHashRecord
 
 logger = get_logger(__name__)
 
@@ -95,6 +98,18 @@ class SubmitContentBytesRequestBody(SubmitRequestBodyBase):
 
     def get_content_ref_details(self) -> t.Tuple[str, ContentRefType]:
         return (self.content_id, ContentRefType.DEFAULT_S3_BUCKET)
+
+
+@dataclass
+class SubmitContentHashRequestBody(SubmitRequestBodyBase):
+    signal_value: str
+    signal_type: str  # SignalType.getname() values
+    content_url: t.Optional[str]
+
+    def get_content_ref_details(self) -> t.Tuple[str, ContentRefType]:
+        if self.content_url:
+            return (self.content_url, ContentRefType.URL)
+        return ("", ContentRefType.NONE)
 
 
 @dataclass
@@ -206,6 +221,8 @@ def get_submit_api(
     image_bucket: str,
     image_prefix: str,
     submissions_queue_url: str,
+    hash_queue_url: str,
+    pdq_hash_queue_url: str,
 ) -> bottle.Bottle:
     """
     A Closure that includes all dependencies that MUST be provided by the root
@@ -319,5 +336,36 @@ def get_submit_api(
             content_id=request.content_id,
             message="Failed to generate upload url",
         )
+
+    @submit_api.post("/hash/", apply=[jsoninator(SubmitContentHashRequestBody)])
+    def submit_hash(
+        request: SubmitContentHashRequestBody,
+    ) -> t.Union[SubmitResponse, SubmitError]:
+        """
+        Endpoint to submit a hash of a piece of content
+        """
+
+        # Record content object (even though we don't store anything just like with url)
+        _record_content_submission_from_request(request)
+
+        # Record hash
+        # todo add MD5 support and branch based on request.hash_type
+        #   note: quality of PDQ hashes should part of `signal_specific_attributes` after #749/related is merged
+        hash_record = PipelineHashRecord(
+            content_id=request.content_id,
+            signal_type=PdqSignal,
+            content_hash=request.signal_value,
+            updated_at=datetime.datetime.now(),
+        )
+        hash_record.write_to_table(dynamodb_table)
+
+        # Send hash directly to matcher
+        # todo this could maybe try and reuse the methods in UnifiedHasher in #749
+        _get_sqs_client().send_message(
+            QueueUrl=pdq_hash_queue_url,
+            MessageBody=json.dumps(hash_record.to_legacy_sqs_message()),
+        )
+
+        return SubmitResponse(content_id=request.content_id, submit_successful=True)
 
     return submit_api

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -221,7 +221,6 @@ def get_submit_api(
     image_prefix: str,
     submissions_queue_url: str,
     hash_queue_url: str,
-    pdq_hash_queue_url: str,
 ) -> bottle.Bottle:
     """
     A Closure that includes all dependencies that MUST be provided by the root
@@ -361,8 +360,8 @@ def get_submit_api(
         # Send hash directly to matcher
         # todo this could maybe try and reuse the methods in UnifiedHasher in #749
         _get_sqs_client().send_message(
-            QueueUrl=pdq_hash_queue_url,
-            MessageBody=json.dumps(hash_record.to_legacy_sqs_message()),
+            QueueUrl=hash_queue_url,
+            MessageBody=json.dumps(hash_record.to_sqs_message()),
         )
 
         return SubmitResponse(content_id=request.content_id, submit_successful=True)

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -12,7 +12,6 @@ from enum import Enum
 from dataclasses import dataclass, asdict
 from mypy_boto3_dynamodb.service_resource import Table
 from mypy_boto3_sqs import SQSClient
-from mypy_boto3_sns import SNSClient
 from botocore.exceptions import ClientError
 import typing as t
 

--- a/hasher-matcher-actioner/scripts/hma_client_lib.py
+++ b/hasher-matcher-actioner/scripts/hma_client_lib.py
@@ -204,6 +204,30 @@ class DeployedInstanceClient:
         ) as err:
             print("Error:", err)
 
+    def submit_test_content_hash(
+        self,
+        content_id="submit_content_test_hash_id_1",
+        signal_value="f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22",  # pdq of "sample_data/b.jpg"
+        additional_fields=[
+            "this-is:a-test-hash",
+            "submitted-from:hma_client_lib.py",
+        ],
+    ):
+        try:
+            self.api.submit_hash(
+                content_id=content_id,
+                signal_value=signal_value,
+                additional_fields=additional_fields,
+            )
+        except (
+            urllib3.exceptions.MaxRetryError,
+            requests.exceptions.HTTPError,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.RequestException,
+        ) as err:
+            print("Error:", err)
+
     def run_basic_test(self, wait_time_seconds=5, retry_limit=25):
         """
         Basic e2e (minus webhook listener) test:

--- a/hasher-matcher-actioner/scripts/hma_script_utils.py
+++ b/hasher-matcher-actioner/scripts/hma_script_utils.py
@@ -158,6 +158,33 @@ class HasherMatcherActionerAPI:
         )
         response.raise_for_status()
 
+    def submit_hash(
+        self,
+        content_id: str,
+        signal_value: str,
+        signal_type: str = "pdq",
+        content_type: str = "photo",
+        url="",
+        additional_fields: t.List[str] = [],
+    ):
+        """
+        Submit hash directy
+        """
+        payload = {
+            "content_id": content_id,
+            "content_type": content_type,
+            "additional_fields": additional_fields,
+            "signal_value": signal_value,
+            "signal_type": signal_type,
+            "content_url": url,
+        }
+        api_path: str = "/submit/hash/"
+        response = self.session.post(
+            self._get_request_url(api_path),
+            data=json.dumps(payload).encode(),
+        )
+        response.raise_for_status()
+
     def get_content_hash_details(
         self,
         content_id: str,

--- a/hasher-matcher-actioner/scripts/hma_shell
+++ b/hasher-matcher-actioner/scripts/hma_shell
@@ -5,7 +5,7 @@
 Prototype of shell wrapper for HMA utils for interactive manual testings
 
 ```
-python3 scripts/hma_shell --pwd <password-of-user>
+python3 scripts/hma_shell --pwd <password-of-user-created-in-pool>
 ```
 
 """

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -48,7 +48,6 @@ resource "aws_lambda_function" "api_root" {
       WRITEBACKS_QUEUE_URL                  = var.writebacks_queue.url
       SUBMISSIONS_QUEUE_URL                 = var.submissions_queue.url
       HASHES_QUEUE_URL                      = var.hashes_queue.url
-      PDQ_HASHES_QUEUE_URL                  = var.pdq_hashes_queue.url
     }
   }
   tags = merge(
@@ -144,7 +143,7 @@ data "aws_iam_policy_document" "api_root" {
   statement {
     effect    = "Allow"
     actions   = ["sqs:SendMessage"]
-    resources = [var.writebacks_queue.arn, var.submissions_queue.arn, var.pdq_hashes_queue.arn, var.hashes_queue.arn]
+    resources = [var.writebacks_queue.arn, var.submissions_queue.arn, var.hashes_queue.arn]
   }
 
 }

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -47,6 +47,8 @@ resource "aws_lambda_function" "api_root" {
       MEASURE_PERFORMANCE                   = var.measure_performance ? "True" : "False"
       WRITEBACKS_QUEUE_URL                  = var.writebacks_queue.url
       SUBMISSIONS_QUEUE_URL                 = var.submissions_queue.url
+      HASHES_QUEUE_URL                      = var.hashes_queue.url
+      PDQ_HASHES_QUEUE_URL                  = var.pdq_hashes_queue.url
     }
   }
   tags = merge(
@@ -82,7 +84,7 @@ resource "aws_iam_role" "api_root" {
 data "aws_iam_policy_document" "api_root" {
   statement {
     effect    = "Allow"
-    actions   = ["dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan", "dynamodb:UpdateItem"]
+    actions   = ["dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan", "dynamodb:PutItem", "dynamodb:UpdateItem"]
     resources = ["${var.datastore.arn}*"]
   }
   statement {
@@ -142,7 +144,7 @@ data "aws_iam_policy_document" "api_root" {
   statement {
     effect    = "Allow"
     actions   = ["sqs:SendMessage"]
-    resources = [var.writebacks_queue.arn, var.submissions_queue.arn]
+    resources = [var.writebacks_queue.arn, var.submissions_queue.arn, var.pdq_hashes_queue.arn, var.hashes_queue.arn]
   }
 
 }

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -111,6 +111,7 @@ variable "submissions_queue" {
     arn = string
   })
 }
+
 variable "hashes_queue" {
   description = "URL and ARN for unified hashes queue. Messages from the submission APIs will be dropped on this queue"
   type = object({
@@ -118,15 +119,6 @@ variable "hashes_queue" {
     arn = string
   })
 }
-
-variable "pdq_hashes_queue" {
-  description = "URL and ARN for pdq hashes queue. Messages from the submission APIs will be dropped on this queue"
-  type = object({
-    url = string
-    arn = string
-  })
-}
-
 
 variable "partner_image_buckets" {
   description = "Names and arns of s3 buckets to consider as inputs to HMA. All images uploaded to these buckets will be processed by the hasher"

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -111,6 +111,22 @@ variable "submissions_queue" {
     arn = string
   })
 }
+variable "hashes_queue" {
+  description = "URL and ARN for unified hashes queue. Messages from the submission APIs will be dropped on this queue"
+  type = object({
+    url = string
+    arn = string
+  })
+}
+
+variable "pdq_hashes_queue" {
+  description = "URL and ARN for pdq hashes queue. Messages from the submission APIs will be dropped on this queue"
+  type = object({
+    url = string
+    arn = string
+  })
+}
+
 
 variable "partner_image_buckets" {
   description = "Names and arns of s3 buckets to consider as inputs to HMA. All images uploaded to these buckets will be processed by the hasher"

--- a/hasher-matcher-actioner/terraform/hasher/variables.tf
+++ b/hasher-matcher-actioner/terraform/hasher/variables.tf
@@ -40,7 +40,7 @@ variable "submissions_queue" {
 }
 
 variable "hashes_queue" {
-  description = "Output Queue to publish topic to publish new hashes to"
+  description = "Output queue to push new hashes on"
   type = object({
     arn = string
     url = string

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -384,10 +384,6 @@ module "api" {
     url = aws_sqs_queue.hashes_queue.id,
     arn = aws_sqs_queue.hashes_queue.arn
   }
-  pdq_hashes_queue = {
-    url = module.pdq_signals.hashes_queue.id,
-    arn = module.pdq_signals.hashes_queue.arn
-  }
   submissions_queue = {
     url = aws_sqs_queue.submissions_queue.id,
     arn = aws_sqs_queue.submissions_queue.arn

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -380,7 +380,14 @@ module "api" {
   te_api_token_secret   = aws_secretsmanager_secret.te_api_token
 
   writebacks_queue = module.actions.writebacks_queue
-
+  hashes_queue = {
+    url = aws_sqs_queue.hashes_queue.id,
+    arn = aws_sqs_queue.hashes_queue.arn
+  }
+  pdq_hashes_queue = {
+    url = module.pdq_signals.hashes_queue.id,
+    arn = module.pdq_signals.hashes_queue.arn
+  }
   submissions_queue = {
     url = aws_sqs_queue.submissions_queue.id,
     arn = aws_sqs_queue.submissions_queue.arn

--- a/hasher-matcher-actioner/terraform/matcher/variables.tf
+++ b/hasher-matcher-actioner/terraform/matcher/variables.tf
@@ -41,7 +41,7 @@ variable "hashes_queue" {
 }
 
 variable "matches_topic_arn" {
-  description = "SNS Toipc to which we'll publish matches."
+  description = "SNS Topic to which we'll publish matches"
   type        = string
 }
 

--- a/hasher-matcher-actioner/terraform/pdq-signals/outputs.tf
+++ b/hasher-matcher-actioner/terraform/pdq-signals/outputs.tf
@@ -15,11 +15,3 @@ output "hashes_queue_name" {
 output "hashes_queue_url" {
   value = aws_sqs_queue.hashes_queue.id
 }
-
-output "hashes_queue" {
-  description = "URL and ARN for pdq hashes queue"
-  value = {
-    id  = aws_sqs_queue.hashes_queue.id
-    arn = aws_sqs_queue.hashes_queue.arn
-  }
-}

--- a/hasher-matcher-actioner/terraform/pdq-signals/outputs.tf
+++ b/hasher-matcher-actioner/terraform/pdq-signals/outputs.tf
@@ -15,3 +15,11 @@ output "hashes_queue_name" {
 output "hashes_queue_url" {
   value = aws_sqs_queue.hashes_queue.id
 }
+
+output "hashes_queue" {
+  description = "URL and ARN for pdq hashes queue"
+  value = {
+    id  = aws_sqs_queue.hashes_queue.id
+    arn = aws_sqs_queue.hashes_queue.arn
+  }
+}


### PR DESCRIPTION
Summary
---------

Created a new submit endpoint `/submit/hash/` for submitting hashes directly. This endpoint currently limited and only supports pdq hashes.

Future work:
- Overwrite flag to be required for resubmits
- Updates to submit UI page to support this option
- Support for MD5 hashes


Test Plan
---------
Submitted the hashes using the new `hma_client_lib.DeployedInstanceClient.submit_test_content_hash` and saw using hma_shell that the following occured:
- Content Object Created
- Match Found
- Action Triggered
```
$ scripts/hma_shell                                                                                                                                                                                                                                                                                                                                 [12:57:13]
Needs a password for user: barretttestuser to authenticate.
Enter password: <redacted>
Welcome! Type help or ? to list commands.

> ?

Documented commands (type help <topic>):
========================================
action_history_for_id  dataset_configs      help            refresh
action_rules           exit                 matches         run_basic_test
actions                hash_details_for_id  matches_for_id

> hash_details_for_id submit_content_test_hash_id_1                                                                                                                                                                                                                                                                                                                                                        
{
  "content_id": "submit_content_test_hash_id_1",
  "content_hash": "f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22",
  "updated_at": "2021-08-18T14:15:13.188818"
}
> matches_for_id submit_content_test_hash_id_1
[
  {
    "content_id": "submit_content_test_hash_id_1",
    "content_hash": "f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22",
    "signal_id": "4109214869142910",
    "signal_hash": "f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22",
    "signal_source": "te",
    "signal_type": "pdq",
    "updated_at": "2021-08-18T14:15:55.957155",
    "metadata": [
      {
        "dataset": "inria-holidays-test",
        "tags": [
          "test_pdq_samples",
          "holidays_jpg1_dataset",
          "but_not_really_it_is_an_extra_photo_see_b_jpg"
        ],
        "opinion": "Disputed",
        "pending_opinion_change": "none"
      }
    ]
  }
]
> action_history_for_id submit_content_test_hash_id_1
[
  {
    "content_id": "submit_content_test_hash_id_1",
    "performed_at": "2021-08-18T14:17:21.797342",
    "action_label": "SubmitContentTestActionWebhookPost",
    "action_performer": "{\"name\": \"SubmitContentTestActionWebhookPost\", \"config_subtype\": \"WebhookPostActionPerformer\", \"url\": \"http://httpstat.us/404\", \"headers\": \"{\\\"this-is-a\\\":\\\"test-header\\\"}\"}",                                                                                                                                                                           
    "action_rules": [
      "{\"name\": \"trigger-on-tag-holidays_jpg1_dataset\", \"action_label\": {\"key\": \"Action\", \"value\": \"SubmitContentTestActionWebhookPost\"}, \"must_have_labels\": [{\"key\": \"Classification\", \"value\": \"holidays_jpg1_dataset\"}], \"must_not_have_labels\": []}"                                                                                                                        
    ]
  }
]
> exit

Closing Shell...
```
