### PR TITLE
[hma][api][auth] store API access token in aws_secret

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_auth.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_auth.py
@@ -9,10 +9,8 @@ import base64
 import functools
 from jwt.algorithms import RSAAlgorithm
 
+from hmalib.aws_secrets import AWSSecrets
 from hmalib.common.logging import get_logger
-
-# ToDo have this eventually be a stored in aws secrets as well as support multiple.
-ACCESS_TOKEN = os.environ["ACCESS_TOKEN"]
 
 USER_POOL_URL = os.environ["USER_POOL_URL"]
 CLIENT_ID = os.environ["CLIENT_ID"]
@@ -60,11 +58,14 @@ def validate_jwt(token: str):
 
 def validate_access_token(token: str):
     response = {"isAuthorized": False, "context": {"AuthInfo": "ServiceAccessToken"}}
-    if not ACCESS_TOKEN or not token:
+
+    access_tokens = AWSSecrets().hma_api_tokens()
+    logger.info(access_tokens)
+    if not access_tokens or not token:
         logger.debug("Rejected empty values")
         return response
 
-    if token == ACCESS_TOKEN:
+    if token in access_tokens:
         logger.debug("Access token approved")
         response["isAuthorized"] = True
 

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_auth.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_auth.py
@@ -60,7 +60,6 @@ def validate_access_token(token: str):
     response = {"isAuthorized": False, "context": {"AuthInfo": "ServiceAccessToken"}}
 
     access_tokens = AWSSecrets().hma_api_tokens()
-    logger.info(access_tokens)
     if not access_tokens or not token:
         logger.debug("Rejected empty values")
         return response

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -178,9 +178,9 @@ resource "aws_lambda_function" "api_auth" {
   memory_size = 128
   environment {
     variables = {
-      ACCESS_TOKEN  = var.integration_api_access_token
-      USER_POOL_URL = local.user_pool_url
-      CLIENT_ID     = var.api_authorizer_audience
+      HMA_ACCESS_TOKEN_SECRET_NAME = var.hma_api_access_tokens_secret.name
+      USER_POOL_URL                = local.user_pool_url
+      CLIENT_ID                    = var.api_authorizer_audience
     }
   }
   tags = merge(
@@ -222,6 +222,11 @@ data "aws_iam_policy_document" "api_auth" {
       "logs:DescribeLogStreams"
     ]
     resources = ["${aws_cloudwatch_log_group.api_auth.arn}:*"]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [var.hma_api_access_tokens_secret.arn]
   }
 }
 

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -98,6 +98,14 @@ variable "te_api_token_secret" {
   })
 }
 
+variable "hma_api_access_tokens_secret" {
+  description = "The aws secret to the set of access tokens checked for in authorizer api as an alternative to cognito user tokens."
+  type = object({
+    name = string
+    arn  = string
+  })
+}
+
 variable "measure_performance" {
   description = "Send metrics to cloudwatch. Useful for benchmarking, but can incur costs. Set to string True for this to work."
   type        = bool
@@ -135,10 +143,4 @@ variable "partner_image_buckets" {
     arn    = string
     params = map(string)
   }))
-}
-
-variable "integration_api_access_token" {
-  description = "Access token checked for in authorizer api as an alternative to cognito user tokens."
-  type        = string
-  sensitive   = true
 }

--- a/hasher-matcher-actioner/terraform/fetcher/variables.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/variables.tf
@@ -60,12 +60,6 @@ variable "fetch_frequency" {
   type        = string
 }
 
-variable "te_api_token" {
-  description = "Token to read data from ThreatExchange"
-  type        = string
-  sensitive   = true
-}
-
 variable "collab_file" {
   description = "An optional file name of ThreatExchange Collaborations objects to prepopulate. See collabs_example.json for the correct formatting"
   type        = string

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -117,9 +117,9 @@ variable "partner_image_buckets" {
   }
 }
 
-variable "integration_api_access_token" {
-  description = "Access token checked for in authorizer api as an alternative to cognito user tokens."
-  type        = string
+variable "integration_api_access_tokens" {
+  description = "Access tokens checked for in authorizer api as an alternative to cognito user tokens."
+  type        = list(string)
   sensitive   = true
-  default     = ""
+  default     = []
 }


### PR DESCRIPTION
Summary
---------

Builds off of #776 
Instead of passing the access token value to api_auth as an raw environment variable, tf will store it in aws_secret and can also be adjusted manually.
This also adds support for multiple access tokens instead of just one therefore the tfvars value defaults to empty list instead of string (though api_auth still has null checks to be safe). e.g. `integration_api_access_tokens  = ['<token1>', '<token2>']`

Test Plan
---------

Made sure all auth flows still worked for failed as expected in the same way they did in #776 
