### PR TITLE
[hma][api] create configurable integration_api_access_token

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_auth.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_auth.py
@@ -1,0 +1,92 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import os
+import json
+import time
+import jwt
+import requests
+import base64
+from jwt.algorithms import RSAAlgorithm
+
+from hmalib.common.logging import get_logger
+
+ACCESS_TOKEN = os.environ["ACCESS_TOKEN"]
+USER_POOL_URL = os.environ["USER_POOL_URL"]
+CLIENT_ID = os.environ["CLIENT_ID"]
+
+keys_url = f"{USER_POOL_URL}/.well-known/jwks.json"
+
+response = requests.get(keys_url)
+key_list = json.loads(response.text).get("keys", [])
+keys = {key["kid"]: json.dumps(key) for key in key_list}
+
+
+def is_jwt(token: str) -> bool:
+    jwt_split = token.split(".")
+    try:
+        if len(jwt_split) != 3:
+            return False
+        header = json.loads(base64.b64decode(jwt_split[0] + "=="))
+        if header["alg"] != "RS256":
+            return False
+    except Exception as e:
+        print("INFO: Provisioning Data is not in JWT format\n {0}".format(e))
+        return False
+    return True
+
+
+def validate_jwt(token: str):
+    logger = get_logger()
+
+    try:
+        if not keys:
+            logger.error("No JWT public keys found. User auth will always fail.")
+
+        kid = jwt.get_unverified_header(token)["kid"]
+        key = keys[kid]
+
+        public_key = RSAAlgorithm.from_jwk(key)
+
+        # Decode does verify_signature
+        decoded = jwt.decode(
+            token, public_key, algorithms=["RS256"], issuer=USER_POOL_URL
+        )
+
+        # Congnito JWT use 'client_id' instead of 'aud' e.g. audience
+        if decoded["client_id"] == CLIENT_ID and decoded["token_use"] == "access":
+            # Because we don't require username as part of the request,
+            # we don't check it beyond making sure it exists.
+            username = decoded["username"]
+            logger.info(f"User: {username} JWT verified.")
+            return {"isAuthorized": True, "context": {"AuthInfo": "JWTTokenCheck"}}
+
+    except Exception as e:
+        logger.exception(e)
+
+    return {"isAuthorized": False, "context": {"AuthInfo": "JWTTokenCheck"}}
+
+
+def validate_access_toke(token: str):
+    response = {"isAuthorized": False, "context": {"AuthInfo": "ServiceAccessToken"}}
+
+    if token == ACCESS_TOKEN:
+        get_logger().info("Access token approved")
+        response["isAuthorized"] = True
+
+    return response
+
+
+def lambda_handler(event, context):
+
+    token = event["identitySource"][0]
+
+    if is_jwt(token):
+        return validate_jwt(token)
+
+    return validate_access_toke(token)
+
+
+if __name__ == "__main__":
+    token = "text_token"
+    event = {"identitySource": [token]}
+    lambda_handler(event, None)

--- a/hasher-matcher-actioner/setup.py
+++ b/hasher-matcher-actioner/setup.py
@@ -13,6 +13,7 @@ setup(
         "threatexchange[faiss,pdq_hasher]>=0.0.23",
         "bottle",
         "apig_wsgi",
+        "pyjwt[crypto]",
         "requests==2.25.1",
     ],
 )

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -160,6 +160,82 @@ resource "aws_iam_role_policy_attachment" "api_root" {
   policy_arn = aws_iam_policy.api_root.arn
 }
 
+# Authorizer API Lambda
+
+locals {
+  user_pool_url = "https://cognito-idp.${var.region}.amazonaws.com/${var.api_and_webapp_user_pool_id}"
+}
+
+resource "aws_lambda_function" "api_auth" {
+  function_name = "${var.prefix}_api_auth"
+  package_type  = "Image"
+  role          = aws_iam_role.api_auth.arn
+  image_uri     = var.lambda_docker_info.uri
+  image_config {
+    command = [var.lambda_docker_info.commands.api_auth]
+  }
+  timeout     = 300
+  memory_size = 512
+  environment {
+    variables = {
+      ACCESS_TOKEN  = var.integration_api_access_token
+      USER_POOL_URL = local.user_pool_url
+      CLIENT_ID     = var.api_authorizer_audience
+    }
+  }
+  tags = merge(
+    var.additional_tags,
+    {
+      Name = "AuthAPIFunction"
+    }
+  )
+}
+
+resource "aws_cloudwatch_log_group" "api_auth" {
+  name              = "/aws/lambda/${aws_lambda_function.api_auth.function_name}"
+  retention_in_days = var.log_retention_in_days
+  tags = merge(
+    var.additional_tags,
+    {
+      Name = "AuthAPILambdaLogGroup"
+    }
+  )
+}
+
+resource "aws_iam_role" "api_auth" {
+  name_prefix        = "${var.prefix}_api_auth"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags = merge(
+    var.additional_tags,
+    {
+      Name = "AuthAPILambdaRole"
+    }
+  )
+}
+
+data "aws_iam_policy_document" "api_auth" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams"
+    ]
+    resources = ["${aws_cloudwatch_log_group.api_auth.arn}:*"]
+  }
+}
+
+resource "aws_iam_policy" "api_auth" {
+  name_prefix = "${var.prefix}_api_auth_role_policy"
+  description = "Permissions for Auth API Lambda"
+  policy      = data.aws_iam_policy_document.api_auth.json
+}
+
+resource "aws_iam_role_policy_attachment" "api_auth" {
+  role       = aws_iam_role.api_auth.name
+  policy_arn = aws_iam_policy.api_auth.arn
+}
+
 # API Gateway
 
 resource "aws_apigatewayv2_api" "hma_apigateway" {
@@ -192,7 +268,7 @@ resource "aws_apigatewayv2_stage" "hma_apigateway" {
 resource "aws_apigatewayv2_route" "hma_apigateway_get" {
   api_id             = aws_apigatewayv2_api.hma_apigateway.id
   route_key          = "GET /{proxy+}"
-  authorization_type = "JWT"
+  authorization_type = "CUSTOM"
   authorizer_id      = aws_apigatewayv2_authorizer.hma_apigateway.id
   target             = "integrations/${aws_apigatewayv2_integration.hma_apigateway.id}"
 }
@@ -200,7 +276,7 @@ resource "aws_apigatewayv2_route" "hma_apigateway_get" {
 resource "aws_apigatewayv2_route" "hma_apigateway_post" {
   api_id             = aws_apigatewayv2_api.hma_apigateway.id
   route_key          = "POST /{proxy+}"
-  authorization_type = "JWT"
+  authorization_type = "CUSTOM"
   authorizer_id      = aws_apigatewayv2_authorizer.hma_apigateway.id
   target             = "integrations/${aws_apigatewayv2_integration.hma_apigateway.id}"
 }
@@ -208,7 +284,7 @@ resource "aws_apigatewayv2_route" "hma_apigateway_post" {
 resource "aws_apigatewayv2_route" "hma_apigateway_put" {
   api_id             = aws_apigatewayv2_api.hma_apigateway.id
   route_key          = "PUT /{proxy+}"
-  authorization_type = "JWT"
+  authorization_type = "CUSTOM"
   authorizer_id      = aws_apigatewayv2_authorizer.hma_apigateway.id
   target             = "integrations/${aws_apigatewayv2_integration.hma_apigateway.id}"
 }
@@ -216,7 +292,7 @@ resource "aws_apigatewayv2_route" "hma_apigateway_put" {
 resource "aws_apigatewayv2_route" "hma_apigateway_delete" {
   api_id             = aws_apigatewayv2_api.hma_apigateway.id
   route_key          = "DELETE /{proxy+}"
-  authorization_type = "JWT"
+  authorization_type = "CUSTOM"
   authorizer_id      = aws_apigatewayv2_authorizer.hma_apigateway.id
   target             = "integrations/${aws_apigatewayv2_integration.hma_apigateway.id}"
 }
@@ -230,16 +306,30 @@ resource "aws_apigatewayv2_integration" "hma_apigateway" {
   payload_format_version = "2.0"
 }
 
-resource "aws_apigatewayv2_authorizer" "hma_apigateway" {
-  api_id           = aws_apigatewayv2_api.hma_apigateway.id
-  authorizer_type  = "JWT"
-  identity_sources = ["$request.header.Authorization"]
-  name             = "${var.prefix}-jwt-authorizer"
+# Old Authorizer that just handles JWT tokens
+# 
+# resource "aws_apigatewayv2_authorizer" "hma_apigateway" {
+#   api_id           = aws_apigatewayv2_api.hma_apigateway.id
+#   authorizer_type  = "JWT"
+#   identity_sources = ["$request.header.Authorization"]
+#   name             = "${var.prefix}-jwt-authorizer"
 
-  jwt_configuration {
-    audience = [var.api_authorizer_audience]
-    issuer   = var.api_authorizer_jwt_issuer
-  }
+#   jwt_configuration {
+#     audience = [var.api_authorizer_audience]
+#     issuer   = local.user_pool_url
+#   }
+# }
+
+resource "aws_apigatewayv2_authorizer" "hma_apigateway" {
+  api_id                            = aws_apigatewayv2_api.hma_apigateway.id
+  authorizer_type                   = "REQUEST"
+  authorizer_credentials_arn        = aws_iam_role.hma_apigateway.arn
+  authorizer_uri                    = aws_lambda_function.api_auth.invoke_arn
+  identity_sources                  = ["$request.header.Authorization"]
+  authorizer_payload_format_version = "2.0"
+  enable_simple_responses           = true
+  authorizer_result_ttl_in_seconds  = 0
+  name                              = "${aws_apigatewayv2_api.hma_apigateway.name}_authorizer"
 }
 
 resource "aws_cloudwatch_log_group" "hma_apigateway" {
@@ -290,7 +380,7 @@ data "aws_iam_policy_document" "hma_apigateway" {
   statement {
     effect    = "Allow"
     actions   = ["lambda:InvokeFunction", ]
-    resources = [aws_lambda_function.api_root.arn]
+    resources = [aws_lambda_function.api_root.arn, aws_lambda_function.api_auth.arn]
   }
 }
 

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -17,8 +17,8 @@ variable "prefix" {
   type        = string
 }
 
-variable "api_authorizer_jwt_issuer" {
-  description = "A URL to the JWT issuer (used by the api gateway authorizer)"
+variable "api_and_webapp_user_pool_id" {
+  description = "user pool id that can be used to create a URL to the JWT issuer (used by the api gateway authorizer)"
   type        = string
 }
 
@@ -135,4 +135,10 @@ variable "partner_image_buckets" {
     arn    = string
     params = map(string)
   }))
+}
+
+variable "integration_api_access_token" {
+  description = "Access token checked for in authorizer api as an alternative to cognito user tokens."
+  type        = string
+  sensitive   = true
 }

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -351,10 +351,10 @@ module "matcher" {
 
 # Set up api
 module "api" {
-  source                    = "./api"
-  prefix                    = var.prefix
-  api_authorizer_jwt_issuer = "https://cognito-idp.${data.aws_region.default.name}.amazonaws.com/${module.authentication.webapp_and_api_user_pool_id}"
-  api_authorizer_audience   = module.authentication.webapp_and_api_user_pool_client_id
+  source                      = "./api"
+  prefix                      = var.prefix
+  api_and_webapp_user_pool_id = module.authentication.webapp_and_api_user_pool_id
+  api_authorizer_audience     = module.authentication.webapp_and_api_user_pool_client_id
   lambda_docker_info = {
     uri = var.hma_lambda_docker_uri
     commands = {
@@ -393,7 +393,8 @@ module "api" {
     url = aws_sqs_queue.submissions_queue.id,
     arn = aws_sqs_queue.submissions_queue.arn
   }
-  partner_image_buckets = var.partner_image_buckets
+  partner_image_buckets        = var.partner_image_buckets
+  integration_api_access_token = var.integration_api_access_token
 }
 
 # Build and deploy webapp

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -90,21 +90,21 @@ variable "set_sqs_windows_to_min" {
 
 variable "partner_image_buckets" {
   description = "Names and arns of s3 buckets to consider as inputs to HMA. All images uploaded to these buckets will be processed by the hasher"
-  type        = list(object({
-    name = string
-    arn  = string
+  type = list(object({
+    name   = string
+    arn    = string
     params = map(string)
   }))
-  default     = []
+  default = []
 
   # Ensure only correct params are used
   validation {
     condition = alltrue(
       [
-        for partner_bucket in var.partner_image_buckets: 
+        for partner_bucket in var.partner_image_buckets :
         alltrue(
           [
-            for param_key in keys(partner_bucket.params):
+            for param_key in keys(partner_bucket.params) :
             # 'prefix' is the prefered term but we also accept 'folder' or 'path'. All these options are processed in the same way
             # similarly, 'suffix' is the prefered term but we also accept 'extension'
             param_key == "prefix" || param_key == "folder" || param_key == "path" || param_key == "suffix" || param_key == "extension"
@@ -115,4 +115,10 @@ variable "partner_image_buckets" {
 
     error_message = "The only accepted params are 'prefix' to specify a prefix/folder/path string where only uploads with that prefix should be sent to HMA and 'suffix' to restrict uploads to only files with a specific extension."
   }
+}
+
+variable "integration_api_access_token" {
+  description = "Access token checked for in authorizer api as an alternative to cognito user tokens."
+  type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
Summary
---------

For integration it is good to have permanent access token disconnected from any specific users. 
This PR updates the APIGateway authorizer to be a custom lambda that is able to validate cognito JWTs as well as check for a specific token given at deployment as a part of `terraform/terraform.tfvars` -> `integration_api_access_token` 

This token can be user everywhere the ephemeral access token from cognito was used. Warning: this effectively give you the ability to have a skeleton key for the API, use with care. 

Test Plan
---------

Made sure HMA still worked e2e and used postman to query the api with the value used for `integration_api_access_token` in the header as { "Authorization" : "<token>"} instead of using OAuth 2.0 (and that non-valid and expired tokens failed).
