### PR TITLE
[hma][api] update root reply to include LastModified

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -89,7 +89,8 @@ def root():
     )["LastModified"]
 
     return {
-        "message": f"Welcome to the HMA API! Last Modified/Deployed: {last_modified}",
+        "message": "Welcome to the HMA API!",
+        "last_modified": last_modified,
     }
 
 

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -78,8 +78,18 @@ def error500(e):
 
 @app.get("/")
 def root():
+    """
+    root endpoint to make sure the API is live and check when it was last updated
+    """
+    context = bottle.request.environ.get("apig_wsgi.context")
+    invoked_function_arn = context.invoked_function_arn
+    client = boto3.client("lambda")
+    last_modified = client.get_function_configuration(
+        FunctionName=invoked_function_arn
+    )["LastModified"]
+
     return {
-        "message": "Hello World, HMA",
+        "message": f"Welcome to the HMA API! Last Modified/Deployed: {last_modified}",
     }
 
 

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -153,6 +153,11 @@ data "aws_iam_policy_document" "api_root" {
     resources = [var.writebacks_queue.arn, var.submissions_queue.arn, var.hashes_queue.arn]
   }
 
+  statement {
+    effect    = "Allow"
+    actions   = ["lambda:GetFunctionConfiguration"]
+    resources = [aws_lambda_function.api_root.arn]
+  }
 }
 
 resource "aws_iam_policy" "api_root" {


### PR DESCRIPTION
Summary
---------

See title. To enable this I had to allow the lambda to query for its own Function Configuration because `LastModified` is included in that [result](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.get_function_configuration) but not part of the [basic context](https://docs.aws.amazon.com/lambda/latest/dg/python-context.html):


Test Plan
---------
<img width="1255" alt="Screen Shot 2021-09-09 at 7 41 18 PM" src="https://user-images.githubusercontent.com/7664526/132776384-2ce38357-a196-4945-9597-c956e8f15ed5.png">
