### PR TITLE
[hma][scripts] have test scripts use custom access tokens instead of user_pool

### DIFF
--- a/hasher-matcher-actioner/scripts/get_auth_token
+++ b/hasher-matcher-actioner/scripts/get_auth_token
@@ -6,6 +6,8 @@ Helper script for a developer to get an API token from cognito based on args
 See 
 https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow.html#amazon-cognito-user-pools-admin-authentication-flow
 
+If you use a more permanent access token via values passed to `integration_api_access_token` in .tfvars you can skip using this script.
+
 Sample Usage (manually editing file):
 ```
 # If you elect to set values in the file
@@ -44,7 +46,7 @@ if __name__ == "__main__":
     EMAIL = ""
 
     parser = argparse.ArgumentParser(
-        description="Request an access token for various test scripts of the API. Rquires AWS account credentials be present locally. Additionally the UserPoolId must allow 'ADMIN_USER_PASSWORD_AUTH'"
+        description="Request an user access token for various test scripts of the API or create a user. Requires AWS account credentials be present locally. Additionally the UserPoolId must allow 'ADMIN_USER_PASSWORD_AUTH'"
     )
     parser.add_argument(
         "--username",

--- a/hasher-matcher-actioner/scripts/hma_client_lib.py
+++ b/hasher-matcher-actioner/scripts/hma_client_lib.py
@@ -37,28 +37,17 @@ class DeployedInstanceClient:
         self,
         api_url: str = "",
         api_token: str = "",
-        client_id: str = None,
-        refresh_token: str = None,
         api: HasherMatcherActionerAPI = None,
     ) -> None:
         if api:
             self.api = api
         else:
-            if not api_token and (not client_id or not refresh_token):
+            if not api_token:
                 raise ValueError(
                     "Test requires an api_token OR a client_id + refresh_token to function"
                 )
 
-            self.api = HasherMatcherActionerAPI(
-                api_url, api_token, client_id, refresh_token
-            )
-
-    def refresh_api_token(self):
-        """
-        Manually refresh api's token
-        TODO Make staleness of the token an internal matter for the API class to handle.
-        """
-        self.api._refresh_token()
+            self.api = HasherMatcherActionerAPI(api_url, api_token)
 
     ### Start HMA API wrapper ###
 
@@ -270,16 +259,12 @@ if __name__ == "__main__":
 
     tf_outputs = get_terraform_outputs()
     api_url = tf_outputs["api_url"]["value"]
-    token, refresh_token, client_id = get_auth_from_env(tf_outputs)
-
+    token = get_auth_from_env(prompt_for_token=True)
     print(
         "This simple tests should take a little over 2 minutes to complete (due to sqs timeout).\n"
     )
 
-    helper = DeployedInstanceClient(api_url, token, client_id, refresh_token)
-
-    if refresh_token and client_id:
-        helper.refresh_api_token()
+    helper = DeployedInstanceClient(api_url, token)
 
     helper.set_up_test()
 

--- a/hasher-matcher-actioner/scripts/hma_shell
+++ b/hasher-matcher-actioner/scripts/hma_shell
@@ -37,12 +37,12 @@ class HMAShell(cmd.Cmd):
     intro = "Welcome! Type help or ? to list commands.\n"
     prompt = "> "
 
-    def __init__(self, api_url: str, refresh_token: str, client_id: str):
+    def __init__(self, api_url: str, token: str):
         super(HMAShell, self).__init__()
         self.api = hma_script_utils.HasherMatcherActionerAPI(
-            api_url, api_token="", client_id=client_id, refresh_token=refresh_token
+            api_url,
+            api_token=token,
         )
-        self.api._refresh_token()
 
     # Query Commands
     def do_dataset_configs(self, arg):
@@ -104,28 +104,13 @@ if __name__ == "__main__":
         description="Start a HMA Shell to intract with a deployed HMA instance."
     )
     parser.add_argument(
-        "--username",
-        help="username of test user, defaults to '<prefix_in_tf_vars>testuser'",
-        default="",
-    )
-    parser.add_argument(
-        "--pwd",
-        help="password of test user",
-        default="",
-    )
-    parser.add_argument(
-        "--email",
-        help="email for test user (required if creating a test user otherwise ignored)",
+        "--access_token",
+        help="access token to be used to authenticate request to HMA API",
         default="",
     )
     parser.add_argument(
         "--tf_output_file",
         help="Instead of using a python helper get_terraform_outputs, read output from a file\n e.g. via 'terraform -chdir=terraform output -json >> tf_outputs.json'",
-    )
-    parser.add_argument(
-        "--create_user",
-        action="store_true",
-        help="Creates a new test user. Require values for 'username', 'pwd', and 'email' args.",
     )
 
     args = parser.parse_args()
@@ -137,29 +122,10 @@ if __name__ == "__main__":
     else:
         tf_outputs = hma_script_utils.get_terraform_outputs()
 
-    pwd = args.pwd
-    user = args.username
-
-    if args.create_user:
-        if not args.email or not pwd:
-            print("Email and pwd required to create user")
-            parser.print_usage()
-            exit()
-
-        if not user:
-            user = hma_script_utils.get_default_user_name(tf_outputs["prefix"]["value"])
-
-        pool_id = tf_outputs["cognito_user_pool_id"]["value"]
-        client_id = tf_outputs["cognito_user_pool_client_id"]["value"]
-
-        hma_script_utils.create_user(
-            args.username, args.email, pool_id=pool_id, client_id=client_id
-        )
-
-    token, refresh_token, client_id = hma_script_utils.get_auth_from_env(
-        tf_outputs, pwd_override=pwd, user_override=user, prompt_for_pwd=True
+    token = hma_script_utils.get_auth_from_env(
+        token_default=args.access_token, prompt_for_pwd=True
     )
 
     api_url = tf_outputs["api_url"]["value"]
 
-    HMAShell(api_url, refresh_token, client_id).cmdloop()
+    HMAShell(api_url, token).cmdloop()

--- a/hasher-matcher-actioner/scripts/submitter.py
+++ b/hasher-matcher-actioner/scripts/submitter.py
@@ -54,7 +54,6 @@ class Submitter(threading.Thread):
             finally:
                 self._lock.release()
             time.sleep(self.seconds_between_batches)
-            self.client.refresh_api_token()
 
     def get_total_submit_count(self) -> int:
         with self._lock:
@@ -76,23 +75,18 @@ class Submitter(threading.Thread):
 if __name__ == "__main__":
 
     API_URL = ""
-    REFRESH_TOKEN = ""
-    CLIENT_ID = ""
+    TOKEN = ""
 
     api_url = os.environ.get(
         "HMA_API_URL",
         API_URL,
     )
-    refresh_token = os.environ.get(
-        "HMA_REFRESH_TOKEN",
-        REFRESH_TOKEN,
+    token = os.environ.get(
+        "HMA_TOKEN",
+        TOKEN,
     )
-    client_id = os.environ.get(
-        "HMA_COGNITO_USER_POOL_CLIENT_ID",
-        CLIENT_ID,
-    )
-    client = DeployedInstanceClient(api_url, "", client_id, refresh_token)
 
+    client = DeployedInstanceClient(api_url, token)
     submitter = Submitter(client, batch_size=5, seconds_between_batches=5)
     submitter.start()
 


### PR DESCRIPTION
Summary
---------
Remove the confusing and overly complex cognito work around/flow for the test scripts as we now have access to the kind of access token added in #776 

Test Plan
---------
`python scripts/hma_client_lib.py` and more.