### PR TITLE
Fetch env vars for your prefix and run lambdas locally

### DIFF
--- a/hasher-matcher-actioner/.gitignore
+++ b/hasher-matcher-actioner/.gitignore
@@ -37,3 +37,6 @@ backend.tf
 
 # Ignore built python distributions
 dist/
+
+# Ignore files for local lambda testing.
+lambda_local.py

--- a/hasher-matcher-actioner/PR.md
+++ b/hasher-matcher-actioner/PR.md
@@ -1,8 +1,0 @@
-
-To change:
-[]- is_deleted to is_removed in bank member
-[]- nit: add note on how this does not filter "IsDeleted" yet.
-[]- move Limit=100 into constant
-[]- with_unprivatised_media_url
-[]- get_content_type_for_name in api/bank.py:143
-- api/main.tf 106 duplication

--- a/hasher-matcher-actioner/hmalib/scripts/cli/command_base.py
+++ b/hasher-matcher-actioner/hmalib/scripts/cli/command_base.py
@@ -69,6 +69,19 @@ class Command:
         """Convenience accessor to stderr"""
         print(*args, file=sys.stderr, **kwargs)
 
+
+# Marker interfaces for main to figure out what to pass
+class NeedsAPIAccess:
     def execute(self, api: utils.HasherMatcherActionerAPI) -> None:
-        """Run the given command"""
+        """
+        Provide implementation for a command which needs access to the HMA API.
+        """
         raise NotImplementedError
+
+
+class NeedsTerraformOutputs:
+    def execute(self, terraform_outputs: t.Dict) -> None:
+        """
+        Provide implementation for a command which needs access to terraform
+        output only.
+        """

--- a/hasher-matcher-actioner/hmalib/scripts/cli/main.py
+++ b/hasher-matcher-actioner/hmalib/scripts/cli/main.py
@@ -19,11 +19,13 @@ import hmalib.scripts.common.utils as utils
 import hmalib.scripts.cli.command_base as base
 import hmalib.scripts.cli.soak as soak
 import hmalib.scripts.cli.shell as shell
+from hmalib.scripts.cli import run_lambda
+
 TERRAFORM_OUTPUTS_CACHE = "/tmp/hma-terraform-outputs.json"
 
 
 def get_subcommands() -> t.List[t.Type[base.Command]]:
-    return [soak.SoakCommand, shell.ShellCommand]
+    return [soak.SoakCommand, shell.ShellCommand, run_lambda.RunLambdaCommand]
 
 
 def get_argparse() -> argparse.ArgumentParser:

--- a/hasher-matcher-actioner/hmalib/scripts/cli/run_lambda.py
+++ b/hasher-matcher-actioner/hmalib/scripts/cli/run_lambda.py
@@ -1,0 +1,74 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import typing as t
+from functools import lru_cache
+import sys
+import argparse
+import importlib
+import boto3
+import os
+import logging.config
+
+LOGGING = {
+    "version": 1,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        }
+    },
+    "root": {"level": "INFO", "handlers": ["console"]},
+}
+
+logging.config.dictConfig(LOGGING)
+
+import hmalib.scripts.cli.command_base as base
+
+
+@lru_cache(maxsize=None)
+def get_lambda_client():
+    return boto3.client("lambda")
+
+
+class RunLambdaCommand(base.Command, base.NeedsTerraformOutputs):
+    @classmethod
+    def init_argparse(cls, ap: argparse.ArgumentParser) -> None:
+        ap.add_argument(
+            "--lambda-name", help="Lambda name without the prefix. eg. hasher, api_root"
+        )
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "run-lambda"
+
+    @classmethod
+    def get_help(cls) -> str:
+        return "Runs a single lambda. You can use this to run or debug lambdas locally."
+
+    def __init__(self, lambda_name: str) -> None:
+        self.lambda_name = lambda_name
+
+    def execute(self, tf_outputs: t.Dict) -> None:
+        full_lambda_name = f"{tf_outputs['prefix']}_{self.lambda_name}"
+        fn_configuration = get_lambda_client().get_function_configuration(
+            FunctionName=full_lambda_name
+        )
+
+        fn_env_vars = fn_configuration["Environment"]["Variables"]
+        fn_method = fn_configuration["ImageConfigResponse"]["ImageConfig"]["Command"][0]
+
+        for k in fn_env_vars:
+            os.environ[k] = fn_env_vars[k]
+
+        module_name, fn_name = fn_method.rsplit(".", 1)
+        module = importlib.import_module(module_name)
+        fn = getattr(module, fn_name)
+
+        try:
+            from lambda_local import event as event_value
+
+            fn(event_value, None)
+        except ModuleNotFoundError:
+            print(
+                "Please define variable `event` in hasher-matcher-actioner/lambda_local.py"
+            )
+            sys.exit(1)

--- a/hasher-matcher-actioner/hmalib/scripts/cli/run_lambda.py
+++ b/hasher-matcher-actioner/hmalib/scripts/cli/run_lambda.py
@@ -64,7 +64,7 @@ class RunLambdaCommand(base.Command, base.NeedsTerraformOutputs):
         fn = getattr(module, fn_name)
 
         try:
-            from lambda_local import event as event_value
+            from lambda_local import event as event_value  # type: ignore
 
             fn(event_value, None)
         except ModuleNotFoundError:

--- a/hasher-matcher-actioner/hmalib/scripts/cli/shell.py
+++ b/hasher-matcher-actioner/hmalib/scripts/cli/shell.py
@@ -26,7 +26,7 @@ from hmalib.common.configs.evaluator import ActionLabel, ActionRule
 from hmalib.common.configs.actioner import ActionPerformer, WebhookPostActionPerformer
 
 
-class ShellCommand(base.Command):
+class ShellCommand(base.Command, base.NeedsAPIAccess):
     """
     Prototype shell using HMA utils to interact via the API.
     """

--- a/hasher-matcher-actioner/hmalib/scripts/cli/soak.py
+++ b/hasher-matcher-actioner/hmalib/scripts/cli/soak.py
@@ -43,7 +43,7 @@ from hmalib.scripts.common.listener import Listener
 from hmalib.scripts.common.submitter import Submitter
 
 
-class SoakCommand(base.Command):
+class SoakCommand(base.Command, base.NeedsAPIAccess):
     """
     Start a soak test on a deployed HMA instance and submit until cancelled
     """

--- a/hasher-matcher-actioner/hmalib/scripts/common/client_lib.py
+++ b/hasher-matcher-actioner/hmalib/scripts/common/client_lib.py
@@ -265,7 +265,7 @@ if __name__ == "__main__":
     # If you want manually test the lib, you can do so here:
 
     tf_outputs = get_terraform_outputs()
-    api_url = tf_outputs["api_url"]["value"]
+    api_url = tf_outputs["api_url"]
     token = get_auth_from_env(prompt_for_token=True)
     print(
         "This simple tests should take a little over 2 minutes to complete (due to sqs timeout).\n"

--- a/hasher-matcher-actioner/hmalib/scripts/common/utils.py
+++ b/hasher-matcher-actioner/hmalib/scripts/common/utils.py
@@ -420,7 +420,7 @@ if __name__ == "__main__":
 
     tf_outputs = get_terraform_outputs()
 
-    api_url = tf_outputs["api_url"]["value"]
+    api_url = tf_outputs["api_url"]
 
     token = get_auth_from_env()
 

--- a/hasher-matcher-actioner/hmalib/scripts/common/utils.py
+++ b/hasher-matcher-actioner/hmalib/scripts/common/utils.py
@@ -296,16 +296,30 @@ class HasherMatcherActionerAPI:
 
 def get_terraform_outputs(
     directory: str = "terraform",
-):
+) -> t.Dict[str, str]:
+    """
+    Converts from the super verbose JSON output to a more natural string -> string map.
+    """
     cmd = ["terraform"]
     cmd.extend(["output", "-json"])
-    out = subprocess.check_output(cmd, cwd=directory)
-    return json.loads(out)
+    out = json.loads(subprocess.check_output(cmd, cwd=directory))
+    return {k: out[k]["value"] for k in out}
 
 
-def get_terraform_outputs_from_file(
+def get_cached_terraform_outputs(
     path: str = "tmp.out",
-):
+) -> t.Dict[str, str]:
+    """
+    Gets output if not already present at path.
+    """
+    file_exists = os.path.exists(path)
+
+    if not file_exists:
+        with open(path, "w") as f:
+            outputs = get_terraform_outputs()
+            f.write(json.dumps(outputs))
+            return outputs
+
     with open(path) as f:
         return json.loads(f.read())
 


### PR DESCRIPTION
Summary
---------
### [`def9004a`](https://github.com/facebook/ThreatExchange/pull/808/commits/def9004a7ddb84b7bad169616256cdc5f7612d90) Use marker interfaces to separate commands which need API access and terraform outputs only
In future commits, we add a new command that does not need API URLs, just terraform outputs.  

### [`ef0481bf`](https://github.com/facebook/ThreatExchange/pull/808/commits/ef0481bf741e1949ea707ca3609ae116536bab6c) Make terraform outputs Dict[str, str] and refresh on demand

### [`0d659c95`](https://github.com/facebook/ThreatExchange/pull/808/commits/0d659c95300f894f36d1cea6f81577b3de2bab20) Add a command to run arbitrary lambda functions locally after pulling all env vars from the deployed instance

### [`7b5a4fb2`](https://github.com/facebook/ThreatExchange/pull/808/commits/7b5a4fb2b5c09008c813e7894d6afff5b513213a) Ignore local_lambda module

### [`c14ed0db`](https://github.com/facebook/ThreatExchange/pull/808/commits/c14ed0db64cf88f9bbf3bbd33a625817b265045e) [embarrasing] remove a local text file describing my PR

Test Plan
---------
```shell
$ python -m hmalib.scripts.cli.main --refresh-tf-outputs run-lambda --lambda-name hasher
Loading faiss with AVX2 support.
Could not load library with AVX2 support due to:
ModuleNotFoundError("No module named 'faiss.swigfaiss_avx2'")
Loading faiss.
Successfully loaded faiss.
Performance measurement requested. Supplying appmetrics instrumentation.
Will use content_id: f561de7a-34af-4df6-98a7-234fa32bc876
```

Provide the value of 'event' to your lambda by definining a module `lambda_local.py` in `hasher-matcher-actioner/`. For hasher, my module looks like:
```python
import json
import uuid
from threatexchange.content_type.photo import PhotoContent
from hmalib.common.messages.submit import URLSubmissionMessage

content_id = str(uuid.uuid4())
print(f"Will use content_id: {content_id}")

event = {
    "Records": [
        {
            "body": json.dumps(
                URLSubmissionMessage(
                    content_type=PhotoContent,
                    content_id=content_id,
                    url="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
                ).to_sqs_message()
            )
        }
    ]
}

```
