### PR TITLE
Add commit message to multi-part-pull-request script

### DIFF
--- a/hasher-matcher-actioner/scripts/multi_part_pull_request_template
+++ b/hasher-matcher-actioner/scripts/multi_part_pull_request_template
@@ -37,6 +37,14 @@ def build_template(pr_number):
         )
         print("".join(["### ", f"[`{sha[:8]}`]", f"({gh_link})", " ", message]))
 
+        commit_message_command = (
+            f"git rev-list --format=%B --max-count=1 {sha} | tail +2"
+        )
+        commit_message = subprocess.run(
+            commit_message_command, shell=True, capture_output=True
+        ).stdout
+        print(" ".join(commit_message.decode("utf-8").split("\n")[2:]))
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)


### PR DESCRIPTION
Summary
---------
When I am doing individual commits, I add a lot of context to those commit messages. They get missed out when running the script. This helps by adding the commit message to the output. Now I only have to copy-paste to github.

Test Plan
---------
```shell
EARLIER
-------
user@vm$ ./scripts/multi_part_pull_request_template --pull-request 805
### [`a4e59ac1`](https://github.com/facebook/ThreatExchange/pull/805/commits/a4e59ac1f1680012338eb6d1d2455ec59b3e0630) Add commit message to multi-part-pull-request script

NOW
------
user@vm$ ./scripts/multi_part_pull_request_template --pull-request 805
### [`a4e59ac1`](https://github.com/facebook/ThreatExchange/pull/805/commits/a4e59ac1f1680012338eb6d1d2455ec59b3e0630) Add commit message to multi-part-pull-request script
When I am doing individual commits, I add a lot of context to those commit messages. They get missed out when running the script. This helps by adding the commit message to the output. Now I only have to copy-paste to github.  
```