### PR TITLE
[hma] add resubmit arg to submission requests and require it if content_id is found.

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/content_models.py
+++ b/hasher-matcher-actioner/hmalib/common/content_models.py
@@ -215,6 +215,14 @@ class ContentObject(ContentObjectBase, JSONifiable):
         )
 
     def write_to_table_if_not_found(self, table: Table) -> bool:
+        """
+        Write operations for this object need to be special cased (to avoid overwritting)
+        Therefore we do not implement `to_dynamodb_item` however basically the body of that
+        method is used here
+
+        Returns false if a content object with that Id is already present
+        and does not write to table. True is write was successful.
+        """
         try:
             table.put_item(
                 Item={

--- a/hasher-matcher-actioner/hmalib/common/content_models.py
+++ b/hasher-matcher-actioner/hmalib/common/content_models.py
@@ -187,20 +187,8 @@ class ContentObject(ContentObjectBase, JSONifiable):
     def write_to_table(self, table: Table):
         """
         Write operations for this object need to be special cased (to avoid overwritting)
-        Therefore we do not implement `to_dynamodb_item`
-
-        If you're curious it would ~look like this:
-        def to_dynamodb_item(self) -> dict:
-            return {
-                "PK": self.get_dynamodb_content_key(self.content_id),
-                "SK": self.get_dynamodb_content_type_key(),
-                "ContentRef": self.content_ref,
-                "ContentRefType": self.content_ref_type,
-                "AdditionalFields": self.additional_fields,
-                "SubmissionTimes": [s.isoformat() for s in self.submission_times],
-                "CreatedOn": self.created_at.isoformat(),
-                "UpdatedAt": self.updated_at.isoformat(),
-            }
+        Therefore we do not implement `to_dynamodb_item` however basically the body of that
+        method is used in this class's impl of `write_to_table_if_not_found`
         """
         # put_item does not support UpdateExpression
         table.update_item(
@@ -225,6 +213,37 @@ class ContentObject(ContentObjectBase, JSONifiable):
                 ":empty_list": [],
             },
         )
+
+    def write_to_table_if_not_found(self, table: Table) -> bool:
+        try:
+            table.put_item(
+                Item={
+                    "PK": self.get_dynamodb_content_key(self.content_id),
+                    "SK": self.get_dynamodb_content_type_key(),
+                    "ContentType": self.content_type.get_name(),
+                    "ContentRef": self.content_ref,
+                    "ContentRefType": self.content_ref_type.value,
+                    "AdditionalFields": self.additional_fields
+                    if self.additional_fields
+                    else {self.ADDITIONAL_FIELDS_PLACE_HOLDER},
+                    "SubmissionTimes": [s.isoformat() for s in self.submission_times],
+                    "CreatedAt": self.created_at.isoformat(),
+                    "UpdatedAt": self.updated_at.isoformat(),
+                },
+                ConditionExpression="attribute_not_exists(PK) AND attribute_not_exists(SK)",
+            )
+        except ClientError as client_error:
+            # boto3 exception handling https://imgflip.com/i/5f5zfj
+            if (
+                client_error.response.get("Error", {"Code", "Unknown"}).get(
+                    "Code", "Unknown"
+                )
+                == "ConditionalCheckFailedException"
+            ):
+                return False
+            else:
+                raise client_error
+        return True
 
     @classmethod
     def get_from_content_id(

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -72,7 +72,7 @@ class SubmitRequestBodyBase(DictParseable):
     content_id: str
     content_type: t.Type[ContentType]
     additional_fields: t.Optional[t.List]
-    resubmit: bool = False
+    force_resubmit: bool = False
 
     def get_content_ref_details(self) -> t.Tuple[str, ContentRefType]:
         raise NotImplementedError
@@ -165,7 +165,7 @@ def record_content_submission(
     content_ref: str,
     content_ref_type: ContentRefType,
     additional_fields: t.Set = set(),
-    resubmit: bool = False,
+    force_resubmit: bool = False,
 ) -> bool:
     """
     Write a content object that is submitted to the dynamodb_table.
@@ -195,7 +195,7 @@ def record_content_submission(
         updated_at=submit_time,
     )
 
-    if resubmit:
+    if force_resubmit:
         # Allow an overwrite or resubmission of content objects
         content_obj.write_to_table(dynamodb_table)
         return True
@@ -246,8 +246,8 @@ def get_submit_api(
 
     def _content_exist_error(content_id: str):
         return bottle.abort(
-            500,
-            f"Content with id '{content_id}' already exists if you want to resubmit `resubmit=True` must be included in payload.",
+            400,
+            f"Content with id '{content_id}' already exists if you want to resubmit `force_resubmit=True` must be included in payload.",
         )
 
     def _record_content_submission_from_request(
@@ -270,7 +270,7 @@ def get_submit_api(
             additional_fields=set(request.additional_fields)
             if request.additional_fields
             else set(),
-            resubmit=request.resubmit,
+            force_resubmit=request.force_resubmit,
         )
 
     @submit_api.post("/", apply=[jsoninator])

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -72,6 +72,7 @@ class SubmitRequestBodyBase(DictParseable):
     content_id: str
     content_type: t.Type[ContentType]
     additional_fields: t.Optional[t.List]
+    resubmit: bool = False
 
     def get_content_ref_details(self) -> t.Tuple[str, ContentRefType]:
         raise NotImplementedError
@@ -85,7 +86,7 @@ class SubmitRequestBodyBase(DictParseable):
 
 @dataclass
 class SubmitContentViaURLRequestBody(SubmitRequestBodyBase):
-    content_url: str
+    content_url: str = ""
 
     def get_content_ref_details(self) -> t.Tuple[str, ContentRefType]:
         return (self.content_url, ContentRefType.URL)
@@ -93,7 +94,7 @@ class SubmitContentViaURLRequestBody(SubmitRequestBodyBase):
 
 @dataclass
 class SubmitContentBytesRequestBody(SubmitRequestBodyBase):
-    content_bytes: bytes
+    content_bytes: bytes = b""
 
     def get_content_ref_details(self) -> t.Tuple[str, ContentRefType]:
         return (self.content_id, ContentRefType.DEFAULT_S3_BUCKET)
@@ -101,9 +102,9 @@ class SubmitContentBytesRequestBody(SubmitRequestBodyBase):
 
 @dataclass
 class SubmitContentHashRequestBody(SubmitRequestBodyBase):
-    signal_value: str
-    signal_type: str  # SignalType.getname() values
-    content_url: t.Optional[str]
+    signal_value: str = ""
+    signal_type: str = ""  # SignalType.getname() values
+    content_url: str = ""
 
     def get_content_ref_details(self) -> t.Tuple[str, ContentRefType]:
         if self.content_url:
@@ -113,7 +114,7 @@ class SubmitContentHashRequestBody(SubmitRequestBodyBase):
 
 @dataclass
 class SubmitContentViaPutURLUploadRequestBody(SubmitRequestBodyBase):
-    file_type: str
+    file_type: str = ""
 
     def get_content_ref_details(self) -> t.Tuple[str, ContentRefType]:
         # Treat this as an S3 submission because
@@ -164,7 +165,8 @@ def record_content_submission(
     content_ref: str,
     content_ref_type: ContentRefType,
     additional_fields: t.Set = set(),
-):
+    resubmit: bool = False,
+) -> bool:
     """
     Write a content object that is submitted to the dynamodb_table.
 
@@ -177,10 +179,12 @@ def record_content_submission(
 
     This function is also called directly by api_root when handling s3 uploads to partner
     banks. If editing, ensure the logic in api_root.process_s3_event is still correct
+
+    Return True with recording was successful.
     """
-    # TODO add a confirm overwrite path for this
+
     submit_time = datetime.datetime.now()
-    ContentObject(
+    content_obj = ContentObject(
         content_id=content_id,
         content_type=content_type,
         content_ref=content_ref,
@@ -189,7 +193,14 @@ def record_content_submission(
         submission_times=[submit_time],  # Note: custom write_to_table impl appends.
         created_at=submit_time,
         updated_at=submit_time,
-    ).write_to_table(dynamodb_table)
+    )
+
+    if resubmit:
+        # Allow an overwrite or resubmission of content objects
+        content_obj.write_to_table(dynamodb_table)
+        return True
+
+    return content_obj.write_to_table_if_not_found(dynamodb_table)
 
 
 def send_submission_to_url_queue(
@@ -233,9 +244,15 @@ def get_submit_api(
     submit_api = bottle.Bottle()
     s3_bucket_image_source = S3BucketContentSource(image_bucket, image_prefix)
 
+    def _content_exist_error(content_id: str):
+        return bottle.abort(
+            500,
+            f"Content with id '{content_id}' already exists if you want to resubmit `resubmit=True` must be included in payload.",
+        )
+
     def _record_content_submission_from_request(
         request: SubmitRequestBodyBase,
-    ):
+    ) -> bool:
         """
         Given a request object submission record the content object to the table passed to
         the API using 'record_content_submission'
@@ -244,7 +261,7 @@ def get_submit_api(
 
         content_ref, content_ref_type = request.get_content_ref_details()
 
-        record_content_submission(
+        return record_content_submission(
             dynamodb_table,
             content_id=request.content_id,
             content_type=request.content_type,
@@ -253,6 +270,7 @@ def get_submit_api(
             additional_fields=set(request.additional_fields)
             if request.additional_fields
             else set(),
+            resubmit=request.resubmit,
         )
 
     @submit_api.post("/", apply=[jsoninator])
@@ -277,7 +295,9 @@ def get_submit_api(
         """
         Submission via a url to content. This does not store a copy of the content in s3
         """
-        _record_content_submission_from_request(request)
+        if not _record_content_submission_from_request(request):
+            return _content_exist_error(request.content_id)
+
         send_submission_to_url_queue(
             dynamodb_table,
             submissions_queue_url,
@@ -300,7 +320,8 @@ def get_submit_api(
 
         # We want to record the submission before triggering and processing on
         # the content itself therefore we write to dynamodb before s3
-        _record_content_submission_from_request(request)
+        if not _record_content_submission_from_request(request):
+            return _content_exist_error(request.content_id)
 
         s3_bucket_image_source.put_image_bytes(content_id, file_contents)
 
@@ -322,7 +343,9 @@ def get_submit_api(
         )
 
         if presigned_url:
-            _record_content_submission_from_request(request)
+            if not _record_content_submission_from_request(request):
+                return _content_exist_error(request.content_id)
+
             return SubmitViaUploadUrlResponse(
                 content_id=request.content_id,
                 file_type=str(request.file_type),
@@ -344,7 +367,8 @@ def get_submit_api(
         """
 
         # Record content object (even though we don't store anything just like with url)
-        _record_content_submission_from_request(request)
+        if not _record_content_submission_from_request(request):
+            return _content_exist_error(request.content_id)
 
         # Record hash
         # todo add MD5 support and branch based on request.hash_type

--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -128,14 +128,14 @@ export async function submitContentViaURL(
   contentType,
   additionalFields,
   content,
-  resubmit,
+  force_resubmit,
 ) {
   return apiPost('/submit/url/', {
     content_id: contentId,
     content_type: contentType,
     additional_fields: additionalFields,
     content_url: content,
-    resubmit,
+    force_resubmit,
   });
 }
 
@@ -144,14 +144,14 @@ export async function submitContentViaPutURLUpload(
   contentType,
   additionalFields,
   content,
-  resubmit,
+  force_resubmit,
 ) {
   const submitResponse = await apiPost('/submit/put-url/', {
     content_id: contentId,
     content_type: contentType,
     additional_fields: additionalFields,
     file_type: content.type,
-    resubmit,
+    force_resubmit,
   });
 
   const requestOptions = {

--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -128,12 +128,14 @@ export async function submitContentViaURL(
   contentType,
   additionalFields,
   content,
+  resubmit,
 ) {
   return apiPost('/submit/url/', {
     content_id: contentId,
     content_type: contentType,
     additional_fields: additionalFields,
     content_url: content,
+    resubmit,
   });
 }
 
@@ -142,12 +144,14 @@ export async function submitContentViaPutURLUpload(
   contentType,
   additionalFields,
   content,
+  resubmit,
 ) {
   const submitResponse = await apiPost('/submit/put-url/', {
     content_id: contentId,
     content_type: contentType,
     additional_fields: additionalFields,
     file_type: content.type,
+    resubmit,
   });
 
   const requestOptions = {

--- a/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
@@ -29,6 +29,7 @@ const FORM_DEFAULTS = {
   contentId: undefined,
   contentType: ContentType.Photo,
   content: undefined,
+  force_resubmit: false,
 };
 
 export default function SubmitContent() {
@@ -83,7 +84,7 @@ export default function SubmitContent() {
         inputs.contentType,
         packageAdditionalFields(),
         inputs.content.raw,
-        inputs.resubmit,
+        inputs.force_resubmit,
       )
         .then(() => {
           setSubmitting(false);
@@ -99,7 +100,7 @@ export default function SubmitContent() {
         inputs.contentType,
         packageAdditionalFields(),
         inputs.content,
-        inputs.resubmit,
+        inputs.force_resubmit,
       )
         .then(() => {
           setSubmitting(false);
@@ -185,7 +186,7 @@ export default function SubmitContent() {
                 <Form.Row>
                   <Form.Check
                     disabled={submitting || submittedId}
-                    name="resubmit"
+                    name="force_resubmit"
                     inline
                     label="Resubmit if content id already present in system"
                     type="checkbox"


### PR DESCRIPTION
Summary
---------

Right now the system pipeline depends on `content_id` given by the client. 
Submitting again with the same `content_id` is possible for things like testing but should not be the default.

Additionally trying to submit different content for the same id is likely to mess with the system and result in undefined behavior.  We have some protections to avoid this but more couldn't hurt.

Once merged if a client wants to submit a content object with the same id they must include `force_resubmit=True` in their request. 

I also added the ability to add this flag on the submit UI using a textbox and improve our error handling. 
- full disclosure I took a short cut on the UI work because it is annoying to work in jsx files right now. I will clean up when changing the file to .tsx (soon(tm)).


Test Plan
---------
Made sure regular submission still works and the resubmit for the same submission media and method went through on the UI.
 
<img width="1248" alt="Screen Shot 2021-08-20 at 12 02 19 PM" src="https://user-images.githubusercontent.com/7664526/130262029-f412d6e6-9e1e-4872-b71c-1dc0583a0ddf.png">

