### PR TITLE
[banks][ui] view-all, add and edit banks

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/models/bank.py
+++ b/hasher-matcher-actioner/hmalib/common/models/bank.py
@@ -208,6 +208,30 @@ class BanksTable:
             for item in self._table.scan(IndexName="BankNameIndex")["Items"]
         ]
 
+    def update_bank(
+        self,
+        bank_id: str,
+        bank_name: t.Optional[str],
+        bank_description: t.Optional[str],
+    ) -> Bank:
+        bank = Bank.from_dynamodb_item(
+            self._table.get_item(
+                Key={"SK": bank_id, "PK": Bank.BANK_OBJECT_PARTITION_KEY}
+            )["Item"]
+        )
+
+        if bank_name:
+            bank.bank_name = bank_name
+
+        if bank_description:
+            bank.bank_description = bank_description
+
+        if bank_name or bank_description:
+            bank.updated_at = datetime.now()
+            bank.write_to_table(table=self._table)
+
+        return bank
+
     def add_bank_member(
         self,
         bank_id: str,

--- a/hasher-matcher-actioner/hmalib/lambdas/api/bank.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/bank.py
@@ -43,4 +43,12 @@ def get_bank_api(bank_table: Table) -> bottle.Bottle:
             bank_description=bottle.request.json["bank_description"],
         )
 
+    @bank_api.post("/update-bank/<bank_id>", apply=[jsoninator])
+    def update_bank(bank_id=None) -> Bank:
+        return table_manager.update_bank(
+            bank_id=bank_id,
+            bank_name=bottle.request.json["bank_name"],
+            bank_description=bottle.request.json["bank_description"],
+        )
+
     return bank_api

--- a/hasher-matcher-actioner/hmalib/lambdas/api/bank.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/bank.py
@@ -29,15 +29,24 @@ def get_bank_api(bank_table: Table) -> bottle.Bottle:
 
     @bank_api.get("/get-all-banks", apply=[jsoninator])
     def get_all_banks() -> AllBanksEnvelope:
+        """
+        Get all banks.
+        """
         return AllBanksEnvelope(banks=table_manager.get_all_banks())
 
     @bank_api.get("/get-bank/<bank_id>", apply=[jsoninator])
     def get_bank(bank_id=None) -> Bank:
+        """
+        Get a specific bank from a bank_id.
+        """
         bank = table_manager.get_bank(bank_id=bank_id)
         return bank
 
     @bank_api.post("/create-bank", apply=[jsoninator])
     def create_bank() -> Bank:
+        """
+        Create a bank using only the name and description.
+        """
         return table_manager.create_bank(
             bank_name=bottle.request.json["bank_name"],
             bank_description=bottle.request.json["bank_description"],
@@ -45,6 +54,9 @@ def get_bank_api(bank_table: Table) -> bottle.Bottle:
 
     @bank_api.post("/update-bank/<bank_id>", apply=[jsoninator])
     def update_bank(bank_id=None) -> Bank:
+        """
+        Update name and description for a bank_id.
+        """
         return table_manager.update_bank(
             bank_id=bank_id,
             bank_name=bottle.request.json["bank_name"],

--- a/hasher-matcher-actioner/webapp/package.json
+++ b/hasher-matcher-actioner/webapp/package.json
@@ -20,6 +20,7 @@
     "date-fns": "^2.22.1",
     "dompurify": "^2.2.9",
     "eslint": "^7.29.0",
+    "formik": "^2.2.9",
     "ionicons": "^5.5.3",
     "node-sass": "^6.0.1",
     "prettier": "^2.3.2",

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -428,18 +428,37 @@ export async function deleteActionRule(name: string): Promise<Response> {
   return apiDelete(`action-rules/${name}`);
 }
 
+type BankWithStringDates = Bank & {
+  created_at: string;
+  updated_at: string;
+};
+
+type AllBanksResponse = {
+  banks: BankWithStringDates[];
+};
+
 export async function fetchAllBanks(): Promise<Bank[]> {
-  return apiGet('banks/get-all-banks').then((response: any) => response.banks);
+  return apiGet<AllBanksResponse>('banks/get-all-banks').then(response =>
+    response.banks.map(item => ({
+      bank_id: item.bank_id!,
+      bank_name: item.bank_name!,
+      bank_description: item.bank_description!,
+      created_at: toDate(item.created_at)!,
+      updated_at: toDate(item.updated_at)!,
+    })),
+  );
 }
 
 export async function fetchBank(bankId: string): Promise<Bank> {
-  return apiGet(`banks/get-bank/${bankId}`).then((response: any) => ({
-    bank_id: response.bank_id!,
-    bank_name: response.bank_name!,
-    bank_description: response.bank_description!,
-    created_at: toDate(response.created_at)!,
-    updated_at: toDate(response.updated_at)!,
-  }));
+  return apiGet<BankWithStringDates>(`banks/get-bank/${bankId}`).then(
+    response => ({
+      bank_id: response.bank_id!,
+      bank_name: response.bank_name!,
+      bank_description: response.bank_description!,
+      created_at: toDate(response.created_at)!,
+      updated_at: toDate(response.updated_at)!,
+    }),
+  );
 }
 
 export async function createBank(
@@ -457,10 +476,10 @@ export async function updateBank(
   bankName: string,
   bankDescription: string,
 ): Promise<Bank> {
-  return apiPost(`banks/update-bank/${bankId}`, {
+  return apiPost<BankWithStringDates>(`banks/update-bank/${bankId}`, {
     bank_name: bankName,
     bank_description: bankDescription,
-  }).then((response: any) => ({
+  }).then(response => ({
     bank_id: response.bank_id!,
     bank_name: response.bank_name!,
     bank_description: response.bank_description!,

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -5,6 +5,8 @@
 import {Auth, API} from 'aws-amplify';
 import {ActionRule, Label} from './pages/settings/ActionRuleSettingsTab';
 import {Action} from './pages/settings/ActionSettingsTab';
+import {Bank} from './messages/BankMessages';
+import {toDate} from './utils/DateTimeUtils';
 
 async function getAuthorizationToken(): Promise<string> {
   const currentSession = await Auth.currentSession();
@@ -424,4 +426,45 @@ export async function updateActionRule(
 
 export async function deleteActionRule(name: string): Promise<Response> {
   return apiDelete(`action-rules/${name}`);
+}
+
+export async function fetchAllBanks(): Promise<Bank[]> {
+  return apiGet('banks/get-all-banks').then((response: any) => response.banks);
+}
+
+export async function fetchBank(bankId: string): Promise<Bank> {
+  return apiGet(`banks/get-bank/${bankId}`).then((response: any) => ({
+    bank_id: response.bank_id!,
+    bank_name: response.bank_name!,
+    bank_description: response.bank_description!,
+    created_at: toDate(response.created_at)!,
+    updated_at: toDate(response.updated_at)!,
+  }));
+}
+
+export async function createBank(
+  bankName: string,
+  bankDescription: string,
+): Promise<void> {
+  return apiPost('banks/create-bank', {
+    bank_name: bankName,
+    bank_description: bankDescription,
+  });
+}
+
+export async function updateBank(
+  bankId: string,
+  bankName: string,
+  bankDescription: string,
+): Promise<Bank> {
+  return apiPost(`banks/update-bank/${bankId}`, {
+    bank_name: bankName,
+    bank_description: bankDescription,
+  }).then((response: any) => ({
+    bank_id: response.bank_id!,
+    bank_name: response.bank_name!,
+    bank_description: response.bank_description!,
+    created_at: toDate(response.created_at)!,
+    updated_at: toDate(response.updated_at)!,
+  }));
 }

--- a/hasher-matcher-actioner/webapp/src/App.tsx
+++ b/hasher-matcher-actioner/webapp/src/App.tsx
@@ -20,6 +20,8 @@ import Dashboard from './pages/Dashboard';
 import Settings from './pages/Settings';
 import SubmitContent from './pages/SubmitContent';
 import ContentDetailsWithStepper from './pages/ContentDetailsWithStepper';
+import ViewAllBanks from './pages/bank-management/ViewAllBanks';
+import ViewBank from './pages/bank-management/ViewBank';
 
 export default function App(): JSX.Element {
   return (
@@ -55,6 +57,12 @@ export default function App(): JSX.Element {
               </Route>
               <Route path="/settings">
                 <Redirect to="/settings/signals" />
+              </Route>
+              <Route path="/banks/bank/:bankId/:tab">
+                <ViewBank />
+              </Route>
+              <Route path="/banks/">
+                <ViewAllBanks />
               </Route>
               <Route path="/">
                 <Dashboard />

--- a/hasher-matcher-actioner/webapp/src/Sidebar.tsx
+++ b/hasher-matcher-actioner/webapp/src/Sidebar.tsx
@@ -47,6 +47,14 @@ export default function Sidebar(
             Submit Content
           </NavLink>
         </li>
+        <li className="nav-item">
+          <NavLink
+            activeClassName="text-white bg-secondary rounded"
+            to="/banks/"
+            className="nav-link px-2">
+            Banks
+          </NavLink>
+        </li>
       </ul>
 
       <ul className="navbar-nav push-down pb-2 pt-1">

--- a/hasher-matcher-actioner/webapp/src/Sidebar.tsx
+++ b/hasher-matcher-actioner/webapp/src/Sidebar.tsx
@@ -47,14 +47,15 @@ export default function Sidebar(
             Submit Content
           </NavLink>
         </li>
-        <li className="nav-item">
+        {/* Hide list-item until we're ready. */}
+        {/* <li className="nav-item">
           <NavLink
             activeClassName="text-white bg-secondary rounded"
             to="/banks/"
             className="nav-link px-2">
             Banks
           </NavLink>
-        </li>
+        </li> */}
       </ul>
 
       <ul className="navbar-nav push-down pb-2 pt-1">

--- a/hasher-matcher-actioner/webapp/src/forms/BankDetailsForm.tsx
+++ b/hasher-matcher-actioner/webapp/src/forms/BankDetailsForm.tsx
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React, {useState, SyntheticEvent, useEffect} from 'react';
+import {Form, Button} from 'react-bootstrap';
+import {useFormik} from 'formik';
+
+type BankDetailsValues = {
+  bankName: string;
+  bankDescription: string;
+};
+
+type BankDetailsFormProps = Partial<BankDetailsValues> & {
+  handleSubmit: (bankName: string, bankDescription: string) => void;
+  formResetCounter?: number;
+};
+
+function validate(values: BankDetailsValues) {
+  const errors: Partial<BankDetailsValues> = {};
+  if (!values.bankName) {
+    errors.bankName = 'Required';
+  }
+
+  if (!values.bankDescription) {
+    errors.bankDescription = 'Required';
+  }
+
+  return errors;
+}
+
+export default function BankDetailsForm({
+  bankName,
+  bankDescription,
+  handleSubmit,
+  formResetCounter,
+}: BankDetailsFormProps) {
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    // Change button state back to enabled when formResetCounter changes
+    setSaving(false);
+  }, [formResetCounter]);
+
+  const formik = useFormik({
+    initialValues: {
+      bankName: bankName || '',
+      bankDescription: bankDescription || '',
+    },
+    validate,
+    onSubmit: values => {
+      setSaving(true);
+      handleSubmit(values.bankName, values.bankDescription);
+    },
+    enableReinitialize: formResetCounter !== undefined,
+  });
+
+  const innerHandleSubmit = (event: SyntheticEvent) => {
+    event.preventDefault();
+    formik.submitForm();
+  };
+
+  return (
+    <Form onSubmit={innerHandleSubmit}>
+      <Form.Group className="mb-3 mt-4">
+        <Form.Label htmlFor="bankName">Bank Name</Form.Label>
+        <Form.Control
+          id="bankName"
+          type="text"
+          placeholder=""
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          isValid={formik.touched.bankName && !formik.errors.bankName}
+          isInvalid={formik.touched.bankName && !!formik.errors.bankName}
+          value={formik.values.bankName}
+        />
+        {formik.touched.bankName && formik.errors.bankName ? (
+          <Form.Control.Feedback type="invalid">
+            {formik.errors.bankName}
+          </Form.Control.Feedback>
+        ) : null}
+      </Form.Group>
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="bankDescription">
+          Bank Description. Help others understand what this bank is for.
+        </Form.Label>
+        <Form.Control
+          id="bankDescription"
+          as="textarea"
+          rows={3}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          isValid={
+            formik.touched.bankDescription && !formik.errors.bankDescription
+          }
+          isInvalid={
+            formik.touched.bankDescription && !!formik.errors.bankDescription
+          }
+          value={formik.values.bankDescription}
+        />
+        {formik.touched.bankDescription && formik.errors.bankDescription ? (
+          <Form.Control.Feedback type="invalid">
+            {formik.errors.bankDescription}
+          </Form.Control.Feedback>
+        ) : null}
+      </Form.Group>
+      <Button type="submit" variant="primary" disabled={saving}>
+        Save
+      </Button>
+    </Form>
+  );
+}
+
+BankDetailsForm.defaultProps = {
+  formResetCounter: undefined,
+};

--- a/hasher-matcher-actioner/webapp/src/messages/BankMessages.tsx
+++ b/hasher-matcher-actioner/webapp/src/messages/BankMessages.tsx
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+/**
+ * Messages sent received between HMA's bank APIs and the UI.
+ */
+
+export type Bank = {
+  // Follows hmalib.common.models.bank.Bank
+  bank_id: string;
+  bank_name: string;
+  bank_description: string;
+  created_at: Date;
+  updated_at: Date;
+};

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/AddBankModal.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/AddBankModal.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React, {useState} from 'react';
+import {Modal, Container, Row, Col, Form, Button} from 'react-bootstrap';
+import {createBank} from '../../Api';
+import BankDetailsForm from '../../forms/BankDetailsForm';
+
+type AddBankModalProps = {
+  show: boolean;
+  onCloseClick: () => void;
+};
+
+/**
+ * Even though this is a modal, it makes API calls and can be initialized on any
+ * page. So DO NOT move this to components.
+ */
+export default function AddBankModal({show, onCloseClick}: AddBankModalProps) {
+  return (
+    <Modal show={show} size="lg" centered>
+      <Modal.Header closeButton onHide={() => onCloseClick()}>
+        <Modal.Title>Add Bank</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Container>
+          <Row>
+            <Col>
+              <BankDetailsForm
+                handleSubmit={(bankName, bankDescription) => {
+                  createBank(bankName, bankDescription).then(() =>
+                    onCloseClick(),
+                  );
+                }}
+              />
+            </Col>
+          </Row>
+        </Container>
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewAllBanks.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewAllBanks.tsx
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React, {useEffect, useState} from 'react';
+import {Row, Col, Card, Button} from 'react-bootstrap';
+import {generatePath, useHistory} from 'react-router-dom';
+import {fetchAllBanks} from '../../Api';
+import {Bank} from '../../messages/BankMessages';
+
+import FixedWidthCenterAlignedLayout from '../layouts/FixedWidthCenterAlignedLayout';
+import AddBankModal from './AddBankModal';
+
+// TODO: Move to components, and other files
+type BankDetails = {
+  bankName: string;
+  bankDescription: string;
+  bankId: string;
+};
+
+function BankCard({
+  bankName,
+  bankDescription,
+  bankId,
+}: BankDetails): JSX.Element {
+  const history = useHistory();
+
+  const navigateToBank = () => {
+    history.push(generatePath('/banks/bank/:bankId/bank-details', {bankId}));
+  };
+
+  return (
+    <Card className="my-4" onClick={navigateToBank}>
+      <Card.Body>
+        <h2>{bankName}</h2>
+        <p>{bankDescription}</p>
+      </Card.Body>
+    </Card>
+  );
+}
+// TODO: move to components and other files
+type EmptyStateProps = {
+  onCreate: () => void;
+};
+
+function EmptyState({onCreate}: EmptyStateProps): JSX.Element {
+  return (
+    <Col xs={{offset: 2, span: 8}} className="py-4">
+      <div className="h-100" style={{textAlign: 'center', paddingTop: '40%)'}}>
+        <p className="lead">
+          You have not created banks yet. Create your first bank!
+        </p>
+        <p className="text-center">
+          <Button variant="success" size="lg" onClick={onCreate}>
+            Create Bank
+          </Button>
+        </p>
+      </div>
+    </Col>
+  );
+}
+
+export default function ViewAllBanks(): JSX.Element {
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [banks, setBanks] = useState<Bank[]>([]);
+
+  // Increment value every time create modal is closed to trigger refetch
+  const [createModalClosed, setCreateModalClosed] = useState(0);
+
+  useEffect(() => {
+    fetchAllBanks().then(setBanks);
+  }, [createModalClosed]);
+
+  return (
+    <FixedWidthCenterAlignedLayout>
+      <Row className="mt-4">
+        <Col xs={{offset: 2, span: 6}}>
+          <h1>Banks</h1>
+        </Col>
+        <Col xs="2">
+          <div className="float-right">
+            {/* Only show the right-aligned create button if we have banks. Do not want to have multiple CTAs. */}
+            {banks.length === 0 ? null : (
+              <Button onClick={() => setShowCreateModal(true)}>Add Bank</Button>
+            )}
+          </div>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={{offset: 2, span: 8}}>
+          <p className="description text-muted mt-4">
+            Use banks to manage sets of images or videos you want to action on.
+            When you &ldquo;submit&rdquo; images or videos, HMA will
+            automatically try to match against these banks. Banks can be
+            configured to automatically take action or prevent other actions
+            from being taken.
+          </p>
+        </Col>
+      </Row>
+      <Row>
+        {banks.length === 0 ? (
+          <EmptyState onCreate={() => setShowCreateModal(true)} />
+        ) : (
+          <Col xs={{offset: 2, span: 8}}>
+            {banks.map(bank => (
+              <BankCard
+                bankId={bank.bank_id}
+                bankName={bank.bank_name}
+                bankDescription={bank.bank_description}
+              />
+            ))}
+          </Col>
+        )}
+      </Row>
+      <AddBankModal
+        onCloseClick={() => {
+          setShowCreateModal(false);
+          setCreateModalClosed(createModalClosed + 1);
+        }}
+        show={showCreateModal}
+      />
+    </FixedWidthCenterAlignedLayout>
+  );
+}

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBank.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBank.tsx
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React, {useEffect, useState} from 'react';
+import {Container, Row, Col, Form, Button, Card} from 'react-bootstrap';
+import Tab from 'react-bootstrap/Tab';
+import Tabs from 'react-bootstrap/Tabs';
+import {generatePath, useHistory, useParams} from 'react-router-dom';
+import {fetchBank, updateBank} from '../../Api';
+import BankDetailsForm from '../../forms/BankDetailsForm';
+import {Bank} from '../../messages/BankMessages';
+import {BlurImage} from '../../utils/MediaUtils';
+
+import FixedWidthCenterAlignedLayout from '../layouts/FixedWidthCenterAlignedLayout';
+
+type BankTabProps = {
+  bankId: string;
+};
+
+function BankDetails({bankId}: BankTabProps): JSX.Element {
+  const [bank, setBank] = useState<Bank>();
+  const [formResetCounter, setFormResetCounter] = useState<number>(0);
+
+  useEffect(() => {
+    fetchBank(bankId).then(setBank);
+  }, []);
+
+  return (
+    <Row>
+      <Col xs="6">
+        {bank !== undefined ? (
+          <BankDetailsForm
+            bankName={bank.bank_name}
+            bankDescription={bank.bank_description}
+            handleSubmit={(bankName, bankDescription) => {
+              updateBank(bankId, bankName, bankDescription).then(setBank);
+              setFormResetCounter(formResetCounter + 1);
+            }}
+            formResetCounter={formResetCounter}
+          />
+        ) : (
+          <p>Loading ...</p>
+        )}
+      </Col>
+    </Row>
+  );
+}
+
+function MemberPreview(): JSX.Element {
+  return (
+    <Col xs="3" className="mb-4">
+      <Card>
+        <BlurImage src="https://upload.wikimedia.org/wikipedia/commons/b/b1/VAN_CAT.png" />
+        <Card.Body>
+          <p className="text-small">First Updated: yesterday</p>
+          <p className="text-small">Last Seen: seconds ago`</p>
+        </Card.Body>
+      </Card>
+    </Col>
+  );
+}
+
+function VideoMembers({bankId}: BankTabProps): JSX.Element {
+  return (
+    <Container>
+      <Row className="my-4">
+        <Col xs="10">
+          <h4>Videos in this bank.</h4>
+        </Col>
+        <Col xs="2" className="text-right">
+          <Button variant="primary">Add Video</Button>
+        </Col>
+      </Row>
+      <Row>
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+      </Row>
+    </Container>
+  );
+}
+
+function PhotoMembers({bankId}: BankTabProps): JSX.Element {
+  return (
+    <Container>
+      <Row className="my-4">
+        <Col xs="10">
+          <h4>Photos in this bank.</h4>
+        </Col>
+        <Col xs="2" className="text-right">
+          <Button variant="primary">Add Photo</Button>
+        </Col>
+      </Row>
+      <Row>
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+        <MemberPreview />
+      </Row>
+    </Container>
+  );
+}
+
+export default function ViewBank(): JSX.Element {
+  const {bankId, tab} = useParams<{bankId: string; tab: string}>();
+  const history = useHistory();
+
+  const pageTitle = 'Edit Bank';
+
+  return (
+    <FixedWidthCenterAlignedLayout title={pageTitle}>
+      <Row>
+        <Col>
+          <Tabs
+            onSelect={key => {
+              history.push(
+                generatePath('/banks/bank/:bankId/:tab', {
+                  bankId,
+                  tab: key !== null ? key : 'bank-details',
+                }),
+              );
+            }}
+            activeKey={tab}>
+            <Tab eventKey="bank-details" title="Bank Details">
+              <BankDetails bankId={bankId} />
+            </Tab>
+            <Tab eventKey="video-memberships" title="Video Memberships">
+              <VideoMembers bankId={bankId} />
+            </Tab>
+            <Tab eventKey="photo-memberships" title="Photo Memberships">
+              <PhotoMembers bankId={bankId} />
+            </Tab>
+          </Tabs>
+        </Col>
+      </Row>
+    </FixedWidthCenterAlignedLayout>
+  );
+}

--- a/hasher-matcher-actioner/webapp/src/pages/layouts/FixedWidthCenterAlignedLayout.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/layouts/FixedWidthCenterAlignedLayout.tsx
@@ -6,13 +6,16 @@ import React from 'react';
 import {Container, Row, Col} from 'react-bootstrap';
 
 type FixedWidthCenterAlignedLayoutProps = {
-  title: string;
+  title?: string;
   children: JSX.Element | JSX.Element[];
 };
 
 /**
  * Uses a bootstrap container to put all content in the center of the main area.
  * Supports a title and any children.
+ *
+ * If title is not provided, does not provide the top row. You should provide
+ * your own.
  *
  * Does not provide rows and cols. That is for pages to provide.
  *
@@ -30,8 +33,7 @@ type FixedWidthCenterAlignedLayoutProps = {
  * )
  * ```
  *
- * Centralizing the layouts like this allows page authors to focus on the
- * page.
+ * Centralizing the layouts like this allows page authors to focus on the page.
  */
 export default function FixedWidthCenterAlignedLayout({
   title,
@@ -39,12 +41,18 @@ export default function FixedWidthCenterAlignedLayout({
 }: FixedWidthCenterAlignedLayoutProps): JSX.Element {
   return (
     <Container>
-      <Row>
-        <Col className="mt-4">
-          <h1>{title}</h1>
-        </Col>
-      </Row>
+      {title !== undefined ? (
+        <Row>
+          <Col className="mt-4">
+            <h1>{title}</h1>
+          </Col>
+        </Row>
+      ) : null}
       {children}
     </Container>
   );
 }
+
+FixedWidthCenterAlignedLayout.defaultProps = {
+  title: undefined,
+};

--- a/hasher-matcher-actioner/webapp/src/utils/MediaUtils.tsx
+++ b/hasher-matcher-actioner/webapp/src/utils/MediaUtils.tsx
@@ -22,7 +22,7 @@ function BlurMedia(
   ) => JSX.Element,
 ): ({src, override}: BlurUntilHoverImageProps) => JSX.Element {
   function BlurMediaInner({src, override}: BlurUntilHoverImageProps) {
-    const [blurred, setBlurred] = useState(false);
+    const [blurred, setBlurred] = useState(true);
 
     function handleMouseLeave() {
       if (override === undefined) {


### PR DESCRIPTION
Summary
---------
Adds a new sidebar entry, a form to add and edit banks. Only supports bank name and bank descriptions. 

Uses `formik`: Provides state-management for forms.

Test Plan
---------
* Deploy to my prefix
* Used the UI to add a bank, view all banks, empty state when no banks exist, edit banks.

<img width="1188" alt="Screen Shot 2021-09-09 at 19 02 09" src="https://user-images.githubusercontent.com/217056/132773695-42a88b59-4a7a-4008-8701-6e035a02b9fd.png">

**Empty State for View All Banks Page**


<img width="871" alt="Screen Shot 2021-09-09 at 19 02 18" src="https://user-images.githubusercontent.com/217056/132773745-44a9a0a4-3a28-483a-afbd-9fc7adda8970.png">

**Modal to create a new bank**


<img width="1178" alt="Screen Shot 2021-09-09 at 19 03 09" src="https://user-images.githubusercontent.com/217056/132773724-d3c82f9c-2352-4af0-ab33-2f54ccd244ac.png">

**View All Banks Page with the newly created bank**

<img width="800" alt="Screen Shot 2021-09-09 at 19 03 16" src="https://user-images.githubusercontent.com/217056/132773764-c18c8468-499f-497f-8798-d4e4890cf101.png">

**View single bank**


