### PR TITLE
clarify cimg license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD License
 
-For ThreatExchange software
+For ThreatExchange software, except pdq/cpp/CImg.h (see pdq/LICENSE):
 
 Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 

--- a/pdq/LICENSE.txt
+++ b/pdq/LICENSE.txt
@@ -1,3 +1,6 @@
+Except for cpp/CImg.h, which is distributed under the CeCILL-C or CeCILL
+license, ThreatExchange software is distributed under the following license:
+
 Copyright (c) 2017- Facebook
 
 All rights reserved.

--- a/pdq/cpp/README.md
+++ b/pdq/cpp/README.md
@@ -5,7 +5,7 @@ Please see `../README.md` and `../../README.md` for context, and `../../hashing.
 # Dependencies
 
 * C++ 11 or higher
-* `CImg.h` is included for reference, although note that its license does not allow commercial use. It is expected that your company will already have image-processing logic. Dependencies of this code on `CImg.h` are confined solely to `io/pdqio.h` and `io/pdqio.cpp` which you can customize for your site.
+* `CImg.h` is included for reference, although note that it is under the separate CeCILL-C or CeCILL licenses. For production use, it is expected that your company will already have image-processing logic. Dependencies of this code on `CImg.h` are confined solely to `io/pdqio.h` and `io/pdqio.cpp` which you can customize for your site.
 * ImageMagick or other JPEG/PNG libraries: for example, `brew install imagemagick` on MacOSX
 
 # Contact


### PR DESCRIPTION
probably the "cleanest" method would be to include it using submodules,
but that is more technically complicated. however, it is important to
notify the user that some components are under separate license, and not
imply that whole repo is using BSD license.

Test Plan
---------

IANAL, but this is obviously superior to the existing disclosure which is clearly both insufficient (LICENSE does not apply to all files in repo) and overreaching (CImg author explicitly claims that at least *some* commercial use is permitted, pursuant to the license).