### PR TITLE
pdq: add -Wno-misleading-indentation for CImg

### DIFF
--- a/pdq/cpp/Makefile
+++ b/pdq/cpp/Makefile
@@ -1,8 +1,8 @@
 # ================================================================
 CC=g++ -g -std=c++11
 IFLAGS=-I../.. -I.
-# -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess is because of CImg.h
-WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Werror
+# -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation is because of CImg.h
+WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation -Werror
 LFLAGS=-lm
 
 CCOPT=$(CC) $(CFLAGS) $(IFLAGS) $(WFLAGS) -O3


### PR DESCRIPTION
./CImg.h:53981:11: error: this 'for' clause does not guard... [-Werror=misleading-indentation]
53981 |           for (int d = 0; d<5; ++d) ndims[d] = (unsigned short)dims[d]; cimg::fwrite(ndims._data,nbdims,nfile); } \
      |           ^~~
./CImg.h:54046:7: note: in expansion of macro '_cimg_save_pandore_case'
54046 |       _cimg_save_pandore_case(0,0,1,"int",9);
      |       ^~~~~~~~~~~~~~~~~~~~~~~

and many many more expansions of _cimg_save_pandore_case.

-Wno-misleading-indentation support goes back to gcc 4.4, long predating
c++11, so we can assume it is supported by gcc.

Test Plan
---------

ran `make` which succeeded (after other changes in other PRs)
