### PR TITLE
[pytx] Fix problem with installing wrong version of urllib library

### DIFF
--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -57,6 +57,7 @@ setup(
     install_requires=[
         "python-Levenshtein",
         "requests>=2.26.0",
+        "urllib3>=1.26.0",  # For allow_methods
         "dataclasses",
         "python-dateutil",
     ],


### PR DESCRIPTION
Summary
---------

We changed over to use allow_methods from the old names. However, we then didn't add install hints to make sure those changes were picked up. Add an install hint.

Test Plan
---------

Before:
```
$ pip install --upgrade .
$ threatexchange fetch

  File "/data/users/dcallies/fork_te/ThreatExchange/python-threatexchange/threatexchange/api.py", line 149, in _get_sess
ion
    backoff_factor=0.2,  # ~1.5 seconds of retries
TypeError: __init__() got an unexpected keyword argument 'allowed_methods'

```

After:
```
$ pip install --upgrade .
$ threatexchange fetch

requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://graph.facebook.com/v9.0/
```

Well... it's progress.