### PR TITLE
[hma][api] add get matches for raw hash endpoint

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/signal_models.py
+++ b/hasher-matcher-actioner/hmalib/common/signal_models.py
@@ -4,7 +4,7 @@ import datetime
 from enum import Enum
 import typing as t
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from mypy_boto3_dynamodb.service_resource import Table
 from boto3.dynamodb.conditions import Attr, Key, And
 from botocore.exceptions import ClientError
@@ -40,6 +40,17 @@ class SignalMetadataBase(DynamoDBItem):
     @staticmethod
     def get_dynamodb_ds_key(ds_id: str) -> str:
         return f"{SignalMetadataBase.DATASET_PREFIX}{ds_id}"
+
+    def to_json(self) -> t.Dict:
+        """
+        Used by '/matches/for-hash' in lambdas/api/matches
+        """
+        result = asdict(self)
+        result.update(
+            updated_at=self.updated_at.isoformat(),
+            pending_opinion_change=self.pending_opinion_change.value,
+        )
+        return result
 
 
 @dataclass

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -51,6 +51,7 @@ IMAGE_FOLDER_KEY = os.environ[
 SUBMISSIONS_QUEUE_URL = os.environ["SUBMISSIONS_QUEUE_URL"]
 HASHES_QUEUE_URL = os.environ["HASHES_QUEUE_URL"]
 
+INDEXES_BUCKET_NAME = os.environ["INDEXES_BUCKET_NAME"]
 
 # Override common errors codes to return json instead of bottle's default html
 @error(404)
@@ -173,6 +174,7 @@ app.mount(
     get_matches_api(
         dynamodb_table=dynamodb.Table(DYNAMODB_TABLE),
         hma_config_table=HMA_CONFIG_TABLE,
+        indexes_bucket_name=INDEXES_BUCKET_NAME,
     ),
 )
 

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -286,6 +286,8 @@ def get_matches_api(
     def for_hash(request: MatchesForHashRequest) -> MatchesForHashResponse:
         """
         For a given hash/signal check the index(es) for matches and return the details
+        NOTE: currently metadata returned will not be written to the dynamodb table
+        unlike in the case of a pipeline match based on submissions.
         """
         signal_type = None
         if request.signal_type == "pdq":

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -2,6 +2,8 @@
 
 import bottle
 import datetime
+import functools
+import dataclasses
 
 from dataclasses import dataclass, asdict
 from mypy_boto3_dynamodb.service_resource import Table
@@ -10,14 +12,32 @@ from enum import Enum
 from logging import Logger
 
 from threatexchange.descriptor import ThreatDescriptor
+
+from threatexchange.signal_type.md5 import VideoMD5Signal
+from threatexchange.signal_type.pdq import PdqSignal
+
 from hmalib.models import MatchRecord
-from hmalib.common.signal_models import PDQSignalMetadata, PendingOpinionChange
+from hmalib.common.signal_models import (
+    PDQSignalMetadata,
+    PendingOpinionChange,
+    SignalMetadataBase,
+)
 from hmalib.common.logging import get_logger
 from hmalib.common.message_models import BankedSignal, WritebackMessage, WritebackTypes
-from .middleware import jsoninator, JSONifiable
+from .middleware import jsoninator, JSONifiable, DictParseable
 from hmalib.common.config import HMAConfig
+from hmalib.matchers.matchers_base import Matcher
+
 
 logger = get_logger(__name__)
+
+
+@functools.lru_cache(maxsize=None)
+def _get_matcher(index_bucket_name: str) -> Matcher:
+    return Matcher(
+        index_bucket_name=index_bucket_name,
+        supported_signal_types=[PdqSignal, VideoMD5Signal],
+    )
 
 
 @dataclass
@@ -145,7 +165,29 @@ def get_opinion_from_tags(tags: t.List[str]) -> OpinionString:
     return OpinionString.UNKNOWN
 
 
-def get_matches_api(dynamodb_table: Table, hma_config_table: str) -> bottle.Bottle:
+@dataclass
+class MatchesForHashRequest(DictParseable):
+    signal_value: str
+    signal_type: str
+
+    @classmethod
+    def from_dict(cls, d):
+        # todo translate signal type to actual type
+        return cls(**{f.name: d.get(f.name, None) for f in dataclasses.fields(cls)})
+
+
+@dataclass
+class MatchesForHashResponse(JSONifiable):
+    matches: t.List[t.Union[PDQSignalMetadata]]
+    signal_value: str
+
+    def to_json(self) -> t.Dict:
+        return {"matches": [match.to_json() for match in self.matches]}
+
+
+def get_matches_api(
+    dynamodb_table: Table, hma_config_table: str, indexes_bucket_name: str
+) -> bottle.Bottle:
     """
     A Closure that includes all dependencies that MUST be provided by the root
     API that this API plugs into. Declare dependencies here, but initialize in
@@ -239,5 +281,33 @@ def get_matches_api(dynamodb_table: Table, hma_config_table: str) -> bottle.Bott
             logger.info(f"Attempting to update {signal} in db failed")
 
         return ChangeSignalOpinionResponse(success)
+
+    @matches_api.get("/for-hash/", apply=[jsoninator(MatchesForHashRequest)])
+    def for_hash(request: MatchesForHashRequest) -> MatchesForHashResponse:
+        """
+        For a given hash/signal check the index(es) for matches and return the details
+        """
+        signal_type = None
+        if request.signal_type == "pdq":
+            # todo translate in MatchesForHashRequest and extend to cover MD5
+            signal_type = PdqSignal
+
+        if not signal_type:
+            # only support PDQ at the moment
+            bottle.response.status = 400
+            return MatchesForHashResponse([], request.signal_value)
+
+        matches = _get_matcher(indexes_bucket_name).match(
+            signal_type, request.signal_value
+        )
+
+        match_objects = []
+
+        for match in matches:
+            match_objects.extend(
+                Matcher.get_metadata_objects_from_match(signal_type, match)
+            )
+
+        return MatchesForHashResponse(match_objects, request.signal_value)
 
     return matches_api

--- a/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
+++ b/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
@@ -142,8 +142,9 @@ class Matcher:
             match.metadata["hash"],
         ).write_to_table(table)
 
+    @classmethod
     def write_signal_if_not_found(
-        self,
+        cls,
         table: Table,
         signal_type: t.Type[SignalType],
         match: IndexMatch,
@@ -159,9 +160,24 @@ class Matcher:
         their own store. Perhaps the API could be useful when building local
         banks. Who knows! :)
         """
+        for signal in cls.get_metadata_objects_from_match(signal_type, match):
+            signal.write_to_table_if_not_found(table)
+
+    @classmethod
+    def get_metadata_objects_from_match(
+        cls,
+        signal_type: t.Type[SignalType],
+        match: IndexMatch,
+    ) -> t.List[t.Union[PDQSignalMetadata]]:
+        """
+        See docstring of `write_signal_if_not_found` we will likely want to move
+        this outside of Matcher. However while the MD5 expansion is still on going
+        better to have it all in once place.
+        Note: changes made here will have an effect on api.matches.get_match_for_hash
+        """
         # TODO: Abstract out MD5SignalMetadata
         if signal_type == PdqSignal:
-            for privacy_group_id in match.metadata.get("privacy_groups", []):
+            return [
                 PDQSignalMetadata(
                     str(match.metadata["id"]),
                     privacy_group_id,
@@ -169,7 +185,10 @@ class Matcher:
                     match.metadata["source"],
                     match.metadata["hash"],
                     match.metadata["tags"].get(privacy_group_id, []),
-                ).write_to_table_if_not_found(table)
+                )
+                for privacy_group_id in match.metadata.get("privacy_groups", [])
+            ]
+        return []  # todo add md5 support
 
     def get_index(self, signal_type: t.Type[SignalType]) -> SignalTypeIndex:
         # If cached, return an index instance for the signal_type. If not, build
@@ -218,3 +237,10 @@ class Matcher:
         )
 
         sns_client.publish(TopicArn=topic_arn, Message=match_message.to_aws_json())
+
+    def flatten_matches(
+        self,
+        signal_type: t.Type[SignalType],
+        matches: t.List[IndexMatch],
+    ):
+        pass

--- a/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
+++ b/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
@@ -237,10 +237,3 @@ class Matcher:
         )
 
         sns_client.publish(TopicArn=topic_arn, Message=match_message.to_aws_json())
-
-    def flatten_matches(
-        self,
-        signal_type: t.Type[SignalType],
-        matches: t.List[IndexMatch],
-    ):
-        pass

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -43,6 +43,7 @@ resource "aws_lambda_function" "api_root" {
       THREAT_EXCHANGE_DATA_BUCKET_NAME      = var.threat_exchange_data.bucket_name
       THREAT_EXCHANGE_DATA_FOLDER           = var.threat_exchange_data.data_folder
       THREAT_EXCHANGE_PDQ_FILE_EXTENSION    = var.threat_exchange_data.pdq_file_extension
+      INDEXES_BUCKET_NAME                   = var.index_data_storage.bucket_name
       THREAT_EXCHANGE_API_TOKEN_SECRET_NAME = var.te_api_token_secret.name
       MEASURE_PERFORMANCE                   = var.measure_performance ? "True" : "False"
       WRITEBACKS_QUEUE_URL                  = var.writebacks_queue.url
@@ -94,7 +95,7 @@ data "aws_iam_policy_document" "api_root" {
   statement {
     effect    = "Allow"
     actions   = ["s3:GetObject", "s3:PutObject"]
-    resources = ["arn:aws:s3:::${var.image_data_storage.bucket_name}/${var.image_data_storage.image_folder_key}*"]
+    resources = ["arn:aws:s3:::${var.image_data_storage.bucket_name}/${var.image_data_storage.image_folder_key}*", "arn:aws:s3:::${var.index_data_storage.bucket_name}/${var.index_data_storage.index_folder_key}*"]
   }
   statement {
     effect = "Allow"

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -46,6 +46,14 @@ variable "image_data_storage" {
   })
 }
 
+variable "index_data_storage" {
+  description = "Configuration information for the S3 Bucket that will hold PDQ Index data"
+  type = object({
+    bucket_name      = string
+    index_folder_key = string
+  })
+}
+
 variable "threat_exchange_data" {
   description = "Configuration information for the S3 Bucket that will hold ThreatExchange Data"
   type = object({

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -367,6 +367,11 @@ module "api" {
     bucket_name      = module.hashing_data.image_folder_info.bucket_name
     image_folder_key = module.hashing_data.image_folder_info.key
   }
+
+  index_data_storage = {
+    bucket_name      = module.hashing_data.index_folder_info.bucket_name
+    index_folder_key = module.hashing_data.index_folder_info.key
+  }
   threat_exchange_data = {
     bucket_name        = module.hashing_data.threat_exchange_data_folder_info.bucket_name
     pdq_file_extension = local.pdq_file_extension


### PR DESCRIPTION
Summary
---------

Instead of submitting content to HMA right away, if the user just want to see if a signal they have ~would~ match they can now submit that signal to `/matches/for-hash/` to get what signal on the live indexes should have found.


Test Plan
---------

<img width="1405" alt="Screen Shot 2021-08-18 at 4 07 25 PM" src="https://user-images.githubusercontent.com/7664526/129965013-97bfe339-ee3f-4c55-88af-46a408ec8e71.png">