### PR TITLE
Link submission to pipeline progress; pipeline progress to content de…

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/SubmitContentFields.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/SubmitContentFields.jsx
@@ -40,14 +40,13 @@ export function ContentUniqueIdField({inputs, handleInputChange}) {
             required
             value={inputs.contentId}
           />
-
           <Form.Group className="mb-0">
             <Form.Control
               onChange={handleInputChange}
               required
               as="select"
               name="contentType"
-              defaultValue="photo"
+              value={inputs.contentType}
               custom>
               {/* (defaults to photo for now) */}
               <option key="empty" value="" hidden>

--- a/hasher-matcher-actioner/webapp/src/pages/ContentDetailsWithStepper.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/ContentDetailsWithStepper.tsx
@@ -3,8 +3,8 @@
  */
 
 import React, {useEffect, useState} from 'react';
-import {Col, Row, Spinner} from 'react-bootstrap';
-import {useParams} from 'react-router-dom';
+import {Col, Container, Row, Spinner} from 'react-bootstrap';
+import {Link, useParams} from 'react-router-dom';
 import {fetchContentPipelineProgress} from '../Api';
 import ContentPreview from '../components/ContentPreview';
 import ContentProgressStepper from '../components/ContentProgressStepper';
@@ -107,6 +107,18 @@ export default function ContentDetailsWithStepper(): JSX.Element {
               actionPerformedAt={actionPerformedAt}
             />
           )}
+
+          <hr />
+
+          <Container>
+            <Row>
+              <Col className="mt-2" xs={{offset: 1}}>
+                <Link to="/matches/{contentId}">
+                  Go to Content Details Page
+                </Link>
+              </Col>
+            </Row>
+          </Container>
         </Col>
       </Row>
     </FixedWidthCenterAlignedLayout>

--- a/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
@@ -234,26 +234,31 @@ export default function SubmitContent() {
                     <Card>
                       <Card.Header>Your content is submitted!</Card.Header>
                       <Card.Body>
-                        <Button variant="primary" onClick={handleSubmitAnother}>
-                          Submit Another
-                        </Button>{' '}
                         <Button
-                          variant="secondary"
+                          variant="primary"
                           onClick={() =>
                             history.push(`/pipeline-progress/${submittedId}`)
                           }>
                           Track Submission
                         </Button>{' '}
+                        <Button
+                          variant="secondary"
+                          onClick={handleSubmitAnother}>
+                          Submit Another
+                        </Button>
                       </Card.Body>
                     </Card>
                   </Col>
                 </Collapse>
                 <Collapse in={submissionError}>
                   <Col className="ml-4">
-                    <Row>
-                      Error submitting. This can occur if content with that id
-                      already exists.
-                    </Row>
+                    <Card border="danger">
+                      <Card.Header>Error when submitting.</Card.Header>
+                      <Card.Body>
+                        Error submitting. This can occur if content with that id
+                        already exists.
+                      </Card.Body>
+                    </Card>
                   </Col>
                 </Collapse>
               </Form.Group>

--- a/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
+++ b/hasher-matcher-actioner/webapp/src/pages/SubmitContent.jsx
@@ -11,8 +11,9 @@ import {
   Collapse,
   Spinner,
   Alert,
+  Card,
 } from 'react-bootstrap';
-import {Link} from 'react-router-dom';
+import {useHistory} from 'react-router-dom';
 
 import {submitContentViaURL, submitContentViaPutURLUpload} from '../Api';
 import {ContentType, SUBMISSION_TYPE} from '../utils/constants';
@@ -26,7 +27,7 @@ import FixedWidthCenterAlignedLayout from './layouts/FixedWidthCenterAlignedLayo
 
 const FORM_DEFAULTS = {
   submissionType: undefined,
-  contentId: undefined,
+  contentId: '',
   contentType: ContentType.Photo,
   content: undefined,
   force_resubmit: false,
@@ -39,6 +40,7 @@ export default function SubmitContent() {
   const [submissionType, setSubmissionType] = useState('');
   const [additionalFields, setAdditionalFields] = useState({});
   const [inputs, setInputs] = useState(FORM_DEFAULTS);
+  const history = useHistory();
 
   // for most input changes we only need to take the input name and store the event value
   const handleInputChange = event => {
@@ -111,6 +113,16 @@ export default function SubmitContent() {
           setSubmissionError(true);
         });
     }
+  };
+
+  const handleSubmitAnother = event => {
+    // Does not change submission type, clears out additional fields. Depending
+    // on feedback we may want to keep additional fields at their current
+    // values.
+    setSubmittedId(undefined);
+    setSubmitting(false);
+    setAdditionalFields({});
+    setInputs(FORM_DEFAULTS);
   };
 
   return (
@@ -199,14 +211,6 @@ export default function SubmitContent() {
                 </Form.Text>
               </Form.Group>
               <Form.Group as={Row}>
-                <Button
-                  style={{maxHeight: 38}}
-                  className="ml-2"
-                  variant="primary"
-                  disabled={submitting}
-                  type="submit">
-                  Submit
-                </Button>
                 <Collapse in={submitting}>
                   <Spinner
                     as="span"
@@ -215,18 +219,33 @@ export default function SubmitContent() {
                     variant="primary"
                   />
                 </Collapse>
+                <Collapse in={!submittedId}>
+                  <Button
+                    style={{maxHeight: 38}}
+                    className="ml-3"
+                    variant="primary"
+                    disabled={submitting}
+                    type="submit">
+                    Submit
+                  </Button>
+                </Collapse>
                 <Collapse in={submittedId}>
-                  <Col className="ml-4">
-                    <Row>
-                      Submitted! It will take a few minutes for the hash to be
-                      generated.
-                    </Row>
-                    <Row>
-                      <Link to={`/matches/${submittedId}`}>
-                        Once created, the hash and any matches found can be
-                        viewed here.
-                      </Link>
-                    </Row>
+                  <Col>
+                    <Card>
+                      <Card.Header>Your content is submitted!</Card.Header>
+                      <Card.Body>
+                        <Button variant="primary" onClick={handleSubmitAnother}>
+                          Submit Another
+                        </Button>{' '}
+                        <Button
+                          variant="secondary"
+                          onClick={() =>
+                            history.push(`/pipeline-progress/${submittedId}`)
+                          }>
+                          Track Submission
+                        </Button>{' '}
+                      </Card.Body>
+                    </Card>
                   </Col>
                 </Collapse>
                 <Collapse in={submissionError}>


### PR DESCRIPTION
Summary
---
So far, there was no way to arrive at the pipeline progress page. Now, in the submission page, we link to the pipeline progress page which has content even before the hashing has happened. We also link to the content details page from the pipeline progress page.

So, one of the first flows of the user will be. Submit -> Track Progress -> Content Details.

- additionally, have a button to clear out content_id and other inputs in submissions page

Test Plan
---------

**See the buttons appear on submission. And how clicking on "Submit Another" clears the input fields.**
![e36a63642639b43d82d31aa26231dcd5](https://user-images.githubusercontent.com/217056/130512147-aa765b34-8ed6-4b98-a512-c47685d80b54.gif)


**See how the rebase did not destroy the resubmit checkbox**
<img width="655" alt="Screen Shot 2021-08-23 at 16 05 46" src="https://user-images.githubusercontent.com/217056/130512431-64a661c2-c795-4c15-9694-66a220ef0baa.png">

**See the link below the pipeline progress indicator**
<img width="1109" alt="Screen Shot 2021-08-23 at 16 06 21" src="https://user-images.githubusercontent.com/217056/130512271-d3da24e0-a8e7-4a62-b57e-c3894536d7d7.png">

