### PR TITLE
[hma][api] Adjust auth lambda and add to dashboard

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_auth.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_auth.py
@@ -56,32 +56,34 @@ def validate_jwt(token: str):
     return {"isAuthorized": False, "context": {"AuthInfo": "JWTTokenCheck"}}
 
 
-def validate_access_token(token: str):
-    response = {"isAuthorized": False, "context": {"AuthInfo": "ServiceAccessToken"}}
+@functools.lru_cache(maxsize=10)
+def validate_access_token(token: str) -> bool:
 
     access_tokens = AWSSecrets().hma_api_tokens()
     if not access_tokens or not token:
-        logger.debug("Rejected empty values")
-        return response
+        logger.debug("No access tokens found")
+        return False
 
     if token in access_tokens:
-        logger.debug("Access token approved")
-        response["isAuthorized"] = True
+        return True
 
-    return response
+    return False
 
 
 def lambda_handler(event, context):
 
     token = event["identitySource"][0]
 
+    if validate_access_token(token):
+        return {"isAuthorized": True, "context": {"AuthInfo": "ServiceAccessToken"}}
+
     try:
         # try to decode without any validation just to see if it is a JWT
         jwt.decode(token, algorithms=["RS256"], options={"verify_signature": False})
         return validate_jwt(token)
     except jwt.DecodeError:
-        # Does not appear to be a JWT, attempt alternative auth check(s)
-        return validate_access_token(token)
+        logger.debug("JWT decode failed.")
+        return {"isAuthorized": False}
 
 
 if __name__ == "__main__":

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_auth.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_auth.py
@@ -56,6 +56,8 @@ def validate_jwt(token: str):
     return {"isAuthorized": False, "context": {"AuthInfo": "JWTTokenCheck"}}
 
 
+# 10 is ~arbitrary: maxsize > 1 because it is possible for their to be more than one
+# access token in use that we want to cache, however a large number is unlikely.
 @functools.lru_cache(maxsize=10)
 def validate_access_token(token: str) -> bool:
 

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -333,7 +333,6 @@ resource "aws_apigatewayv2_authorizer" "hma_apigateway" {
   identity_sources                  = ["$request.header.Authorization"]
   authorizer_payload_format_version = "2.0"
   enable_simple_responses           = true
-  authorizer_result_ttl_in_seconds  = 0
   name                              = "${aws_apigatewayv2_api.hma_apigateway.name}_authorizer"
 }
 

--- a/hasher-matcher-actioner/terraform/api/outputs.tf
+++ b/hasher-matcher-actioner/terraform/api/outputs.tf
@@ -8,6 +8,10 @@ output "api_root_function_name" {
   value = aws_lambda_function.api_root.function_name
 }
 
+output "api_auth_function_name" {
+  value = aws_lambda_function.api_auth.function_name
+}
+
 output "api_gateway_id" {
   value = aws_apigatewayv2_api.hma_apigateway.id
 }

--- a/hasher-matcher-actioner/terraform/dashboard/variables.tf
+++ b/hasher-matcher-actioner/terraform/dashboard/variables.tf
@@ -36,6 +36,12 @@ variable "api_lambda_name" {
   default     = null
 }
 
+variable "auth_lambda_name" {
+  description = "Name of lambda used as the root api"
+  type        = string
+  default     = null
+}
+
 variable "other_lambdas" {
   description = "Extra lambdas to be included in set of concurrent counts"
   type        = list(string)

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -532,7 +532,8 @@ module "dashboard" {
     (["Action Evaluator", module.actions.action_evaluator_function_name]),
     (["Action Performer", module.actions.action_performer_function_name])
   ] # Not currently included fetcher, indexer, writebacker, and counter functions
-  api_lambda_name = module.api.api_root_function_name
+  api_lambda_name  = module.api.api_root_function_name
+  auth_lambda_name = module.api.api_auth_function_name
   other_lambdas = [
     module.fetcher.fetcher_function_name,
     module.indexer.indexer_function_name,


### PR DESCRIPTION
Summary
---------

In trying to benchmark the `/matches/for-hash/` endpoint I noticed a few things about the auth lambda added in #776 
1) It was not on the dashboard.
2) Unlike the JWT Authorizer it replaced, it has `authorizer_result_ttl_in_seconds = 0` (default is 300 or 5 mins)
3) Service token method check could be more cached and because it was after a ~non-trivial JWT checks and exceptions throw.

So this PR:
1) Added it to the dashboard next to the API widget (see photo in test plan)
2) Removed that ttl line to enable the default caching (helped benchmark significantly) 
3) Move check for service api tokens to before JWT tokens and cached the method (also boosted benchmark).


With these changes instead of hitting our lambda concurrency limits in auth and rapidly throttling anything for anything > 2800 QPS

We are able to get the promising (but preliminary) numbers seen by the use of ApacheBench in the test plan.
`Requests per second:    4875.15 [#/sec] (mean)`

Test Plan
---------
```
ubuntu@ip-123-45-67-890:~$ ab -k -q -n 50000 -c 200 -H "Authorization:<auth-token-redacted>" "https://<app_id-redacted>.execute-api.us-east-1.amazonaws.com/matches/for-hash/?signal_value=f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22&signal_type=pdq"

...
Benchmarking <auth-token-redacted>.execute-api.us-east-1.amazonaws.com (be patient).....done


Server Software:
Server Hostname:        <auth-token-redacted>.execute-api.us-east-1.amazonaws.com
Server Port:            443
SSL/TLS Protocol:       TLSv1.2,ECDHE-RSA-AES128-GCM-SHA256,2048,128
Server Temp Key:        ECDH P-256 256 bits
TLS Server Name:        <auth-token-redacted>.execute-api.us-east-1.amazonaws.com

Document Path:          /matches/for-hash/?signal_value=f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22&signal_type=pdq
Document Length:        390 bytes

Concurrency Level:      200
Time taken for tests:   10.256 seconds
Complete requests:      50000
Failed requests:        0
Keep-Alive requests:    50000
Total transferred:      27900000 bytes
HTML transferred:       19500000 bytes
Requests per second:    4875.15 [#/sec] (mean)
Time per request:       41.024 [ms] (mean)
Time per request:       0.205 [ms] (mean, across all concurrent requests)
Transfer rate:          2656.58 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   7.0      0     134
Processing:    20   40  14.0     37     277
Waiting:       20   40  14.0     37     277
Total:         20   40  16.5     37     392

Percentage of the requests served within a certain time (ms)
  50%     37
  66%     41
  75%     44
  80%     47
  90%     55
  95%     64
  98%     80
  99%     99
 100%    392 (longest request)
```

<img width="3035" alt="Screen Shot 2021-09-07 at 4 26 31 PM" src="https://user-images.githubusercontent.com/7664526/132406464-62341d44-1158-4760-b013-8c06c4a51d61.png">