### PR TITLE
[hma][api] generalize for-hash and fix to_json for match data

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/models/signal.py
+++ b/hasher-matcher-actioner/hmalib/common/models/signal.py
@@ -104,6 +104,7 @@ class ThreatExchangeSignalMetadata(DynamoDBItem):
         """
         result = asdict(self)
         result.update(
+            signal_type=self.signal_type.get_name(),
             updated_at=self.updated_at.isoformat(),
             pending_opinion_change=self.pending_opinion_change.value,
         )

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -188,7 +188,7 @@ class MatchesForHashRequest(DictParseable):
 
 @dataclass
 class MatchesForHashResponse(JSONifiable):
-    matches: t.List[t.Union[ThreatExchangeSignalMetadata]]
+    matches: t.List[ThreatExchangeSignalMetadata]
     signal_value: str
 
     def to_json(self) -> t.Dict:
@@ -302,7 +302,9 @@ def get_matches_api(
 
         return ChangeSignalOpinionResponse(success)
 
-    @matches_api.get("/for-hash/", apply=[jsoninator(MatchesForHashRequest)])
+    @matches_api.get(
+        "/for-hash/", apply=[jsoninator(MatchesForHashRequest, from_query=True)]
+    )
     def for_hash(request: MatchesForHashRequest) -> MatchesForHashResponse:
         """
         For a given hash/signal check the index(es) for matches and return the details
@@ -314,7 +316,8 @@ def get_matches_api(
             request.signal_type, request.signal_value
         )
 
-        match_objects = []
+        match_objects: t.List[ThreatExchangeSignalMetadata] = []
+
         for match in matches:
             match_objects.extend(
                 Matcher.get_metadata_objects_from_match(request.signal_type, match)

--- a/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
@@ -66,7 +66,8 @@ class DictParseable:
 def jsoninator(
     view_fn_or_request_type: t.Union[
         t.Callable[[int, int], JSONifiable], t.Type[DictParseable]
-    ]
+    ],
+    from_query=False,
 ):
     """
     Bottle plugin which allows you to create 'typed' views.
@@ -115,14 +116,17 @@ def jsoninator(
             def wrapper(*args, **kwargs):
                 try:
                     # Try to extract request
-                    request_object = request_type.from_dict(bottle.request.json)
+                    if from_query:
+                        request_object = request_type.from_dict(bottle.request.query)
+                    else:
+                        request_object = request_type.from_dict(bottle.request.json)
                 except Exception as e:
                     logger.error(
-                        "Failed to deserialize JSON for type: %s", str(request_type)
+                        "Failed to deserialize request for type: %s", str(request_type)
                     )
                     logger.exception(e)
                     bottle.response.status = 400
-                    return "Could not parse JSON."
+                    return "Could not parse request."
 
                 response_object = view_fn(request_object, *args, **kwargs)
 

--- a/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
@@ -79,6 +79,9 @@ def jsoninator(
 
     If request type provided like jsoninator(RequestType), will de-serialize
     request payload into the first argument to the view function.
+
+    Additionlly if `from_query` is set to True then the `from_dict` call will
+    be attempted on the query params instead of the json body of the request.
     """
 
     # I feel like I'm doing a lot of work to support a common API for typed


### PR DESCRIPTION
Summary
---------

 Generalize `/matches/for-hash/` (i.e. the "M") endpoint so that it can support both 'pdq' and 'video_md5'

Also fixes a tiny bug in `ThreatExchangeSignalMetadata.to_json` from changes  #784

Test Plan
---------

Used postman to hit the endpoint using both signal types:

exact pdq:
<img width="1254" alt="Screen Shot 2021-08-31 at 4 13 12 PM" src="https://user-images.githubusercontent.com/7664526/131570489-5115547f-ea0f-4969-b6cf-27d1989e8169.png">

exact md5:
<img width="1246" alt="Screen Shot 2021-08-31 at 4 17 18 PM" src="https://user-images.githubusercontent.com/7664526/131570466-4be7484a-5fa9-4b3b-bccb-38f0f9d67d98.png">

near pdq:
<img width="1139" alt="Screen Shot 2021-08-31 at 4 17 38 PM" src="https://user-images.githubusercontent.com/7664526/131570442-2ad18ac4-dcca-46c1-b31c-70be93aae036.png">

