### PR TITLE
[python-tx] fix import error for not having tlsh installed

### DIFF
--- a/python-threatexchange/threatexchange/signal_type/pdq_ocr.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_ocr.py
@@ -49,7 +49,7 @@ class PdqOcrSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
                 "Getting both PDQ hash and text of an image file using OCR requires additional libraries already be installed; install threatexchange with the [pdq_hasher & ocr] extra and see ocr_utils.py",
                 category=UserWarning,
             )
-            return []
+            return ""
 
         pdq_hash, quality = pdq_from_file(file)
         ocr_text = text_from_image_file(file)

--- a/python-threatexchange/threatexchange/signal_type/tlsh_pdf.py
+++ b/python-threatexchange/threatexchange/signal_type/tlsh_pdf.py
@@ -9,13 +9,6 @@ import pathlib
 import typing as t
 import warnings
 from io import StringIO
-import tlsh
-from pdfminer.converter import TextConverter
-from pdfminer.layout import LAParams
-from pdfminer.pdfdocument import PDFDocument
-from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
-from pdfminer.pdfpage import PDFPage
-from pdfminer.pdfparser import PDFParser
 
 from ..descriptor import SimpleDescriptorRollup, ThreatDescriptor
 from . import signal_base
@@ -53,6 +46,21 @@ class TLSHSignal(
         if not str(file).endswith(".pdf"):
             warnings.warn("File does not appear to be a pdf. ", category=UserWarning)
             return ""
+
+        try:
+            import tlsh
+            from pdfminer.converter import TextConverter
+            from pdfminer.layout import LAParams
+            from pdfminer.pdfdocument import PDFDocument
+            from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
+            from pdfminer.pdfpage import PDFPage
+            from pdfminer.pdfparser import PDFParser
+        except:
+            warnings.warn(
+                "Getting the tlsh hash of a pdf requires additional libraries already be installed; install threatexchange with the [pdf] extra",
+                category=UserWarning,
+            )
+            return ""
         text = StringIO()
         with open(file, "rb") as in_file:
             parser = PDFParser(in_file)
@@ -66,6 +74,14 @@ class TLSHSignal(
 
     def match_hash(self, signal_str: str) -> t.List[signal_base.SignalMatch]:
         matches = []
+        try:
+            import tlsh
+        except:
+            warnings.warn(
+                "Matching a tlsh hash requires additional libraries already be installed; install threatexchange with the [pdf] extra",
+                category=UserWarning,
+            )
+            return []
         if len(signal_str) == EXPECT_TLSH_HASH_LENGTH:
             for x in TEMP_MATCH_IMPLEMNTATION_CHECK_DB:
                 if tlsh.diffxlen(x[0], signal_str) <= TLSH_CONFIDENT_MATCH_THRESHOLD:


### PR DESCRIPTION
Summary
---------

`python-threatexchange/threatexchange/signal_type/tlsh_pdf.py` was over zealous with its imports meaning that `tlsh` & `pdfminer` were actually required not just an extra if [pdf] was included. 

Moved this imports to the functions themselves instead (like is done with `pdq.py` for `Pillow` etc.)

Test Plan
---------

`pytest python-threatexchange` after `make local_install`
