### PR TITLE
Make PDQSignalMetadata signal-type agnostic -> ThreatExchangeSignalMetadata

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/messages/writeback.py
+++ b/hasher-matcher-actioner/hmalib/common/messages/writeback.py
@@ -9,7 +9,7 @@ from hmalib.common.classification_models import (
     WritebackTypes,
 )
 from hmalib.common.messages.match import MatchMessage, BankedSignal
-from hmalib.common.models.signal import PendingOpinionChange
+from hmalib.common.models.signal import PendingThreatExchangeOpinionChange
 from hmalib.common.aws_dataclass import HasAWSSerialization
 from hmalib.common.logging import get_logger
 
@@ -48,12 +48,14 @@ class WritebackMessage(HasAWSSerialization):
 
     @classmethod
     def from_banked_signal_and_opinion_change(
-        cls, banked_signal: BankedSignal, opinion_change: PendingOpinionChange
+        cls,
+        banked_signal: BankedSignal,
+        opinion_change: PendingThreatExchangeOpinionChange,
     ) -> "WritebackMessage":
         opinion_change_to_writeback_type = {
-            PendingOpinionChange.MARK_TRUE_POSITIVE: WritebackTypes.TruePositive,
-            PendingOpinionChange.MARK_FALSE_POSITIVE: WritebackTypes.FalsePositive,
-            PendingOpinionChange.REMOVE_OPINION: WritebackTypes.RemoveOpinion,
+            PendingThreatExchangeOpinionChange.MARK_TRUE_POSITIVE: WritebackTypes.TruePositive,
+            PendingThreatExchangeOpinionChange.MARK_FALSE_POSITIVE: WritebackTypes.FalsePositive,
+            PendingThreatExchangeOpinionChange.REMOVE_OPINION: WritebackTypes.RemoveOpinion,
         }
 
         writeback_type = opinion_change_to_writeback_type.get(

--- a/hasher-matcher-actioner/hmalib/common/models/signal.py
+++ b/hasher-matcher-actioner/hmalib/common/models/signal.py
@@ -1,18 +1,46 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+r"""Signal Models
+
+The structure of a signal and the data we want to retain on it is
+super-dependent on the source of the signal. Trying to make a "base" signal
+model can be futile because of the disparity of attributes and actions that
+different sources can have.
+
+Instead of abstracting out, for signals, we are creating separate models for
+each source with their own feature evolution. This reality must also manifest on
+the UI. eg. The actions you can take for threatexchange signals are distinct
+from the actions you can take on your local bank's signals.
+
+But, since the id-universes of the signals are distinct, how do we precisely
+refer to a signal when using a signal id? This is a little complex because a
+signal is uniquely defined by two of its attributes: `signal_source` and
+`signal_id`.
+
+So, every signal class needs to define a property `signal_source` which will be
+used in indexing, queries etc.
+
+When we add more signal sources, we'll understand the complexity and identify a
+clean path for supporting multiple signal-sources. For now, only support
+threatexchange.
+"""
+
 import datetime
 from enum import Enum
 import typing as t
-
 from dataclasses import dataclass, field, asdict
+
 from mypy_boto3_dynamodb.service_resource import Table
 from boto3.dynamodb.conditions import Attr, Key, And
 from botocore.exceptions import ClientError
+from threatexchange.content_type.meta import get_signal_types_by_name
+
+from threatexchange.signal_type.signal_base import SignalType
 
 from hmalib.common.models.models_base import DynamoDBItem
 
 
-class PendingOpinionChange(Enum):
+class PendingThreatExchangeOpinionChange(Enum):
     MARK_TRUE_POSITIVE = "mark_true_positive"
     MARK_FALSE_POSITIVE = "mark_false_positive"
     REMOVE_OPINION = "remove_opinion"
@@ -20,26 +48,49 @@ class PendingOpinionChange(Enum):
 
 
 @dataclass
-class SignalMetadataBase(DynamoDBItem):
+class ThreatExchangeSignalMetadata(DynamoDBItem):
     """
-    Base for signal metadata.
-    'ds' refers to dataset which for the time being is
-    quivalent to collab or privacy group (and in the long term could map to bank)
+    This object is designed to be an ~lookaside on some of the values used by
+    MatchRecord for easier and more consistent updating by the syncer and UI.
+
+    We only write these objects when we match against a signal from
+    threatexchange. Updates can happen when:
+      a. a user registers an opinion against this signal.
+      b. the signal's attributes are updated in threatexchange.
+
+    User's registration of an opinion is a multi-stage process. The opinion is
+    first recorded on this object as a 'pending' opinion directly by the UI.
+    Once the opinion is written to threatexchange and synced back, the 'pending'
+    opinion is cleared.
+
+    Storage
+    ---
+    PK: s#{source_short_code}#{signal_id}
+    SK: #threatexchange-signal-metadata
+
+    Where
+    {source_short_code} = "te"
+    and signal_id = {indicator_id} in threatexchange.
     """
 
+    SIGNAL_SOURCE_SHORTCODE = "te"
     DATASET_PREFIX = "ds#"
 
     signal_id: str
-    ds_id: str
+    privacy_group_id: str
     updated_at: datetime.datetime
-    signal_source: str
-    signal_hash: str  # duplicated field with PDQMatchRecord having both for now to help with debuging/testing
+    signal_type: t.Type[SignalType]
+    signal_hash: str
     tags: t.List[str] = field(default_factory=list)
-    pending_opinion_change: PendingOpinionChange = PendingOpinionChange.NONE
+    pending_opinion_change: PendingThreatExchangeOpinionChange = (
+        PendingThreatExchangeOpinionChange.NONE
+    )
+
+    PROJECTION_EXPRESSION = "PK, SignalHash, SignalSource, SignalType, PrivacyGroup, Tags, PendingThreatExchangeOpinionChange, UpdatedAt"
 
     @staticmethod
-    def get_dynamodb_ds_key(ds_id: str) -> str:
-        return f"{SignalMetadataBase.DATASET_PREFIX}{ds_id}"
+    def get_sort_key() -> str:
+        return "#threatexchange-signal-metadata"
 
     def to_json(self) -> t.Dict:
         """
@@ -52,31 +103,19 @@ class SignalMetadataBase(DynamoDBItem):
         )
         return result
 
-
-@dataclass
-class PDQSignalMetadata(SignalMetadataBase):
-    """
-    PDQ Signal metadata.
-    This object is designed to be an ~lookaside on some of the values used by
-    PDQMatchRecord for easier and more consistent updating by the syncer and UI.
-
-    Otherwise updates on a signals metadata would require updating all
-    PDQMatchRecord associated; TODO: For now there will be some overlap between
-    this object and PDQMatchRecord.
-    """
-
-    SIGNAL_TYPE = "pdq"
-
     def to_dynamodb_item(self) -> dict:
         return {
-            "PK": self.get_dynamodb_signal_key(self.signal_source, self.signal_id),
-            "SK": self.get_dynamodb_ds_key(self.ds_id),
+            "PK": self.get_dynamodb_signal_key(
+                self.SIGNAL_SOURCE_SHORTCODE, self.signal_id
+            ),
+            "SK": self.get_sort_key(),
             "SignalHash": self.signal_hash,
-            "SignalSource": self.signal_source,
+            "SignalSource": self.SIGNAL_SOURCE_SHORTCODE,
             "UpdatedAt": self.updated_at.isoformat(),
-            "HashType": self.SIGNAL_TYPE,
+            "SignalType": self.signal_type.get_name(),
+            "PrivacyGroup": self.privacy_group_id,
             "Tags": self.tags,
-            "PendingOpinionChange": self.pending_opinion_change.value,
+            "PendingThreatExchangeOpinionChange": self.pending_opinion_change.value,
         }
 
     def update_tags_in_table_if_exists(self, table: Table) -> bool:
@@ -90,7 +129,7 @@ class PDQSignalMetadata(SignalMetadataBase):
         return self._update_field_in_table_if_exists(
             table,
             field_value=self.pending_opinion_change.value,
-            field_name="PendingOpinionChange",
+            field_name="PendingThreatExchangeOpinionChange",
         )
 
     def _update_field_in_table_if_exists(
@@ -105,9 +144,9 @@ class PDQSignalMetadata(SignalMetadataBase):
             table.update_item(
                 Key={
                     "PK": self.get_dynamodb_signal_key(
-                        self.signal_source, self.signal_id
+                        self.SIGNAL_SOURCE_SHORTCODE, self.signal_id
                     ),
-                    "SK": self.get_dynamodb_ds_key(self.ds_id),
+                    "SK": self.get_sort_key(),
                 },
                 # service_resource.Table.update_item's ConditionExpression params is not typed to use its own objects here...
                 ConditionExpression=And(Attr("PK").exists(), Attr("SK").exists()),  # type: ignore
@@ -132,30 +171,16 @@ class PDQSignalMetadata(SignalMetadataBase):
         cls,
         table: Table,
         signal_id: t.Union[str, int],
-        signal_source: str,
-    ) -> t.List["PDQSignalMetadata"]:
+    ) -> t.Optional["ThreatExchangeSignalMetadata"]:
         """
-        Load the metadata objects relaed to this signal.
-        Optionally provide a data set id to filter to
+        Load the metadata object related to this signal.
         """
-        items = table.query(
-            KeyConditionExpression=Key("PK").eq(
-                cls.get_dynamodb_signal_key(signal_source, signal_id)
-            )
-            & Key("SK").begins_with(cls.DATASET_PREFIX),
-            FilterExpression=Attr("HashType").eq(cls.SIGNAL_TYPE),
-            ProjectionExpression="PK, ContentHash, UpdatedAt, SK, SignalSource, SignalHash, Tags, PendingOpinionChange",
-        ).get("Items", [])
-        return cls._result_items_to_metadata(items)
-
-    @classmethod
-    def get_from_signal_and_ds_id(
-        cls, table: Table, signal_id: t.Union[str, int], signal_source: str, ds_id: str
-    ) -> t.Optional["PDQSignalMetadata"]:
         item = table.get_item(
             Key={
-                "PK": cls.get_dynamodb_signal_key(signal_source, signal_id),
-                "SK": cls.DATASET_PREFIX + ds_id,
+                "PK": cls.get_dynamodb_signal_key(
+                    cls.SIGNAL_SOURCE_SHORTCODE, signal_id
+                ),
+                "SK": cls.get_sort_key(),
             },
         ).get("Item")
         return cls._result_item_to_metadata(item) if item else None
@@ -164,22 +189,25 @@ class PDQSignalMetadata(SignalMetadataBase):
     def _result_items_to_metadata(
         cls,
         items: t.List[t.Dict],
-    ) -> t.List["PDQSignalMetadata"]:
+    ) -> t.List["ThreatExchangeSignalMetadata"]:
         return [cls._result_item_to_metadata(item) for item in items]
 
     @classmethod
     def _result_item_to_metadata(
         cls,
         item: t.Dict,
-    ) -> "PDQSignalMetadata":
-        return PDQSignalMetadata(
+    ) -> "ThreatExchangeSignalMetadata":
+        return ThreatExchangeSignalMetadata(
             signal_id=cls.remove_signal_key_prefix(item["PK"], item["SignalSource"]),
-            ds_id=item["SK"][len(cls.DATASET_PREFIX) :],
+            privacy_group_id=item["PrivacyGroup"],
             updated_at=datetime.datetime.fromisoformat(item["UpdatedAt"]),
-            signal_source=item["SignalSource"],
+            signal_type=get_signal_types_by_name()[item["SignalType"]],
             signal_hash=item["SignalHash"],
             tags=item["Tags"],
-            pending_opinion_change=PendingOpinionChange(
-                item.get("PendingOpinionChange", PendingOpinionChange.NONE.value)
+            pending_opinion_change=PendingThreatExchangeOpinionChange(
+                item.get(
+                    "PendingThreatExchangeOpinionChange",
+                    PendingThreatExchangeOpinionChange.NONE.value,
+                )
             ),
         )

--- a/hasher-matcher-actioner/hmalib/common/models/tests/test_pipeline_models.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/test_pipeline_models.py
@@ -9,7 +9,10 @@ from threatexchange.signal_type.pdq import PdqSignal
 from threatexchange.signal_type.md5 import PhotoMD5Signal
 
 from hmalib.common.models import pipeline as models
-from hmalib.common.models.signal import PDQSignalMetadata, PendingOpinionChange
+from hmalib.common.models.signal import (
+    ThreatExchangeSignalMetadata,
+    PendingThreatExchangeOpinionChange,
+)
 from hmalib.common.count_models import MatchByPrivacyGroupCounter
 
 from ddb_test_common import DynamoDBTableTestBase
@@ -119,11 +122,11 @@ class TestPDQModels(DynamoDBTableTestBase, unittest.TestCase):
     @staticmethod
     def get_example_pdq_signal_metadata():
         pdq_hash = "a0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"
-        return PDQSignalMetadata(
+        return ThreatExchangeSignalMetadata(
             signal_id=TestPDQModels.TEST_SIGNAL_ID,
-            ds_id=TestPDQModels.TEST_DATASET_ID,
+            privacy_group_id=TestPDQModels.TEST_DATASET_ID,
             updated_at=datetime.datetime.now(),
-            signal_source=TestPDQModels.TEST_SIGNAL_SOURCE,
+            signal_type=PdqSignal,
             signal_hash=pdq_hash,
             tags=["test_tag1", "test_tag2"],
         )
@@ -283,8 +286,8 @@ class TestPDQModels(DynamoDBTableTestBase, unittest.TestCase):
 
         result = self.table.get_item(
             Key={
-                "PK": f"s#{TestPDQModels.TEST_SIGNAL_SOURCE}#{TestPDQModels.TEST_SIGNAL_ID}",
-                "SK": f"ds#{TestPDQModels.TEST_DATASET_ID}",
+                "PK": f"s#{ThreatExchangeSignalMetadata.SIGNAL_SOURCE_SHORTCODE}#{TestPDQModels.TEST_SIGNAL_ID}",
+                "SK": f"{ThreatExchangeSignalMetadata.get_sort_key()}",
             },
         )
         items = result.get("Item")
@@ -301,9 +304,9 @@ class TestPDQModels(DynamoDBTableTestBase, unittest.TestCase):
 
         metadata.write_to_table(self.table)
 
-        query_metadata = PDQSignalMetadata.get_from_signal(
-            self.table, TestPDQModels.TEST_SIGNAL_ID, TestPDQModels.TEST_SIGNAL_SOURCE
-        )[0]
+        query_metadata = ThreatExchangeSignalMetadata.get_from_signal(
+            self.table, TestPDQModels.TEST_SIGNAL_ID
+        )
 
         assert metadata.signal_hash == query_metadata.signal_hash
         for tag in metadata.tags:
@@ -324,9 +327,9 @@ class TestPDQModels(DynamoDBTableTestBase, unittest.TestCase):
 
         metadata.write_to_table(self.table)
 
-        query_metadata = PDQSignalMetadata.get_from_signal(
-            self.table, new_signal_id, TestPDQModels.TEST_SIGNAL_SOURCE
-        )[0]
+        query_metadata = ThreatExchangeSignalMetadata.get_from_signal(
+            self.table, new_signal_id
+        )
         assert metadata.signal_hash == query_metadata.signal_hash
         for tag in metadata.tags:
             assert tag in query_metadata.tags
@@ -336,9 +339,9 @@ class TestPDQModels(DynamoDBTableTestBase, unittest.TestCase):
 
         # second attmept at update should succeed
         assert metadata.update_tags_in_table_if_exists(self.table)
-        query_metadata = PDQSignalMetadata.get_from_signal(
-            self.table, new_signal_id, TestPDQModels.TEST_SIGNAL_SOURCE
-        )[0]
+        query_metadata = ThreatExchangeSignalMetadata.get_from_signal(
+            self.table, new_signal_id
+        )
         for tag in replaced_tags:
             assert tag in query_metadata.tags
 
@@ -357,24 +360,26 @@ class TestPDQModels(DynamoDBTableTestBase, unittest.TestCase):
 
         metadata.write_to_table(self.table)
 
-        query_metadata = PDQSignalMetadata.get_from_signal(
-            self.table, new_signal_id, TestPDQModels.TEST_SIGNAL_SOURCE
-        )[0]
+        query_metadata = ThreatExchangeSignalMetadata.get_from_signal(
+            self.table, new_signal_id
+        )
         assert metadata.signal_hash == query_metadata.signal_hash
         assert (
-            PendingOpinionChange.NONE.value
+            PendingThreatExchangeOpinionChange.NONE.value
             == query_metadata.pending_opinion_change.value
         )
 
-        metadata.pending_opinion_change = PendingOpinionChange.MARK_TRUE_POSITIVE
+        metadata.pending_opinion_change = (
+            PendingThreatExchangeOpinionChange.MARK_TRUE_POSITIVE
+        )
 
         # second attmept at update should succeed
         assert metadata.update_pending_opinion_change_in_table_if_exists(self.table)
-        query_metadata = PDQSignalMetadata.get_from_signal(
-            self.table, new_signal_id, TestPDQModels.TEST_SIGNAL_SOURCE
-        )[0]
+        query_metadata = ThreatExchangeSignalMetadata.get_from_signal(
+            self.table, new_signal_id
+        )
         assert (
-            PendingOpinionChange.MARK_TRUE_POSITIVE.value
+            PendingThreatExchangeOpinionChange.MARK_TRUE_POSITIVE.value
             == query_metadata.pending_opinion_change.value
         )
 

--- a/hasher-matcher-actioner/hmalib/common/models/tests/test_pipeline_models.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/test_pipeline_models.py
@@ -287,7 +287,7 @@ class TestPDQModels(DynamoDBTableTestBase, unittest.TestCase):
         result = self.table.get_item(
             Key={
                 "PK": f"s#{ThreatExchangeSignalMetadata.SIGNAL_SOURCE_SHORTCODE}#{TestPDQModels.TEST_SIGNAL_ID}",
-                "SK": f"{ThreatExchangeSignalMetadata.get_sort_key()}",
+                "SK": f"{ThreatExchangeSignalMetadata.get_sort_key(TestPDQModels.TEST_DATASET_ID)}",
             },
         )
         items = result.get("Item")
@@ -306,7 +306,7 @@ class TestPDQModels(DynamoDBTableTestBase, unittest.TestCase):
 
         query_metadata = ThreatExchangeSignalMetadata.get_from_signal(
             self.table, TestPDQModels.TEST_SIGNAL_ID
-        )
+        )[0]
 
         assert metadata.signal_hash == query_metadata.signal_hash
         for tag in metadata.tags:
@@ -329,7 +329,7 @@ class TestPDQModels(DynamoDBTableTestBase, unittest.TestCase):
 
         query_metadata = ThreatExchangeSignalMetadata.get_from_signal(
             self.table, new_signal_id
-        )
+        )[0]
         assert metadata.signal_hash == query_metadata.signal_hash
         for tag in metadata.tags:
             assert tag in query_metadata.tags
@@ -341,7 +341,7 @@ class TestPDQModels(DynamoDBTableTestBase, unittest.TestCase):
         assert metadata.update_tags_in_table_if_exists(self.table)
         query_metadata = ThreatExchangeSignalMetadata.get_from_signal(
             self.table, new_signal_id
-        )
+        )[0]
         for tag in replaced_tags:
             assert tag in query_metadata.tags
 
@@ -362,7 +362,7 @@ class TestPDQModels(DynamoDBTableTestBase, unittest.TestCase):
 
         query_metadata = ThreatExchangeSignalMetadata.get_from_signal(
             self.table, new_signal_id
-        )
+        )[0]
         assert metadata.signal_hash == query_metadata.signal_hash
         assert (
             PendingThreatExchangeOpinionChange.NONE.value
@@ -377,7 +377,7 @@ class TestPDQModels(DynamoDBTableTestBase, unittest.TestCase):
         assert metadata.update_pending_opinion_change_in_table_if_exists(self.table)
         query_metadata = ThreatExchangeSignalMetadata.get_from_signal(
             self.table, new_signal_id
-        )
+        )[0]
         assert (
             PendingThreatExchangeOpinionChange.MARK_TRUE_POSITIVE.value
             == query_metadata.pending_opinion_change.value

--- a/hasher-matcher-actioner/hmalib/common/s3_adapters.py
+++ b/hasher-matcher-actioner/hmalib/common/s3_adapters.py
@@ -547,9 +547,12 @@ class ThreatUpdateS3Store(tu.ThreatUpdatesStore):
                 # e.g (10736405276340','096a6f9...064f', '1234567890', '2020-07-31T18:47:45+0000', 'true_positive hma_test')
                 new_tags = row[4].split(" ") if row[4] else []
 
-                metadata = ThreatExchangeSignalMetadata.get_from_signal(
-                    table,
-                    int(row[1]),
+                metadata = (
+                    ThreatExchangeSignalMetadata.get_from_signal_and_privacy_group(
+                        table,
+                        int(row[1]),  # indicator-id or signal-id
+                        str(self.privacy_group),
+                    )
                 )
 
                 if metadata:

--- a/hasher-matcher-actioner/hmalib/common/s3_adapters.py
+++ b/hasher-matcher-actioner/hmalib/common/s3_adapters.py
@@ -26,7 +26,10 @@ from threatexchange.signal_type.md5 import VideoMD5Signal
 from threatexchange.signal_type.pdq import PdqSignal
 
 
-from hmalib.common.models.signal import PDQSignalMetadata, PendingOpinionChange
+from hmalib.common.models.signal import (
+    ThreatExchangeSignalMetadata,
+    PendingThreatExchangeOpinionChange,
+)
 from hmalib import metrics
 from hmalib.common.logging import get_logger
 
@@ -485,7 +488,7 @@ class ThreatUpdateS3Store(tu.ThreatUpdatesStore):
         post_apply_fn(updated)
 
     def get_new_pending_opinion_change(
-        self, metadata: PDQSignalMetadata, new_tags: t.List[str]
+        self, metadata: ThreatExchangeSignalMetadata, new_tags: t.List[str]
     ):
         # Figure out if we have a new opinion about this indicator and clear out a pending change if so
 
@@ -498,25 +501,25 @@ class ThreatUpdateS3Store(tu.ThreatUpdatesStore):
         # If our opinion changed or if our pending change has already happend,
         # set the pending opinion change to None, otherwise keep it unchanged
         if old_opinion != new_opinion:
-            return PendingOpinionChange.NONE
+            return PendingThreatExchangeOpinionChange.NONE
         elif (
             (
                 new_opinion == [ThreatDescriptor.TRUE_POSITIVE]
                 and metadata.pending_opinion_change
-                == PendingOpinionChange.MARK_TRUE_POSITIVE
+                == PendingThreatExchangeOpinionChange.MARK_TRUE_POSITIVE
             )
             or (
                 new_opinion == [ThreatDescriptor.FALSE_POSITIVE]
                 and metadata.pending_opinion_change
-                == PendingOpinionChange.MARK_FALSE_POSITIVE
+                == PendingThreatExchangeOpinionChange.MARK_FALSE_POSITIVE
             )
             or (
                 new_opinion == []
                 and metadata.pending_opinion_change
-                == PendingOpinionChange.REMOVE_OPINION
+                == PendingThreatExchangeOpinionChange.REMOVE_OPINION
             )
         ):
-            return PendingOpinionChange.NONE
+            return PendingThreatExchangeOpinionChange.NONE
         else:
             return metadata.pending_opinion_change
 
@@ -544,11 +547,9 @@ class ThreatUpdateS3Store(tu.ThreatUpdatesStore):
                 # e.g (10736405276340','096a6f9...064f', '1234567890', '2020-07-31T18:47:45+0000', 'true_positive hma_test')
                 new_tags = row[4].split(" ") if row[4] else []
 
-                metadata = PDQSignalMetadata.get_from_signal_and_ds_id(
+                metadata = ThreatExchangeSignalMetadata.get_from_signal(
                     table,
                     int(row[1]),
-                    S3ThreatDataConfig.SOURCE_STR,
-                    str(self.privacy_group),
                 )
 
                 if metadata:
@@ -559,11 +560,11 @@ class ThreatUpdateS3Store(tu.ThreatUpdatesStore):
                     # If this is a new indicator without metadata there is nothing for us to update
                     return
 
-                metadata = PDQSignalMetadata(
+                metadata = ThreatExchangeSignalMetadata(
                     signal_id=row[1],
-                    ds_id=str(self.privacy_group),
+                    privacy_group_id=str(self.privacy_group),
                     updated_at=datetime.now(),
-                    signal_source=S3ThreatDataConfig.SOURCE_STR,
+                    signal_type=PdqSignal,
                     signal_hash=row[
                         0
                     ],  # note: not used by update_tags_in_table_if_exists

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -136,14 +136,10 @@ def get_match_details(table: Table, content_id: str) -> t.List[MatchDetail]:
 def get_signal_details(
     table: Table, signal_id: t.Union[str, int], signal_source: str
 ) -> t.List[MatchDetailMetadata]:
+    # TODO: Remove need for signal_source. That's part of the *SignalMetadata class now.
     if not signal_id or not signal_source:
         return []
 
-    metadata = ThreatExchangeSignalMetadata.get_from_signal(table, signal_id)
-    if not metadata:
-        return []
-
-    metadata = t.cast(ThreatExchangeSignalMetadata, metadata)
     return [
         MatchDetailMetadata(
             dataset=metadata.privacy_group_id,
@@ -153,6 +149,7 @@ def get_signal_details(
             opinion=get_opinion_from_tags(metadata.tags).value,
             pending_opinion_change=metadata.pending_opinion_change.value,
         )
+        for metadata in ThreatExchangeSignalMetadata.get_from_signal(table, signal_id)
     ]
 
 
@@ -277,8 +274,8 @@ def get_matches_api(
             f"Opinion change enqueued for {signal_source}:{signal_id} in {ds_id} change={opinion_change}"
         )
 
-        signal = ThreatExchangeSignalMetadata.get_from_signal(
-            dynamodb_table, signal_id=signal_id
+        signal = ThreatExchangeSignalMetadata.get_from_signal_and_privacy_group(
+            dynamodb_table, signal_id=signal_id, privacy_group_id=ds_id
         )
 
         if not signal:

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -80,12 +80,6 @@ class ThreatExchangeMatchDetailMetadata(JSONifiable):
         return asdict(self)
 
 
-# For when we support multiple signal sources.
-AnyMatchDetailMetadata = t.NewType(
-    "AnyMatchDetailMetadata", t.Union[ThreatExchangeSignalMetadata]
-)
-
-
 @dataclass
 class MatchDetail(JSONifiable):
     content_id: str
@@ -95,7 +89,7 @@ class MatchDetail(JSONifiable):
     signal_source: str
     signal_type: str
     updated_at: str
-    metadata: t.List[AnyMatchDetailMetadata]
+    metadata: t.List[ThreatExchangeMatchDetailMetadata]
 
     def to_json(self) -> t.Dict:
         result = asdict(self)

--- a/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/pdq/pdq_matcher.py
@@ -15,7 +15,7 @@ from threatexchange.signal_type.pdq import PdqSignal
 from hmalib import metrics
 from hmalib.common.models.pipeline import MatchRecord
 from hmalib.common.messages.match import BankedSignal, MatchMessage
-from hmalib.common.models.signal import PDQSignalMetadata
+from hmalib.common.models.signal import ThreatExchangeSignalMetadata
 from hmalib.common.logging import get_logger
 from hmalib.common.config import HMAConfig
 from hmalib.common.configs.fetcher import ThreatExchangeConfig

--- a/hasher-matcher-actioner/webapp/src/Api.jsx
+++ b/hasher-matcher-actioner/webapp/src/Api.jsx
@@ -108,16 +108,16 @@ export function fetchStats(statName, timeSpan) {
 export async function requestSignalOpinionChange(
   signalId,
   signalSource,
-  dataset,
+  privacyGroupId,
   opinionChange,
 ) {
   apiPost(
     '/matches/request-signal-opinion-change/',
     {},
     {
-      signal_q: signalId,
+      signal_id: signalId,
       signal_source: signalSource,
-      dataset_q: dataset,
+      privacy_group_id: privacyGroupId,
       opinion_change: opinionChange,
     },
   );

--- a/hasher-matcher-actioner/webapp/src/components/ContentMatchTable.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/ContentMatchTable.jsx
@@ -53,7 +53,7 @@ export default function ContentMatchTable({contentKey}) {
                   <th>MatchedSignal Type</th>
                   <th>MatchedSignal</th>
                   <th>Last Updated</th>
-                  <th>Dataset</th>
+                  <th>Privacy Group</th>
                   <th>Opinion</th>
                   <th>Classifications</th>
                 </tr>
@@ -83,10 +83,10 @@ export default function ContentMatchTable({contentKey}) {
                             <td />
                           </>
                         )}
-                        <td>{metadata.dataset}</td>
+                        <td>{metadata.privacy_group_id}</td>
                         <td>
                           <OpinionTableCell
-                            dataset={metadata.dataset}
+                            privacyGroupId={metadata.privacy_group_id}
                             signalId={match.signal_id}
                             signalSource={match.signal_source}
                             opinion={metadata.opinion}

--- a/hasher-matcher-actioner/webapp/src/components/OpinionChangeConfirmModal.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/OpinionChangeConfirmModal.jsx
@@ -13,7 +13,7 @@ export default function OpinionChangeConfirmModal({
   show,
   onHide,
   onSubmit,
-  dataset,
+  privacyGroupId,
   signalId,
   signalSource,
   opinion,
@@ -54,7 +54,7 @@ export default function OpinionChangeConfirmModal({
           <Row className="mb-2">
             Signal ID: {`(${signalSource}) ${signalId} `}
           </Row>
-          <Row className="mb-2">Dataset ID: {dataset}</Row>
+          <Row className="mb-2">PrivacyGroup ID: {privacyGroupId}</Row>
           <Row as="strong" className="mb-2">
             Current Opinion: {opinion}
           </Row>
@@ -75,7 +75,7 @@ export default function OpinionChangeConfirmModal({
             requestSignalOpinionChange(
               signalId,
               signalSource,
-              dataset,
+              privacyGroupId,
               pendingOpinionChange,
             ).then(() => {
               setSubmitting(false);
@@ -94,7 +94,7 @@ OpinionChangeConfirmModal.propTypes = {
   show: PropTypes.bool,
   onHide: PropTypes.func,
   onSubmit: PropTypes.func,
-  dataset: PropTypes.string,
+  privacyGroupId: PropTypes.string,
   signalId: PropTypes.string,
   signalSource: PropTypes.string,
   opinion: PropTypes.oneOf(Object.values(OPINION_STRING)),
@@ -105,7 +105,7 @@ OpinionChangeConfirmModal.defaultProps = {
   show: false,
   onHide: undefined,
   onSubmit: undefined,
-  dataset: undefined,
+  privacyGroupId: undefined,
   signalId: undefined,
   signalSource: undefined,
   opinion: undefined,

--- a/hasher-matcher-actioner/webapp/src/components/OpinionTableCell.jsx
+++ b/hasher-matcher-actioner/webapp/src/components/OpinionTableCell.jsx
@@ -10,7 +10,7 @@ import {OPINION_STRING, PENDING_OPINION_CHANGE} from '../utils/constants';
 import OpinionChangeConfirmModal from './OpinionChangeConfirmModal';
 
 export default function OpinionTableCell({
-  dataset,
+  privacyGroupId,
   signalId,
   signalSource,
   opinion,
@@ -116,7 +116,7 @@ export default function OpinionTableCell({
           setShowToast(true);
           setUpdatePending(true);
         }}
-        dataset={dataset}
+        privacyGroupId={privacyGroupId}
         signalId={signalId}
         signalSource={signalSource}
         opinion={opinion}
@@ -127,7 +127,7 @@ export default function OpinionTableCell({
 }
 
 OpinionTableCell.propTypes = {
-  dataset: PropTypes.string,
+  privacyGroupId: PropTypes.string,
   signalId: PropTypes.string,
   signalSource: PropTypes.string,
   opinion: PropTypes.oneOf(Object.values(OPINION_STRING)),
@@ -136,7 +136,7 @@ OpinionTableCell.propTypes = {
 };
 
 OpinionTableCell.defaultProps = {
-  dataset: undefined,
+  privacyGroupId: undefined,
   signalId: undefined,
   signalSource: undefined,
   opinion: OPINION_STRING.UKNOWN,


### PR DESCRIPTION
NOTE: All current signal metadata objects will be unusable after this. On matches on your instance, new signal metadata objects will be created. If your opinions have synced with threatexchange, you've nothing to worry about.

Summary
---------
This is in the lead-up to supporting video-md5 signal metadata.
Be sure to go through the module docstring for `hmalib.common.models.signal`

To reviewer: There may be questions on choice of PK / SK for signal metadata. Happy to respond in inline comments. 

Test Plan
---------
```
$ python -m black hmalib
$ python -m mypy hmalib
$ python -m py.test
```

A URL upload for an image in our test privacy groups was done. This resulted in matches and actions. These were visually verified on the pipeline progress page.

On the content details page as shown in a series of screenshots, I removed the opinion and added it back again. After every change, I manually triggered fetcher because I did not want to wait for 15 minutes to have passed. ;) 

### Original: Has opinion
<img width="1126" alt="Screen Shot 2021-08-24 at 16 59 52" src="https://user-images.githubusercontent.com/217056/130690251-05e04f55-0ec0-455b-b8aa-690848a7bca6.png">

### UI used to remove opinion
<img width="1120" alt="Screen Shot 2021-08-24 at 17 00 02" src="https://user-images.githubusercontent.com/217056/130690288-b6dd4327-3101-4b8f-b222-b3a474b41aad.png">

\< Runs fetcher manually \>

### Opinion was removed.
<img width="1126" alt="Screen Shot 2021-08-24 at 17 01 00" src="https://user-images.githubusercontent.com/217056/130690356-52c65735-0b28-417f-89dc-cba10130caee.png">

I also added the opinion back and got it to reflect in the UI.
Not adding screenshots. You get the drift..

### Before the fetcher was run, refreshing the content details page gave me the interim state
<img width="1129" alt="Screen Shot 2021-08-24 at 14 31 53" src="https://user-images.githubusercontent.com/217056/130690538-0d291f2e-d4d8-4692-ac3c-8e02b391538b.png">
