### PR TITLE
Parse URLs and headers in Actions

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/configs/actioner.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/actioner.py
@@ -6,7 +6,7 @@ import typing as t
 
 from dataclasses import dataclass
 from hmalib.common.logging import get_logger
-from hmalib.common.messages.match import BankedSignal, MatchMessage
+from hmalib.common.messages.match import MatchMessage
 from hmalib.common.aws_dataclass import HasAWSSerialization
 from requests import get, post, put, delete, Response
 
@@ -78,7 +78,7 @@ class WebhookPostActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a POST"""
 
     def call(self, url: str, headers: str, data: str) -> Response:
-        logger.info(f"Performing a POST request to URL. {self.url}")
+        logger.info(f"Performing a POST request to URL. {url}")
         return post(url, data, headers=json.loads(headers))
 
 
@@ -87,8 +87,8 @@ class WebhookGetActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a GET"""
 
     def call(self, url: str, headers: str, data: str) -> Response:
-        logger.info(f"Performing a GET request to URL. {self.url}")
-        return get(url, data, headers=json.loads(headers))
+        logger.info(f"Performing a GET request to URL. {url}")
+        return get(url, headers=json.loads(headers))
 
 
 @dataclass
@@ -96,7 +96,7 @@ class WebhookPutActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a PUT"""
 
     def call(self, url: str, headers: str, data: str) -> Response:
-        logger.info(f"Performing a PUT request to URL. {self.url}")
+        logger.info(f"Performing a PUT request to URL. {url}")
         return put(url, data, headers=json.loads(headers))
 
 
@@ -104,33 +104,6 @@ class WebhookPutActionPerformer(WebhookActionPerformer):
 class WebhookDeleteActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a DELETE"""
 
-    def call(self, url: str, headers: str, _data: str) -> Response:
-        logger.info(f"Performing a DELETE request to URL. {self.url}")
+    def call(self, url: str, headers: str, data: str) -> Response:
+        logger.info(f"Performing a DELETE request to URL. {url}")
         return delete(url, headers=json.loads(headers))
-
-
-if __name__ == "__main__":
-    content_id = "cid1"
-    content_hash = "0374f1g34f12g34f8"
-
-    banked_signal = BankedSignal(
-        banked_content_id="4169895076385542",
-        bank_id="303636684709969",
-        bank_source="te",
-    )
-
-    action_performer = WebhookPostActionPerformer(
-        name="EnqueueForReview",
-        url="https://webhook.site/d0dbb19d-2a6f-40be-ad4d-fa9c8b34c8df",
-        headers='{"Connection":"keep-alive", "content-id" : "<content-id>", "content-hash" : "<content-hash>"}',
-        # monitoring page:
-        # https://webhook.site/#!/d0dbb19d-2a6f-40be-ad4d-fa9c8b34c8df
-    )
-
-    match_message = MatchMessage(
-        content_id,
-        content_hash,
-        [banked_signal],
-    )
-
-    action_performer.perform_action(match_message)

--- a/hasher-matcher-actioner/hmalib/common/configs/actioner.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/actioner.py
@@ -44,7 +44,6 @@ class ActionPerformer(config.HMAConfigWithSubtypes, HasAWSSerialization):
 # function on the match message
 WEBHOOK_ACTION_PERFORMER_REPLACEMENTS: t.Dict[str, t.Callable[[MatchMessage], str]] = {
     "<content-id>": lambda match_message: match_message.content_key,
-    "<content-hash>": lambda match_message: match_message.content_hash,
 }
 
 
@@ -56,7 +55,7 @@ class WebhookActionPerformer(ActionPerformer):
     headers: str
 
     def perform_action(self, match_message: MatchMessage) -> None:
-        parsed_url, parsed_headers = self.url, self.headers
+        parsed_url = self.url
         for (
             replacement_str,
             replacement_func,
@@ -64,12 +63,9 @@ class WebhookActionPerformer(ActionPerformer):
             parsed_url = parsed_url.replace(
                 replacement_str, replacement_func(match_message)
             )
-            parsed_headers = parsed_headers.replace(
-                replacement_str, replacement_func(match_message)
-            )
-        self.call(parsed_url, parsed_headers, data=json.dumps(match_message.to_aws()))
+        self.call(parsed_url, data=json.dumps(match_message.to_aws()))
 
-    def call(self, url: str, headers: str, data: str) -> Response:
+    def call(self, url: str, data: str) -> Response:
         raise NotImplementedError()
 
 
@@ -77,33 +73,33 @@ class WebhookActionPerformer(ActionPerformer):
 class WebhookPostActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a POST"""
 
-    def call(self, url: str, headers: str, data: str) -> Response:
+    def call(self, url: str, data: str) -> Response:
         logger.info(f"Performing a POST request to URL. {url}")
-        return post(url, data, headers=json.loads(headers))
+        return post(url, data, headers=json.loads(self.headers))
 
 
 @dataclass
 class WebhookGetActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a GET"""
 
-    def call(self, url: str, headers: str, data: str) -> Response:
+    def call(self, url: str, data: str) -> Response:
         logger.info(f"Performing a GET request to URL. {url}")
-        return get(url, headers=json.loads(headers))
+        return get(url, headers=json.loads(self.headers))
 
 
 @dataclass
 class WebhookPutActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a PUT"""
 
-    def call(self, url: str, headers: str, data: str) -> Response:
+    def call(self, url: str, data: str) -> Response:
         logger.info(f"Performing a PUT request to URL. {url}")
-        return put(url, data, headers=json.loads(headers))
+        return put(url, data, headers=json.loads(self.headers))
 
 
 @dataclass
 class WebhookDeleteActionPerformer(WebhookActionPerformer):
     """Hit an arbitrary endpoint with a DELETE"""
 
-    def call(self, url: str, headers: str, data: str) -> Response:
+    def call(self, url: str, data: str) -> Response:
         logger.info(f"Performing a DELETE request to URL. {url}")
-        return delete(url, headers=json.loads(headers))
+        return delete(url, headers=json.loads(self.headers))

--- a/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
@@ -165,8 +165,8 @@ class ActionRuleEvaluationTestCase(unittest.TestCase):
         action_performers = [
             performer_class(
                 name="EnqueueForReview",
-                url="https://webhook.site/d0dbb19d-2a6f-40be-ad4d-fa9c8b34c8df",
-                headers='{"Connection":"keep-alive", "content-id" : "<content-id>", "content-hash" : "<content-hash>"}',
+                url="https://webhook.site/d0dbb19d-2a6f-40be-ad4d-fa9c8b34c8df/<content-id>",
+                headers='{"Connection":"keep-alive"}',
                 # monitoring page:
                 # https://webhook.site/#!/d0dbb19d-2a6f-40be-ad4d-fa9c8b34c8df
             )

--- a/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_action_rule_evaluation.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from hmalib.common.configs.actioner import WebhookActionPerformer
 import typing as t
 import unittest
 
@@ -144,3 +145,33 @@ class ActionRuleEvaluationTestCase(unittest.TestCase):
             action_label_to_action_rules,
             "enqueue_sailboat_for_review_action_label should be in action_label_to_action_rules",
         )
+
+    def test_webhook_action_repalcement(self):
+        content_id = "cid1"
+        content_hash = "0374f1g34f12g34f8"
+
+        banked_signal = BankedSignal(
+            banked_content_id="4169895076385542",
+            bank_id="303636684709969",
+            bank_source="te",
+        )
+
+        match_message = MatchMessage(
+            content_id,
+            content_hash,
+            [banked_signal],
+        )
+
+        action_performers = [
+            performer_class(
+                name="EnqueueForReview",
+                url="https://webhook.site/d0dbb19d-2a6f-40be-ad4d-fa9c8b34c8df",
+                headers='{"Connection":"keep-alive", "content-id" : "<content-id>", "content-hash" : "<content-hash>"}',
+                # monitoring page:
+                # https://webhook.site/#!/d0dbb19d-2a6f-40be-ad4d-fa9c8b34c8df
+            )
+            for performer_class in WebhookActionPerformer.__subclasses__()
+        ]
+
+        for action_performer in action_performers:
+            action_performer.perform_action(match_message)


### PR DESCRIPTION
Summary
---------

Enable users to include the content ID and content hash in webhook actions.

When we send webhooks in the action framework, the context of the match is included in the data of the HTTP request. However, for the workplace integration, and potentially other integrations as well, including content ID and/or hash in the url or the headers of the request is required.

This diff enables that by parsing the urls and headers of the action rule and replacing the strings `<content-id>` with the matched content ID and `<content-hash>` with the matched content hash

Test Plan
---------

Run `pytest` which will send real requests to the webhook monitoring page
 
 Navigate to [the monitoring page](https://webhook.site/#!/d0dbb19d-2a6f-40be-ad4d-fa9c8b34c8df/11074918-20e3-4f8f-8d72-9b77a3a6f6ae/1) and confirm the headers are correct
![Screen Shot 2021-08-30 at 12 08 56 PM](https://user-images.githubusercontent.com/24800630/131369891-0a4be691-37b1-4eff-970a-84bad3a847de.png)
