### PR TITLE
hotfix: ensure open principals on queue policy when creating bucket notifications

### DIFF
--- a/hasher-matcher-actioner/terraform/hashing-data/main.tf
+++ b/hasher-matcher-actioner/terraform/hashing-data/main.tf
@@ -31,6 +31,10 @@ data "aws_iam_policy_document" "allow_create_events_from_primary_bucket_policy" 
     effect    = "Allow"
     actions   = ["sqs:SendMessage"]
     resources = [var.submissions_queue.queue_arn]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"

--- a/hasher-matcher-actioner/terraform/hashing-data/main.tf
+++ b/hasher-matcher-actioner/terraform/hashing-data/main.tf
@@ -32,8 +32,8 @@ data "aws_iam_policy_document" "allow_create_events_from_primary_bucket_policy" 
     actions   = ["sqs:SendMessage"]
     resources = [var.submissions_queue.queue_arn]
     principals {
-      type        = "*"
-      identifiers = ["*"]
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
     }
     condition {
       test     = "ArnEquals"


### PR DESCRIPTION
Summary
---------
A handrolled SQS config was indistinguishable to terraform from the one it was supposed to update. A principal field was missing. This prevented the sqs bucket notification from getting created.

Added the principals identifier and verified that the generated JSON matches what I had handwritten.

Test Plan
---------
```
$ terraform taint module.hashing_data.aws_s3_bucket_notification.bucket_notifications
$ terraform taint module.hashing_data.aws_sqs_queue_policy.allow_create_events_from_primary_bucket
$ terraform apply
```

Destroy 2, Create 2 < Accept.

Created the bucket notifications on the s3 bucket.