### PR TITLE
[hma][small] Update `post_url` to `put-url` to be clearer and match convention

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -112,7 +112,7 @@ class SubmitContentHashRequestBody(SubmitRequestBodyBase):
 
 
 @dataclass
-class SubmitContentViaPostURLUploadRequestBody(SubmitRequestBodyBase):
+class SubmitContentViaPutURLUploadRequestBody(SubmitRequestBodyBase):
     file_type: str
 
     def get_content_ref_details(self) -> t.Tuple[str, ContentRefType]:
@@ -307,13 +307,13 @@ def get_submit_api(
         return SubmitResponse(content_id=request.content_id, submit_successful=True)
 
     @submit_api.post(
-        "/post_url/", apply=[jsoninator(SubmitContentViaPostURLUploadRequestBody)]
+        "/put-url/", apply=[jsoninator(SubmitContentViaPutURLUploadRequestBody)]
     )
-    def submit_post_url(
-        request: SubmitContentViaPostURLUploadRequestBody,
+    def submit_put_url(
+        request: SubmitContentViaPutURLUploadRequestBody,
     ) -> t.Union[SubmitViaUploadUrlResponse, SubmitError]:
         """
-        Submission of content to the system's s3 bucket by providing a post url to client
+        Submission of content to the system's s3 bucket by providing a put url to client
         """
         presigned_url = create_presigned_put_url(
             bucket_name=image_bucket,

--- a/hasher-matcher-actioner/scripts/hma_script_utils.py
+++ b/hasher-matcher-actioner/scripts/hma_script_utils.py
@@ -119,7 +119,7 @@ class HasherMatcherActionerAPI:
             "additional_fields": additional_fields,
             "file_type": "image/jpeg",
         }
-        api_path: str = "/submit/post_url/"
+        api_path: str = "/submit/put-url/"
         response = self.session.post(
             self._get_request_url(api_path),
             data=json.dumps(payload).encode(),

--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -131,13 +131,13 @@ export async function submitContentViaURL(
   });
 }
 
-export async function submitContentViaPostURLUpload(
+export async function submitContentViaPutURLUpload(
   contentId,
   contentType,
   additionalFields,
   content,
 ) {
-  const submitResponse = await apiPost('/submit/post_url/', {
+  const submitResponse = await apiPost('/submit/put-url/', {
     content_id: contentId,
     content_type: contentType,
     additional_fields: additionalFields,
@@ -150,7 +150,7 @@ export async function submitContentViaPostURLUpload(
   };
 
   // Content object was created. Now the content itself needs to be uploaded to s3
-  // using the post url in the response.
+  // using the put url in the response.
   const result = await fetch(submitResponse.presigned_url, requestOptions);
   return result;
 }

--- a/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
@@ -14,7 +14,7 @@ import {
 } from 'react-bootstrap';
 import {Link} from 'react-router-dom';
 
-import {submitContentViaURL, submitContentViaPostURLUpload} from '../Api';
+import {submitContentViaURL, submitContentViaPutURLUpload} from '../Api';
 import {ContentType, SUBMISSION_TYPE} from '../utils/constants';
 
 import {
@@ -75,8 +75,8 @@ export default function SubmitContent() {
   const handleSubmit = event => {
     event.preventDefault();
     setSubmitting(true);
-    if (inputs.submissionType === 'POST_URL_UPLOAD') {
-      submitContentViaPostURLUpload(
+    if (inputs.submissionType === 'PUT_URL_UPLOAD') {
+      submitContentViaPutURLUpload(
         inputs.contentId,
         inputs.contentType,
         packageAdditionalFields(),
@@ -152,7 +152,7 @@ export default function SubmitContent() {
                   </Form.Group>
                 )}
 
-                {submissionType === SUBMISSION_TYPE.POST_URL_UPLOAD && (
+                {submissionType === SUBMISSION_TYPE.PUT_URL_UPLOAD && (
                   <PhotoUploadField
                     inputs={inputs}
                     handleInputChangeUpload={handleInputChangeUpload}

--- a/hasher-matcher-actioner/webapp/src/utils/constants.jsx
+++ b/hasher-matcher-actioner/webapp/src/utils/constants.jsx
@@ -24,7 +24,7 @@ export const PENDING_OPINION_CHANGE = Object.freeze({
 
 // Corseponds  SubmissionType in hmalib/api/submit.py
 export const SUBMISSION_TYPE = Object.freeze({
-  POST_URL_UPLOAD: 'Upload',
+  PUT_URL_UPLOAD: 'Upload',
   FROM_URL: 'From URL',
 });
 


### PR DESCRIPTION
Summary
---------

Small change. The submit API for upload returns a signed url to the client. Code calls this a 'post_url' but the url is actually designed to be used in a put request. Also I used an `_` instead of a `-` in the path (we agreed to use the dash awhile ago and should stick to it). 

Test Plan
---------

Made sure both manual submission and `python scripts/hma_client_lib.py` still worked. 