### PR TITLE
Make Actions and ActionRules Settings pages update automatically

### DIFF
--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -347,9 +347,13 @@ export async function fetchAllActions(): Promise<Action[]> {
 }
 
 export async function createAction(
-  newAction = {},
+  newAction: Action,
 ): Promise<{response: string}> {
-  return apiPost('actions/', newAction);
+  return apiPost('actions/', {
+    name: newAction.name,
+    config_subtype: newAction.config_subtype,
+    fields: newAction.params,
+  });
 }
 
 export async function updateAction(
@@ -357,7 +361,11 @@ export async function updateAction(
   old_config_subtype: string,
   updatedAction: Action,
 ): Promise<{response: string}> {
-  return apiPut(`actions/${old_name}/${old_config_subtype}`, updatedAction);
+  return apiPut(`actions/${old_name}/${old_config_subtype}`, {
+    name: updatedAction.name,
+    config_subtype: updatedAction.config_subtype,
+    fields: updatedAction.params,
+  });
 }
 
 export async function deleteAction(name: string): Promise<{response: string}> {

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -372,6 +372,8 @@ export async function deleteAction(name: string): Promise<{response: string}> {
   return apiDelete(`actions/${name}`);
 }
 
+// We need two different ActionRule types because the mackend model (must (not) have labels) is different
+// from the Frontend model (classification conditions)
 type APIActionRule = {
   name: string;
   must_have_labels: Label[];

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerColumns.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerColumns.tsx
@@ -2,24 +2,30 @@
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  */
 
-import React from 'react';
+import React, {useState} from 'react';
 import Form from 'react-bootstrap/Form';
-import PropTypes from 'prop-types';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
 import WebhookActioner from './WebhookActioner';
+import {Action} from '../../../pages/settings/ActionSettingsTab';
 
 export type WebhookActionPerformerParams = {
   url: string;
   headers: string;
 };
 
+const Actioners: ActionerMap = {
+  WebhookPostActionPerformer: WebhookActioner,
+  WebhookGetActionPerformer: WebhookActioner,
+  WebhookDeleteActionPerformer: WebhookActioner,
+  WebhookPutActionPerformer: WebhookActioner,
+  '': WebhookActioner,
+};
+
 type ActionPerformerColumn = {
-  name: string;
-  type: string;
-  params: WebhookActionPerformerParams;
+  action: Action;
   editing: boolean;
-  onChange: (key: string, keyValueMap: {[key: string]: string}) => void;
+  updateAction: (action: Action) => void;
   canNotDeleteOrUpdateName: boolean;
 };
 
@@ -28,24 +34,17 @@ interface ActionerMap {
 }
 
 export default function ActionPerformerColumns({
-  name,
-  type,
-  params,
+  action,
   editing,
-  onChange,
+  updateAction,
   canNotDeleteOrUpdateName,
 }: ActionPerformerColumn): JSX.Element {
-  const Actioners: ActionerMap = {
-    WebhookPostActionPerformer: WebhookActioner,
-    WebhookGetActionPerformer: WebhookActioner,
-    WebhookDeleteActionPerformer: WebhookActioner,
-    WebhookPutActionPerformer: WebhookActioner,
-    '': WebhookActioner,
-  };
+  const [name, setName] = useState(action.name);
+
   return (
     <>
       <td>
-        <div hidden={editing}>{name}</div>
+        <div hidden={editing}>{action.name}</div>
 
         <div hidden={!editing}>
           <Form>
@@ -67,9 +66,12 @@ export default function ActionPerformerColumns({
                 <Form.Control
                   type="text"
                   placeholder="New Action Name"
-                  value={name}
+                  value={action.name}
                   onChange={e => {
-                    onChange('name', {name: e.target.value});
+                    setName(e.target.value);
+                    const newAction = action;
+                    newAction.name = e.target.value;
+                    updateAction(newAction);
                   }}
                 />
               </Form.Group>
@@ -78,25 +80,12 @@ export default function ActionPerformerColumns({
         </div>
       </td>
       <td>
-        {Actioners[type]({
-          webhookType: type,
+        {Actioners[action.config_subtype]({
+          action,
           editing,
-          ...params,
-          onChange,
+          updateAction,
         })}
       </td>
     </>
   );
 }
-
-ActionPerformerColumns.propTypes = {
-  name: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired,
-  editing: PropTypes.bool.isRequired,
-  params: PropTypes.shape({
-    url: PropTypes.string.isRequired,
-    headers: PropTypes.string.isRequired,
-  }).isRequired,
-  onChange: PropTypes.func.isRequired,
-  canNotDeleteOrUpdateName: PropTypes.bool.isRequired,
-};

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.tsx
@@ -30,7 +30,14 @@ export default function ActionPerformerRows({
     useState(false);
   const [showUpdateActionConfirmation, setShowUpdateActionConfirmation] =
     useState(false);
-  const [updatedAction, setUpdatedAction] = useState(action);
+  const [updatedAction, setUpdatedAction] = useState(
+    new Action(
+      action.name,
+      action.config_subtype,
+      action.params.url,
+      action.params.headers,
+    ),
+  );
 
   const resetForm = () => {
     setUpdatedAction(action);
@@ -99,7 +106,7 @@ export default function ActionPerformerRows({
           ) : null}
         </td>
         <ActionPerformerColumns
-          action={action}
+          action={updatedAction}
           editing={false}
           updateAction={setUpdatedAction}
           canNotDeleteOrUpdateName={canNotDeleteOrUpdateName}

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.tsx
@@ -9,69 +9,31 @@ import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
+import {Action} from '../../../pages/settings/ActionSettingsTab';
 import ActionPerformerColumns from './ActionPerformerColumns';
 
-type Params = {
-  url: string;
-  headers: string;
-};
-
-type Action = {
-  name: string;
-  type: string;
-  updatedAction: any;
-};
-
 type ActionPerformerRowsProps = {
-  name: string;
-  type: string;
-  params: Params;
-  edit: boolean;
-  onSave: (key: Action) => void;
-  onDelete: (key: string) => void;
+  action: Action;
+  saveAction: (newAction: Action) => void;
+  deleteAction: (oldAction: Action) => void;
   canNotDeleteOrUpdateName: boolean;
 };
 
 export default function ActionPerformerRows({
-  name,
-  type,
-  params,
-  edit,
-  onSave,
-  onDelete,
+  action,
+  saveAction,
+  deleteAction,
   canNotDeleteOrUpdateName,
 }: ActionPerformerRowsProps): JSX.Element {
-  const [editing, setEditing] = useState(edit);
+  const [editing, setEditing] = useState(false);
   const [showDeleteActionConfirmation, setShowDeleteActionConfirmation] =
     useState(false);
   const [showUpdateActionConfirmation, setShowUpdateActionConfirmation] =
     useState(false);
-  const [updatedAction, setUpdatedAction] = useState({
-    name,
-    config_subtype: type,
-    fields: params,
-  });
-
-  const onUpdatedActionChange = (
-    key: string,
-    value: {[key: string]: string},
-  ) => {
-    if (key === 'name' || key === 'config_subtype') {
-      setUpdatedAction({...updatedAction, ...value});
-    } else {
-      setUpdatedAction({
-        ...updatedAction,
-        fields: {...updatedAction.fields, ...value},
-      });
-    }
-  };
+  const [updatedAction, setUpdatedAction] = useState(action);
 
   const resetForm = () => {
-    setUpdatedAction({
-      name,
-      config_subtype: type,
-      fields: params,
-    });
+    setUpdatedAction(action);
   };
 
   return (
@@ -101,7 +63,7 @@ export default function ActionPerformerRows({
             <Modal.Body>
               <p>
                 Please confirm you want to delete the action named{' '}
-                <strong>{name}</strong>.
+                <strong>{action.name}</strong>.
               </p>
             </Modal.Body>
             <Modal.Footer>
@@ -110,7 +72,12 @@ export default function ActionPerformerRows({
                 onClick={() => setShowDeleteActionConfirmation(false)}>
                 Cancel
               </Button>
-              <Button variant="primary" onClick={() => onDelete(name)}>
+              <Button
+                variant="primary"
+                onClick={() => {
+                  deleteAction(action);
+                  setShowDeleteActionConfirmation(false);
+                }}>
                 Yes, Delete This Action
               </Button>
             </Modal.Footer>
@@ -118,10 +85,10 @@ export default function ActionPerformerRows({
           {canNotDeleteOrUpdateName ? (
             <OverlayTrigger
               overlay={
-                <Tooltip id={`tooltip-${name}`}>
-                  The action {name} can not be deleted because it is currently
-                  being used by one or more action rules. Please edit the
-                  rule(s) to refer to another action, or delete the rule(s),
+                <Tooltip id={`tooltip-${action.name}`}>
+                  The action {action.name} can not be deleted because it is
+                  currently being used by one or more action rules. Please edit
+                  the rule(s) to refer to another action, or delete the rule(s),
                   then retry.
                 </Tooltip>
               }>
@@ -132,12 +99,9 @@ export default function ActionPerformerRows({
           ) : null}
         </td>
         <ActionPerformerColumns
-          key={updatedAction.name}
-          name={updatedAction.name}
-          type={updatedAction.config_subtype}
-          params={updatedAction.fields}
+          action={action}
           editing={false}
-          onChange={onUpdatedActionChange}
+          updateAction={setUpdatedAction}
           canNotDeleteOrUpdateName={canNotDeleteOrUpdateName}
         />
       </tr>
@@ -170,7 +134,7 @@ export default function ActionPerformerRows({
             <Modal.Body>
               <p>
                 Please confirm you want to update the action named{' '}
-                <strong>{name}</strong>.
+                <strong>{action.name}</strong>.
               </p>
             </Modal.Body>
             <Modal.Footer>
@@ -183,7 +147,7 @@ export default function ActionPerformerRows({
                 variant="primary"
                 onClick={() => {
                   setEditing(false);
-                  onSave({name, type, updatedAction});
+                  saveAction(updatedAction);
                   setShowUpdateActionConfirmation(false);
                 }}>
                 Yes, Update This Action
@@ -192,11 +156,9 @@ export default function ActionPerformerRows({
           </Modal>
         </td>
         <ActionPerformerColumns
-          name={updatedAction.name}
-          type={updatedAction.config_subtype}
-          params={updatedAction.fields}
+          action={updatedAction}
           editing
-          onChange={onUpdatedActionChange}
+          updateAction={setUpdatedAction}
           canNotDeleteOrUpdateName={canNotDeleteOrUpdateName}
         />
       </tr>

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.tsx
@@ -50,9 +50,9 @@ export default function WebhookActioner({
   editing,
   updateAction,
 }: WebhookActioner): JSX.Element {
-  const [url, setURL] = useState(action.params.url);
-  const [headers, setHeaders] = useState(action.params.headers);
-  const [webhookType, setWebhookType] = useState(action.config_subtype);
+  const [, setURL] = useState(action.params.url);
+  const [, setHeaders] = useState(action.params.headers);
+  const [, setWebhookType] = useState(action.config_subtype);
 
   return (
     <Card>

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.tsx
@@ -2,10 +2,10 @@
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  */
 
-import React from 'react';
+import React, {useState} from 'react';
 import Card from 'react-bootstrap/Card';
 import Form from 'react-bootstrap/Form';
-import PropTypes from 'prop-types';
+import {Action} from '../../../pages/settings/ActionSettingsTab';
 
 interface WebhookTypeInterface extends Record<string, any> {
   WebhookPostActionPerformer: string;
@@ -14,45 +14,45 @@ interface WebhookTypeInterface extends Record<string, any> {
   WebhookPutActionPerformer: string;
 }
 
+const ActionerTypes = {
+  WebhookActioner: {
+    args: {
+      url: {description: 'The url to send a webhook to'},
+      webhookType: {
+        description: 'What type of webhook should be sent?',
+        default: 'POST',
+      },
+      headers: {
+        description: 'Optional json object of headers to include in webhook',
+        default: '{}',
+      },
+    },
+    description:
+      'When a match occurs, a webhook will be sent to the specified url with data describing the match',
+  },
+};
+const WebhookType: WebhookTypeInterface = {
+  WebhookPostActionPerformer: 'POST',
+  WebhookGetActionPerformer: 'GET',
+  WebhookDeleteActionPerformer: 'DELETE',
+  WebhookPutActionPerformer: 'PUT',
+};
+const actionerDetails = ActionerTypes.WebhookActioner;
+
 type WebhookActioner = {
-  url: string;
-  headers: string;
-  webhookType: string;
+  action: Action;
   editing: boolean;
-  onChange: (key: string, keyValueMap: {[key: string]: string}) => void;
+  updateAction: (action: Action) => void;
 };
 
 export default function WebhookActioner({
-  url,
-  headers,
-  webhookType,
+  action,
   editing,
-  onChange,
+  updateAction,
 }: WebhookActioner): JSX.Element {
-  const ActionerTypes = {
-    WebhookActioner: {
-      args: {
-        url: {description: 'The url to send a webhook to'},
-        webhookType: {
-          description: 'What type of webhook should be sent?',
-          default: 'POST',
-        },
-        headers: {
-          description: 'Optional json object of headers to include in webhook',
-          default: '{}',
-        },
-      },
-      description:
-        'When a match occurs, a webhook will be sent to the specified url with data describing the match',
-    },
-  };
-  const WebhookType: WebhookTypeInterface = {
-    WebhookPostActionPerformer: 'POST',
-    WebhookGetActionPerformer: 'GET',
-    WebhookDeleteActionPerformer: 'DELETE',
-    WebhookPutActionPerformer: 'PUT',
-  };
-  const actionerDetails = ActionerTypes.WebhookActioner;
+  const [url, setURL] = useState(action.params.url);
+  const [headers, setHeaders] = useState(action.params.headers);
+  const [webhookType, setWebhookType] = useState(action.config_subtype);
 
   return (
     <Card>
@@ -65,11 +65,11 @@ export default function WebhookActioner({
           </Form.Text>
         </Card.Header>
         <Card.Body>
-          URL : {url}
+          URL : {action.params.url}
           <br />
-          Webhook Type : {WebhookType[webhookType]}
+          Webhook Type : {WebhookType[action.config_subtype]}
           <br />
-          Headers : {headers}
+          Headers : {action.params.headers}
           <br />
         </Card.Body>
       </div>
@@ -93,9 +93,12 @@ export default function WebhookActioner({
               </Form.Text>
               <Form.Control
                 type="url"
-                value={url}
+                value={action.params.url}
                 onChange={e => {
-                  onChange('url', {url: e.target.value});
+                  setURL(e.target.value);
+                  const newAction = action;
+                  newAction.params.url = e.target.value;
+                  updateAction(newAction);
                 }}
               />
               <br />
@@ -106,11 +109,12 @@ export default function WebhookActioner({
                 </Form.Text>
                 <Form.Control
                   as="select"
-                  value={webhookType}
+                  value={action.config_subtype}
                   onChange={e => {
-                    onChange('config_subtype', {
-                      config_subtype: e.target.value,
-                    });
+                    setWebhookType(e.target.value);
+                    const newAction = action;
+                    newAction.config_subtype = e.target.value;
+                    updateAction(newAction);
                   }}>
                   <option value="">Please select one option</option>
                   <option value="WebhookPostActionPerformer">POST</option>
@@ -126,9 +130,12 @@ export default function WebhookActioner({
               </Form.Text>
               <Form.Control
                 type="text"
-                value={headers}
+                value={action.params.headers}
                 onChange={e => {
-                  onChange('headers', {headers: e.target.value});
+                  setHeaders(e.target.value);
+                  const newAction = action;
+                  newAction.params.headers = e.target.value;
+                  updateAction(newAction);
                 }}
               />
             </Form.Group>
@@ -138,11 +145,3 @@ export default function WebhookActioner({
     </Card>
   );
 }
-
-WebhookActioner.propTypes = {
-  url: PropTypes.string.isRequired,
-  headers: PropTypes.string.isRequired,
-  editing: PropTypes.bool.isRequired,
-  webhookType: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-};

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/WebhookActioner.tsx
@@ -50,9 +50,9 @@ export default function WebhookActioner({
   editing,
   updateAction,
 }: WebhookActioner): JSX.Element {
-  const [, setURL] = useState(action.params.url);
-  const [, setHeaders] = useState(action.params.headers);
-  const [, setWebhookType] = useState(action.config_subtype);
+  const [url, setURL] = useState(action.params.url);
+  const [headers, setHeaders] = useState(action.params.headers);
+  const [webhookType, setWebhookType] = useState(action.config_subtype);
 
   return (
     <Card>
@@ -65,11 +65,11 @@ export default function WebhookActioner({
           </Form.Text>
         </Card.Header>
         <Card.Body>
-          URL : {action.params.url}
+          URL : {url}
           <br />
-          Webhook Type : {WebhookType[action.config_subtype]}
+          Webhook Type : {WebhookType[webhookType]}
           <br />
-          Headers : {action.params.headers}
+          Headers : {headers}
           <br />
         </Card.Body>
       </div>
@@ -93,7 +93,7 @@ export default function WebhookActioner({
               </Form.Text>
               <Form.Control
                 type="url"
-                value={action.params.url}
+                value={url}
                 onChange={e => {
                   setURL(e.target.value);
                   const newAction = action;
@@ -109,7 +109,7 @@ export default function WebhookActioner({
                 </Form.Text>
                 <Form.Control
                   as="select"
-                  value={action.config_subtype}
+                  value={webhookType}
                   onChange={e => {
                     setWebhookType(e.target.value);
                     const newAction = action;
@@ -130,7 +130,7 @@ export default function WebhookActioner({
               </Form.Text>
               <Form.Control
                 type="text"
-                value={action.params.headers}
+                value={headers}
                 onChange={e => {
                   setHeaders(e.target.value);
                   const newAction = action;

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRuleFormColumns.tsx
@@ -8,10 +8,10 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Button from 'react-bootstrap/Button';
 import type {
-  Action,
   ActionRule,
   ClassificationCondition,
 } from '../../pages/settings/ActionRuleSettingsTab';
+import {Action} from '../../pages/settings/ActionSettingsTab';
 
 export const classificationTypeTBD = 'TBD';
 
@@ -22,7 +22,7 @@ type Input = {
   nameIsUnique: (newName: string, oldName: string) => boolean;
   oldName: string;
   onChange: (
-    field_name: string,
+    field_name: 'name' | 'action_id' | 'classification_conditions',
     new_value: string | ClassificationCondition[],
   ) => void;
 };
@@ -63,14 +63,29 @@ export default function ActionRuleFormColumns({
             showErrors &&
             classification.classificationType === classificationTypeTBD
           }>
-          <option value={classificationTypeTBD}> Select... </option>
-          <option value="BankSourceClassification">Dataset Source</option>
-          <option value="BankIDClassification">Dataset ID</option>
-          <option value="BankedContentIDClassification">
+          <option key="tbd" value={classificationTypeTBD}>
+            {' '}
+            Select...{' '}
+          </option>
+          <option
+            key="BankSourceClassification"
+            value="BankSourceClassification">
+            Dataset Source
+          </option>
+          <option key="BankIDClassification" value="BankIDClassification">
+            Dataset ID
+          </option>
+          <option
+            key="BankedContentIDClassification"
+            value="BankedContentIDClassification">
             MatchedSignal ID
           </option>
-          <option value="Classification">MatchedSignal</option>
-          <option value="SubmittedContent">SubmittedContent Label</option>
+          <option key="Classification" value="Classification">
+            MatchedSignal
+          </option>
+          <option key="SubmittedContent" value="SubmittedContent">
+            SubmittedContent Label
+          </option>
         </Form.Control>
       </Col>
       <Col xs={2}>
@@ -87,8 +102,12 @@ export default function ActionRuleFormColumns({
             newClassification.equalTo = e.target.value === 'Equals';
             onClassificationChange(newClassification);
           }}>
-          <option value="Equals">=</option>
-          <option value="Not Equals">≠</option>
+          <option key="e" value="Equals">
+            =
+          </option>
+          <option key="ne" value="Not Equals">
+            ≠
+          </option>
         </Form.Control>
       </Col>
       <Col>
@@ -110,7 +129,7 @@ export default function ActionRuleFormColumns({
 
   const actionOptions = actions
     ? actions.map(action => (
-        <option key={action.id} value={action.id}>
+        <option key={action.name} value={action.name}>
           {action.name}
         </option>
       ))
@@ -194,7 +213,7 @@ export default function ActionRuleFormColumns({
       <td>
         <Form.Label>
           Action
-          <span hidden={!showErrors || actionRule.action_id !== '0'}>
+          <span hidden={!showErrors || actionRule.action !== '0'}>
             {' '}
             (required)
           </span>
@@ -202,9 +221,9 @@ export default function ActionRuleFormColumns({
         <Form.Control
           as="select"
           required
-          value={actionRule.action_id}
+          value={actionRule.action}
           onChange={e => onChange('action_id', e.target.value)}
-          isInvalid={showErrors && actionRule.action_id === '0'}>
+          isInvalid={showErrors && actionRule.action === '0'}>
           <option value="0" key="0">
             Select ...
           </option>

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.tsx
@@ -11,10 +11,10 @@ import Modal from 'react-bootstrap/Modal';
 import ActionRuleFormColumns from './ActionRuleFormColumns';
 import '../../styles/_settings.scss';
 import type {
-  Action,
   ActionRule,
   ClassificationCondition,
 } from '../../pages/settings/ActionRuleSettingsTab';
+import {Action} from '../../pages/settings/ActionSettingsTab';
 
 type Input = {
   actionRule: ActionRule;
@@ -43,7 +43,7 @@ export default function ActionRulesTableRow({
   const [showErrors, setShowErrors] = useState(false);
 
   const onUpdatedActionRuleChange = (
-    update_name: string,
+    update_name: 'name' | 'action_id' | 'classification_conditions',
     new_value: string | ClassificationCondition[],
   ) => {
     const newUpdatedActionRule = updatedActionRule.copyAndProcessUpdate(
@@ -61,13 +61,13 @@ export default function ActionRulesTableRow({
     if (
       actions === undefined ||
       actions.length === 0 ||
-      actionRule.action_id === undefined ||
-      actionRule.action_id.length === 0
+      actionRule.action === undefined ||
+      actionRule.action.length === 0
     ) {
       return <span>&mdash;</span>;
     }
     const actionPerformer = actions.find(
-      action => action.id === actionRule.action_id,
+      action => action.name === actionRule.action,
     );
     if (actionPerformer) {
       return actionPerformer.name;

--- a/hasher-matcher-actioner/webapp/src/pages/Settings.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Settings.tsx
@@ -2,12 +2,15 @@
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  */
 
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import Tab from 'react-bootstrap/Tab';
 import Tabs from 'react-bootstrap/Tabs';
 import {useHistory, useParams} from 'react-router-dom';
-import ActionRuleSettingsTab from './settings/ActionRuleSettingsTab';
-import ActionSettingsTab from './settings/ActionSettingsTab';
+import {fetchAllActionRules, fetchAllActions} from '../Api';
+import ActionRuleSettingsTab, {
+  ActionRule,
+} from './settings/ActionRuleSettingsTab';
+import ActionSettingsTab, {Action} from './settings/ActionSettingsTab';
 import ThreatExchangeSettingsTab from './settings/ThreatExchangeSettingsTab';
 
 // This array must include the eventKey attribute value of any Tab in Tabs as
@@ -17,6 +20,21 @@ const tabEventKeys = ['threatexchange', 'actions', 'action-rules'];
 export default function Settings(): JSX.Element {
   const {tab} = useParams<{tab: string}>();
   const history = useHistory();
+  const [actions, setActions] = useState<Action[]>([]);
+  const [actionRules, setActionRules] = useState<ActionRule[]>([]);
+
+  useEffect(() => {
+    fetchAllActionRules().then(fetchedActionRules => {
+      setActionRules(fetchedActionRules);
+    });
+  }, []);
+
+  useEffect(() => {
+    fetchAllActions().then(fetchedActions => {
+      setActions(fetchedActions);
+    });
+  }, []);
+
   if (tab === undefined || !tab || !tabEventKeys.includes(tab)) {
     window.location.href = '/settings/threatexchange';
   }
@@ -32,10 +50,18 @@ export default function Settings(): JSX.Element {
           <ThreatExchangeSettingsTab />
         </Tab>
         <Tab eventKey="actions" title="Actions">
-          <ActionSettingsTab />
+          <ActionSettingsTab
+            actions={actions}
+            setActions={setActions}
+            actionRules={actionRules}
+          />
         </Tab>
         <Tab eventKey="action-rules" title="Action Rules">
-          <ActionRuleSettingsTab />
+          <ActionRuleSettingsTab
+            actions={actions}
+            actionRules={actionRules}
+            setActionRules={setActionRules}
+          />
         </Tab>
       </Tabs>
     </>

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ActionSettingsTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ActionSettingsTab.tsx
@@ -41,7 +41,11 @@ export class Action {
   }
 }
 
-const defaultAction = new Action('', '', '', '');
+const defaultAction = {
+  name: '',
+  config_subtype: '',
+  params: {url: '', headers: ''},
+};
 
 /**
  * TODO This used to have an ActionLabel Settings component here. The
@@ -56,7 +60,7 @@ export default function ActionSettingsTab({
   actionRules,
 }: Input): JSX.Element {
   const [adding, setAdding] = useState(false);
-  const [newAction, setNewAction] = useState<Action>(defaultAction);
+  const [newAction, setNewAction] = useState(defaultAction);
   const [showToast, setShowToast] = useState(false);
   const [toastMessage, setToastMessage] = useState('');
   const resetForm = () => {
@@ -66,7 +70,7 @@ export default function ActionSettingsTab({
     if (key === 'name' || key === 'config_subtype') {
       setNewAction({...newAction, ...value});
     } else {
-      setNewAction({...newAction, fields: {...newAction.fields, ...value}});
+      setNewAction({...newAction, params: {...newAction.params, ...value}});
     }
   };
   const displayToast = (message: string) => {
@@ -79,12 +83,12 @@ export default function ActionSettingsTab({
     );
     setActions(filteredActions);
   };
-  const onActionUpdate = (updatedAction: Action) => {
-    updateAction(
-      updatedAction.name,
-      updatedAction.type,
-      updatedAction.updatedAction,
-    )
+  const onActionUpdate = (key: {
+    name: string;
+    type: string;
+    updatedAction: any;
+  }) => {
+    updateAction(key.name, key.type, key.updatedAction)
       .then(response => {
         displayToast(response.response);
       })
@@ -176,7 +180,7 @@ export default function ActionSettingsTab({
                 <ActionPerformerColumns
                   name={newAction.name}
                   type={newAction.config_subtype}
-                  params={newAction.fields}
+                  params={newAction.params}
                   editing
                   onChange={onNewActionChange}
                   canNotDeleteOrUpdateName={false}
@@ -186,7 +190,9 @@ export default function ActionSettingsTab({
                 ? null
                 : actions.map(action => (
                     <ActionPerformerRows
-                      action={action}
+                      name={action.name}
+                      type={action.config_subtype}
+                      params={action.params}
                       edit={false}
                       onSave={onActionUpdate}
                       onDelete={onActionDelete}

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ActionSettingsTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ActionSettingsTab.tsx
@@ -69,22 +69,22 @@ export default function ActionSettingsTab({
   const onActionUpdate = (
     old_name: string,
     old_type: string,
-    updatedAction: any,
+    updatedAction: Action,
   ) => {
     updateAction(old_name, old_type, updatedAction)
       .then(response => {
-        actions.unshift(
-          new Action(
-            updatedAction.name,
-            updatedAction.config_subtype,
-            updatedAction.fields.url,
-            updatedAction.fields.headers,
-          ),
-        );
-        setActions(actions);
+        const updatedActions = actions.map(action => {
+          if (action.name === old_name) {
+            return updatedAction;
+          }
+          return action;
+        });
+        setActions(updatedActions);
         displayToast(response.response);
       })
-      .catch(() => {
+      .catch(e => {
+        /* eslint-disable-next-line no-console */
+        console.log(e);
         displayToast('Errors when updating the action. Please try again later');
       });
   };
@@ -186,6 +186,7 @@ export default function ActionSettingsTab({
                 ? null
                 : actions.map(action => (
                     <ActionPerformerRows
+                      key={action.name}
                       action={action}
                       saveAction={updatedAction =>
                         onActionUpdate(


### PR DESCRIPTION
Issue #779

Summary
---------

OK. Bear with me here...

I went about trying to make the Actions and ActionRules Settings pages update automatically. Formerly, if you added, deleted, or updated an Action, the change would not automatically show up on the ActionRules page until you refreshed. Similarly, changes to actionrules wouldn't show up on the actions page. The solution here was to move the React State components from the child tab classes to the parent settings class so they could be shared.

In making this change however I started doing some refactoring and adding additional tying. These changes grew until I was no longer sure which changes were for the initial feature and which were simply refactors.


All together the new changes are:
- Adding stricter typing across Actions and ActionRules specifically in interacting with the API
- Pass around Action and ActionRule objects rather than individual fields
- Using the same classes for Actions and ActionRules throughout the UI
- Handle API errors at the API level in `API.tsx`
- better function names
- remove old typing structure (`propTypes`)
- add missing key params to option lists

Test Plan
---------

### Video of new feature
1. ActionRule is set up to use Action 1
2. Change ActionRule 1 to use Action 2
3. Show that Action 1 can now be deleted without refreshing the page
4. Change name of Action 1
5. Show that new name appears without refresh when editing ActionRule

https://user-images.githubusercontent.com/24800630/132585681-4ac16600-55ea-45fc-a8c5-cde8c180e822.mov


### Video demonstrating all other functionality still works
1. Add, Delete, and Update Actions
2. Add, Delete, and Update ActionRules
3. Refresh page to demonstrate that changes are stored in DB

https://user-images.githubusercontent.com/24800630/132586372-af4e86b7-7fbf-4059-a937-a00ef5854384.mov

