### PR TITLE
[hma][api] Add VPC support to HMA API 

### DIFF
--- a/hasher-matcher-actioner/examples/vpc_deploy/README.md
+++ b/hasher-matcher-actioner/examples/vpc_deploy/README.md
@@ -8,7 +8,7 @@ Just like the main terraform folder you will need `backend.tf` and `terraform.tf
 
 example `backend.tf`
 
-```json
+```HCL
 terraform {
   backend "s3" {
     bucket         = "<your-project>-tf-state"
@@ -21,7 +21,7 @@ terraform {
 
 example `terraform.tfvars`
 
-```json
+```HCL
 prefix = "<prefix>"
 ```
 

--- a/hasher-matcher-actioner/examples/vpc_deploy/README.md
+++ b/hasher-matcher-actioner/examples/vpc_deploy/README.md
@@ -1,0 +1,36 @@
+# Example VPC Deployment
+
+In order to test VPC support for HMA, a VPC and moreover a way to invoke the API is needed. These terraform files get you close to that point but require a few extra steps to fully test.
+
+## Setup
+
+Just like the main terraform folder you will need `backend.tf` and `terraform.tfvars` files.
+
+example `backend.tf`
+
+```json
+terraform {
+  backend "s3" {
+    bucket         = "<your-project>-tf-state"
+    key            = "state/hasher-matcher-actioner-<prefix>-vpc-example.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-state-locking"
+  }
+}
+```
+
+example `terraform.tfvars`
+
+```json
+prefix = "<prefix>"
+```
+
+Before deploying you will need to follow the steps [here](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/client-authentication.html#mutual) to create the certificates used by the VPN.
+
+Then after running `terraform init` & `terraform apply` the necessary pieces should be created for you then [export and edit the config file](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-working-endpoints.html#cvpn-working-endpoint-export) to add the profile to the [AWS Client VPN](https://aws.amazon.com/vpn/client-vpn-download/)
+
+## Passing value to HMA
+
+The outputs of apply, specifically `vpc_id`, `priv_subnets`, and `security_group_id` can then be given in the `terraform.tfvars` of the main module as `vpc_id`, `vpc_subnets`, and `security_groups` respectively with `security_groups` being passed as a one element list.
+
+You should then be able to test deploy HMA behind a VPC and only access the API's invoke URL when connected to the VPN created in this example.

--- a/hasher-matcher-actioner/examples/vpc_deploy/terraform/.terraform.lock.hcl
+++ b/hasher-matcher-actioner/examples/vpc_deploy/terraform/.terraform.lock.hcl
@@ -1,0 +1,57 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.60.0"
+  constraints = "~> 3.0, >= 3.28.0, >= 3.38.0"
+  hashes = [
+    "h1:vwRjnpZOFwDlbFb2WX10JM2zNEEVyRLc8cBwkxCXlAE=",
+    "zh:01323eedb8f006c8f9fffdfc23b449625b1446c1e43b8454e4a40a7461193661",
+    "zh:03513ffdae205832be480b30d332b47a573e48623390e8f9f833141c8ceccb6a",
+    "zh:47611a8b361ced9a3b58b9868be2004677cf4ea0d04cfb5f54c6ae95e997e7c7",
+    "zh:9a7e80c2a2ed0f2e59b05e27374daaafd64785161546ed40f4db11048fbc78a7",
+    "zh:9e809746c4fdaa4214700e81a67b35f02afc1f2873591b0360c473cfd7193877",
+    "zh:a009d48e4ebcf78e24af9299c6a8664e0375411b4f16d5d0d7c7454b12052c10",
+    "zh:adc910f48f5ddc402e7653e70429d150d61bee5190aba7495575303aba6ca6c8",
+    "zh:b702e219532bc09be58f8a30cb3239626ffc9bc0e42b44497b0644f9ecc657b5",
+    "zh:bc50d787593e714acb54d65e8df026490a968e54d2184496efda7ba07c211836",
+    "zh:bd74e3b1c815d5a9c710cb5c55f2d5f6742471a23e63f924fd3a6493f384cd43",
+    "zh:fa7eb23bcf4c01f93d74c509c0e9b039148f43424c3b4ce64619af17ee12265c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.1.0"
+  hashes = [
+    "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
+    "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
+    "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
+    "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
+    "zh:719dfd97bb9ddce99f7d741260b8ece2682b363735c764cac83303f02386075a",
+    "zh:7598bb86e0378fd97eaa04638c1a4c75f960f62f69d3662e6d80ffa5a89847fe",
+    "zh:ad0a188b52517fec9eca393f1e2c9daea362b33ae2eb38a857b6b09949a727c1",
+    "zh:c46846c8df66a13fee6eff7dc5d528a7f868ae0dcf92d79deaac73cc297ed20c",
+    "zh:dc1a20a2eec12095d04bf6da5321f535351a594a636912361db20eb2a707ccc4",
+    "zh:e57ab4771a9d999401f6badd8b018558357d3cbdf3d33cc0c4f83e818ca8e94b",
+    "zh:ebdcde208072b4b0f8d305ebf2bfdc62c926e0717599dcf8ec2fd8c5845031c3",
+    "zh:ef34c52b68933bedd0868a13ccfd59ff1c820f299760b3c02e008dc95e2ece91",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.0"
+  hashes = [
+    "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
+    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
+    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
+    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
+    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
+    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
+    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
+    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
+    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
+    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
+    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
+    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
+  ]
+}

--- a/hasher-matcher-actioner/examples/vpc_deploy/terraform/main.tf
+++ b/hasher-matcher-actioner/examples/vpc_deploy/terraform/main.tf
@@ -1,0 +1,94 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_region" "default" {}
+
+locals {
+  common_tags = merge(var.additional_tags, {
+    "HMAPrefix"  = var.prefix
+    "VPCExample" = "vpc-eg"
+  })
+  region = data.aws_region.default.name
+}
+
+### VPC (eg) ###
+module "vpc_eg" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name            = "${var.prefix}-eg-vpc"
+  cidr            = "20.10.0.0/16"
+  azs             = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  private_subnets = ["20.10.1.0/24", "20.10.2.0/24", "20.10.3.0/24"]
+  public_subnets  = ["20.10.11.0/24", "20.10.12.0/24", "20.10.13.0/24"]
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(var.additional_tags, {
+    Terraform   = "true"
+    Environment = "dev"
+  })
+}
+
+
+# VPN https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-getting-started.html
+# after following https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/client-authentication.html#mutual
+
+data "aws_acm_certificate" "client" {
+  domain   = "client1.domain.tld"
+  statuses = ["ISSUED"]
+}
+
+data "aws_acm_certificate" "server" {
+  domain   = "server"
+  statuses = ["ISSUED"]
+}
+
+resource "aws_ec2_client_vpn_endpoint" "eg" {
+  server_certificate_arn = data.aws_acm_certificate.server.arn
+  client_cidr_block      = "10.0.0.0/16"
+
+  authentication_options {
+    type                       = "certificate-authentication"
+    root_certificate_chain_arn = data.aws_acm_certificate.client.arn
+  }
+
+  connection_log_options {
+    enabled = false
+  }
+}
+
+resource "aws_ec2_client_vpn_network_association" "eg" {
+  depends_on = [
+    module.vpc_eg.public_subnets
+  ]
+  client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.eg.id
+  subnet_id              = module.vpc_eg.public_subnets[0]
+}
+
+resource "aws_ec2_client_vpn_authorization_rule" "eg" {
+  client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.eg.id
+  target_network_cidr    = module.vpc_eg.vpc_cidr_block
+  authorize_all_groups   = true
+}
+
+resource "aws_ec2_client_vpn_route" "eg" {
+  client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.eg.id
+  destination_cidr_block = "0.0.0.0/0"
+  target_vpc_subnet_id   = aws_ec2_client_vpn_network_association.eg.subnet_id
+}

--- a/hasher-matcher-actioner/examples/vpc_deploy/terraform/outputs.tf
+++ b/hasher-matcher-actioner/examples/vpc_deploy/terraform/outputs.tf
@@ -1,0 +1,17 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+output "vpc_id" {
+  value = module.vpc_eg.vpc_id
+}
+output "pub_subnets" {
+  value = module.vpc_eg.public_subnets
+}
+output "priv_subnets" {
+  value = module.vpc_eg.private_subnets
+}
+output "security_group_id" {
+  value = module.vpc_eg.default_security_group_id
+}
+output "vpc_cidr_block" {
+  value = module.vpc_eg.vpc_cidr_block
+}

--- a/hasher-matcher-actioner/examples/vpc_deploy/terraform/variables.tf
+++ b/hasher-matcher-actioner/examples/vpc_deploy/terraform/variables.tf
@@ -1,0 +1,13 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+variable "prefix" {
+  description = "Prefix to use for resource names"
+  type        = string
+  default     = "hma"
+}
+
+variable "additional_tags" {
+  description = "Additional resource tags. Will be applied to ALL resources created."
+  type        = map(string)
+  default     = {}
+}

--- a/hasher-matcher-actioner/hmalib/lambdas/api/action_rules.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/action_rules.py
@@ -8,7 +8,12 @@ from botocore.exceptions import ClientError
 from bottle import response
 from dataclasses import dataclass, field
 from hmalib.common.logging import get_logger
-from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
+from hmalib.lambdas.api.middleware import (
+    jsoninator,
+    JSONifiable,
+    DictParseable,
+    SubApp,
+)
 from hmalib.common.config import HMAConfig
 from hmalib.common import config as hmaconfig
 from hmalib.common.configs.evaluator import ActionRule
@@ -49,7 +54,7 @@ def handle_unexpected_error(e: Exception):
 
 def get_action_rules_api(hma_config_table: str) -> bottle.Bottle:
     # The endpoints below imply a prefix of '/action-rules'
-    action_rules_api = bottle.Bottle()
+    action_rules_api = SubApp()
     HMAConfig.initialize(hma_config_table)
 
     @action_rules_api.get("/", apply=[jsoninator])

--- a/hasher-matcher-actioner/hmalib/lambdas/api/actions.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/actions.py
@@ -3,7 +3,12 @@
 import bottle
 import typing as t
 from dataclasses import dataclass, asdict
-from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
+from hmalib.lambdas.api.middleware import (
+    jsoninator,
+    JSONifiable,
+    DictParseable,
+    SubApp,
+)
 from hmalib.common.config import HMAConfig
 from hmalib.common import config as hmaconfig
 from hmalib.common.configs.actioner import ActionPerformer
@@ -58,7 +63,7 @@ class DeleteActionResponse(JSONifiable):
 
 def get_actions_api(hma_config_table: str) -> bottle.Bottle:
     # The documentation below expects prefix to be '/actions/'
-    actions_api = bottle.Bottle()
+    actions_api = SubApp()
     HMAConfig.initialize(hma_config_table)
 
     @actions_api.get("/", apply=[jsoninator])

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -79,6 +79,7 @@ def error500(e):
 
 
 @app.get("/")
+@app.get("/root/")
 def root():
     """
     root endpoint to make sure the API is live and check when it was last updated

--- a/hasher-matcher-actioner/hmalib/lambdas/api/bank.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/bank.py
@@ -18,7 +18,11 @@ from threatexchange.content_type.video import VideoContent
 
 from hmalib.common.models.bank import Bank, BankMember, BanksTable, BankMemberSignal
 from hmalib.banks import bank_operations as bank_ops
-from hmalib.lambdas.api.middleware import jsoninator, JSONifiable
+from hmalib.lambdas.api.middleware import (
+    jsoninator,
+    JSONifiable,
+    SubApp,
+)
 from hmalib.lambdas.api.submit import create_presigned_put_url, create_presigned_url
 
 
@@ -101,7 +105,7 @@ def get_bank_api(
     Closure for dependencies of the bank API
     """
 
-    bank_api = bottle.Bottle()
+    bank_api = SubApp()
     table_manager = BanksTable(table=bank_table)
 
     # Bank Management

--- a/hasher-matcher-actioner/hmalib/lambdas/api/content.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/content.py
@@ -14,7 +14,12 @@ import typing as t
 from threatexchange.signal_type.signal_base import SignalType
 from threatexchange.content_type.content_base import ContentType
 
-from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
+from hmalib.lambdas.api.middleware import (
+    jsoninator,
+    JSONifiable,
+    DictParseable,
+    SubApp,
+)
 from hmalib.common.models.pipeline import MatchRecord, PipelineHashRecord
 from hmalib.common.models.content import (
     ContentObject,
@@ -131,7 +136,7 @@ def get_content_api(
 
     # A prefix to all routes must be provided by the api_root app
     # The documentation below expects prefix to be '/content/'
-    content_api = bottle.Bottle()
+    content_api = SubApp()
 
     @content_api.get("/", apply=[jsoninator])
     def content() -> t.Optional[ContentObject]:

--- a/hasher-matcher-actioner/hmalib/lambdas/api/content.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/content.py
@@ -123,7 +123,7 @@ def get_content_api(
         preview it.
         """
         content_object = t.cast(ContentObject, content_object)
-
+        preview_url = ""
         if content_object.content_ref_type == ContentRefType.DEFAULT_S3_BUCKET:
             source = S3BucketContentSource(image_bucket, image_prefix)
 
@@ -132,6 +132,8 @@ def get_content_api(
             )
         elif content_object.content_ref_type == ContentRefType.URL:
             preview_url = content_object.content_ref
+        if not preview_url:
+            return bottle.abort(400, "preview_url not found.")
         return preview_url
 
     # A prefix to all routes must be provided by the api_root app

--- a/hasher-matcher-actioner/hmalib/lambdas/api/datasets.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/datasets.py
@@ -16,7 +16,12 @@ from hmalib.common.threatexchange_config import (
     create_privacy_group_if_not_exists,
 )
 
-from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
+from hmalib.lambdas.api.middleware import (
+    jsoninator,
+    JSONifiable,
+    DictParseable,
+    SubApp,
+)
 
 
 @dataclass
@@ -225,7 +230,7 @@ def get_datasets_api(
     ToDo / FixMe: this file is probably more about privacy groups than datasets...
     """
     # The documentation below expects prefix to be '/datasets/'
-    datasets_api = bottle.Bottle()
+    datasets_api = SubApp()
     HMAConfig.initialize(hma_config_table)
 
     @datasets_api.get("/", apply=[jsoninator])

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -33,6 +33,7 @@ from hmalib.lambdas.api.middleware import (
     jsoninator,
     JSONifiable,
     DictParseable,
+    SubApp,
 )
 from hmalib.common.config import HMAConfig
 from hmalib.matchers.matchers_base import Matcher
@@ -235,7 +236,7 @@ def get_matches_api(
 
     # A prefix to all routes must be provided by the api_root app
     # The documentation below expects prefix to be '/matches/'
-    matches_api = bottle.Bottle()
+    matches_api = SubApp()
     HMAConfig.initialize(hma_config_table)
 
     @matches_api.get("/", apply=[jsoninator])

--- a/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
@@ -157,8 +157,8 @@ def jsoninator(
 
 
 class SubApp(bottle.Bottle):
-    def __init__(self):
-        super(SubApp, self).__init__()
+    def __init__(self, **kwargs):
+        super(SubApp, self).__init__(**kwargs)
         self.add_hook("after_request", SubApp.enable_cors_in_response_header)
 
     def default_error_handler(self, res):

--- a/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
@@ -154,3 +154,17 @@ def jsoninator(
             return json.dumps(body.to_json())
 
         return wrapper
+
+
+class SubApp(bottle.Bottle):
+    def __init__(self):
+        super(SubApp, self).__init__()
+        self.add_hook("after_request", SubApp.enable_cors_after_request_hook)
+
+    @staticmethod
+    def enable_cors_after_request_hook():
+        """
+        This executes after every route. We use it to attach CORS headers when
+        applicable.
+        """
+        bottle.response.headers["Access-Control-Allow-Origin"] = "*"

--- a/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
@@ -159,12 +159,17 @@ def jsoninator(
 class SubApp(bottle.Bottle):
     def __init__(self):
         super(SubApp, self).__init__()
-        self.add_hook("after_request", SubApp.enable_cors_after_request_hook)
+        self.add_hook("after_request", SubApp.enable_cors_in_response_header)
+
+    def default_error_handler(self, res):
+        logger.error(f"{res}")
+        bottle.response.content_type = "application/json"
+        SubApp.enable_cors_in_response_header()
+        return json.dumps(dict(error=res.body, status_code=res.status_code))
 
     @staticmethod
-    def enable_cors_after_request_hook():
+    def enable_cors_in_response_header():
         """
-        This executes after every route. We use it to attach CORS headers when
-        applicable.
+        Attach CORS headers when applicable.
         """
         bottle.response.headers["Access-Control-Allow-Origin"] = "*"

--- a/hasher-matcher-actioner/hmalib/lambdas/api/stats.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/stats.py
@@ -12,7 +12,11 @@ from hmalib import metrics
 from hmalib.metrics import query as metrics_query
 from hmalib.metrics.query import is_publishing_metrics
 
-from hmalib.lambdas.api.middleware import jsoninator, JSONifiable
+from hmalib.lambdas.api.middleware import (
+    jsoninator,
+    JSONifiable,
+    SubApp,
+)
 
 logger = get_logger(__name__)
 
@@ -55,7 +59,7 @@ def get_stats_api(dynamodb_table: Table) -> bottle.Bottle:
 
     # A prefix to all routes must be provided by the api_root app
     # The documentation below expects prefix to be '/stats/'
-    stats_api = bottle.Bottle()
+    stats_api = SubApp()
 
     stat_name_to_metric = {
         "hashes": metrics.names.pdq_hasher_lambda.hash,

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -23,7 +23,12 @@ from threatexchange.content_type.meta import (
 )
 
 
-from hmalib.lambdas.api.middleware import jsoninator, JSONifiable, DictParseable
+from hmalib.lambdas.api.middleware import (
+    jsoninator,
+    JSONifiable,
+    DictParseable,
+    SubApp,
+)
 from hmalib.common.content_sources import S3BucketContentSource
 from hmalib.common.models.content import ContentObject, ContentRefType
 from hmalib.common.logging import get_logger
@@ -249,7 +254,7 @@ def get_submit_api(
 
     # A prefix to all routes must be provided by the api_root app
     # The documentation below expects prefix to be '/submit/'
-    submit_api = bottle.Bottle()
+    submit_api = SubApp()
     s3_bucket_image_source = S3BucketContentSource(image_bucket, image_prefix)
 
     def _content_exist_error(content_id: str):

--- a/hasher-matcher-actioner/hmalib/scripts/common/utils.py
+++ b/hasher-matcher-actioner/hmalib/scripts/common/utils.py
@@ -51,11 +51,11 @@ class HasherMatcherActionerAPI:
     def _get_request_url(self, api_path: str) -> str:
         return urljoin(self.api_url, api_path)
 
-    def get(self, api_path: str = ""):
+    def get(self, api_path: str = "root/"):
         response = self.session.get(self._get_request_url(api_path))
         return response.json()
 
-    def get_all_matches(self, api_path: str = "/matches/"):
+    def get_all_matches(self, api_path: str = "matches/"):
         response = self.session.get(self._get_request_url(api_path))
         response.raise_for_status()
         return response.json().get("match_summaries", [])
@@ -72,7 +72,7 @@ class HasherMatcherActionerAPI:
             "additional_fields": additional_fields,
             "content_bytes": b64_file_contents,
         }
-        api_path: str = "/submit/bytes/"
+        api_path: str = "submit/bytes/"
         response = self.session.post(
             self._get_request_url(api_path),
             data=json.dumps(payload).encode("utf-8"),
@@ -91,7 +91,7 @@ class HasherMatcherActionerAPI:
             "additional_fields": additional_fields,
             "file_type": "image/jpeg",
         }
-        api_path: str = "/submit/put-url/"
+        api_path: str = "submit/put-url/"
         response = self.session.post(
             self._get_request_url(api_path),
             data=json.dumps(payload).encode(),
@@ -123,7 +123,7 @@ class HasherMatcherActionerAPI:
             "additional_fields": additional_fields,
             "content_url": url,
         }
-        api_path: str = "/submit/url/"
+        api_path: str = "submit/url/"
         response = self.session.post(
             self._get_request_url(api_path),
             data=json.dumps(payload).encode(),
@@ -150,7 +150,7 @@ class HasherMatcherActionerAPI:
             "signal_type": signal_type,
             "content_url": url,
         }
-        api_path: str = "/submit/hash/"
+        api_path: str = "submit/hash/"
         response = self.session.post(
             self._get_request_url(api_path),
             data=json.dumps(payload).encode(),
@@ -160,7 +160,7 @@ class HasherMatcherActionerAPI:
     def get_content_hash_details(
         self,
         content_id: str,
-        api_path: str = "/content/hash/",
+        api_path: str = "content/hash/",
     ):
         return self.session.get(
             self._get_request_url(api_path),
@@ -170,7 +170,7 @@ class HasherMatcherActionerAPI:
     def get_content_action_history(
         self,
         content_id: str,
-        api_path: str = "/content/action-history/",
+        api_path: str = "content/action-history/",
     ):
         response = self.session.get(
             self._get_request_url(api_path),
@@ -181,7 +181,7 @@ class HasherMatcherActionerAPI:
     def get_content_matches(
         self,
         content_id: str,
-        api_path: str = "/matches/match/",
+        api_path: str = "matches/match/",
     ):
         response = self.session.get(
             self._get_request_url(api_path),
@@ -191,7 +191,7 @@ class HasherMatcherActionerAPI:
 
     def get_dataset_configs(
         self,
-        api_path: str = "/datasets/",
+        api_path: str = "datasets/",
     ):
         response = self.session.get(self._get_request_url(api_path))
         return response.json().get("threat_exchange_datasets", [])
@@ -204,7 +204,7 @@ class HasherMatcherActionerAPI:
         matcher_active: bool = True,
         fetcher_active: bool = False,
         write_back: bool = False,
-        api_path: str = "/datasets/create",
+        api_path: str = "datasets/create",
     ):
         payload = {
             "privacy_group_id": privacy_group_id,
@@ -221,7 +221,7 @@ class HasherMatcherActionerAPI:
 
     def get_actions(
         self,
-        api_path: str = "/actions/",
+        api_path: str = "actions/",
     ):
         response = self.session.get(self._get_request_url(api_path))
         return response.json().get("actions_response", [])
@@ -231,7 +231,7 @@ class HasherMatcherActionerAPI:
         name: str,
         config_subtype: str,
         fields: t.Dict[str, t.Any],
-        api_path: str = "/actions/",
+        api_path: str = "actions/",
     ):
         payload = {
             "name": name,
@@ -246,13 +246,13 @@ class HasherMatcherActionerAPI:
     def delete_action(
         self,
         action_name: str,
-        api_path: str = "/actions/",
+        api_path: str = "actions/",
     ):
         self.session.delete(self._get_request_url(api_path + action_name))
 
     def get_action_rules(
         self,
-        api_path: str = "/action-rules/",
+        api_path: str = "action-rules/",
     ):
         response = self.session.get(self._get_request_url(api_path))
         return response.json().get("action_rules", [])
@@ -260,7 +260,7 @@ class HasherMatcherActionerAPI:
     def create_action_rule(
         self,
         action_rule: t.Any,
-        api_path: str = "/action-rules/",
+        api_path: str = "action-rules/",
     ):
         payload = {
             "action_rule": action_rule,
@@ -273,7 +273,7 @@ class HasherMatcherActionerAPI:
     def delete_action_rule(
         self,
         action_rule_name: str,
-        api_path: str = "/action-rules/",
+        api_path: str = "action-rules/",
     ):
         self.session.delete(self._get_request_url(api_path + action_rule_name))
 
@@ -281,7 +281,7 @@ class HasherMatcherActionerAPI:
         self,
         signal_type: str,
         signal_value: str,
-        api_path: str = "/matches/for-hash/",
+        api_path: str = "matches/for-hash/",
     ):
         params = {
             "signal_type": signal_type,
@@ -421,7 +421,6 @@ if __name__ == "__main__":
     tf_outputs = get_terraform_outputs()
 
     api_url = tf_outputs["api_url"]
-
     token = get_auth_from_env()
 
     api = HasherMatcherActionerAPI(

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -14,6 +14,11 @@ data "aws_iam_policy_document" "lambda_assume_role" {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+}
 # HMA Root/Main API Lambda
 
 resource "aws_lambda_function" "api_root" {
@@ -251,112 +256,6 @@ resource "aws_iam_role_policy_attachment" "api_auth" {
 
 # API Gateway
 
-resource "aws_apigatewayv2_api" "hma_apigateway" {
-  name          = "${var.prefix}_hma_api"
-  protocol_type = "HTTP"
-  tags = merge(
-    var.additional_tags,
-    {
-      Name = "HMAAPIGateway"
-    }
-  )
-  cors_configuration {
-    allow_headers = ["*"]
-    allow_methods = ["*"]
-    allow_origins = ["*"]
-  }
-}
-
-resource "aws_apigatewayv2_stage" "hma_apigateway" {
-  name        = "$default"
-  api_id      = aws_apigatewayv2_api.hma_apigateway.id
-  auto_deploy = true
-  # TODO have enable/disable of access logs be configurable
-  access_log_settings {
-    destination_arn = aws_cloudwatch_log_group.hma_apigateway.arn
-    format          = "$context.identity.sourceIp - - [$context.requestTime] \"$context.httpMethod $context.routeKey $context.protocol\" $context.status $context.responseLength $context.requestId $context.integrationErrorMessage"
-  }
-}
-
-resource "aws_apigatewayv2_route" "hma_apigateway_get" {
-  api_id             = aws_apigatewayv2_api.hma_apigateway.id
-  route_key          = "GET /{proxy+}"
-  authorization_type = "CUSTOM"
-  authorizer_id      = aws_apigatewayv2_authorizer.hma_apigateway.id
-  target             = "integrations/${aws_apigatewayv2_integration.hma_apigateway.id}"
-}
-
-resource "aws_apigatewayv2_route" "hma_apigateway_post" {
-  api_id             = aws_apigatewayv2_api.hma_apigateway.id
-  route_key          = "POST /{proxy+}"
-  authorization_type = "CUSTOM"
-  authorizer_id      = aws_apigatewayv2_authorizer.hma_apigateway.id
-  target             = "integrations/${aws_apigatewayv2_integration.hma_apigateway.id}"
-}
-
-resource "aws_apigatewayv2_route" "hma_apigateway_put" {
-  api_id             = aws_apigatewayv2_api.hma_apigateway.id
-  route_key          = "PUT /{proxy+}"
-  authorization_type = "CUSTOM"
-  authorizer_id      = aws_apigatewayv2_authorizer.hma_apigateway.id
-  target             = "integrations/${aws_apigatewayv2_integration.hma_apigateway.id}"
-}
-
-resource "aws_apigatewayv2_route" "hma_apigateway_delete" {
-  api_id             = aws_apigatewayv2_api.hma_apigateway.id
-  route_key          = "DELETE /{proxy+}"
-  authorization_type = "CUSTOM"
-  authorizer_id      = aws_apigatewayv2_authorizer.hma_apigateway.id
-  target             = "integrations/${aws_apigatewayv2_integration.hma_apigateway.id}"
-}
-
-resource "aws_apigatewayv2_integration" "hma_apigateway" {
-  api_id                 = aws_apigatewayv2_api.hma_apigateway.id
-  credentials_arn        = aws_iam_role.hma_apigateway.arn
-  integration_type       = "AWS_PROXY"
-  integration_method     = "POST"
-  integration_uri        = aws_lambda_function.api_root.invoke_arn
-  payload_format_version = "2.0"
-}
-
-# Old Authorizer that just handles JWT tokens
-# 
-# resource "aws_apigatewayv2_authorizer" "hma_apigateway" {
-#   api_id           = aws_apigatewayv2_api.hma_apigateway.id
-#   authorizer_type  = "JWT"
-#   identity_sources = ["$request.header.Authorization"]
-#   name             = "${var.prefix}-jwt-authorizer"
-
-#   jwt_configuration {
-#     audience = [var.api_authorizer_audience]
-#     issuer   = local.user_pool_url
-#   }
-# }
-
-resource "aws_apigatewayv2_authorizer" "hma_apigateway" {
-  api_id                            = aws_apigatewayv2_api.hma_apigateway.id
-  authorizer_type                   = "REQUEST"
-  authorizer_credentials_arn        = aws_iam_role.hma_apigateway.arn
-  authorizer_uri                    = aws_lambda_function.api_auth.invoke_arn
-  identity_sources                  = ["$request.header.Authorization"]
-  authorizer_payload_format_version = "2.0"
-  enable_simple_responses           = true
-  name                              = "${aws_apigatewayv2_api.hma_apigateway.name}_authorizer"
-}
-
-resource "aws_cloudwatch_log_group" "hma_apigateway" {
-  name              = "/aws/apigateway/${aws_apigatewayv2_api.hma_apigateway.name}"
-  retention_in_days = var.log_retention_in_days
-  tags = merge(
-    var.additional_tags,
-    {
-      Name = "HMAAPIGatewayLogGroup"
-    }
-  )
-}
-
-# IAM Policy for Gateway
-
 data "aws_iam_policy_document" "apigateway_assume_role" {
   statement {
     effect  = "Allow"
@@ -368,8 +267,73 @@ data "aws_iam_policy_document" "apigateway_assume_role" {
   }
 }
 
-resource "aws_iam_role" "hma_apigateway" {
-  name_prefix        = "${var.prefix}_hma_apigateway"
+resource "aws_api_gateway_rest_api" "hma_api_gw" {
+  name = "${var.prefix}_hma_api_gw"
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+  binary_media_types = ["*/*"]
+}
+
+resource "aws_api_gateway_resource" "hma_api_gw" {
+  parent_id   = aws_api_gateway_rest_api.hma_api_gw.root_resource_id
+  path_part   = "{proxy+}"
+  rest_api_id = aws_api_gateway_rest_api.hma_api_gw.id
+}
+
+resource "aws_api_gateway_method" "hma_api_gw" {
+  authorization = "CUSTOM"
+  http_method   = "ANY"
+  authorizer_id = aws_api_gateway_authorizer.hma_api_gw.id
+  resource_id   = aws_api_gateway_resource.hma_api_gw.id
+  rest_api_id   = aws_api_gateway_rest_api.hma_api_gw.id
+}
+
+resource "aws_api_gateway_authorizer" "hma_api_gw" {
+  rest_api_id            = aws_api_gateway_rest_api.hma_api_gw.id
+  type                   = "REQUEST"
+  authorizer_credentials = aws_iam_role.hma_api_gw.arn
+  authorizer_uri         = aws_lambda_function.api_auth.invoke_arn
+  name                   = "${aws_api_gateway_rest_api.hma_api_gw.name}_authorizer"
+  identity_source        = "method.request.header.Authorization"
+}
+
+resource "aws_api_gateway_integration" "hma_api_gw" {
+  http_method             = aws_api_gateway_method.hma_api_gw.http_method
+  resource_id             = aws_api_gateway_resource.hma_api_gw.id
+  rest_api_id             = aws_api_gateway_rest_api.hma_api_gw.id
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.api_root.invoke_arn
+}
+
+resource "aws_api_gateway_deployment" "hma_api_gw" {
+  rest_api_id = aws_api_gateway_rest_api.hma_api_gw.id
+  triggers = {
+    redeployment = sha1(jsonencode([
+      var.lambda_docker_info.uri,
+      aws_api_gateway_resource.hma_api_gw.id,
+      aws_api_gateway_method.hma_api_gw.id,
+      aws_api_gateway_integration.hma_api_gw.id,
+      aws_lambda_function.api_auth.id,
+      aws_lambda_function.api_root.id,
+      "${sha1(file("${path.module}/main.tf"))}"
+    ]))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "hma_api_gw" {
+  deployment_id = aws_api_gateway_deployment.hma_api_gw.id
+  rest_api_id   = aws_api_gateway_rest_api.hma_api_gw.id
+  stage_name    = "api"
+}
+
+resource "aws_iam_role" "hma_api_gw" {
+  name_prefix        = "${var.prefix}_hma_api_gw"
   assume_role_policy = data.aws_iam_policy_document.apigateway_assume_role.json
   tags = merge(
     var.additional_tags,
@@ -379,7 +343,7 @@ resource "aws_iam_role" "hma_apigateway" {
   )
 }
 
-data "aws_iam_policy_document" "hma_apigateway" {
+data "aws_iam_policy_document" "hma_api_gw" {
   statement {
     effect = "Allow"
     actions = [
@@ -387,24 +351,92 @@ data "aws_iam_policy_document" "hma_apigateway" {
       "logs:PutLogEvents",
       "logs:DescribeLogStreams"
     ]
-    resources = ["${aws_cloudwatch_log_group.hma_apigateway.arn}:*"]
+    resources = ["${aws_cloudwatch_log_group.hma_api_gw.arn}:*"]
   }
   statement {
     effect    = "Allow"
     actions   = ["lambda:InvokeFunction", ]
-    resources = [aws_lambda_function.api_root.arn, aws_lambda_function.api_auth.arn]
+    resources = ["${aws_lambda_function.api_root.arn}:*", aws_lambda_function.api_auth.arn]
   }
 }
 
-resource "aws_iam_policy" "hma_apigateway" {
-  name_prefix = "${var.prefix}_hma_apigateway_role_policy"
-  description = "Permissions for HMA API Gateway"
-  policy      = data.aws_iam_policy_document.hma_apigateway.json
+resource "aws_iam_policy" "hma_api_gw" {
+  name_prefix = "${var.prefix}_hma_api_gw_role_policy"
+  description = "Permissions for HMA Rest API Gateway"
+  policy      = data.aws_iam_policy_document.hma_api_gw.json
 }
 
-resource "aws_iam_role_policy_attachment" "hma_apigateway" {
-  role       = aws_iam_role.hma_apigateway.name
-  policy_arn = aws_iam_policy.hma_apigateway.arn
+resource "aws_iam_role_policy_attachment" "hma_api_gw" {
+  role       = aws_iam_role.hma_api_gw.name
+  policy_arn = aws_iam_policy.hma_api_gw.arn
+}
+
+resource "aws_cloudwatch_log_group" "hma_api_gw" {
+  name              = "/aws/apigateway/${aws_api_gateway_rest_api.hma_api_gw.name}"
+  retention_in_days = var.log_retention_in_days
+  tags = merge(
+    var.additional_tags,
+    {
+      Name = "HMAAPIGatewayLogGroup"
+    }
+  )
+}
+
+resource "aws_lambda_permission" "apigw_lambda" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.api_root.function_name
+  principal     = "apigateway.amazonaws.com"
+
+  # More: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html
+  source_arn = "arn:aws:execute-api:${var.region}:${local.account_id}:${aws_api_gateway_rest_api.hma_api_gw.id}/*/${aws_api_gateway_method.hma_api_gw.http_method}${aws_api_gateway_resource.hma_api_gw.path}"
+}
+
+resource "aws_api_gateway_method" "cors" {
+  rest_api_id   = aws_api_gateway_rest_api.hma_api_gw.id
+  resource_id   = aws_api_gateway_resource.hma_api_gw.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "cors" {
+  rest_api_id = aws_api_gateway_rest_api.hma_api_gw.id
+  resource_id = aws_api_gateway_resource.hma_api_gw.id
+  http_method = aws_api_gateway_method.cors.http_method
+  type        = "MOCK"
+  request_templates = {
+    "application/json" : "{\"statusCode\": 200}"
+  }
+  content_handling = "CONVERT_TO_TEXT"
+}
+
+resource "aws_api_gateway_method_response" "cors" {
+  depends_on  = [aws_api_gateway_method.cors]
+  rest_api_id = aws_api_gateway_rest_api.hma_api_gw.id
+  resource_id = aws_api_gateway_resource.hma_api_gw.id
+  http_method = aws_api_gateway_method.cors.http_method
+  status_code = "200"
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Origin"  = true,
+    "method.response.header.Access-Control-Allow-Methods" = true,
+    "method.response.header.Access-Control-Allow-Headers" = true
+  }
+  response_models = {
+    "application/json" = "Empty"
+  }
+}
+
+resource "aws_api_gateway_integration_response" "cors" {
+  depends_on  = [aws_api_gateway_integration.cors, aws_api_gateway_method_response.cors]
+  rest_api_id = aws_api_gateway_rest_api.hma_api_gw.id
+  resource_id = aws_api_gateway_resource.hma_api_gw.id
+  http_method = aws_api_gateway_method.cors.http_method
+  status_code = "200"
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Origin"  = "'*'",
+    "method.response.header.Access-Control-Allow-Headers" = "'Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token, Authorization'",
+    "method.response.header.Access-Control-Allow-Methods" = "'GET, POST, PUT, DELETE, OPTIONS'", # remove or add methods as needed
+  }
 }
 
 # Connect partner s3 buckets to api_root 

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -310,6 +310,9 @@ resource "aws_api_gateway_integration" "hma_api_gw" {
 }
 
 resource "aws_api_gateway_deployment" "hma_api_gw" {
+  depends_on = [
+    aws_vpc_endpoint.vpce
+  ]
   rest_api_id = aws_api_gateway_rest_api.hma_api_gw.id
   triggers = {
     redeployment = sha1(jsonencode([

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -270,7 +270,7 @@ data "aws_iam_policy_document" "apigateway_assume_role" {
 resource "aws_api_gateway_rest_api" "hma_api_gw" {
   name = "${var.prefix}_hma_api_gw"
   endpoint_configuration {
-    types            = var.vpc_id != "" ? ["PRIVATE"] : ["REGIONAL"]
+    types            = var.api_in_vpc ? ["PRIVATE"] : ["REGIONAL"]
     vpc_endpoint_ids = length(aws_vpc_endpoint.vpce) > 0 ? aws_vpc_endpoint.vpce[*].id : null
   }
   policy             = length(data.aws_iam_policy_document.hma_api_gw_in_vpc) > 0 ? data.aws_iam_policy_document.hma_api_gw_in_vpc[0].json : null
@@ -450,7 +450,7 @@ data "aws_vpc_endpoint_service" "vpc_service" {
 }
 
 resource "aws_vpc_endpoint" "vpce" {
-  count               = var.vpc_id != "" ? 1 : 0
+  count               = var.api_in_vpc ? 1 : 0
   vpc_id              = var.vpc_id
   service_name        = data.aws_vpc_endpoint_service.vpc_service.service_name
   vpc_endpoint_type   = "Interface"
@@ -461,12 +461,12 @@ resource "aws_vpc_endpoint" "vpce" {
 }
 
 resource "aws_api_gateway_rest_api_policy" "hma_api_gw" {
-  count       = var.vpc_id != "" ? 1 : 0
+  count       = var.api_in_vpc ? 1 : 0
   rest_api_id = aws_api_gateway_rest_api.hma_api_gw.id
   policy      = data.aws_iam_policy_document.hma_api_gw_in_vpc[0].json
 }
 data "aws_iam_policy_document" "hma_api_gw_in_vpc" {
-  count = var.vpc_id != "" ? 1 : 0
+  count = var.api_in_vpc ? 1 : 0
 
   statement {
     effect    = "Allow"

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -389,7 +389,7 @@ resource "aws_lambda_permission" "apigw_lambda" {
   principal     = "apigateway.amazonaws.com"
 
   # More: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html
-  source_arn = "arn:aws:execute-api:${var.region}:${local.account_id}:${aws_api_gateway_rest_api.hma_api_gw.id}/*/${aws_api_gateway_method.hma_api_gw.http_method}${aws_api_gateway_resource.hma_api_gw.path}"
+  source_arn = "arn:aws:execute-api:${data.aws_region.current.name}:${local.account_id}:${aws_api_gateway_rest_api.hma_api_gw.id}/*/${aws_api_gateway_method.hma_api_gw.http_method}${aws_api_gateway_resource.hma_api_gw.path}"
 }
 
 resource "aws_api_gateway_method" "cors" {

--- a/hasher-matcher-actioner/terraform/api/outputs.tf
+++ b/hasher-matcher-actioner/terraform/api/outputs.tf
@@ -2,7 +2,7 @@
 
 # the format of the invoke_url changes if we are using a private API
 output "invoke_url" {
-  value = var.vpc_id != "" ? "https://${aws_api_gateway_rest_api.hma_api_gw.id}-${aws_vpc_endpoint.vpce[0].id}.execute-api.${data.aws_region.current.name}.amazonaws.com/${aws_api_gateway_stage.hma_api_gw.stage_name}/" : "${aws_api_gateway_stage.hma_api_gw.invoke_url}/"
+  value = var.api_in_vpc ? "https://${aws_api_gateway_rest_api.hma_api_gw.id}-${aws_vpc_endpoint.vpce[0].id}.execute-api.${data.aws_region.current.name}.amazonaws.com/${aws_api_gateway_stage.hma_api_gw.stage_name}/" : "${aws_api_gateway_stage.hma_api_gw.invoke_url}/"
 }
 
 output "api_root_function_name" {

--- a/hasher-matcher-actioner/terraform/api/outputs.tf
+++ b/hasher-matcher-actioner/terraform/api/outputs.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 output "invoke_url" {
-  value = aws_apigatewayv2_stage.hma_apigateway.invoke_url
+  value = "${aws_api_gateway_stage.hma_api_gw.invoke_url}/"
 }
 
 output "api_root_function_name" {
@@ -13,5 +13,5 @@ output "api_auth_function_name" {
 }
 
 output "api_gateway_id" {
-  value = aws_apigatewayv2_api.hma_apigateway.id
+  value = aws_api_gateway_rest_api.hma_api_gw.id
 }

--- a/hasher-matcher-actioner/terraform/api/outputs.tf
+++ b/hasher-matcher-actioner/terraform/api/outputs.tf
@@ -1,7 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+# the format of the invoke_url changes if we are using a private API
 output "invoke_url" {
-  value = "${aws_api_gateway_stage.hma_api_gw.invoke_url}/"
+  value = var.vpc_id != "" ? "https://${aws_api_gateway_rest_api.hma_api_gw.id}-${aws_vpc_endpoint.vpce[0].id}.execute-api.${data.aws_region.current.name}.amazonaws.com/${aws_api_gateway_stage.hma_api_gw.stage_name}/" : "${aws_api_gateway_stage.hma_api_gw.invoke_url}/"
 }
 
 output "api_root_function_name" {

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -150,3 +150,21 @@ variable "banks_media_storage" {
     bucket_arn  = string
   })
 }
+
+variable "vpc_id" {
+  description = "Optional vpc that locks down the API and UI to the specfic vpc_subnets and security_groups non empty values will result in the API gateway being private"
+  type        = string
+  default     = ""
+}
+
+variable "vpc_subnets" {
+  description = "Subnets of the vpc given in for vpc_id"
+  type        = list(string)
+  default     = []
+}
+
+variable "security_groups" {
+  description = "Security groups to be used with the vpc given in for vpc_id"
+  type        = list(string)
+  default     = []
+}

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -151,20 +151,25 @@ variable "banks_media_storage" {
   })
 }
 
+variable "api_in_vpc" {
+  description = "Should the API gateway used with HMA be made private behind a VPC. (Either way API will also require authorization)"
+  type        = bool
+}
+
 variable "vpc_id" {
-  description = "Optional vpc that locks down the API and UI to the specfic vpc_subnets and security_groups non empty values will result in the API gateway being private"
+  description = "vpc that locks down the API and UI to the specfic vpc_subnets and security_groups. Required if api_in_vpc = true"
   type        = string
   default     = ""
 }
 
 variable "vpc_subnets" {
-  description = "Subnets of the vpc given in for vpc_id"
+  description = "Subnet ids of the vpc given in for vpc_id. Required if api_in_vpc = true"
   type        = list(string)
   default     = []
 }
 
 variable "security_groups" {
-  description = "Security groups to be used with the vpc given in for vpc_id"
+  description = "Security group ids to be used with the vpc given in for vpc_id. Required if api_in_vpc = true"
   type        = list(string)
   default     = []
 }

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -199,7 +199,7 @@ module "webapp" {
   source                          = "./webapp"
   prefix                          = var.prefix
   organization                    = var.organization
-  include_cloudfront_distribution = var.include_cloudfront_distribution && !var.use_shared_user_pool
+  include_cloudfront_distribution = var.include_cloudfront_distribution && !var.use_shared_user_pool && var.vpc_id == ""
 }
 
 /**
@@ -471,6 +471,9 @@ module "api" {
     arn = aws_sqs_queue.submissions_queue.arn
   }
   partner_image_buckets = var.partner_image_buckets
+  vpc_id                = var.vpc_id
+  vpc_subnets           = var.vpc_subnets
+  security_groups       = var.security_groups
 }
 
 # Build and deploy webapp

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -199,7 +199,7 @@ module "webapp" {
   source                          = "./webapp"
   prefix                          = var.prefix
   organization                    = var.organization
-  include_cloudfront_distribution = var.include_cloudfront_distribution && !var.use_shared_user_pool && var.vpc_id == ""
+  include_cloudfront_distribution = var.include_cloudfront_distribution && !var.use_shared_user_pool && !var.api_in_vpc
 }
 
 /**
@@ -471,9 +471,11 @@ module "api" {
     arn = aws_sqs_queue.submissions_queue.arn
   }
   partner_image_buckets = var.partner_image_buckets
-  vpc_id                = var.vpc_id
-  vpc_subnets           = var.vpc_subnets
-  security_groups       = var.security_groups
+
+  api_in_vpc      = var.api_in_vpc
+  vpc_id          = var.vpc_id
+  vpc_subnets     = var.vpc_subnets
+  security_groups = var.security_groups
 }
 
 # Build and deploy webapp

--- a/hasher-matcher-actioner/terraform/terraform.tfvars.example
+++ b/hasher-matcher-actioner/terraform/terraform.tfvars.example
@@ -4,9 +4,14 @@ hma_lambda_docker_uri = # DOCKER_IMAGE_URI
 prefix = # ENVIRONMENT_PREFIX
 organization = # a name or acronym for your organization (use only lower case alpha a-z, and, optionally, hyphens)
 log_retention_in_days = # DAYS to retain logs
-include_cloudfront_distribution = true
+include_cloudfront_distribution = false
 te_api_token = "<threat-exchange-api-token>"
 use_shared_user_pool = false # if true, run terraform apply from /authentication-shared terraform and use its outputs for webapp_and_api_shared_user_pool_id and webapp_and_api_shared_user_pool_client_id
 webapp_and_api_shared_user_pool_id = # "<webapp_and_api_shared_user_pool_id>" output when terraform apply is run from /authentication-shared directory
 webapp_and_api_shared_user_pool_client_id = # "<webapp_and_api_shared_user_pool_client_id>" output when terraform apply is run from /authentication-shared directory
 integration_api_access_tokens             = # Optional_list_of_tokens e.g. ['<super_secret_token1>']
+
+api_in_vpc = false 
+vpc_id = "" # required to be nonempty if api_in_vpc = true. Note VPC must be in the same region that HMA is deployed in.
+vpc_subnets = [] # required to be nonempty if api_in_vpc = true
+security_groups = [] # required to be nonempty if api_in_vpc = true

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -82,12 +82,6 @@ variable "set_sqs_windows_to_min" {
   default     = false
 }
 
-variable "api_in_vpc" {
-  description = "Instead of the usual API establish a private one in a VPC."
-  type        = bool
-  default     = false
-}
-
 variable "partner_image_buckets" {
   description = "Names and arns of s3 buckets to consider as inputs to HMA. All images uploaded to these buckets will be processed by the hasher"
   type = list(object({
@@ -121,5 +115,23 @@ variable "integration_api_access_tokens" {
   description = "Access tokens checked for in authorizer api as an alternative to cognito user tokens."
   type        = list(string)
   sensitive   = true
+  default     = []
+}
+
+variable "vpc_id" {
+  description = "Optional vpc that locks down the API and UI to the specfic vpc_subnets and security_groups"
+  type        = string
+  default     = ""
+}
+
+variable "vpc_subnets" {
+  description = "Subnets of the vpc given in for vpc_id"
+  type        = list(string)
+  default     = []
+}
+
+variable "security_groups" {
+  description = "security_groups to be used with the vpc given in for vpc_id"
+  type        = list(string)
   default     = []
 }

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -82,6 +82,12 @@ variable "set_sqs_windows_to_min" {
   default     = false
 }
 
+variable "api_in_vpc" {
+  description = "Instead of the usual API establish a private one in a VPC."
+  type        = bool
+  default     = false
+}
+
 variable "partner_image_buckets" {
   description = "Names and arns of s3 buckets to consider as inputs to HMA. All images uploaded to these buckets will be processed by the hasher"
   type = list(object({

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -118,20 +118,25 @@ variable "integration_api_access_tokens" {
   default     = []
 }
 
+variable "api_in_vpc" {
+  description = "Should the API gateway used with HMA be made private behind a VPC. (Either way API will also require authorization)"
+  type        = bool
+}
+
 variable "vpc_id" {
-  description = "Optional vpc that locks down the API and UI to the specfic vpc_subnets and security_groups"
+  description = "vpc that locks down the API and UI to the specfic vpc_subnets and security_groups. Required if api_in_vpc = true. Note VPC must be in the same region that HMA is deployed in."
   type        = string
   default     = ""
 }
 
 variable "vpc_subnets" {
-  description = "Subnets of the vpc given in for vpc_id"
+  description = "Subnet ids of the vpc given in for vpc_id. Required if api_in_vpc = true"
   type        = list(string)
   default     = []
 }
 
 variable "security_groups" {
-  description = "security_groups to be used with the vpc given in for vpc_id"
+  description = "Security group ids to be used with the vpc given in for vpc_id. Required if api_in_vpc = true"
   type        = list(string)
   default     = []
 }

--- a/hasher-matcher-actioner/webapp/package-lock.json
+++ b/hasher-matcher-actioner/webapp/package-lock.json
@@ -18,7 +18,6 @@
         "@types/react-dom": "^17.0.8",
         "aws-amplify": "^4.1.2",
         "axios": "^0.21.1",
-        "base64-arraybuffer": "^0.2.0",
         "bootstrap": "^4.6.0",
         "classnames": "^2.3.1",
         "clipboard-copy": "^4.0.1",
@@ -36,8 +35,8 @@
         "react-dropzone": "^11.4.0",
         "react-router-dom": "^5.2.0",
         "react-scripts": "^4.0.3",
-        "uplot": "1.6.13",
-        "uplot-react": "1.1.0"
+        "uplot": "^1.6.13",
+        "uplot-react": "^1.1.0"
       },
       "devDependencies": {
         "@types/dompurify": "^2.2.3",
@@ -55,12 +54,12 @@
       }
     },
     "node_modules/@aws-amplify/analytics": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.0.15.tgz",
-      "integrity": "sha512-AP++UPU/rmXJ6Z+id5WBDSR4ioMkMYlPDlBZl0zIl67Om+J4G3Q0zJ6Q5ft6oZOkGotw+7smI3hBRSBoeF6kxg==",
+      "version": "5.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.0.19.tgz",
+      "integrity": "sha512-TDnDOTjb1gZ9ASs8JyiejVB8nIU79BMq5CSEsuBDOg7WpM5zeIRC5dXpdfw2e92w5W+ACr9vTKwmgv8c2JYeow==",
       "dependencies": {
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
         "@aws-sdk/client-firehose": "3.6.1",
         "@aws-sdk/client-kinesis": "3.6.1",
         "@aws-sdk/client-personalize-events": "3.6.1",
@@ -80,24 +79,24 @@
       }
     },
     "node_modules/@aws-amplify/api": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.15.tgz",
-      "integrity": "sha512-GTm8d5PLstQxwYA+b7OPBCMarc4Nwp4A5VFxYsXHI63fOShXhqCX9Le6Ivnk0X1Vcg9hrtips//qkRFjOQyEiw==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.19.tgz",
+      "integrity": "sha512-+bP1sSAkRlbId/cCBYrPkaqybvOBRK8ldolr5CH5pWhWKGWO0FsjDRMu7gQI4wKGDk3NdmB40XUa+abT2jPz2g==",
       "dependencies": {
-        "@aws-amplify/api-graphql": "2.2.4",
-        "@aws-amplify/api-rest": "2.0.15"
+        "@aws-amplify/api-graphql": "2.2.8",
+        "@aws-amplify/api-rest": "2.0.19"
       }
     },
     "node_modules/@aws-amplify/api-graphql": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.2.4.tgz",
-      "integrity": "sha512-ZNeOe6p8GGAPN7A1wDTfwRyfJUlMraB0K/dAUiUqb8pPmdaqq9YYbAmJ9h+7itDZ5/gahGeByx8CAhomylwwsA==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.2.8.tgz",
+      "integrity": "sha512-FMwUUNkK/WU6xCRfxDuxGZPay+Lbiz6i4rvD7mfUfeCc7zN8sZa832Buu+0CwYhlC75PlQOeU23UARDwWcConQ==",
       "dependencies": {
-        "@aws-amplify/api-rest": "2.0.15",
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/pubsub": "4.1.7",
+        "@aws-amplify/api-rest": "2.0.19",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/pubsub": "4.1.11",
         "graphql": "14.0.0",
         "uuid": "^3.2.1",
         "zen-observable-ts": "0.8.19"
@@ -113,37 +112,37 @@
       }
     },
     "node_modules/@aws-amplify/api-rest": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.15.tgz",
-      "integrity": "sha512-jGPwdV2egaIoxV5sHR9UcjQtloE8hf6/ZavZdDSlOSmfztC20kfK5y+UibYdZdD4DroTrKkSlkRt9XiaXLq1tw==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.19.tgz",
+      "integrity": "sha512-FvEV/nX5beeD0zHTvwIcCrrgSfWymhvvrcDX7L5RPoitv415sruXcbj0e6ODCAm0Aw2bieW2K2fXIQ1gNa0JtQ==",
       "dependencies": {
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/core": "4.3.1",
         "axios": "0.21.4"
       }
     },
     "node_modules/@aws-amplify/auth": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.3.5.tgz",
-      "integrity": "sha512-EhlpiMh3yIMR0Df79TQqp0z37gKpHAp1+QBRmwp0NSDAM8JMpGwt/rb7+WGyEMLVVhMMb24YuE75UshhNegQcQ==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.3.9.tgz",
+      "integrity": "sha512-E61GTg9GaHAsC5NrRqD1JGMHWvyWKeMjD8Cjt9kZEwQq7Y33oP9KJ7vUinSpGi2Eh2pnJSXg5z23Xx8BGVZeag==",
       "dependencies": {
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
-        "amazon-cognito-identity-js": "5.1.0",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
+        "amazon-cognito-identity-js": "5.2.0",
         "crypto-js": "^4.1.1"
       }
     },
     "node_modules/@aws-amplify/cache": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.17.tgz",
-      "integrity": "sha512-I+ND9ZU65dZXIT0VR+du7qZTq61vdFJdL5uhNCh7XQATJCqJtulH86csMpfJ6gosQM3+pcg4rEPQSgDnqPaE3w==",
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.21.tgz",
+      "integrity": "sha512-tJK9ShFq4LJgOGrGI3ilr0bxrNLXLmmAsRpPwfqyQvKG7ZyUI9r8K5sQi8ov8QIhr/ogoDpQOeWcN5Fhp3Gj2A==",
       "dependencies": {
-        "@aws-amplify/core": "4.2.9"
+        "@aws-amplify/core": "4.3.1"
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.2.9.tgz",
-      "integrity": "sha512-a5xSu1fOQNxgpQsfuUkJbzRBkoD+JcasdfMpXGcgYr1Iuj5Sua4xcLe4Z9O4VaGaUy1Y7laHDP4aa+Mn/RJq9w==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.3.1.tgz",
+      "integrity": "sha512-qYQIs95F/AdBGbUFNXzKp3nAFPpQtivvBGOFQa+plqK/mzV23fh33BxRh/Hc3A+bcfpM8lBDZbIn9LPVRj3VLA==",
       "dependencies": {
         "@aws-crypto/sha256-js": "1.0.0-alpha.0",
         "@aws-sdk/client-cloudwatch-logs": "3.6.1",
@@ -156,15 +155,15 @@
       }
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.4.3.tgz",
-      "integrity": "sha512-XgjyzOX6bY+zAsv/ylvX0aeElZfbpzq0X8bw9Zx1zrb9wIGOYfSjDC3HzeffoGkFBb/lOscFvN1jbAsxQygWsw==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.4.7.tgz",
+      "integrity": "sha512-UB9CdZCC397Gl3G8neIxTx86JSFL27ftMNIKPrYTvWQEF2sKy5zP7Kr572pW60I5cw7+FERlH3BJ+SIbzYcuKg==",
       "dependencies": {
-        "@aws-amplify/api": "4.0.15",
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/pubsub": "4.1.7",
-        "amazon-cognito-identity-js": "5.1.0",
+        "@aws-amplify/api": "4.0.19",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/pubsub": "4.1.11",
+        "amazon-cognito-identity-js": "5.2.0",
         "idb": "5.0.6",
         "immer": "9.0.6",
         "ulid": "2.3.0",
@@ -182,22 +181,32 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/@aws-amplify/interactions": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-4.0.15.tgz",
-      "integrity": "sha512-OaLAGzu/gu2GNDZLX41i1bT67eEnBJiyyS/eh5c3skrFvYI3zyjAEzD3cIsOVU2LwhnLZRMNSwoXNqAlkFbtHQ==",
+    "node_modules/@aws-amplify/geo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/geo/-/geo-1.1.1.tgz",
+      "integrity": "sha512-sasyp6l+/ZMXcCVWaKyEZiV7hGGzTQV9D3dbU1iqi6/BHEFRfJxnubt3P39XaR672SQ1e8qhFDx36TiL5mePcA==",
       "dependencies": {
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-sdk/client-location": "3.22.0",
+        "camelcase-keys": "6.2.2"
+      }
+    },
+    "node_modules/@aws-amplify/interactions": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-4.0.19.tgz",
+      "integrity": "sha512-g33BUZbMkI6Qkwa9KyCCHMaoUmprY8XVJRVuamVo6+3qCMZXn5KDXa/cTad7+NCASDzMo/XWb65vmWeo9hyw8Q==",
+      "dependencies": {
+        "@aws-amplify/core": "4.3.1",
         "@aws-sdk/client-lex-runtime-service": "3.6.1"
       }
     },
     "node_modules/@aws-amplify/predictions": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-4.0.15.tgz",
-      "integrity": "sha512-bfsWlRd6ZyV5PbqSohpug9KzW5GR82K2UdFU+s90UPCHuj78eSFLflttl/ako95u7tFFFq4MUWtC+rWX5+miMQ==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-4.0.19.tgz",
+      "integrity": "sha512-bHT7gYECVLkkcenQ8filTqeDndx+PrV1MlncYfgsaZp0xjnZ4WaQsvIvSf+ZUvQxk3ayzn85p0MRwPKJR4yEqQ==",
       "dependencies": {
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/storage": "4.3.10",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/storage": "4.4.2",
         "@aws-sdk/client-comprehend": "3.6.1",
         "@aws-sdk/client-polly": "3.6.1",
         "@aws-sdk/client-rekognition": "3.6.1",
@@ -218,13 +227,13 @@
       }
     },
     "node_modules/@aws-amplify/pubsub": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.1.7.tgz",
-      "integrity": "sha512-ES9E4utrsers96bHl1E7clKZanlH9modcjjovJPswLi85q0tybTAG+fi9QRYHp07XSN+EjmEF4Jxrw47w4Hmzw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.1.11.tgz",
+      "integrity": "sha512-Z7xZ244LY6sIK2i6NIBkhuZGXhcVPLFLhyZc1adACuxDWPnZo0Xtiu6SWdZ1Sf575iHRHBCg6DG6TWf8m1YpaA==",
       "dependencies": {
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
         "graphql": "14.0.0",
         "paho-mqtt": "^1.1.0",
         "uuid": "^3.2.1",
@@ -241,11 +250,11 @@
       }
     },
     "node_modules/@aws-amplify/storage": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-4.3.10.tgz",
-      "integrity": "sha512-Mplgkd+mmWxoB7P4m+0UK++Nb+97eeH7/ZKemLIFL8s8N1n2voQZJLK9uTkY3vvIS17sT9QvWCMl63v6TPnebw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-4.4.2.tgz",
+      "integrity": "sha512-BjdDq+PcKCS7taMcwc3moKEIykw0vfgzKBClSBBwyXP5ewHQJNYMhe7sGlVt17MyFBTQkBVWJtt9QsvcNcw98w==",
       "dependencies": {
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/core": "4.3.1",
         "@aws-sdk/client-s3": "3.6.1",
         "@aws-sdk/s3-request-presigner": "3.6.1",
         "@aws-sdk/util-create-request": "3.6.1",
@@ -261,9 +270,9 @@
       "integrity": "sha512-LxbmPGD/S4bWzUh2PXMPSt/rXeUVJTsCbMpwH18XilTkXgOSmKH/eyVZNXUBY8C/xwqjzMTC68EtTlsM1DCq1A=="
     },
     "node_modules/@aws-amplify/ui-components": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-components/-/ui-components-1.7.8.tgz",
-      "integrity": "sha512-BR31SXO5ppyhhOkw+Qys2sSkDV0rjHDO/5NAkJwP9OhOm47QgIIaKCdTurIYnaskelMflKgetVAts+2xUymegg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-components/-/ui-components-1.8.2.tgz",
+      "integrity": "sha512-w+iJh66itkpZ13MSmIL0LW5frrk4dP9FdcH5KvGAgUDjLSM4dOqeBa1wuPHHJ5pkilByZMK9LHkqP7TIAMdWdA==",
       "dependencies": {
         "qrcode": "^1.4.4",
         "uuid": "^8.2.0"
@@ -273,11 +282,11 @@
       }
     },
     "node_modules/@aws-amplify/ui-react": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-1.2.15.tgz",
-      "integrity": "sha512-baBOFmJiuqiaeEZaT/TW2ZjxcsdciwiCTFC2qaOXJHMNAYyUzMXY7mOHeaNblBrI+uzppm4dvjVPqmB8zcjr7A==",
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-1.2.19.tgz",
+      "integrity": "sha512-qf+XZujT/i8eNHgV7P5P2UGCTzJldrgYCdSW15jSJhPSZ3iJNvHjVbeB7FAdIIm2hH65/WJkF2kixsf5G6rwEQ==",
       "dependencies": {
-        "@aws-amplify/ui-components": "1.7.8"
+        "@aws-amplify/ui-components": "1.8.2"
       },
       "peerDependencies": {
         "react": ">= 16.7.0",
@@ -285,18 +294,20 @@
       }
     },
     "node_modules/@aws-amplify/xr": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-3.0.15.tgz",
-      "integrity": "sha512-sINduNuGaPjeyZ/9iDbzevHyNWiHRHYeDVfzbgNFE8lf92uqN3m1rN8acg7wJHjnaDpw/0qFPGzN/tT+s/SvDg==",
+      "version": "3.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-3.0.19.tgz",
+      "integrity": "sha512-wogJDDVLXrDribhhW/OUK8ZTqFAmVuDHn8O/tusBOdpnjfYULddDML6BSBtYMsP3TGkOz7c7v/HPTtWBfRR2ZQ==",
       "dependencies": {
-        "@aws-amplify/core": "4.2.9"
+        "@aws-amplify/core": "4.3.1"
       }
     },
     "node_modules/@aws-crypto/crc32": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.1.0.tgz",
-      "integrity": "sha512-ifvfaaJVvT+JUTi3zSkX4wtuGGVJrAcjN7ftg+JiE/frNBP3zNwo4xipzWBsMLZfNuzMZuaesEYyqkZcs5tzCQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.2.1.tgz",
+      "integrity": "sha512-Ydso55lIn3Vudui5jXNKcxmyVr9BNWeIkAhleGuG9zpb0Pu5yXf2Jth2A07fUyLSXX2gwfv0d84zwvKK2FMbuA==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
+        "@aws-sdk/types": "^3.1.0",
         "tslib": "^1.11.1"
       }
     },
@@ -319,26 +330,26 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-browser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.1.1.tgz",
-      "integrity": "sha512-nS4vdan97It6HcweV58WXtjPbPSc0JXd3sAwlw3Ou5Mc3WllSycAS32Tv2LRn8butNQoU9AE3jEQAOgiMdNC1Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.1.tgz",
+      "integrity": "sha512-WX/Wp6sXPhcBWx/w1aSJv3bDJL0ut5Ik6hl7yfqA1pn3cfsahl4rgHzRRXqYfJ+hnhnCqdgadS17wyBbVPsK+w==",
       "dependencies": {
         "@aws-crypto/ie11-detection": "^1.0.0",
-        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-crypto/sha256-js": "^1.2.1",
         "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
     "node_modules/@aws-crypto/sha256-browser/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -387,6 +398,21 @@
       }
     },
     "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.1.tgz",
+      "integrity": "sha512-H6Qrl28lzGGXZgLkdP7DQpJ3D3jJagQJugziThcqZCJVUT0HABHJt9EQMiiuf93KcUV/MMoisl56UfCxCFfmWQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
@@ -477,12 +503,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -533,12 +559,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -590,12 +616,12 @@
       }
     },
     "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -655,12 +681,12 @@
       }
     },
     "node_modules/@aws-sdk/client-firehose/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -715,12 +741,12 @@
       }
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -771,12 +797,12 @@
       }
     },
     "node_modules/@aws-sdk/client-lex-runtime-service/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -784,6 +810,575 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-location": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-location/-/client-location-3.22.0.tgz",
+      "integrity": "sha512-1DOpMgEtln581fo2rYjDpgsKE5ScpFBPwbZKYDjiPo8qF3Rcl/LKI7HLgmeCDQBWobvOtnKB8+9bZVpqx1rEUA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "^1.1.0",
+        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-sdk/client-sts": "3.22.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/credential-provider-node": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-crypto/sha256-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+      "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+      "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.22.0.tgz",
+      "integrity": "sha512-vbM4hcH28fyos2BAtt1ANhEEZynYpFgdMTdw2d8jJMDITE4gtMzomVOdz/7ZVf9WFUJf9iYV6U3fXSqalFeeew==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.22.0.tgz",
+      "integrity": "sha512-d1nAy6OM+7+Yat5Yx0u5r2lRZxcCaxykblDO2rcicdsINxxcSglQsD4pud3t/dfyUfkrnznlNE5VY0H+90kx8g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.22.0.tgz",
+      "integrity": "sha512-uq9vn+qNmhBNaWu1CkuLKAKJPce7h2O8uuDRLwPfk5zWhLgeW1pjGyMyG+8aX1nytzNH+TXL+GvkMHf/Qzn11w==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.22.0",
+        "@aws-sdk/credential-provider-imds": "3.22.0",
+        "@aws-sdk/credential-provider-sso": "3.22.0",
+        "@aws-sdk/credential-provider-web-identity": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.22.0.tgz",
+      "integrity": "sha512-A3MONEY+Ul9gB2whV69n5V2sMeVXXYVA1MejG3v51d7csEi/XNlBQK5IfhEur6qi49km84xVsfHdO5/a/DNTqg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.22.0",
+        "@aws-sdk/credential-provider-imds": "3.22.0",
+        "@aws-sdk/credential-provider-ini": "3.22.0",
+        "@aws-sdk/credential-provider-process": "3.22.0",
+        "@aws-sdk/credential-provider-sso": "3.22.0",
+        "@aws-sdk/credential-provider-web-identity": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.22.0.tgz",
+      "integrity": "sha512-5glIbC8jTiiBEMZnsX8KN9m3IC9EdVOj8H+DavwHpTv801j27NhuNYwR2JOLxhjW+PiNX1iyA5k7wfUlLJultQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+      "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/hash-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+      "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+      "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+      "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+      "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+      "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+      "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+      "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/service-error-classification": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+      "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+      "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+      "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+      "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+      "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+      "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/property-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+      "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+      "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+      "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+      "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+      "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+      "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+      "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-hex-encoding": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+      "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/url-parser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+      "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+      "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+      "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+      "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+      "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+      "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+      "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+      "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+      "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+      "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+      "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+      "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/@aws-sdk/client-personalize-events": {
       "version": "3.6.1",
@@ -827,12 +1422,12 @@
       }
     },
     "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -883,12 +1478,12 @@
       }
     },
     "node_modules/@aws-sdk/client-pinpoint/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -939,12 +1534,12 @@
       }
     },
     "node_modules/@aws-sdk/client-polly/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -996,12 +1591,12 @@
       }
     },
     "node_modules/@aws-sdk/client-rekognition/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -1067,12 +1662,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -1080,6 +1675,1060 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.22.0.tgz",
+      "integrity": "sha512-LXskY6Mvo/wk2dL1FNTazzhWiHiI3+nJdAT7iNOAg2Q1EUGVAfK+6EccEFPqaBtJDN4kv047HxXNVXKxJSyICg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+      "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+      "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+      "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/hash-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+      "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+      "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+      "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+      "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+      "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+      "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+      "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/service-error-classification": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+      "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+      "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+      "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+      "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+      "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/property-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+      "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+      "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+      "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+      "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+      "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+      "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+      "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-hex-encoding": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+      "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/url-parser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+      "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+      "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+      "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+      "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+      "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+      "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+      "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+      "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+      "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+      "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+      "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+      "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.22.0.tgz",
+      "integrity": "sha512-3htpVHnnD4AvHPo+8VfkPbegN4WPAqcNIXPKCMNkNbYmnLLbtB4MlzKsRgpBP4LvRhi/2kt8fapRTQuTXo/8Mg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/credential-provider-node": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-sdk-sts": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+      "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+      "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.22.0.tgz",
+      "integrity": "sha512-vbM4hcH28fyos2BAtt1ANhEEZynYpFgdMTdw2d8jJMDITE4gtMzomVOdz/7ZVf9WFUJf9iYV6U3fXSqalFeeew==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.22.0.tgz",
+      "integrity": "sha512-d1nAy6OM+7+Yat5Yx0u5r2lRZxcCaxykblDO2rcicdsINxxcSglQsD4pud3t/dfyUfkrnznlNE5VY0H+90kx8g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.22.0.tgz",
+      "integrity": "sha512-uq9vn+qNmhBNaWu1CkuLKAKJPce7h2O8uuDRLwPfk5zWhLgeW1pjGyMyG+8aX1nytzNH+TXL+GvkMHf/Qzn11w==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.22.0",
+        "@aws-sdk/credential-provider-imds": "3.22.0",
+        "@aws-sdk/credential-provider-sso": "3.22.0",
+        "@aws-sdk/credential-provider-web-identity": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.22.0.tgz",
+      "integrity": "sha512-A3MONEY+Ul9gB2whV69n5V2sMeVXXYVA1MejG3v51d7csEi/XNlBQK5IfhEur6qi49km84xVsfHdO5/a/DNTqg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.22.0",
+        "@aws-sdk/credential-provider-imds": "3.22.0",
+        "@aws-sdk/credential-provider-ini": "3.22.0",
+        "@aws-sdk/credential-provider-process": "3.22.0",
+        "@aws-sdk/credential-provider-sso": "3.22.0",
+        "@aws-sdk/credential-provider-web-identity": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.22.0.tgz",
+      "integrity": "sha512-5glIbC8jTiiBEMZnsX8KN9m3IC9EdVOj8H+DavwHpTv801j27NhuNYwR2JOLxhjW+PiNX1iyA5k7wfUlLJultQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+      "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/hash-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+      "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+      "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+      "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+      "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+      "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+      "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+      "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/service-error-classification": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+      "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+      "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+      "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+      "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+      "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+      "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/property-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+      "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+      "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+      "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+      "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+      "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+      "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+      "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-hex-encoding": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+      "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/url-parser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+      "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+      "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+      "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+      "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+      "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+      "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+      "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+      "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+      "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+      "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+      "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+      "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
     },
     "node_modules/@aws-sdk/client-textract": {
       "version": "3.6.1",
@@ -1123,12 +2772,12 @@
       }
     },
     "node_modules/@aws-sdk/client-textract/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -1180,12 +2829,12 @@
       }
     },
     "node_modules/@aws-sdk/client-translate/node_modules/@aws-crypto/sha256-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+      "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
       "dependencies": {
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
     },
@@ -1337,6 +2986,86 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.22.0.tgz",
+      "integrity": "sha512-lgqvFIJctJmD2kjWY/BjXdKhH2Fndj/8CPRTDs8ja9AOXU/C3ExnDA15vqhDm5JvKmlkafQEtmypg5n+AZCwSw==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/property-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+      "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+      "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.22.0.tgz",
+      "integrity": "sha512-4CTVRuh3EMbH+EYtY0balZ+05BvjcTcW+n0uISK4a4KSMvVBWbhmiIm3U5ducPZfKAenf2mS0UHYRmV/nRLJzA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/property-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+      "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/@aws-sdk/eventstream-marshaller": {
       "version": "3.6.1",
@@ -1733,6 +3462,117 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.22.0.tgz",
+      "integrity": "sha512-CpfPpKTKEcxyooDwa7tFZDhhB3RwByxwzQ+jEAUcDvSLRALyNb1jvwAfgJJQBx6uZgqj97Z46UYpMJIDoCebTA==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+      "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+      "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/property-provider": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+      "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+      "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+      "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-hex-encoding": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+      "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+      "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/@aws-sdk/middleware-serde": {
       "version": "3.6.1",
@@ -2166,6 +4006,29 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/@aws-sdk/util-credentials": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.22.0.tgz",
+      "integrity": "sha512-PI4aYgYgLIM8m2zNxXCK/GDlcHUX2akN1QKshM7uPhp5ZsjXVpR//FQ9DsRp+gKFk8VN+4zGo3eIIuJOAVEe3Q==",
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-credentials/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+      "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-format-url": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.6.1.tgz",
@@ -2201,9 +4064,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.29.0.tgz",
-      "integrity": "sha512-gvcbl9UdTOvuCCzgbtTTsKnL1l/cnT/CFl0f6ZCQ6qubUTRCuL/aK8DvgWa1n9p/ddCiVKPLmHu/L1xtX4gc0A==",
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.35.0.tgz",
+      "integrity": "sha512-ZxmoNR378O1RGy0nqbynX1XhZOkGuNsiyeYXFNLf7Ye6Ye07bJO+hROWKj62ZjvRjRkJOsXYztXes4qaxf0vVg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2325,9 +4188,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
+      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
       "dependencies": {
         "@babel/highlight": "^7.14.5"
       },
@@ -2344,19 +4207,19 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.15.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
-      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.8.tgz",
+      "integrity": "sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==",
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
+        "@babel/code-frame": "^7.15.8",
+        "@babel/generator": "^7.15.8",
         "@babel/helper-compilation-targets": "^7.15.4",
-        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.8",
         "@babel/helpers": "^7.15.4",
-        "@babel/parser": "^7.15.5",
+        "@babel/parser": "^7.15.8",
         "@babel/template": "^7.15.4",
         "@babel/traverse": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/types": "^7.15.6",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -2389,11 +4252,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
-      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
+      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
       "dependencies": {
-        "@babel/types": "^7.15.4",
+        "@babel/types": "^7.15.6",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -2586,18 +4449,18 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
-      "integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz",
+      "integrity": "sha512-DfAfA6PfpG8t4S6npwzLvTUpp0sS7JrcuaMiy1Y5645laRJIp/LiLGIBbQKaXSInK8tiGNI7FL7L8UvB8gdUZg==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.15.4",
         "@babel/helper-replace-supers": "^7.15.4",
         "@babel/helper-simple-access": "^7.15.4",
         "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "@babel/template": "^7.15.4",
         "@babel/traverse": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.15.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2683,9 +4546,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2803,9 +4666,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
-      "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
+      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -2830,9 +4693,9 @@
       }
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.4.tgz",
-      "integrity": "sha512-2zt2g5vTXpMC3OmK6uyjvdXptbhBXfA77XGrd3gh93zwG8lZYBLOBImiGBEG0RANu3JqKEACCz5CGk73OJROBw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.8.tgz",
+      "integrity": "sha512-2Z5F2R2ibINTc63mY7FLqGfEbmofrHU9FitJW1Q7aPaKFhiPvSq6QEt/BoWN5oME3GVyjcRuNNSRbb9LC0CSWA==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-remap-async-to-generator": "^7.15.4",
@@ -3862,15 +5725,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.0.tgz",
-      "integrity": "sha512-sfHYkLGjhzWTq6xsuQ01oEsUYjkHRux9fW1iUA68dC7Qd8BS1Unq4aZ8itmQp95zUzIcyR2EbNMTzAicFj+guw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.8.tgz",
+      "integrity": "sha512-+6zsde91jMzzvkzuEA3k63zCw+tm/GvuuabkpisgbDMTPQsIMHllE3XczJFFtEHLjjhKQFZmGQVRdELetlWpVw==",
       "peer": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-module-imports": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
         "babel-plugin-polyfill-corejs2": "^0.2.2",
-        "babel-plugin-polyfill-corejs3": "^0.2.2",
+        "babel-plugin-polyfill-corejs3": "^0.2.5",
         "babel-plugin-polyfill-regenerator": "^0.2.2",
         "semver": "^6.3.0"
       },
@@ -3905,12 +5768,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.6.tgz",
-      "integrity": "sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.15.8.tgz",
+      "integrity": "sha512-/daZ8s2tNaRekl9YJa9X4bzjpeRZLt122cpgFnQPLGUe61PH8zMEBmYqKkW5xF5JUEh5buEGXJoQpqBmIbpmEQ==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3962,9 +5825,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.4.tgz",
-      "integrity": "sha512-sM1/FEjwYjXvMwu1PJStH11kJ154zd/lpY56NQJ5qH2D0mabMv1CAy/kdvS9RP4Xgfj9fBBA3JiSLdDHgXdzOA==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.8.tgz",
+      "integrity": "sha512-ZXIkJpbaf6/EsmjeTbiJN/yMxWPFWvlr7sEG1P95Xb4S4IBcrf2n7s/fItIhsAmOf8oSh3VJPDppO6ExfAfKRQ==",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -4007,16 +5870,16 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.6.tgz",
-      "integrity": "sha512-L+6jcGn7EWu7zqaO2uoTDjjMBW+88FXzV8KvrBl2z6MtRNxlsmUNRlZPaNNPUTgqhyC5DHNFk/2Jmra+ublZWw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.8.tgz",
+      "integrity": "sha512-rCC0wH8husJgY4FPbHsiYyiLxSY8oMDJH7Rl6RQMknbN9oDDHhM9RDFvnGM2MgkbUJzSQB4gtuwygY5mCqGSsA==",
       "dependencies": {
         "@babel/compat-data": "^7.15.0",
         "@babel/helper-compilation-targets": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.15.4",
-        "@babel/plugin-proposal-async-generator-functions": "^7.15.4",
+        "@babel/plugin-proposal-async-generator-functions": "^7.15.8",
         "@babel/plugin-proposal-class-properties": "^7.14.5",
         "@babel/plugin-proposal-class-static-block": "^7.15.4",
         "@babel/plugin-proposal-dynamic-import": "^7.14.5",
@@ -4071,7 +5934,7 @@
         "@babel/plugin-transform-regenerator": "^7.14.5",
         "@babel/plugin-transform-reserved-words": "^7.14.5",
         "@babel/plugin-transform-shorthand-properties": "^7.14.5",
-        "@babel/plugin-transform-spread": "^7.14.6",
+        "@babel/plugin-transform-spread": "^7.15.8",
         "@babel/plugin-transform-sticky-regex": "^7.14.5",
         "@babel/plugin-transform-template-literals": "^7.14.5",
         "@babel/plugin-transform-typeof-symbol": "^7.14.5",
@@ -4080,7 +5943,7 @@
         "@babel/preset-modules": "^0.1.4",
         "@babel/types": "^7.15.6",
         "babel-plugin-polyfill-corejs2": "^0.2.2",
-        "babel-plugin-polyfill-corejs3": "^0.2.2",
+        "babel-plugin-polyfill-corejs3": "^0.2.5",
         "babel-plugin-polyfill-regenerator": "^0.2.2",
         "core-js-compat": "^3.16.0",
         "semver": "^6.3.0"
@@ -4098,6 +5961,23 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/preset-flow": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.14.5.tgz",
+      "integrity": "sha512-pP5QEb4qRUSVGzzKx9xqRuHUrM/jEzMqdrZpdMA+oUCRgd5zM1qGr5y5+ZgAL/1tVv1H0dyk5t4SKJntqyiVtg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-flow-strip-types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-modules": {
@@ -4135,12 +6015,17 @@
       }
     },
     "node_modules/@babel/preset-typescript": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.12.1.tgz",
-      "integrity": "sha512-hNK/DhmoJPsksdHuI/RVrcEws7GN5eamhi28JkO52MqIxU8Z0QpmiSOQxZHWOHV7I3P4UjHV97ay4TcamMA6Kw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.15.0.tgz",
+      "integrity": "sha512-lt0Y/8V3y06Wq/8H/u0WakrqciZ7Fz7mwPDHWUJAXlABL5hiUG42BNlRXiELNjeWjO5rWmnNKlx+yzJvxezHow==",
+      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-transform-typescript": "^7.12.1"
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-typescript": "^7.15.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -4310,9 +6195,9 @@
       "deprecated": "This version has been deprecated and is no longer supported or maintained"
     },
     "node_modules/@hapi/hoek": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
-      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
       "peer": true
     },
     "node_modules/@hapi/joi": {
@@ -4370,9 +6255,9 @@
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w=="
     },
     "node_modules/@ionic/core": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.8.0.tgz",
-      "integrity": "sha512-rzjAgS5pJgy/Ggtq1lgogl6thiEMMusnm96D6RsVLa4nxYrHIt9Oua062uIYrf0LdasqatekSxIqcU5Fl9YKEg==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.8.2.tgz",
+      "integrity": "sha512-BWIh6hyhq+tzVvebPMfRa+IhTV5/yXh4wO3a0U3Qo4PL4KDzWyBJfoiPi6bOEc+BAlFnCtOooTTXTumgXXOojg==",
       "dependencies": {
         "@stencil/core": "^2.4.0",
         "ionicons": "^5.5.3",
@@ -4380,11 +6265,11 @@
       }
     },
     "node_modules/@ionic/react": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-5.8.0.tgz",
-      "integrity": "sha512-xV1X+veFcYA2pYc7FnkUumNL5R8I7K6nuz2yl3ipco0EocWWMnjdAoepLuNp7L+hmFaLm2ZKrFTo7v2HtVwS4Q==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-5.8.2.tgz",
+      "integrity": "sha512-xOMjEXedN5cbB2GUXZnv5eD7BJOcSI0sqWAIj9/nuARu3eizGQG7WPVrdFeIgqJII1x2SnCZHZHKZI2iMy95zQ==",
       "dependencies": {
-        "@ionic/core": "5.8.0",
+        "@ionic/core": "5.8.2",
         "ionicons": "^5.1.2",
         "tslib": "*"
       },
@@ -4758,12 +6643,12 @@
       }
     },
     "node_modules/@jest/create-cache-key-function": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.2.0.tgz",
-      "integrity": "sha512-o+Q6CAT/mPNxiOGn6+UD/buY8O5cyDHbjD8FXDCUZbzfCwt6zYlmCMObLE+k1i/XJc5M3YIvEeaa6L7x7uAeYQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.2.4.tgz",
+      "integrity": "sha512-Cd9A6ugtkkHiQHDNbifdFrBBTgsKHp1KgCAjyAGMCrxFudR2icTKIPkXN2R2/IoMAMObUidMRBLDJy/RgX7uDQ==",
       "peer": true,
       "dependencies": {
-        "@jest/types": "^27.1.1"
+        "@jest/types": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -5223,10 +7108,21 @@
         "@types/yargs-parser": "*"
       }
     },
+    "node_modules/@jest/transform/node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
     "node_modules/@jest/types": {
-      "version": "27.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.1.tgz",
-      "integrity": "sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.4.tgz",
+      "integrity": "sha512-IDO2ezTxeMvQAHxzG/ZvEyA47q0aVfzT95rGFl7bZs/Go0aIucvfDbS2rmnoEdXxlLQhcolmoG/wvL/uKx4tKA==",
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -5303,24 +7199,25 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.1.tgz",
-      "integrity": "sha512-HnUhk1Sy9IuKrxEMdIRCxpIqPw6BFsbYSEUO9p/hNw5sMld/+3OLMWQP80F8/db9qsv3qUjs7ZR5bS/R+iinXw==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
+      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@react-native-community/cli": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.0.0.tgz",
-      "integrity": "sha512-wTbdpai58WzUBrw8lNbF/cSzX3pOWz+y+d46ip3M3Abd5yHNRvhuejRMVQC1o9luOM+ESJa4imYSbVdh7y5g+w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.1.0.tgz",
+      "integrity": "sha512-Ck1XjvsnYYVYqooxmSlvRvGMGgxj3t+evUGlg80b+TxnurhlGq8D8pW7++L/sECChI43YWMBtLIdAYG/lGkN8Q==",
       "peer": true,
       "dependencies": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-hermes": "^6.0.0",
-        "@react-native-community/cli-server-api": "^6.0.0-rc.0",
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-hermes": "^6.1.0",
+        "@react-native-community/cli-plugin-metro": "^6.1.0",
+        "@react-native-community/cli-server-api": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "@react-native-community/cli-types": "^6.0.0",
         "appdirsjs": "^1.2.4",
         "chalk": "^3.0.0",
@@ -5337,12 +7234,6 @@
         "joi": "^17.2.1",
         "leven": "^3.1.0",
         "lodash": "^4.17.15",
-        "metro": "^0.66.1",
-        "metro-config": "^0.66.1",
-        "metro-core": "^0.66.1",
-        "metro-react-native-babel-transformer": "^0.66.1",
-        "metro-resolver": "^0.66.1",
-        "metro-runtime": "^0.66.1",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
         "node-stream-zip": "^1.9.1",
@@ -5362,7 +7253,7 @@
         "node": ">=12"
       },
       "peerDependencies": {
-        "react-native": ">=0.65.0-rc.0 || 0.0.0-*"
+        "react-native": "*"
       }
     },
     "node_modules/@react-native-community/cli-debugger-ui": {
@@ -5375,13 +7266,13 @@
       }
     },
     "node_modules/@react-native-community/cli-hermes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.0.0.tgz",
-      "integrity": "sha512-YUX8MEmDsEYdFuo/juCZUUDPPRQ/su3K/SPcSVmv7AIAwO/7ItuQ7+58PRI914XNvnRmY1GNVHKfWhUoNXMxvA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.1.0.tgz",
+      "integrity": "sha512-BJyzGlUqnggbBL4Vh4cIC08oKOK4PoelxZFEo7TjFjfdBKvbM6955JN77ExJ7IdeLuGVpY4vaMwAJdx5l7LxKg==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-platform-android": "^6.0.0",
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-platform-android": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "chalk": "^3.0.0",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
@@ -5401,12 +7292,12 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-android": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.0.0.tgz",
-      "integrity": "sha512-yXyrM2elKM8/thf1d8EMMm0l0KdeWmIMhWZzCoRpCIQoUuVtiCEMyrZF+aufvNvy74soKiCFeAmGNI8LPk2hzg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.1.0.tgz",
+      "integrity": "sha512-MBYGfgCpieoqskKc5QyQYIPc74DBEW60JaacQLntHjPLCEXG+hPsJi3AuXeNTJYPki5pyiSp3kviqciUvrS96A==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "chalk": "^3.0.0",
         "execa": "^1.0.0",
         "fs-extra": "^8.1.0",
@@ -5432,12 +7323,12 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.0.0.tgz",
-      "integrity": "sha512-+f6X4jDGuPpVcY2NsVAstnId4stnG7EvzLUhs7FUpMFjzss9c1ZJhsqQeKikOtzZbwLzFrpki/QrTK79ur7xSg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.1.0.tgz",
+      "integrity": "sha512-whIm55fUeJUHrqZ2ecZ6FycZ5c/R3ZK8ViHwZQ+wM4uhXY8YSkrjnrJPUg68Q8inLkrAliLisypfm1z+VqJljw==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "chalk": "^3.0.0",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
@@ -5459,14 +7350,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/@react-native-community/cli-plugin-metro": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.1.0.tgz",
+      "integrity": "sha512-ltHJquEgA6H4OTIUqWIkNm/xxAB9D4DK2K9M0jie9FfkOoqBXA7QS2WnC8GEa6a+3VIDwevB0RJsch218FdZCw==",
+      "peer": true,
+      "dependencies": {
+        "@react-native-community/cli-server-api": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.1.0",
+        "chalk": "^3.0.0",
+        "metro": "^0.66.1",
+        "metro-config": "^0.66.1",
+        "metro-core": "^0.66.1",
+        "metro-react-native-babel-transformer": "^0.66.1",
+        "metro-resolver": "^0.66.1",
+        "metro-runtime": "^0.66.1",
+        "mkdirp": "^0.5.1",
+        "readline": "^1.3.0"
+      }
+    },
+    "node_modules/@react-native-community/cli-plugin-metro/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@react-native-community/cli-server-api": {
-      "version": "6.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.0.0-rc.0.tgz",
-      "integrity": "sha512-shPG9RXXpDYeluoB3tzaYU9Ut0jTvZ3osatLLUJkWjbRjFreK9zUcnoFDDrsVT6fEoyeBftp5DSa+wCUnPmcJA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.1.0.tgz",
+      "integrity": "sha512-WEJzdoF4JNUogZAd+Gdgbr+D/S/PHGjxH+PDjk3ST9pAUxEHb6naNwEl5dSJUY/ecBV63latNZkKunRyvFAx9A==",
       "peer": true,
       "dependencies": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
@@ -5533,16 +7456,19 @@
       }
     },
     "node_modules/@react-native-community/cli-tools": {
-      "version": "6.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.0.0-rc.0.tgz",
-      "integrity": "sha512-N31BhNacTe0UGYQxUx0WHWPKnF4pBe62hNRV9WNJdWqVl4TP45T1Fd/7ziiosfalIar+tOo9Sk0Pqq48x1+wNw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.1.0.tgz",
+      "integrity": "sha512-MT8syhvk0vpfyYyHlcDoGicKcqMtBN7WPmDeyW16u+eKBtw/+EKq+86cFCuOHCfHK20ujG1mZqA1txxlCbu8GA==",
       "peer": true,
       "dependencies": {
+        "appdirsjs": "^1.2.4",
         "chalk": "^3.0.0",
         "lodash": "^4.17.15",
         "mime": "^2.4.1",
+        "mkdirp": "^0.5.1",
         "node-fetch": "^2.6.0",
         "open": "^6.2.0",
+        "semver": "^6.3.0",
         "shell-quote": "1.6.1"
       }
     },
@@ -5557,6 +7483,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli-tools/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@react-native-community/cli-types": {
@@ -5765,9 +7700,9 @@
       "peer": true
     },
     "node_modules/@react-native/polyfills": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-1.0.0.tgz",
-      "integrity": "sha512-0jbp4RxjYopTsIdLl+/Fy2TiwVYHy4mgeu07DG4b/LyM0OS/+lPP5c9sbnt/AMlnF6qz2JRZpPpGw1eMNS6A4w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
+      "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==",
       "peer": true
     },
     "node_modules/@restart/context": {
@@ -6213,9 +8148,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.5.0.tgz",
-      "integrity": "sha512-O0fmHFaPlqaYCpa/cBL0cvroMridb9vZsMLacgIqrlxj+fd+bGF8UfAgwsLCHRF84KLBafWlm9CuOvxeNTlodw==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.7.2.tgz",
+      "integrity": "sha512-2zN0Zv9dMnaMAd4c/1E1ZChu4QrICyvWtkUvHFQBPhS1oG3VYGcM7SLGLYdda7187ILRXzIUOvOsbXQm4EASjA==",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6264,9 +8199,9 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.0.tgz",
-      "integrity": "sha512-Ge3Ht3qXE82Yv9lyPpQ7ZWgzo/HgOcHu569Y4ZGWcZME38iOFiOg87qnu6hTEa8jTJVL7zYovnvD3GE2nsNIoQ==",
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
+      "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0"
@@ -6350,9 +8285,9 @@
       "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
     "node_modules/@types/dompurify": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.2.3.tgz",
-      "integrity": "sha512-CLtc2mZK8+axmrz1JqtpklO/Kvn38arGc8o1l3UVopZaXXuer9ONdZwJ/9f226GrhRLtUmLr9WrvZsRSNpS8og==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.3.1.tgz",
+      "integrity": "sha512-YJth9qa0V/E6/XPH1Jq4BC8uCMmO8V1fKWn8PCvuZcAhMn7q0ez9LW6naQT04UZzjFfAPhyRMZmI2a2rbMlEFA==",
       "dev": true,
       "dependencies": {
         "@types/trusted-types": "*"
@@ -6513,9 +8448,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "node_modules/@types/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
@@ -6528,9 +8463,9 @@
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
     },
     "node_modules/@types/react": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.21.tgz",
-      "integrity": "sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==",
+      "version": "17.0.27",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.27.tgz",
+      "integrity": "sha512-zgiJwtsggVGtr53MndV7jfiUESTqrbxOcBvwfe6KS/9bzaVPCTDieTWnFNecVNx6EAaapg5xsLLWFfHHR437AA==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -6546,9 +8481,9 @@
       }
     },
     "node_modules/@types/react-router": {
-      "version": "5.1.16",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.16.tgz",
-      "integrity": "sha512-8d7nR/fNSqlTFGHti0R3F9WwIertOaaA1UEB8/jr5l5mDMOs4CidEgvvYMw4ivqrBK+vtVLxyTj2P+Pr/dtgzg==",
+      "version": "5.1.17",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.17.tgz",
+      "integrity": "sha512-RNSXOyb3VyRs/EOGmjBhhGKTbnN6fHWvy5FNLzWfOWOGjgVUKqJZXfpKzLmgoU8h6Hj8mpALj/mbXQASOb92wQ==",
       "dev": true,
       "dependencies": {
         "@types/history": "*",
@@ -6556,9 +8491,9 @@
       }
     },
     "node_modules/@types/react-router-dom": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.9.tgz",
-      "integrity": "sha512-Go0vxZSigXTyXx8xPkGiBrrc3YbBs82KE14WENMLS6TSUKcRFSmYVbL19zFOnNFqJhqrPqEs2h5eUpJhSRrwZw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.1.tgz",
+      "integrity": "sha512-UvyRy73318QI83haXlaMwmklHHzV9hjl3u71MmM6wYNu0hOVk9NLTa0vGukf8zXUqnwz4O06ig876YSPpeK28A==",
       "dev": true,
       "dependencies": {
         "@types/history": "*",
@@ -6567,9 +8502,9 @@
       }
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.2.tgz",
-      "integrity": "sha512-KibDWL6nshuOJ0fu8ll7QnV/LVTo3PzQ9aCPnRUYPfX7eZohHwLIdNHj7pftanREzHNP4/nJa8oeM73uSiavMQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.3.tgz",
+      "integrity": "sha512-fUx5muOWSYP8Bw2BUQ9M9RK9+W1XBK/7FLJ8PTQpnpTEkn0ccyMffyEQvan4C3h53gHdx7KE5Qrxi/LnUGQtdg==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -6674,14 +8609,15 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.1.tgz",
-      "integrity": "sha512-UDqhWmd5i0TvPLmbK5xY3UZB0zEGseF+DHPghZ37Sb83Qd3p8ujhvAtkU4OF46Ka5Pm5kWvFIx0cCTBFKo0alA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.31.1",
-        "@typescript-eslint/scope-manager": "4.31.1",
+        "@typescript-eslint/experimental-utils": "4.33.0",
+        "@typescript-eslint/scope-manager": "4.33.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
         "regexpp": "^3.1.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
@@ -6703,15 +8639,23 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.1.tgz",
-      "integrity": "sha512-NtoPsqmcSsWty0mcL5nTZXMf7Ei0Xr2MT8jWjXMVgRK0/1qeQ2jZzLFUh4QtyJ4+/lPUyMw5cSfeeME+Zrtp9Q==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
+      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.31.1",
-        "@typescript-eslint/types": "4.31.1",
-        "@typescript-eslint/typescript-estree": "4.31.1",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -6744,13 +8688,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.31.1.tgz",
-      "integrity": "sha512-dnVZDB6FhpIby6yVbHkwTKkn2ypjVIfAR9nh+kYsA/ZL0JlTsd22BiDjouotisY3Irmd3OW1qlk9EI5R8GrvRQ==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.31.1",
-        "@typescript-eslint/types": "4.31.1",
-        "@typescript-eslint/typescript-estree": "4.31.1",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -6770,12 +8714,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.31.1.tgz",
-      "integrity": "sha512-N1Uhn6SqNtU2XpFSkD4oA+F0PfKdWHyr4bTX0xTj8NRx1314gBDRL1LUuZd5+L3oP+wo6hCbZpaa1in6SwMcVQ==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
       "dependencies": {
-        "@typescript-eslint/types": "4.31.1",
-        "@typescript-eslint/visitor-keys": "4.31.1"
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -6786,9 +8730,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.31.1.tgz",
-      "integrity": "sha512-kixltt51ZJGKENNW88IY5MYqTBA8FR0Md8QdGbJD2pKZ+D5IvxjTYDNtJPDxFBiXmka2aJsITdB1BtO1fsgmsQ==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
       },
@@ -6798,12 +8742,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.1.tgz",
-      "integrity": "sha512-EGHkbsUvjFrvRnusk6yFGqrqMBTue5E5ROnS5puj3laGQPasVUgwhrxfcgkdHNFECHAewpvELE1Gjv0XO3mdWg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
       "dependencies": {
-        "@typescript-eslint/types": "4.31.1",
-        "@typescript-eslint/visitor-keys": "4.31.1",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -6824,11 +8768,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.1.tgz",
-      "integrity": "sha512-PCncP8hEqKw6SOJY+3St4LVtoZpPPn+Zlpm7KW5xnviMhdqcsBty4Lsg4J/VECpJjw1CkROaZhH4B8M1OfnXTQ==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
       "dependencies": {
-        "@typescript-eslint/types": "4.31.1",
+        "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -7162,9 +9106,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "node_modules/amazon-cognito-identity-js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.1.0.tgz",
-      "integrity": "sha512-zGJo9jpTBHaTrir9nBWxMnteR+uPMSq3SO9AT0EOAO/e1CyJ27sawe0Pd3218HPzsooOMZt0iYaWkpVrsQ3nSQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.0.tgz",
+      "integrity": "sha512-7nRkGb9Cinf1rD5t34B0NDWXO7lmyapXzLmSXq4IBOdiBMrmxToEHcRwfwT2jJfBWzzZiOS0gvQhKI32A+rmvg==",
       "dependencies": {
         "buffer": "4.9.2",
         "crypto-js": "^4.1.1",
@@ -7383,15 +9327,15 @@
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
     },
     "node_modules/array-includes": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
-      "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
+        "es-abstract": "^1.19.1",
         "get-intrinsic": "^1.1.1",
-        "is-string": "^1.0.5"
+        "is-string": "^1.0.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7437,13 +9381,13 @@
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
-      "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
+      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
+        "es-abstract": "^1.19.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7453,14 +9397,13 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
-      "integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
+      "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.19.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7544,6 +9487,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -7617,15 +9572,15 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "9.8.6",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
-      "integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
+      "version": "9.8.8",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
+      "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
       "dependencies": {
         "browserslist": "^4.12.0",
         "caniuse-lite": "^1.0.30001109",
-        "colorette": "^1.2.1",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
+        "picocolors": "^0.2.1",
         "postcss": "^7.0.32",
         "postcss-value-parser": "^4.1.0"
       },
@@ -7638,22 +9593,23 @@
       }
     },
     "node_modules/aws-amplify": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.2.9.tgz",
-      "integrity": "sha512-kMbXfgmcTjN3KLsMYAGBe7iy8Ih1/3Den5ZPEvEg7YTlkgtQ7YguyltdekE/yHV5JCCKTB8G1D2wmsvfHkid5w==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.3.1.tgz",
+      "integrity": "sha512-dvBVTDbpMfS91E0b9qxltIALTCP3b2pQpTyVQxUa9tuevEsi4YFL7EDcvQF4ScJkNwnuoTKVJsNCjrq8SJCJMg==",
       "dependencies": {
-        "@aws-amplify/analytics": "5.0.15",
-        "@aws-amplify/api": "4.0.15",
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/datastore": "3.4.3",
-        "@aws-amplify/interactions": "4.0.15",
-        "@aws-amplify/predictions": "4.0.15",
-        "@aws-amplify/pubsub": "4.1.7",
-        "@aws-amplify/storage": "4.3.10",
+        "@aws-amplify/analytics": "5.0.19",
+        "@aws-amplify/api": "4.0.19",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/datastore": "3.4.7",
+        "@aws-amplify/geo": "1.1.1",
+        "@aws-amplify/interactions": "4.0.19",
+        "@aws-amplify/predictions": "4.0.19",
+        "@aws-amplify/pubsub": "4.1.11",
+        "@aws-amplify/storage": "4.4.2",
         "@aws-amplify/ui": "2.0.3",
-        "@aws-amplify/xr": "3.0.15"
+        "@aws-amplify/xr": "3.0.19"
       }
     },
     "node_modules/aws-sign2": {
@@ -7689,6 +9645,15 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
+    },
+    "node_modules/babel-core": {
+      "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "peer": true,
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
     },
     "node_modules/babel-eslint": {
       "version": "10.1.0",
@@ -7925,12 +9890,12 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.4.tgz",
-      "integrity": "sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.5.tgz",
+      "integrity": "sha512-ninF5MQNwAX9Z7c9ED+H2pGt1mXdP4TqzlHKyPIYmJIYz0N+++uwdM7RnJukklhzJ54Q84vA4ZJkgs7lu5vqcw==",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.2.2",
-        "core-js-compat": "^3.14.0"
+        "core-js-compat": "^3.16.2"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -8278,6 +10243,18 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/babel-preset-react-app/node_modules/@babel/preset-typescript": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.12.1.tgz",
+      "integrity": "sha512-hNK/DhmoJPsksdHuI/RVrcEws7GN5eamhi28JkO52MqIxU8Z0QpmiSOQxZHWOHV7I3P4UjHV97ay4TcamMA6Kw==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-transform-typescript": "^7.12.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/babel-preset-react-app/node_modules/@babel/runtime": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
@@ -8364,14 +10341,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
-      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -8419,9 +10388,9 @@
       }
     },
     "node_modules/big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "version": "1.6.49",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.49.tgz",
+      "integrity": "sha512-KJ7VhqH+f/BOt9a3yMwJNmcZjG53ijWMTjSAGMveQWyLwqIiwkjNP5PFgDob3Snnx86SjDj6I89fIbv0dkQeNw==",
       "peer": true,
       "engines": {
         "node": ">=0.6"
@@ -8719,15 +10688,15 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-      "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.3.tgz",
+      "integrity": "sha512-59IqHJV5VGdcJZ+GZ2hU5n4Kv3YiASzW6Xk5g9tf5a/MAzGeFwgGWU39fVzNIOVcgB3+Gp+kiQu0HEfTVU/3VQ==",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001254",
-        "colorette": "^1.3.0",
-        "electron-to-chromium": "^1.3.830",
+        "caniuse-lite": "^1.0.30001264",
+        "electron-to-chromium": "^1.3.857",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.75"
+        "node-releases": "^1.1.77",
+        "picocolors": "^0.2.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -8969,9 +10938,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001257",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
-      "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
+      "version": "1.0.30001265",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
+      "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -9212,9 +11181,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
-      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -9473,7 +11442,17 @@
     "node_modules/colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "peer": true
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -9714,9 +11693,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
-      "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.2.tgz",
+      "integrity": "sha512-zNhPOUoSgoizoSQFdX1MeZO16ORRb9FFQLts8gSYbZU5FcgXhp24iMWMxnOQo5uIaIG7/6FA/IqJPwev1o9ZXQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -9724,11 +11703,11 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.17.3.tgz",
-      "integrity": "sha512-+in61CKYs4hQERiADCJsdgewpdl/X0GhEX77pjKgbeibXviIt2oxEjTc8O2fqHX8mDdBrDvX8MYD/RYsBv4OiA==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.18.2.tgz",
+      "integrity": "sha512-25VJYCJtGjZwLguj7d66oiHfmnVw3TMOZ0zV8DyMJp/aeQ3OjR519iOOeck08HMyVVRAqXxafc2Hl+5QstJrsQ==",
       "dependencies": {
-        "browserslist": "^4.17.0",
+        "browserslist": "^4.17.3",
         "semver": "7.0.0"
       },
       "funding": {
@@ -9745,9 +11724,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.17.3.tgz",
-      "integrity": "sha512-YusrqwiOTTn8058JDa0cv9unbXdIiIgcgI9gXso0ey4WgkFLd3lYlV9rp9n7nDCsYxXsMDTjA4m1h3T348mdlQ==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.18.2.tgz",
+      "integrity": "sha512-4hMMLUlZhKJKOWbbGD1/VDUxGPEhEoN/T01k7bx271WiBKCvCfkgPzy0IeRS4PB50p6/N1q/SZL4B/TRsTE5bA==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -10266,10 +12245,34 @@
         "node": ">=10"
       }
     },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "dependencies": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/date-fns": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
-      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
+      "integrity": "sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w==",
       "engines": {
         "node": ">=0.11"
       },
@@ -10749,9 +12752,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.2.tgz",
-      "integrity": "sha512-jXJnvWloI+scD+N5uBikpUMsYXZb0LCAXxLFAOLS5duCzKfXLqBCpuINvFOiI4eJgTLggrngljT18HNoakHUsA=="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.3.tgz",
+      "integrity": "sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -10847,9 +12850,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw=="
+      "version": "1.3.861",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.861.tgz",
+      "integrity": "sha512-GZyflmpMnZRdZ1e2yAyvuFwz1MPSVQelwHX4TJZyXypB8NcxdPvPNwy5lOTxnlkrK13EiQzyTPugRSnj6cBgKg=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -11015,9 +13018,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.18.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
-      "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -11030,7 +13033,9 @@
         "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.1",
         "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
         "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
         "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
@@ -11186,6 +13191,7 @@
       "version": "7.32.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -11243,6 +13249,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
       "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-config-airbnb-base": "^14.2.1",
         "object.assign": "^4.1.2",
@@ -11426,9 +13433,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.4.0.tgz",
-      "integrity": "sha512-8qnt/hgtZ94E9dA6viqfViKBfkJwFHXgJmTWlMGDgunw1XJEGqm3eiPjDsTanM3/u/3Az82nyQM9GX7PM/QGmg==",
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.5.2.tgz",
+      "integrity": "sha512-lrI3sGAyZi513RRmP08sIW241Ti/zMnn/6wbE4ZBhb3M2pJ9ztaZMnSKSKKBUfotVdwqU8W1KtD8ao2/FR8DIg==",
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
       },
@@ -11449,6 +13456,7 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz",
       "integrity": "sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "aria-query": "^4.2.2",
@@ -11491,22 +13499,23 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.1.tgz",
-      "integrity": "sha512-P4j9K1dHoFXxDNP05AtixcJEvIT6ht8FhYKsrkY0MPCPaUMYijhpWwNiRDZVtA8KFuZOkGSeft6QwH8KuVpJug==",
+      "version": "7.26.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
+      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
       "dependencies": {
         "array-includes": "^3.1.3",
         "array.prototype.flatmap": "^1.2.4",
         "doctrine": "^2.1.0",
         "estraverse": "^5.2.0",
-        "has": "^1.0.3",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
         "object.entries": "^1.1.4",
         "object.fromentries": "^2.0.4",
+        "object.hasown": "^1.0.0",
         "object.values": "^1.1.4",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
         "string.prototype.matchall": "^4.0.5"
       },
       "engines": {
@@ -11548,6 +13557,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-testing-library": {
@@ -12217,9 +14234,9 @@
       }
     },
     "node_modules/ext": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.5.0.tgz",
-      "integrity": "sha512-+ONcYoWj/SoQwUofMr94aGu05Ou4FepKi7N7b+O8T4jVfyIsZQV1/xeS8jpaBzF0csAk0KLXoHCxU7cKYZjo1Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
       "dependencies": {
         "type": "^2.5.0"
       }
@@ -12344,11 +14361,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "node_modules/fast-xml-parser": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.20.0.tgz",
-      "integrity": "sha512-cMQwDJYVDjMPU56DviszewgMKuNzuf4NQSBuDf9RgZ6FKm5QEMxW05Za8lvnuL6moxoeZVUWBlL733WmovvV6g==",
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.20.3.tgz",
+      "integrity": "sha512-FfHJ/QCpo4K2gquBX7dIAcmShSBG4dMtYJ3ghSiR4w7YqlUujuamrM57C+mKLNWS3mvZzmm2B2Qx8Q6Gfw+lDQ==",
       "dependencies": {
-        "strnum": "^1.0.3"
+        "strnum": "^1.0.4"
       },
       "bin": {
         "xml2js": "cli.js"
@@ -12447,11 +14464,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/file-selector/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -12621,6 +14633,15 @@
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
       "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
       "deprecated": "flatten is deprecated in favor of utility frameworks such as lodash."
+    },
+    "node_modules/flow-parser": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.121.0.tgz",
+      "integrity": "sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
@@ -13155,9 +15176,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -13271,6 +15292,25 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/globule/node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/graceful-fs": {
@@ -13543,9 +15583,9 @@
       }
     },
     "node_modules/hermes-engine": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.8.1.tgz",
-      "integrity": "sha512-as9Iccj/qrqqtDmfYUHbOIjt5xsQbUB6pjNIW3i1+RVr+pCAdz5S8/Jry778mz3rJWplYzHWdR1u1xQSYfBRYw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.9.0.tgz",
+      "integrity": "sha512-r7U+Y4P2Qg/igFVZN+DpT7JFfXUn1MM4dFne8aW+cCrF6RRymof+VqrUHs1kl07j8h8V2CNesU19RKgWbr3qPw==",
       "peer": true
     },
     "node_modules/hermes-parser": {
@@ -14126,9 +16166,9 @@
       }
     },
     "node_modules/import-local": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
-      "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
+      "integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
       "dependencies": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -14440,9 +16480,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
+      "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -14546,9 +16586,9 @@
       }
     },
     "node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -14692,6 +16732,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -14732,6 +16780,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -14860,9 +16919,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.3.tgz",
+      "integrity": "sha512-0i77ZFLsb9U3DHi22WzmIngVzfoyxxbQcZRqlF3KoKmCJGq9nhFHoGi8FqBztN2rE8w6hURnZghetn0xpkVb6A==",
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
@@ -15218,13 +17277,13 @@
       }
     },
     "node_modules/jest-cli/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -16789,13 +18848,13 @@
       }
     },
     "node_modules/jest-runtime/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -17353,6 +19412,169 @@
       "integrity": "sha512-KmxeBlRjwoqCnBBKGsihFtvsBHyUFlBxJPK4FzeYcIuBfdjv6jFys44JITAgSTbQD+vIdwMEfyZklsuQX0yI1Q==",
       "peer": true
     },
+    "node_modules/jscodeshift": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.11.0.tgz",
+      "integrity": "sha512-SdRK2C7jjs4k/kT2mwtO07KJN9RnjxtKn03d9JVj6c3j9WwaLcFYsICYDnLAzY0hp+wG2nxl+Cm2jWLiNVYb8g==",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.1.6",
+        "@babel/parser": "^7.1.6",
+        "@babel/plugin-proposal-class-properties": "^7.1.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.1.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.1.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+        "@babel/preset-flow": "^7.0.0",
+        "@babel/preset-typescript": "^7.1.0",
+        "@babel/register": "^7.0.0",
+        "babel-core": "^7.0.0-bridge.0",
+        "colors": "^1.1.2",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^3.1.10",
+        "neo-async": "^2.5.0",
+        "node-dir": "^0.1.17",
+        "recast": "^0.20.3",
+        "temp": "^0.8.1",
+        "write-file-atomic": "^2.3.0"
+      },
+      "bin": {
+        "jscodeshift": "bin/jscodeshift.js"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "peer": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "peer": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "peer": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "peer": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "peer": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "peer": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "peer": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jscodeshift/node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "peer": true,
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/jsdom": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
@@ -17407,6 +19629,30 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "dependencies": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jsdom/node_modules/ws": {
@@ -17501,7 +19747,10 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/jsprim": {
       "version": "1.4.1",
@@ -17518,11 +19767,11 @@
       }
     },
     "node_modules/jsx-ast-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
-      "integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
+      "integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
       "dependencies": {
-        "array-includes": "^3.1.2",
+        "array-includes": "^3.1.3",
         "object.assign": "^4.1.2"
       },
       "engines": {
@@ -17944,14 +20193,14 @@
       }
     },
     "node_modules/logkitty/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -18106,9 +20355,9 @@
       }
     },
     "node_modules/map-obj": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
-      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "engines": {
         "node": ">=8"
       },
@@ -18659,14 +20908,14 @@
       }
     },
     "node_modules/metro-inspector-proxy/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -19065,14 +21314,14 @@
       }
     },
     "node_modules/metro/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -19183,19 +21432,19 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
+      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.32",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+      "version": "2.1.33",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
+      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
       "dependencies": {
-        "mime-db": "1.49.0"
+        "mime-db": "1.50.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -19479,9 +21728,9 @@
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "node_modules/nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.29.tgz",
+      "integrity": "sha512-dW2pUSGZ8ZnCFIlBIA31SV8huOGCHb6OwzVCc7A69rb/a+SgPBwfmLvK5TKQ3INPbRkcI8a/Owo0XbiTNH19wg==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -19584,10 +21833,25 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.5"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
       }
@@ -19698,9 +21962,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.75",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
+      "version": "1.1.77",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+      "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ=="
     },
     "node_modules/node-sass": {
       "version": "6.0.1",
@@ -19891,9 +22155,9 @@
       }
     },
     "node_modules/nth-check": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
-      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -20085,27 +22349,26 @@
       }
     },
     "node_modules/object.entries": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
-      "integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.2"
+        "es-abstract": "^1.19.1"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.4.tgz",
-      "integrity": "sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
-        "has": "^1.0.3"
+        "es-abstract": "^1.19.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -20115,16 +22378,28 @@
       }
     },
     "node_modules/object.getownpropertydescriptors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz",
-      "integrity": "sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.3.tgz",
+      "integrity": "sha512-VdDoCwvJI4QdC6ndjpqFmoL3/+HxffFBbcJzKi5hwLLqqx3mdbedRpfZDdK0SrOSauj8X4GzBvnDZl4vTN7dOw==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2"
+        "es-abstract": "^1.19.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.hasown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
+      "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -20142,13 +22417,13 @@
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
-      "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.2"
+        "es-abstract": "^1.19.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -20645,6 +22920,11 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
+    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -20789,13 +23069,12 @@
       }
     },
     "node_modules/postcss": {
-      "version": "7.0.36",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-      "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
       "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -21829,12 +24108,12 @@
       }
     },
     "node_modules/postcss-safe-parser/node_modules/postcss": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
-      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+      "version": "8.3.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.9.tgz",
+      "integrity": "sha512-f/ZFyAKh9Dnqytx5X62jgjhhzttjZS7hMsohcI7HEI5tjELX/HxCy3EFhsRxyzGvrzFF+82XPvCS8T9TFleVJw==",
       "dependencies": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
+        "nanoid": "^3.1.28",
+        "picocolors": "^0.2.1",
         "source-map-js": "^0.6.2"
       },
       "engines": {
@@ -21924,81 +24203,6 @@
         "node": ">=6.14.4"
       }
     },
-    "node_modules/postcss/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss/node_modules/chalk/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/postcss/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "node_modules/postcss/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/postcss/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss/node_modules/supports-color": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -22016,9 +24220,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.0.tgz",
-      "integrity": "sha512-DsEPLY1dE5HF3BxCRBmD4uYZ+5DCbvatnolqTqcxEgKVZnL2kUfyu7b8pPQ5+hTBkdhU9SLUmK0/pHb07RE4WQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -22059,12 +24263,12 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.0.tgz",
-      "integrity": "sha512-KyJdmgBkMscLqo8A7K77omgLx5PWPiXJswtTtFV7XgVZv2+qPk6UivpXXO+5k6ZEbWIbLoKdx1pZ6ldINzbwTA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.4.tgz",
+      "integrity": "sha512-NUjw22WJHldzxyps2YjLZkUj6q1HvjqFezkB9Y2cklN8NtVZN/kZEXGZdFw4uny3oENzV5EEMESrkI0YDUH8vg==",
       "dependencies": {
-        "@jest/types": "^27.1.1",
-        "ansi-regex": "^5.0.0",
+        "@jest/types": "^27.2.4",
+        "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
@@ -22462,9 +24666,9 @@
       }
     },
     "node_modules/react-bootstrap": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.3.tgz",
-      "integrity": "sha512-zsd4l0g68pusOmJ/R5LhTfofT+9RniCwcZsMMNFGJo97d1vT1H2nGlbhLWp/j/pfeXXj9zzR8ugUtKkadcoWnA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.4.tgz",
+      "integrity": "sha512-z3BhBD4bEZuLP8VrYqAD7OT7axdcSkkyvWBWnS2U/4MhyabUihrUyucPWkan7aMI1XIHbmH4LCpEtzWGfx/yfA==",
       "dependencies": {
         "@babel/runtime": "^7.14.0",
         "@restart/context": "^2.1.4",
@@ -22809,6 +25013,17 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
     },
+    "node_modules/react-dev-utils/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/react-dev-utils/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -22821,9 +25036,9 @@
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.18.0.tgz",
-      "integrity": "sha512-Kg/LhDkdt9J0ned1D1RfeuSdX4cKW83/valJLYswGdsYc0g2msmD0kfYozsaRacjDoZwcKlxGOES1wrkET5O6Q==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.19.1.tgz",
+      "integrity": "sha512-2wJiGffPWK0KggBjVwnTaAk+Z3MSxKInHmdzPTrBh1mAarexsa93Kw+WMX88+XjN+TtYgAiLe9xeTqcO5FfJTw==",
       "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
@@ -22865,9 +25080,9 @@
       }
     },
     "node_modules/react-dropzone": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.4.0.tgz",
-      "integrity": "sha512-5NRpAN4ZmpEn0kvtkO18rPInE7n4eVjGeTLP/c0JcGAnV+5yrpr5QHdPH27M05SP2tsjkRoRf02DCK/4fxbsog==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.4.2.tgz",
+      "integrity": "sha512-ocYzYn7Qgp0tFc1gQtUTOaHHSzVTwhWHxxY+r7cj2jJTPfMTZB5GWSJHdIVoxsl+EQENpjJ/6Zvcw0BqKZQ+Eg==",
       "dependencies": {
         "attr-accept": "^2.2.1",
         "file-selector": "^0.2.2",
@@ -22901,9 +25116,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-native": {
-      "version": "0.65.1",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.65.1.tgz",
-      "integrity": "sha512-0UOVSnlssweQZjuaUtzViCifE/4tXm8oRbxwakopc8GavPu9vLulde145GOw6QVYiOy4iL50f+2XXRdX9NmMeQ==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.0.tgz",
+      "integrity": "sha512-m26TKwzsfHVdZ1hDG+7mZ4M4ftxFFZrhtiT0OXuwfBzmNtB3xhsJtYszPeizw33c9YNp8rvehKT3c4ldDCW6kA==",
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^27.0.1",
@@ -22912,12 +25127,12 @@
         "@react-native-community/cli-platform-ios": "^6.0.0",
         "@react-native/assets": "1.0.0",
         "@react-native/normalize-color": "1.0.0",
-        "@react-native/polyfills": "1.0.0",
+        "@react-native/polyfills": "2.0.0",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "base64-js": "^1.1.2",
         "event-target-shim": "^5.0.1",
-        "hermes-engine": "~0.8.1",
+        "hermes-engine": "~0.9.0",
         "invariant": "^2.2.4",
         "jsc-android": "^250230.2.1",
         "metro-babel-register": "0.66.2",
@@ -22928,7 +25143,8 @@
         "pretty-format": "^26.5.2",
         "promise": "^8.0.3",
         "prop-types": "^15.7.2",
-        "react-devtools-core": "^4.6.0",
+        "react-devtools-core": "^4.13.0",
+        "react-native-codegen": "^0.0.7",
         "react-refresh": "^0.4.0",
         "regenerator-runtime": "^0.13.2",
         "scheduler": "^0.20.2",
@@ -22945,6 +25161,17 @@
       },
       "peerDependencies": {
         "react": "17.0.2"
+      }
+    },
+    "node_modules/react-native-codegen": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.0.7.tgz",
+      "integrity": "sha512-dwNgR8zJ3ALr480QnAmpTiqvFo+rDtq6V5oCggKhYFlRjzOmVSFn3YD41u8ltvKS5G2nQ8gCs2vReFFnRGLYng==",
+      "peer": true,
+      "dependencies": {
+        "flow-parser": "^0.121.0",
+        "jscodeshift": "^0.11.0",
+        "nullthrows": "^1.1.1"
       }
     },
     "node_modules/react-native-get-random-values": {
@@ -23461,6 +25688,27 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/readline": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw=",
+      "peer": true
+    },
+    "node_modules/recast": {
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
+      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
+      "peer": true,
+      "dependencies": {
+        "ast-types": "0.14.2",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -23817,6 +26065,54 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/resolve-url-loader/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-url-loader/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-url-loader/node_modules/chalk/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-url-loader/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/resolve-url-loader/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
     "node_modules/resolve-url-loader/node_modules/convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -23831,6 +26127,22 @@
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/resolve-url-loader/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/resolve-url-loader/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/resolve-url-loader/node_modules/json5": {
@@ -23855,6 +26167,34 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/resolve-url-loader/node_modules/postcss": {
+      "version": "7.0.36",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+      "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/resolve-url-loader/node_modules/supports-color": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/restore-cursor": {
@@ -24298,6 +26638,9 @@
         "lodash": "^4.0.0",
         "scss-tokenizer": "^0.2.3",
         "yargs": "^13.3.2"
+      },
+      "bin": {
+        "sassgraph": "bin/sassgraph"
       }
     },
     "node_modules/sass-loader": {
@@ -24702,9 +27045,9 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ=="
     },
     "node_modules/simple-plist": {
       "version": "1.1.1",
@@ -25209,6 +27552,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25230,12 +27578,11 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
     "node_modules/stack-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.4.tgz",
-      "integrity": "sha512-ERg+H//lSSYlZhBIUu+wJnqg30AbyBbpZlIhcshpn7BNzpoRODZgfyr9J+8ERf3ooC6af3u7Lcl01nleau7MrA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
       "dependencies": {
-        "escape-string-regexp": "^2.0.0",
-        "source-map-support": "^0.5.20"
+        "escape-string-regexp": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -25500,13 +27847,13 @@
       }
     },
     "node_modules/string.prototype.matchall": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.5.tgz",
-      "integrity": "sha512-Z5ZaXO0svs0M2xd/6By3qpeKpLKd9mO4v4q3oMEQrk8Ck4xOD5d5XeBOOjGrmVZZ/AHB1S0CgG4N5r1G9N3E2Q==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
+      "integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.2",
+        "es-abstract": "^1.19.1",
         "get-intrinsic": "^1.1.1",
         "has-symbols": "^1.0.2",
         "internal-slot": "^1.0.3",
@@ -25555,11 +27902,11 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -25624,9 +27971,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.3.tgz",
-      "integrity": "sha512-GVoRjsqAYZkAH16GDzfTuafuwKxzKdaaCQyLaWf37gOP1e2PPbAKWoME1OmO+c4RCKMfNrrPRDLFCNBFU45N/A=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.4.tgz",
+      "integrity": "sha512-lMzNMfDpaQOLt4B2mEbfzYS0+T7dvCXeojnlGf6f1AygvWDMcWyXYaLbyICfjVu29sErR8fnRagQfBW/N/hGgw=="
     },
     "node_modules/style-loader": {
       "version": "1.3.0",
@@ -25711,6 +28058,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
       "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
+      "deprecated": "This SVGO version is no longer supported. Upgrade to v2.x.x.",
       "dependencies": {
         "chalk": "^2.4.1",
         "coa": "^2.0.2",
@@ -25856,16 +28204,16 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "node_modules/table": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
-      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
+      "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0"
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -25929,13 +28277,13 @@
       }
     },
     "node_modules/table/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -26229,9 +28577,9 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/terser": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.8.0.tgz",
-      "integrity": "sha512-f0JH+6yMpneYcRJN314lZrSwu9eKkUFEHLN/kNy8ceh8gaRiLgFPJqrB9HsXjhEGdv4e/ekjTOFxIlL6xlma8A==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
+      "integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
       "dependencies": {
         "commander": "^2.20.0",
         "source-map": "~0.7.2",
@@ -26402,15 +28750,9 @@
       }
     },
     "node_modules/tr46": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
@@ -26842,14 +29184,14 @@
       }
     },
     "node_modules/uplot": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.13.tgz",
-      "integrity": "sha512-O5NHrZwetCUMUrYMN2/OG6v0poPXtlb68XBCERHqvvePFJvFPIuJI/SxdyZOygKzh0pAjMTX0xz3S0msAsPX0w=="
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.16.tgz",
+      "integrity": "sha512-Rh0WtFgtZdYk70Knu1VyZYbwlx5GuoIFBezZuHwlEUiREsIjOKpe3CXLXLaKc7/49Z7XhQ/bazgF/f1zercxgw=="
     },
     "node_modules/uplot-react": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/uplot-react/-/uplot-react-1.1.0.tgz",
-      "integrity": "sha512-tU6noQZ7UbXWLEAMPPJyhHfoR1aDFYh8yo2hBHiFRcy7FtmupVXOKBfvyGhO8laMyM3G1v529KL9o3bDBJOtYg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/uplot-react/-/uplot-react-1.1.1.tgz",
+      "integrity": "sha512-zCvwyZVm4nfYDi+KjaK0FppqftGzga/x+u0h2baRWj1vXMB9/hfJ1qb9gXAdXMfp17C9Rk57HoZDE9MewNWLfg==",
       "license": "MIT",
       "engines": {
         "node": ">=8.10"
@@ -28332,17 +30674,18 @@
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
     },
     "node_modules/whatwg-url": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
-      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dependencies": {
-        "lodash": "^4.7.0",
-        "tr46": "^2.1.0",
-        "webidl-conversions": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/whatwg-url/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -28674,14 +31017,14 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "peer": true,
       "dependencies": {
+        "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
+        "signal-exit": "^3.0.2"
       }
     },
     "node_modules/ws": {
@@ -28942,12 +31285,12 @@
   },
   "dependencies": {
     "@aws-amplify/analytics": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.0.15.tgz",
-      "integrity": "sha512-AP++UPU/rmXJ6Z+id5WBDSR4ioMkMYlPDlBZl0zIl67Om+J4G3Q0zJ6Q5ft6oZOkGotw+7smI3hBRSBoeF6kxg==",
+      "version": "5.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.0.19.tgz",
+      "integrity": "sha512-TDnDOTjb1gZ9ASs8JyiejVB8nIU79BMq5CSEsuBDOg7WpM5zeIRC5dXpdfw2e92w5W+ACr9vTKwmgv8c2JYeow==",
       "requires": {
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
         "@aws-sdk/client-firehose": "3.6.1",
         "@aws-sdk/client-kinesis": "3.6.1",
         "@aws-sdk/client-personalize-events": "3.6.1",
@@ -28965,24 +31308,24 @@
       }
     },
     "@aws-amplify/api": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.15.tgz",
-      "integrity": "sha512-GTm8d5PLstQxwYA+b7OPBCMarc4Nwp4A5VFxYsXHI63fOShXhqCX9Le6Ivnk0X1Vcg9hrtips//qkRFjOQyEiw==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.19.tgz",
+      "integrity": "sha512-+bP1sSAkRlbId/cCBYrPkaqybvOBRK8ldolr5CH5pWhWKGWO0FsjDRMu7gQI4wKGDk3NdmB40XUa+abT2jPz2g==",
       "requires": {
-        "@aws-amplify/api-graphql": "2.2.4",
-        "@aws-amplify/api-rest": "2.0.15"
+        "@aws-amplify/api-graphql": "2.2.8",
+        "@aws-amplify/api-rest": "2.0.19"
       }
     },
     "@aws-amplify/api-graphql": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.2.4.tgz",
-      "integrity": "sha512-ZNeOe6p8GGAPN7A1wDTfwRyfJUlMraB0K/dAUiUqb8pPmdaqq9YYbAmJ9h+7itDZ5/gahGeByx8CAhomylwwsA==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.2.8.tgz",
+      "integrity": "sha512-FMwUUNkK/WU6xCRfxDuxGZPay+Lbiz6i4rvD7mfUfeCc7zN8sZa832Buu+0CwYhlC75PlQOeU23UARDwWcConQ==",
       "requires": {
-        "@aws-amplify/api-rest": "2.0.15",
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/pubsub": "4.1.7",
+        "@aws-amplify/api-rest": "2.0.19",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/pubsub": "4.1.11",
         "graphql": "14.0.0",
         "uuid": "^3.2.1",
         "zen-observable-ts": "0.8.19"
@@ -28996,37 +31339,37 @@
       }
     },
     "@aws-amplify/api-rest": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.15.tgz",
-      "integrity": "sha512-jGPwdV2egaIoxV5sHR9UcjQtloE8hf6/ZavZdDSlOSmfztC20kfK5y+UibYdZdD4DroTrKkSlkRt9XiaXLq1tw==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.19.tgz",
+      "integrity": "sha512-FvEV/nX5beeD0zHTvwIcCrrgSfWymhvvrcDX7L5RPoitv415sruXcbj0e6ODCAm0Aw2bieW2K2fXIQ1gNa0JtQ==",
       "requires": {
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/core": "4.3.1",
         "axios": "0.21.4"
       }
     },
     "@aws-amplify/auth": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.3.5.tgz",
-      "integrity": "sha512-EhlpiMh3yIMR0Df79TQqp0z37gKpHAp1+QBRmwp0NSDAM8JMpGwt/rb7+WGyEMLVVhMMb24YuE75UshhNegQcQ==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.3.9.tgz",
+      "integrity": "sha512-E61GTg9GaHAsC5NrRqD1JGMHWvyWKeMjD8Cjt9kZEwQq7Y33oP9KJ7vUinSpGi2Eh2pnJSXg5z23Xx8BGVZeag==",
       "requires": {
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
-        "amazon-cognito-identity-js": "5.1.0",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
+        "amazon-cognito-identity-js": "5.2.0",
         "crypto-js": "^4.1.1"
       }
     },
     "@aws-amplify/cache": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.17.tgz",
-      "integrity": "sha512-I+ND9ZU65dZXIT0VR+du7qZTq61vdFJdL5uhNCh7XQATJCqJtulH86csMpfJ6gosQM3+pcg4rEPQSgDnqPaE3w==",
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.21.tgz",
+      "integrity": "sha512-tJK9ShFq4LJgOGrGI3ilr0bxrNLXLmmAsRpPwfqyQvKG7ZyUI9r8K5sQi8ov8QIhr/ogoDpQOeWcN5Fhp3Gj2A==",
       "requires": {
-        "@aws-amplify/core": "4.2.9"
+        "@aws-amplify/core": "4.3.1"
       }
     },
     "@aws-amplify/core": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.2.9.tgz",
-      "integrity": "sha512-a5xSu1fOQNxgpQsfuUkJbzRBkoD+JcasdfMpXGcgYr1Iuj5Sua4xcLe4Z9O4VaGaUy1Y7laHDP4aa+Mn/RJq9w==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.3.1.tgz",
+      "integrity": "sha512-qYQIs95F/AdBGbUFNXzKp3nAFPpQtivvBGOFQa+plqK/mzV23fh33BxRh/Hc3A+bcfpM8lBDZbIn9LPVRj3VLA==",
       "requires": {
         "@aws-crypto/sha256-js": "1.0.0-alpha.0",
         "@aws-sdk/client-cloudwatch-logs": "3.6.1",
@@ -29039,15 +31382,15 @@
       }
     },
     "@aws-amplify/datastore": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.4.3.tgz",
-      "integrity": "sha512-XgjyzOX6bY+zAsv/ylvX0aeElZfbpzq0X8bw9Zx1zrb9wIGOYfSjDC3HzeffoGkFBb/lOscFvN1jbAsxQygWsw==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.4.7.tgz",
+      "integrity": "sha512-UB9CdZCC397Gl3G8neIxTx86JSFL27ftMNIKPrYTvWQEF2sKy5zP7Kr572pW60I5cw7+FERlH3BJ+SIbzYcuKg==",
       "requires": {
-        "@aws-amplify/api": "4.0.15",
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/pubsub": "4.1.7",
-        "amazon-cognito-identity-js": "5.1.0",
+        "@aws-amplify/api": "4.0.19",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/pubsub": "4.1.11",
+        "amazon-cognito-identity-js": "5.2.0",
         "idb": "5.0.6",
         "immer": "9.0.6",
         "ulid": "2.3.0",
@@ -29063,22 +31406,32 @@
         }
       }
     },
-    "@aws-amplify/interactions": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-4.0.15.tgz",
-      "integrity": "sha512-OaLAGzu/gu2GNDZLX41i1bT67eEnBJiyyS/eh5c3skrFvYI3zyjAEzD3cIsOVU2LwhnLZRMNSwoXNqAlkFbtHQ==",
+    "@aws-amplify/geo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/geo/-/geo-1.1.1.tgz",
+      "integrity": "sha512-sasyp6l+/ZMXcCVWaKyEZiV7hGGzTQV9D3dbU1iqi6/BHEFRfJxnubt3P39XaR672SQ1e8qhFDx36TiL5mePcA==",
       "requires": {
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-sdk/client-location": "3.22.0",
+        "camelcase-keys": "6.2.2"
+      }
+    },
+    "@aws-amplify/interactions": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-4.0.19.tgz",
+      "integrity": "sha512-g33BUZbMkI6Qkwa9KyCCHMaoUmprY8XVJRVuamVo6+3qCMZXn5KDXa/cTad7+NCASDzMo/XWb65vmWeo9hyw8Q==",
+      "requires": {
+        "@aws-amplify/core": "4.3.1",
         "@aws-sdk/client-lex-runtime-service": "3.6.1"
       }
     },
     "@aws-amplify/predictions": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-4.0.15.tgz",
-      "integrity": "sha512-bfsWlRd6ZyV5PbqSohpug9KzW5GR82K2UdFU+s90UPCHuj78eSFLflttl/ako95u7tFFFq4MUWtC+rWX5+miMQ==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-4.0.19.tgz",
+      "integrity": "sha512-bHT7gYECVLkkcenQ8filTqeDndx+PrV1MlncYfgsaZp0xjnZ4WaQsvIvSf+ZUvQxk3ayzn85p0MRwPKJR4yEqQ==",
       "requires": {
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/storage": "4.3.10",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/storage": "4.4.2",
         "@aws-sdk/client-comprehend": "3.6.1",
         "@aws-sdk/client-polly": "3.6.1",
         "@aws-sdk/client-rekognition": "3.6.1",
@@ -29097,13 +31450,13 @@
       }
     },
     "@aws-amplify/pubsub": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.1.7.tgz",
-      "integrity": "sha512-ES9E4utrsers96bHl1E7clKZanlH9modcjjovJPswLi85q0tybTAG+fi9QRYHp07XSN+EjmEF4Jxrw47w4Hmzw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.1.11.tgz",
+      "integrity": "sha512-Z7xZ244LY6sIK2i6NIBkhuZGXhcVPLFLhyZc1adACuxDWPnZo0Xtiu6SWdZ1Sf575iHRHBCg6DG6TWf8m1YpaA==",
       "requires": {
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
         "graphql": "14.0.0",
         "paho-mqtt": "^1.1.0",
         "uuid": "^3.2.1",
@@ -29118,11 +31471,11 @@
       }
     },
     "@aws-amplify/storage": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-4.3.10.tgz",
-      "integrity": "sha512-Mplgkd+mmWxoB7P4m+0UK++Nb+97eeH7/ZKemLIFL8s8N1n2voQZJLK9uTkY3vvIS17sT9QvWCMl63v6TPnebw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-4.4.2.tgz",
+      "integrity": "sha512-BjdDq+PcKCS7taMcwc3moKEIykw0vfgzKBClSBBwyXP5ewHQJNYMhe7sGlVt17MyFBTQkBVWJtt9QsvcNcw98w==",
       "requires": {
-        "@aws-amplify/core": "4.2.9",
+        "@aws-amplify/core": "4.3.1",
         "@aws-sdk/client-s3": "3.6.1",
         "@aws-sdk/s3-request-presigner": "3.6.1",
         "@aws-sdk/util-create-request": "3.6.1",
@@ -29138,35 +31491,37 @@
       "integrity": "sha512-LxbmPGD/S4bWzUh2PXMPSt/rXeUVJTsCbMpwH18XilTkXgOSmKH/eyVZNXUBY8C/xwqjzMTC68EtTlsM1DCq1A=="
     },
     "@aws-amplify/ui-components": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-components/-/ui-components-1.7.8.tgz",
-      "integrity": "sha512-BR31SXO5ppyhhOkw+Qys2sSkDV0rjHDO/5NAkJwP9OhOm47QgIIaKCdTurIYnaskelMflKgetVAts+2xUymegg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-components/-/ui-components-1.8.2.tgz",
+      "integrity": "sha512-w+iJh66itkpZ13MSmIL0LW5frrk4dP9FdcH5KvGAgUDjLSM4dOqeBa1wuPHHJ5pkilByZMK9LHkqP7TIAMdWdA==",
       "requires": {
         "qrcode": "^1.4.4",
         "uuid": "^8.2.0"
       }
     },
     "@aws-amplify/ui-react": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-1.2.15.tgz",
-      "integrity": "sha512-baBOFmJiuqiaeEZaT/TW2ZjxcsdciwiCTFC2qaOXJHMNAYyUzMXY7mOHeaNblBrI+uzppm4dvjVPqmB8zcjr7A==",
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-1.2.19.tgz",
+      "integrity": "sha512-qf+XZujT/i8eNHgV7P5P2UGCTzJldrgYCdSW15jSJhPSZ3iJNvHjVbeB7FAdIIm2hH65/WJkF2kixsf5G6rwEQ==",
       "requires": {
-        "@aws-amplify/ui-components": "1.7.8"
+        "@aws-amplify/ui-components": "1.8.2"
       }
     },
     "@aws-amplify/xr": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-3.0.15.tgz",
-      "integrity": "sha512-sINduNuGaPjeyZ/9iDbzevHyNWiHRHYeDVfzbgNFE8lf92uqN3m1rN8acg7wJHjnaDpw/0qFPGzN/tT+s/SvDg==",
+      "version": "3.0.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-3.0.19.tgz",
+      "integrity": "sha512-wogJDDVLXrDribhhW/OUK8ZTqFAmVuDHn8O/tusBOdpnjfYULddDML6BSBtYMsP3TGkOz7c7v/HPTtWBfRR2ZQ==",
       "requires": {
-        "@aws-amplify/core": "4.2.9"
+        "@aws-amplify/core": "4.3.1"
       }
     },
     "@aws-crypto/crc32": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.1.0.tgz",
-      "integrity": "sha512-ifvfaaJVvT+JUTi3zSkX4wtuGGVJrAcjN7ftg+JiE/frNBP3zNwo4xipzWBsMLZfNuzMZuaesEYyqkZcs5tzCQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.2.1.tgz",
+      "integrity": "sha512-Ydso55lIn3Vudui5jXNKcxmyVr9BNWeIkAhleGuG9zpb0Pu5yXf2Jth2A07fUyLSXX2gwfv0d84zwvKK2FMbuA==",
       "requires": {
+        "@aws-crypto/util": "^1.2.1",
+        "@aws-sdk/types": "^3.1.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -29193,26 +31548,26 @@
       }
     },
     "@aws-crypto/sha256-browser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.1.1.tgz",
-      "integrity": "sha512-nS4vdan97It6HcweV58WXtjPbPSc0JXd3sAwlw3Ou5Mc3WllSycAS32Tv2LRn8butNQoU9AE3jEQAOgiMdNC1Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.1.tgz",
+      "integrity": "sha512-WX/Wp6sXPhcBWx/w1aSJv3bDJL0ut5Ik6hl7yfqA1pn3cfsahl4rgHzRRXqYfJ+hnhnCqdgadS17wyBbVPsK+w==",
       "requires": {
         "@aws-crypto/ie11-detection": "^1.0.0",
-        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-crypto/sha256-js": "^1.2.1",
         "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-crypto/util": "^1.2.1",
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           }
         },
@@ -29258,6 +31613,23 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
       "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
       "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.1.tgz",
+      "integrity": "sha512-H6Qrl28lzGGXZgLkdP7DQpJ3D3jJagQJugziThcqZCJVUT0HABHJt9EQMiiuf93KcUV/MMoisl56UfCxCFfmWQ==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -29354,12 +31726,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -29411,12 +31783,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -29469,12 +31841,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -29531,12 +31903,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -29592,12 +31964,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -29649,12 +32021,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -29663,6 +32035,471 @@
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
             }
+          }
+        }
+      }
+    },
+    "@aws-sdk/client-location": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-location/-/client-location-3.22.0.tgz",
+      "integrity": "sha512-1DOpMgEtln581fo2rYjDpgsKE5ScpFBPwbZKYDjiPo8qF3Rcl/LKI7HLgmeCDQBWobvOtnKB8+9bZVpqx1rEUA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.1.0",
+        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-sdk/client-sts": "3.22.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/credential-provider-node": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.1",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+          "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+          "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.22.0.tgz",
+          "integrity": "sha512-vbM4hcH28fyos2BAtt1ANhEEZynYpFgdMTdw2d8jJMDITE4gtMzomVOdz/7ZVf9WFUJf9iYV6U3fXSqalFeeew==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.22.0.tgz",
+          "integrity": "sha512-d1nAy6OM+7+Yat5Yx0u5r2lRZxcCaxykblDO2rcicdsINxxcSglQsD4pud3t/dfyUfkrnznlNE5VY0H+90kx8g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.22.0.tgz",
+          "integrity": "sha512-uq9vn+qNmhBNaWu1CkuLKAKJPce7h2O8uuDRLwPfk5zWhLgeW1pjGyMyG+8aX1nytzNH+TXL+GvkMHf/Qzn11w==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.22.0",
+            "@aws-sdk/credential-provider-imds": "3.22.0",
+            "@aws-sdk/credential-provider-sso": "3.22.0",
+            "@aws-sdk/credential-provider-web-identity": "3.22.0",
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-credentials": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.22.0.tgz",
+          "integrity": "sha512-A3MONEY+Ul9gB2whV69n5V2sMeVXXYVA1MejG3v51d7csEi/XNlBQK5IfhEur6qi49km84xVsfHdO5/a/DNTqg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.22.0",
+            "@aws-sdk/credential-provider-imds": "3.22.0",
+            "@aws-sdk/credential-provider-ini": "3.22.0",
+            "@aws-sdk/credential-provider-process": "3.22.0",
+            "@aws-sdk/credential-provider-sso": "3.22.0",
+            "@aws-sdk/credential-provider-web-identity": "3.22.0",
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.22.0.tgz",
+          "integrity": "sha512-5glIbC8jTiiBEMZnsX8KN9m3IC9EdVOj8H+DavwHpTv801j27NhuNYwR2JOLxhjW+PiNX1iyA5k7wfUlLJultQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-credentials": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+          "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-base64-browser": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+          "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+          "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+          "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+          "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+          "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+          "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+          "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/service-error-classification": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+          "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+          "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+          "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+          "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+          "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+          "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+          "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+          "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+          "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+          "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+          "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+          "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+          "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-hex-encoding": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+          "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+          "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+          "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+          "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+          "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+          "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+          "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+          "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+          "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+          "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+          "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+          "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+          "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+          "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
           }
         }
       }
@@ -29706,12 +32543,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -29763,12 +32600,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -29820,12 +32657,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -29878,12 +32715,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -29950,12 +32787,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -29965,6 +32802,863 @@
               "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
             }
           }
+        }
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.22.0.tgz",
+      "integrity": "sha512-LXskY6Mvo/wk2dL1FNTazzhWiHiI3+nJdAT7iNOAg2Q1EUGVAfK+6EccEFPqaBtJDN4kv047HxXNVXKxJSyICg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.1",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+          "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+          "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+          "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-base64-browser": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+          "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+          "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+          "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+          "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+          "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+          "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+          "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/service-error-classification": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+          "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+          "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+          "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+          "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+          "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+          "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+          "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+          "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+          "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+          "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+          "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+          "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-hex-encoding": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+          "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+          "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+          "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+          "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+          "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+          "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+          "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+          "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+          "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+          "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+          "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+          "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+          "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+          "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.22.0.tgz",
+      "integrity": "sha512-3htpVHnnD4AvHPo+8VfkPbegN4WPAqcNIXPKCMNkNbYmnLLbtB4MlzKsRgpBP4LvRhi/2kt8fapRTQuTXo/8Mg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/credential-provider-node": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-sdk-sts": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.1",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+          "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+          "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.22.0.tgz",
+          "integrity": "sha512-vbM4hcH28fyos2BAtt1ANhEEZynYpFgdMTdw2d8jJMDITE4gtMzomVOdz/7ZVf9WFUJf9iYV6U3fXSqalFeeew==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.22.0.tgz",
+          "integrity": "sha512-d1nAy6OM+7+Yat5Yx0u5r2lRZxcCaxykblDO2rcicdsINxxcSglQsD4pud3t/dfyUfkrnznlNE5VY0H+90kx8g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.22.0.tgz",
+          "integrity": "sha512-uq9vn+qNmhBNaWu1CkuLKAKJPce7h2O8uuDRLwPfk5zWhLgeW1pjGyMyG+8aX1nytzNH+TXL+GvkMHf/Qzn11w==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.22.0",
+            "@aws-sdk/credential-provider-imds": "3.22.0",
+            "@aws-sdk/credential-provider-sso": "3.22.0",
+            "@aws-sdk/credential-provider-web-identity": "3.22.0",
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-credentials": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.22.0.tgz",
+          "integrity": "sha512-A3MONEY+Ul9gB2whV69n5V2sMeVXXYVA1MejG3v51d7csEi/XNlBQK5IfhEur6qi49km84xVsfHdO5/a/DNTqg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.22.0",
+            "@aws-sdk/credential-provider-imds": "3.22.0",
+            "@aws-sdk/credential-provider-ini": "3.22.0",
+            "@aws-sdk/credential-provider-process": "3.22.0",
+            "@aws-sdk/credential-provider-sso": "3.22.0",
+            "@aws-sdk/credential-provider-web-identity": "3.22.0",
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.22.0.tgz",
+          "integrity": "sha512-5glIbC8jTiiBEMZnsX8KN9m3IC9EdVOj8H+DavwHpTv801j27NhuNYwR2JOLxhjW+PiNX1iyA5k7wfUlLJultQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-credentials": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+          "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-base64-browser": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+          "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+          "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+          "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+          "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+          "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+          "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+          "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/service-error-classification": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+          "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+          "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+          "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+          "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+          "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+          "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+          "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+          "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+          "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+          "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+          "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+          "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+          "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-hex-encoding": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+          "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+          "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+          "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+          "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+          "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+          "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+          "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+          "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+          "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+          "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+          "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+          "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+          "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+          "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "3.19.0",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+          "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
         }
       }
     },
@@ -30007,12 +33701,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -30065,12 +33759,12 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
-          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.1.tgz",
+          "integrity": "sha512-KtZ4qFDWZy6pKcky6RvwSytR/I8vPX9Z47pXh9sOuTcxjjtcegzS2uupg9vo0vbFcAWkSHVOEmNPh6ygiC3VFQ==",
           "requires": {
+            "@aws-crypto/util": "^1.2.1",
             "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
@@ -30213,6 +33907,69 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.22.0.tgz",
+      "integrity": "sha512-lgqvFIJctJmD2kjWY/BjXdKhH2Fndj/8CPRTDs8ja9AOXU/C3ExnDA15vqhDm5JvKmlkafQEtmypg5n+AZCwSw==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+          "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+          "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+          "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.22.0.tgz",
+      "integrity": "sha512-4CTVRuh3EMbH+EYtY0balZ+05BvjcTcW+n0uISK4a4KSMvVBWbhmiIm3U5ducPZfKAenf2mS0UHYRmV/nRLJzA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+          "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+          "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
         }
       }
     },
@@ -30598,6 +34355,92 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.22.0.tgz",
+      "integrity": "sha512-CpfPpKTKEcxyooDwa7tFZDhhB3RwByxwzQ+jEAUcDvSLRALyNb1jvwAfgJJQBx6uZgqj97Z46UYpMJIDoCebTA==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/signature-v4": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+          "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+          "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+          "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+          "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+          "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-hex-encoding": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+          "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+          "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+          "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
         }
       }
     },
@@ -31012,6 +34855,25 @@
         }
       }
     },
+    "@aws-sdk/util-credentials": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.22.0.tgz",
+      "integrity": "sha512-PI4aYgYgLIM8m2zNxXCK/GDlcHUX2akN1QKshM7uPhp5ZsjXVpR//FQ9DsRp+gKFk8VN+4zGo3eIIuJOAVEe3Q==",
+      "requires": {
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+          "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        }
+      }
+    },
     "@aws-sdk/util-format-url": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.6.1.tgz",
@@ -31045,9 +34907,9 @@
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.29.0.tgz",
-      "integrity": "sha512-gvcbl9UdTOvuCCzgbtTTsKnL1l/cnT/CFl0f6ZCQ6qubUTRCuL/aK8DvgWa1n9p/ddCiVKPLmHu/L1xtX4gc0A==",
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.35.0.tgz",
+      "integrity": "sha512-ZxmoNR378O1RGy0nqbynX1XhZOkGuNsiyeYXFNLf7Ye6Ye07bJO+hROWKj62ZjvRjRkJOsXYztXes4qaxf0vVg==",
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -31165,9 +35027,9 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
+      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
       "requires": {
         "@babel/highlight": "^7.14.5"
       }
@@ -31178,19 +35040,19 @@
       "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA=="
     },
     "@babel/core": {
-      "version": "7.15.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
-      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.8.tgz",
+      "integrity": "sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==",
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
+        "@babel/code-frame": "^7.15.8",
+        "@babel/generator": "^7.15.8",
         "@babel/helper-compilation-targets": "^7.15.4",
-        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.8",
         "@babel/helpers": "^7.15.4",
-        "@babel/parser": "^7.15.5",
+        "@babel/parser": "^7.15.8",
         "@babel/template": "^7.15.4",
         "@babel/traverse": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/types": "^7.15.6",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -31212,11 +35074,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
-      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
+      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
       "requires": {
-        "@babel/types": "^7.15.4",
+        "@babel/types": "^7.15.6",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -31358,18 +35220,18 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
-      "integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz",
+      "integrity": "sha512-DfAfA6PfpG8t4S6npwzLvTUpp0sS7JrcuaMiy1Y5645laRJIp/LiLGIBbQKaXSInK8tiGNI7FL7L8UvB8gdUZg==",
       "requires": {
         "@babel/helper-module-imports": "^7.15.4",
         "@babel/helper-replace-supers": "^7.15.4",
         "@babel/helper-simple-access": "^7.15.4",
         "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "@babel/template": "^7.15.4",
         "@babel/traverse": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.15.6"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -31431,9 +35293,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
     },
     "@babel/helper-validator-option": {
       "version": "7.14.5",
@@ -31523,9 +35385,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
-      "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q=="
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
+      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA=="
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.15.4",
@@ -31538,9 +35400,9 @@
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.4.tgz",
-      "integrity": "sha512-2zt2g5vTXpMC3OmK6uyjvdXptbhBXfA77XGrd3gh93zwG8lZYBLOBImiGBEG0RANu3JqKEACCz5CGk73OJROBw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.8.tgz",
+      "integrity": "sha512-2Z5F2R2ibINTc63mY7FLqGfEbmofrHU9FitJW1Q7aPaKFhiPvSq6QEt/BoWN5oME3GVyjcRuNNSRbb9LC0CSWA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-remap-async-to-generator": "^7.15.4",
@@ -32179,15 +36041,15 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.0.tgz",
-      "integrity": "sha512-sfHYkLGjhzWTq6xsuQ01oEsUYjkHRux9fW1iUA68dC7Qd8BS1Unq4aZ8itmQp95zUzIcyR2EbNMTzAicFj+guw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.8.tgz",
+      "integrity": "sha512-+6zsde91jMzzvkzuEA3k63zCw+tm/GvuuabkpisgbDMTPQsIMHllE3XczJFFtEHLjjhKQFZmGQVRdELetlWpVw==",
       "peer": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-module-imports": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
         "babel-plugin-polyfill-corejs2": "^0.2.2",
-        "babel-plugin-polyfill-corejs3": "^0.2.2",
+        "babel-plugin-polyfill-corejs3": "^0.2.5",
         "babel-plugin-polyfill-regenerator": "^0.2.2",
         "semver": "^6.3.0"
       },
@@ -32209,12 +36071,12 @@
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.6.tgz",
-      "integrity": "sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.15.8.tgz",
+      "integrity": "sha512-/daZ8s2tNaRekl9YJa9X4bzjpeRZLt122cpgFnQPLGUe61PH8zMEBmYqKkW5xF5JUEh5buEGXJoQpqBmIbpmEQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.15.4"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -32242,9 +36104,9 @@
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.4.tgz",
-      "integrity": "sha512-sM1/FEjwYjXvMwu1PJStH11kJ154zd/lpY56NQJ5qH2D0mabMv1CAy/kdvS9RP4Xgfj9fBBA3JiSLdDHgXdzOA==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.8.tgz",
+      "integrity": "sha512-ZXIkJpbaf6/EsmjeTbiJN/yMxWPFWvlr7sEG1P95Xb4S4IBcrf2n7s/fItIhsAmOf8oSh3VJPDppO6ExfAfKRQ==",
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -32269,16 +36131,16 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.6.tgz",
-      "integrity": "sha512-L+6jcGn7EWu7zqaO2uoTDjjMBW+88FXzV8KvrBl2z6MtRNxlsmUNRlZPaNNPUTgqhyC5DHNFk/2Jmra+ublZWw==",
+      "version": "7.15.8",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.8.tgz",
+      "integrity": "sha512-rCC0wH8husJgY4FPbHsiYyiLxSY8oMDJH7Rl6RQMknbN9oDDHhM9RDFvnGM2MgkbUJzSQB4gtuwygY5mCqGSsA==",
       "requires": {
         "@babel/compat-data": "^7.15.0",
         "@babel/helper-compilation-targets": "^7.15.4",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.15.4",
-        "@babel/plugin-proposal-async-generator-functions": "^7.15.4",
+        "@babel/plugin-proposal-async-generator-functions": "^7.15.8",
         "@babel/plugin-proposal-class-properties": "^7.14.5",
         "@babel/plugin-proposal-class-static-block": "^7.15.4",
         "@babel/plugin-proposal-dynamic-import": "^7.14.5",
@@ -32333,7 +36195,7 @@
         "@babel/plugin-transform-regenerator": "^7.14.5",
         "@babel/plugin-transform-reserved-words": "^7.14.5",
         "@babel/plugin-transform-shorthand-properties": "^7.14.5",
-        "@babel/plugin-transform-spread": "^7.14.6",
+        "@babel/plugin-transform-spread": "^7.15.8",
         "@babel/plugin-transform-sticky-regex": "^7.14.5",
         "@babel/plugin-transform-template-literals": "^7.14.5",
         "@babel/plugin-transform-typeof-symbol": "^7.14.5",
@@ -32342,7 +36204,7 @@
         "@babel/preset-modules": "^0.1.4",
         "@babel/types": "^7.15.6",
         "babel-plugin-polyfill-corejs2": "^0.2.2",
-        "babel-plugin-polyfill-corejs3": "^0.2.2",
+        "babel-plugin-polyfill-corejs3": "^0.2.5",
         "babel-plugin-polyfill-regenerator": "^0.2.2",
         "core-js-compat": "^3.16.0",
         "semver": "^6.3.0"
@@ -32353,6 +36215,17 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
+      }
+    },
+    "@babel/preset-flow": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.14.5.tgz",
+      "integrity": "sha512-pP5QEb4qRUSVGzzKx9xqRuHUrM/jEzMqdrZpdMA+oUCRgd5zM1qGr5y5+ZgAL/1tVv1H0dyk5t4SKJntqyiVtg==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-flow-strip-types": "^7.14.5"
       }
     },
     "@babel/preset-modules": {
@@ -32381,12 +36254,14 @@
       }
     },
     "@babel/preset-typescript": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.12.1.tgz",
-      "integrity": "sha512-hNK/DhmoJPsksdHuI/RVrcEws7GN5eamhi28JkO52MqIxU8Z0QpmiSOQxZHWOHV7I3P4UjHV97ay4TcamMA6Kw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.15.0.tgz",
+      "integrity": "sha512-lt0Y/8V3y06Wq/8H/u0WakrqciZ7Fz7mwPDHWUJAXlABL5hiUG42BNlRXiELNjeWjO5rWmnNKlx+yzJvxezHow==",
+      "peer": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-transform-typescript": "^7.12.1"
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-typescript": "^7.15.0"
       }
     },
     "@babel/register": {
@@ -32517,9 +36392,9 @@
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
     "@hapi/hoek": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
-      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
       "peer": true
     },
     "@hapi/joi": {
@@ -32573,9 +36448,9 @@
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w=="
     },
     "@ionic/core": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.8.0.tgz",
-      "integrity": "sha512-rzjAgS5pJgy/Ggtq1lgogl6thiEMMusnm96D6RsVLa4nxYrHIt9Oua062uIYrf0LdasqatekSxIqcU5Fl9YKEg==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.8.2.tgz",
+      "integrity": "sha512-BWIh6hyhq+tzVvebPMfRa+IhTV5/yXh4wO3a0U3Qo4PL4KDzWyBJfoiPi6bOEc+BAlFnCtOooTTXTumgXXOojg==",
       "requires": {
         "@stencil/core": "^2.4.0",
         "ionicons": "^5.5.3",
@@ -32583,11 +36458,11 @@
       }
     },
     "@ionic/react": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-5.8.0.tgz",
-      "integrity": "sha512-xV1X+veFcYA2pYc7FnkUumNL5R8I7K6nuz2yl3ipco0EocWWMnjdAoepLuNp7L+hmFaLm2ZKrFTo7v2HtVwS4Q==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-5.8.2.tgz",
+      "integrity": "sha512-xOMjEXedN5cbB2GUXZnv5eD7BJOcSI0sqWAIj9/nuARu3eizGQG7WPVrdFeIgqJII1x2SnCZHZHKZI2iMy95zQ==",
       "requires": {
-        "@ionic/core": "5.8.0",
+        "@ionic/core": "5.8.2",
         "ionicons": "^5.1.2",
         "tslib": "*"
       }
@@ -32875,12 +36750,12 @@
       }
     },
     "@jest/create-cache-key-function": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.2.0.tgz",
-      "integrity": "sha512-o+Q6CAT/mPNxiOGn6+UD/buY8O5cyDHbjD8FXDCUZbzfCwt6zYlmCMObLE+k1i/XJc5M3YIvEeaa6L7x7uAeYQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.2.4.tgz",
+      "integrity": "sha512-Cd9A6ugtkkHiQHDNbifdFrBBTgsKHp1KgCAjyAGMCrxFudR2icTKIPkXN2R2/IoMAMObUidMRBLDJy/RgX7uDQ==",
       "peer": true,
       "requires": {
-        "@jest/types": "^27.1.1"
+        "@jest/types": "^27.2.4"
       }
     },
     "@jest/environment": {
@@ -33256,13 +37131,24 @@
           "requires": {
             "@types/yargs-parser": "*"
           }
+        },
+        "write-file-atomic": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
         }
       }
     },
     "@jest/types": {
-      "version": "27.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.1.tgz",
-      "integrity": "sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.4.tgz",
+      "integrity": "sha512-IDO2ezTxeMvQAHxzG/ZvEyA47q0aVfzT95rGFl7bZs/Go0aIucvfDbS2rmnoEdXxlLQhcolmoG/wvL/uKx4tKA==",
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -33320,20 +37206,21 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.1.tgz",
-      "integrity": "sha512-HnUhk1Sy9IuKrxEMdIRCxpIqPw6BFsbYSEUO9p/hNw5sMld/+3OLMWQP80F8/db9qsv3qUjs7ZR5bS/R+iinXw=="
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
+      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
     },
     "@react-native-community/cli": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.0.0.tgz",
-      "integrity": "sha512-wTbdpai58WzUBrw8lNbF/cSzX3pOWz+y+d46ip3M3Abd5yHNRvhuejRMVQC1o9luOM+ESJa4imYSbVdh7y5g+w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.1.0.tgz",
+      "integrity": "sha512-Ck1XjvsnYYVYqooxmSlvRvGMGgxj3t+evUGlg80b+TxnurhlGq8D8pW7++L/sECChI43YWMBtLIdAYG/lGkN8Q==",
       "peer": true,
       "requires": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-hermes": "^6.0.0",
-        "@react-native-community/cli-server-api": "^6.0.0-rc.0",
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-hermes": "^6.1.0",
+        "@react-native-community/cli-plugin-metro": "^6.1.0",
+        "@react-native-community/cli-server-api": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "@react-native-community/cli-types": "^6.0.0",
         "appdirsjs": "^1.2.4",
         "chalk": "^3.0.0",
@@ -33350,12 +37237,6 @@
         "joi": "^17.2.1",
         "leven": "^3.1.0",
         "lodash": "^4.17.15",
-        "metro": "^0.66.1",
-        "metro-config": "^0.66.1",
-        "metro-core": "^0.66.1",
-        "metro-react-native-babel-transformer": "^0.66.1",
-        "metro-resolver": "^0.66.1",
-        "metro-runtime": "^0.66.1",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
         "node-stream-zip": "^1.9.1",
@@ -33521,13 +37402,13 @@
       }
     },
     "@react-native-community/cli-hermes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.0.0.tgz",
-      "integrity": "sha512-YUX8MEmDsEYdFuo/juCZUUDPPRQ/su3K/SPcSVmv7AIAwO/7ItuQ7+58PRI914XNvnRmY1GNVHKfWhUoNXMxvA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.1.0.tgz",
+      "integrity": "sha512-BJyzGlUqnggbBL4Vh4cIC08oKOK4PoelxZFEo7TjFjfdBKvbM6955JN77ExJ7IdeLuGVpY4vaMwAJdx5l7LxKg==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-platform-android": "^6.0.0",
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-platform-android": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "chalk": "^3.0.0",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
@@ -33546,12 +37427,12 @@
       }
     },
     "@react-native-community/cli-platform-android": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.0.0.tgz",
-      "integrity": "sha512-yXyrM2elKM8/thf1d8EMMm0l0KdeWmIMhWZzCoRpCIQoUuVtiCEMyrZF+aufvNvy74soKiCFeAmGNI8LPk2hzg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.1.0.tgz",
+      "integrity": "sha512-MBYGfgCpieoqskKc5QyQYIPc74DBEW60JaacQLntHjPLCEXG+hPsJi3AuXeNTJYPki5pyiSp3kviqciUvrS96A==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "chalk": "^3.0.0",
         "execa": "^1.0.0",
         "fs-extra": "^8.1.0",
@@ -33576,12 +37457,12 @@
       }
     },
     "@react-native-community/cli-platform-ios": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.0.0.tgz",
-      "integrity": "sha512-+f6X4jDGuPpVcY2NsVAstnId4stnG7EvzLUhs7FUpMFjzss9c1ZJhsqQeKikOtzZbwLzFrpki/QrTK79ur7xSg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.1.0.tgz",
+      "integrity": "sha512-whIm55fUeJUHrqZ2ecZ6FycZ5c/R3ZK8ViHwZQ+wM4uhXY8YSkrjnrJPUg68Q8inLkrAliLisypfm1z+VqJljw==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "chalk": "^3.0.0",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
@@ -33602,14 +37483,45 @@
         }
       }
     },
+    "@react-native-community/cli-plugin-metro": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.1.0.tgz",
+      "integrity": "sha512-ltHJquEgA6H4OTIUqWIkNm/xxAB9D4DK2K9M0jie9FfkOoqBXA7QS2WnC8GEa6a+3VIDwevB0RJsch218FdZCw==",
+      "peer": true,
+      "requires": {
+        "@react-native-community/cli-server-api": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.1.0",
+        "chalk": "^3.0.0",
+        "metro": "^0.66.1",
+        "metro-config": "^0.66.1",
+        "metro-core": "^0.66.1",
+        "metro-react-native-babel-transformer": "^0.66.1",
+        "metro-resolver": "^0.66.1",
+        "metro-runtime": "^0.66.1",
+        "mkdirp": "^0.5.1",
+        "readline": "^1.3.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "peer": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
     "@react-native-community/cli-server-api": {
-      "version": "6.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.0.0-rc.0.tgz",
-      "integrity": "sha512-shPG9RXXpDYeluoB3tzaYU9Ut0jTvZ3osatLLUJkWjbRjFreK9zUcnoFDDrsVT6fEoyeBftp5DSa+wCUnPmcJA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.1.0.tgz",
+      "integrity": "sha512-WEJzdoF4JNUogZAd+Gdgbr+D/S/PHGjxH+PDjk3ST9pAUxEHb6naNwEl5dSJUY/ecBV63latNZkKunRyvFAx9A==",
       "peer": true,
       "requires": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-tools": "^6.0.0-rc.0",
+        "@react-native-community/cli-tools": "^6.1.0",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
@@ -33672,16 +37584,19 @@
       }
     },
     "@react-native-community/cli-tools": {
-      "version": "6.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.0.0-rc.0.tgz",
-      "integrity": "sha512-N31BhNacTe0UGYQxUx0WHWPKnF4pBe62hNRV9WNJdWqVl4TP45T1Fd/7ziiosfalIar+tOo9Sk0Pqq48x1+wNw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.1.0.tgz",
+      "integrity": "sha512-MT8syhvk0vpfyYyHlcDoGicKcqMtBN7WPmDeyW16u+eKBtw/+EKq+86cFCuOHCfHK20ujG1mZqA1txxlCbu8GA==",
       "peer": true,
       "requires": {
+        "appdirsjs": "^1.2.4",
         "chalk": "^3.0.0",
         "lodash": "^4.17.15",
         "mime": "^2.4.1",
+        "mkdirp": "^0.5.1",
         "node-fetch": "^2.6.0",
         "open": "^6.2.0",
+        "semver": "^6.3.0",
         "shell-quote": "1.6.1"
       },
       "dependencies": {
@@ -33694,6 +37609,12 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "peer": true
         }
       }
     },
@@ -33719,9 +37640,9 @@
       "peer": true
     },
     "@react-native/polyfills": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-1.0.0.tgz",
-      "integrity": "sha512-0jbp4RxjYopTsIdLl+/Fy2TiwVYHy4mgeu07DG4b/LyM0OS/+lPP5c9sbnt/AMlnF6qz2JRZpPpGw1eMNS6A4w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
+      "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==",
       "peer": true
     },
     "@restart/context": {
@@ -34021,9 +37942,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.5.0.tgz",
-      "integrity": "sha512-O0fmHFaPlqaYCpa/cBL0cvroMridb9vZsMLacgIqrlxj+fd+bGF8UfAgwsLCHRF84KLBafWlm9CuOvxeNTlodw==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.7.2.tgz",
+      "integrity": "sha512-2zN0Zv9dMnaMAd4c/1E1ZChu4QrICyvWtkUvHFQBPhS1oG3VYGcM7SLGLYdda7187ILRXzIUOvOsbXQm4EASjA==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -34063,9 +37984,9 @@
       }
     },
     "@testing-library/react": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.0.tgz",
-      "integrity": "sha512-Ge3Ht3qXE82Yv9lyPpQ7ZWgzo/HgOcHu569Y4ZGWcZME38iOFiOg87qnu6hTEa8jTJVL7zYovnvD3GE2nsNIoQ==",
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
+      "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0"
@@ -34132,9 +38053,9 @@
       "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
     "@types/dompurify": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.2.3.tgz",
-      "integrity": "sha512-CLtc2mZK8+axmrz1JqtpklO/Kvn38arGc8o1l3UVopZaXXuer9ONdZwJ/9f226GrhRLtUmLr9WrvZsRSNpS8og==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.3.1.tgz",
+      "integrity": "sha512-YJth9qa0V/E6/XPH1Jq4BC8uCMmO8V1fKWn8PCvuZcAhMn7q0ez9LW6naQT04UZzjFfAPhyRMZmI2a2rbMlEFA==",
       "dev": true,
       "requires": {
         "@types/trusted-types": "*"
@@ -34291,9 +38212,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw=="
     },
     "@types/prop-types": {
       "version": "15.7.4",
@@ -34306,9 +38227,9 @@
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
     },
     "@types/react": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.21.tgz",
-      "integrity": "sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==",
+      "version": "17.0.27",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.27.tgz",
+      "integrity": "sha512-zgiJwtsggVGtr53MndV7jfiUESTqrbxOcBvwfe6KS/9bzaVPCTDieTWnFNecVNx6EAaapg5xsLLWFfHHR437AA==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -34324,9 +38245,9 @@
       }
     },
     "@types/react-router": {
-      "version": "5.1.16",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.16.tgz",
-      "integrity": "sha512-8d7nR/fNSqlTFGHti0R3F9WwIertOaaA1UEB8/jr5l5mDMOs4CidEgvvYMw4ivqrBK+vtVLxyTj2P+Pr/dtgzg==",
+      "version": "5.1.17",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.17.tgz",
+      "integrity": "sha512-RNSXOyb3VyRs/EOGmjBhhGKTbnN6fHWvy5FNLzWfOWOGjgVUKqJZXfpKzLmgoU8h6Hj8mpALj/mbXQASOb92wQ==",
       "dev": true,
       "requires": {
         "@types/history": "*",
@@ -34334,9 +38255,9 @@
       }
     },
     "@types/react-router-dom": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.9.tgz",
-      "integrity": "sha512-Go0vxZSigXTyXx8xPkGiBrrc3YbBs82KE14WENMLS6TSUKcRFSmYVbL19zFOnNFqJhqrPqEs2h5eUpJhSRrwZw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.1.tgz",
+      "integrity": "sha512-UvyRy73318QI83haXlaMwmklHHzV9hjl3u71MmM6wYNu0hOVk9NLTa0vGukf8zXUqnwz4O06ig876YSPpeK28A==",
       "dev": true,
       "requires": {
         "@types/history": "*",
@@ -34345,9 +38266,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.2.tgz",
-      "integrity": "sha512-KibDWL6nshuOJ0fu8ll7QnV/LVTo3PzQ9aCPnRUYPfX7eZohHwLIdNHj7pftanREzHNP4/nJa8oeM73uSiavMQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.3.tgz",
+      "integrity": "sha512-fUx5muOWSYP8Bw2BUQ9M9RK9+W1XBK/7FLJ8PTQpnpTEkn0ccyMffyEQvan4C3h53gHdx7KE5Qrxi/LnUGQtdg==",
       "requires": {
         "@types/react": "*"
       }
@@ -34451,28 +38372,36 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.1.tgz",
-      "integrity": "sha512-UDqhWmd5i0TvPLmbK5xY3UZB0zEGseF+DHPghZ37Sb83Qd3p8ujhvAtkU4OF46Ka5Pm5kWvFIx0cCTBFKo0alA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.31.1",
-        "@typescript-eslint/scope-manager": "4.31.1",
+        "@typescript-eslint/experimental-utils": "4.33.0",
+        "@typescript-eslint/scope-manager": "4.33.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
         "regexpp": "^3.1.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.1.tgz",
-      "integrity": "sha512-NtoPsqmcSsWty0mcL5nTZXMf7Ei0Xr2MT8jWjXMVgRK0/1qeQ2jZzLFUh4QtyJ4+/lPUyMw5cSfeeME+Zrtp9Q==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
+      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.31.1",
-        "@typescript-eslint/types": "4.31.1",
-        "@typescript-eslint/typescript-estree": "4.31.1",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -34488,37 +38417,37 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.31.1.tgz",
-      "integrity": "sha512-dnVZDB6FhpIby6yVbHkwTKkn2ypjVIfAR9nh+kYsA/ZL0JlTsd22BiDjouotisY3Irmd3OW1qlk9EI5R8GrvRQ==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
       "requires": {
-        "@typescript-eslint/scope-manager": "4.31.1",
-        "@typescript-eslint/types": "4.31.1",
-        "@typescript-eslint/typescript-estree": "4.31.1",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.31.1.tgz",
-      "integrity": "sha512-N1Uhn6SqNtU2XpFSkD4oA+F0PfKdWHyr4bTX0xTj8NRx1314gBDRL1LUuZd5+L3oP+wo6hCbZpaa1in6SwMcVQ==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
       "requires": {
-        "@typescript-eslint/types": "4.31.1",
-        "@typescript-eslint/visitor-keys": "4.31.1"
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.31.1.tgz",
-      "integrity": "sha512-kixltt51ZJGKENNW88IY5MYqTBA8FR0Md8QdGbJD2pKZ+D5IvxjTYDNtJPDxFBiXmka2aJsITdB1BtO1fsgmsQ=="
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ=="
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.1.tgz",
-      "integrity": "sha512-EGHkbsUvjFrvRnusk6yFGqrqMBTue5E5ROnS5puj3laGQPasVUgwhrxfcgkdHNFECHAewpvELE1Gjv0XO3mdWg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
       "requires": {
-        "@typescript-eslint/types": "4.31.1",
-        "@typescript-eslint/visitor-keys": "4.31.1",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -34527,11 +38456,11 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.31.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.1.tgz",
-      "integrity": "sha512-PCncP8hEqKw6SOJY+3St4LVtoZpPPn+Zlpm7KW5xnviMhdqcsBty4Lsg4J/VECpJjw1CkROaZhH4B8M1OfnXTQ==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
       "requires": {
-        "@typescript-eslint/types": "4.31.1",
+        "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -34821,9 +38750,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "amazon-cognito-identity-js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.1.0.tgz",
-      "integrity": "sha512-zGJo9jpTBHaTrir9nBWxMnteR+uPMSq3SO9AT0EOAO/e1CyJ27sawe0Pd3218HPzsooOMZt0iYaWkpVrsQ3nSQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.0.tgz",
+      "integrity": "sha512-7nRkGb9Cinf1rD5t34B0NDWXO7lmyapXzLmSXq4IBOdiBMrmxToEHcRwfwT2jJfBWzzZiOS0gvQhKI32A+rmvg==",
       "requires": {
         "buffer": "4.9.2",
         "crypto-js": "^4.1.1",
@@ -34992,15 +38921,15 @@
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
     },
     "array-includes": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
-      "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
+        "es-abstract": "^1.19.1",
         "get-intrinsic": "^1.1.1",
-        "is-string": "^1.0.5"
+        "is-string": "^1.0.7"
       }
     },
     "array-map": {
@@ -35031,24 +38960,23 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.flat": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
-      "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
+      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
+        "es-abstract": "^1.19.0"
       }
     },
     "array.prototype.flatmap": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
-      "integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
+      "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.19.0"
       }
     },
     "arrify": {
@@ -35121,6 +39049,15 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
+    "ast-types": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.0.1"
+      }
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -35176,36 +39113,37 @@
       "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
     },
     "autoprefixer": {
-      "version": "9.8.6",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
-      "integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
+      "version": "9.8.8",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
+      "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
       "requires": {
         "browserslist": "^4.12.0",
         "caniuse-lite": "^1.0.30001109",
-        "colorette": "^1.2.1",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
+        "picocolors": "^0.2.1",
         "postcss": "^7.0.32",
         "postcss-value-parser": "^4.1.0"
       }
     },
     "aws-amplify": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.2.9.tgz",
-      "integrity": "sha512-kMbXfgmcTjN3KLsMYAGBe7iy8Ih1/3Den5ZPEvEg7YTlkgtQ7YguyltdekE/yHV5JCCKTB8G1D2wmsvfHkid5w==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.3.1.tgz",
+      "integrity": "sha512-dvBVTDbpMfS91E0b9qxltIALTCP3b2pQpTyVQxUa9tuevEsi4YFL7EDcvQF4ScJkNwnuoTKVJsNCjrq8SJCJMg==",
       "requires": {
-        "@aws-amplify/analytics": "5.0.15",
-        "@aws-amplify/api": "4.0.15",
-        "@aws-amplify/auth": "4.3.5",
-        "@aws-amplify/cache": "4.0.17",
-        "@aws-amplify/core": "4.2.9",
-        "@aws-amplify/datastore": "3.4.3",
-        "@aws-amplify/interactions": "4.0.15",
-        "@aws-amplify/predictions": "4.0.15",
-        "@aws-amplify/pubsub": "4.1.7",
-        "@aws-amplify/storage": "4.3.10",
+        "@aws-amplify/analytics": "5.0.19",
+        "@aws-amplify/api": "4.0.19",
+        "@aws-amplify/auth": "4.3.9",
+        "@aws-amplify/cache": "4.0.21",
+        "@aws-amplify/core": "4.3.1",
+        "@aws-amplify/datastore": "3.4.7",
+        "@aws-amplify/geo": "1.1.1",
+        "@aws-amplify/interactions": "4.0.19",
+        "@aws-amplify/predictions": "4.0.19",
+        "@aws-amplify/pubsub": "4.1.11",
+        "@aws-amplify/storage": "4.4.2",
         "@aws-amplify/ui": "2.0.3",
-        "@aws-amplify/xr": "3.0.15"
+        "@aws-amplify/xr": "3.0.19"
       }
     },
     "aws-sign2": {
@@ -35235,6 +39173,13 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
+    },
+    "babel-core": {
+      "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "peer": true,
+      "requires": {}
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -35423,12 +39368,12 @@
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.4.tgz",
-      "integrity": "sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.5.tgz",
+      "integrity": "sha512-ninF5MQNwAX9Z7c9ED+H2pGt1mXdP4TqzlHKyPIYmJIYz0N+++uwdM7RnJukklhzJ54Q84vA4ZJkgs7lu5vqcw==",
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.2.2",
-        "core-js-compat": "^3.14.0"
+        "core-js-compat": "^3.16.2"
       }
     },
     "babel-plugin-polyfill-regenerator": {
@@ -35724,6 +39669,15 @@
             "@babel/plugin-transform-react-pure-annotations": "^7.12.1"
           }
         },
+        "@babel/preset-typescript": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.12.1.tgz",
+          "integrity": "sha512-hNK/DhmoJPsksdHuI/RVrcEws7GN5eamhi28JkO52MqIxU8Z0QpmiSOQxZHWOHV7I3P4UjHV97ay4TcamMA6Kw==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-transform-typescript": "^7.12.1"
+          }
+        },
         "@babel/runtime": {
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
@@ -35799,11 +39753,6 @@
         }
       }
     },
-    "base64-arraybuffer": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
-      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ=="
-    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -35834,9 +39783,9 @@
       }
     },
     "big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "version": "1.6.49",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.49.tgz",
+      "integrity": "sha512-KJ7VhqH+f/BOt9a3yMwJNmcZjG53ijWMTjSAGMveQWyLwqIiwkjNP5PFgDob3Snnx86SjDj6I89fIbv0dkQeNw==",
       "peer": true
     },
     "big.js": {
@@ -36087,15 +40036,15 @@
       }
     },
     "browserslist": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-      "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.3.tgz",
+      "integrity": "sha512-59IqHJV5VGdcJZ+GZ2hU5n4Kv3YiASzW6Xk5g9tf5a/MAzGeFwgGWU39fVzNIOVcgB3+Gp+kiQu0HEfTVU/3VQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001254",
-        "colorette": "^1.3.0",
-        "electron-to-chromium": "^1.3.830",
+        "caniuse-lite": "^1.0.30001264",
+        "electron-to-chromium": "^1.3.857",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.75"
+        "node-releases": "^1.1.77",
+        "picocolors": "^0.2.1"
       }
     },
     "bser": {
@@ -36286,9 +40235,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001257",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
-      "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA=="
+      "version": "1.0.30001265",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
+      "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -36472,9 +40421,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
-      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
       "peer": true
     },
     "clipboard-copy": {
@@ -36673,7 +40622,14 @@
     "colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "peer": true
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "peer": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -36884,16 +40840,16 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
-      "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw=="
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.2.tgz",
+      "integrity": "sha512-zNhPOUoSgoizoSQFdX1MeZO16ORRb9FFQLts8gSYbZU5FcgXhp24iMWMxnOQo5uIaIG7/6FA/IqJPwev1o9ZXQ=="
     },
     "core-js-compat": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.17.3.tgz",
-      "integrity": "sha512-+in61CKYs4hQERiADCJsdgewpdl/X0GhEX77pjKgbeibXviIt2oxEjTc8O2fqHX8mDdBrDvX8MYD/RYsBv4OiA==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.18.2.tgz",
+      "integrity": "sha512-25VJYCJtGjZwLguj7d66oiHfmnVw3TMOZ0zV8DyMJp/aeQ3OjR519iOOeck08HMyVVRAqXxafc2Hl+5QstJrsQ==",
       "requires": {
-        "browserslist": "^4.17.0",
+        "browserslist": "^4.17.3",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -36905,9 +40861,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.17.3.tgz",
-      "integrity": "sha512-YusrqwiOTTn8058JDa0cv9unbXdIiIgcgI9gXso0ey4WgkFLd3lYlV9rp9n7nDCsYxXsMDTjA4m1h3T348mdlQ=="
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.18.2.tgz",
+      "integrity": "sha512-4hMMLUlZhKJKOWbbGD1/VDUxGPEhEoN/T01k7bx271WiBKCvCfkgPzy0IeRS4PB50p6/N1q/SZL4B/TRsTE5bA=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -37313,12 +41269,32 @@
         "abab": "^2.0.3",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+          "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "whatwg-url": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+          "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+          "requires": {
+            "lodash": "^4.7.0",
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          }
+        }
       }
     },
     "date-fns": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
-      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA=="
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
+      "integrity": "sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w=="
     },
     "dayjs": {
       "version": "1.10.7",
@@ -37694,9 +41670,9 @@
       }
     },
     "dompurify": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.2.tgz",
-      "integrity": "sha512-jXJnvWloI+scD+N5uBikpUMsYXZb0LCAXxLFAOLS5duCzKfXLqBCpuINvFOiI4eJgTLggrngljT18HNoakHUsA=="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.3.tgz",
+      "integrity": "sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg=="
     },
     "domutils": {
       "version": "2.8.0",
@@ -37778,9 +41754,9 @@
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw=="
+      "version": "1.3.861",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.861.tgz",
+      "integrity": "sha512-GZyflmpMnZRdZ1e2yAyvuFwz1MPSVQelwHX4TJZyXypB8NcxdPvPNwy5lOTxnlkrK13EiQzyTPugRSnj6cBgKg=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -37911,9 +41887,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
-      "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -37926,7 +41902,9 @@
         "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.1",
         "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
         "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
         "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
@@ -38225,9 +42203,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.4.0.tgz",
-      "integrity": "sha512-8qnt/hgtZ94E9dA6viqfViKBfkJwFHXgJmTWlMGDgunw1XJEGqm3eiPjDsTanM3/u/3Az82nyQM9GX7PM/QGmg==",
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.5.2.tgz",
+      "integrity": "sha512-lrI3sGAyZi513RRmP08sIW241Ti/zMnn/6wbE4ZBhb3M2pJ9ztaZMnSKSKKBUfotVdwqU8W1KtD8ao2/FR8DIg==",
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
       }
@@ -38260,22 +42238,23 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.1.tgz",
-      "integrity": "sha512-P4j9K1dHoFXxDNP05AtixcJEvIT6ht8FhYKsrkY0MPCPaUMYijhpWwNiRDZVtA8KFuZOkGSeft6QwH8KuVpJug==",
+      "version": "7.26.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
+      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
       "requires": {
         "array-includes": "^3.1.3",
         "array.prototype.flatmap": "^1.2.4",
         "doctrine": "^2.1.0",
         "estraverse": "^5.2.0",
-        "has": "^1.0.3",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
         "object.entries": "^1.1.4",
         "object.fromentries": "^2.0.4",
+        "object.hasown": "^1.0.0",
         "object.values": "^1.1.4",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
         "string.prototype.matchall": "^4.0.5"
       },
       "dependencies": {
@@ -38295,6 +42274,11 @@
             "is-core-module": "^2.2.0",
             "path-parse": "^1.0.6"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -38794,9 +42778,9 @@
       }
     },
     "ext": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.5.0.tgz",
-      "integrity": "sha512-+ONcYoWj/SoQwUofMr94aGu05Ou4FepKi7N7b+O8T4jVfyIsZQV1/xeS8jpaBzF0csAk0KLXoHCxU7cKYZjo1Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
       "requires": {
         "type": "^2.5.0"
       },
@@ -38904,11 +42888,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-xml-parser": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.20.0.tgz",
-      "integrity": "sha512-cMQwDJYVDjMPU56DviszewgMKuNzuf4NQSBuDf9RgZ6FKm5QEMxW05Za8lvnuL6moxoeZVUWBlL733WmovvV6g==",
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.20.3.tgz",
+      "integrity": "sha512-FfHJ/QCpo4K2gquBX7dIAcmShSBG4dMtYJ3ghSiR4w7YqlUujuamrM57C+mKLNWS3mvZzmm2B2Qx8Q6Gfw+lDQ==",
       "requires": {
-        "strnum": "^1.0.3"
+        "strnum": "^1.0.4"
       }
     },
     "fastq": {
@@ -38975,13 +42959,6 @@
       "integrity": "sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==",
       "requires": {
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        }
       }
     },
     "file-uri-to-path": {
@@ -39116,6 +43093,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
       "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg=="
+    },
+    "flow-parser": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.121.0.tgz",
+      "integrity": "sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg==",
+      "peer": true
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -39523,9 +43506,9 @@
       }
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -39607,6 +43590,21 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "graceful-fs": {
@@ -39806,9 +43804,9 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "hermes-engine": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.8.1.tgz",
-      "integrity": "sha512-as9Iccj/qrqqtDmfYUHbOIjt5xsQbUB6pjNIW3i1+RVr+pCAdz5S8/Jry778mz3rJWplYzHWdR1u1xQSYfBRYw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.9.0.tgz",
+      "integrity": "sha512-r7U+Y4P2Qg/igFVZN+DpT7JFfXUn1MM4dFne8aW+cCrF6RRymof+VqrUHs1kl07j8h8V2CNesU19RKgWbr3qPw==",
       "peer": true
     },
     "hermes-parser": {
@@ -40262,9 +44260,9 @@
       }
     },
     "import-local": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
-      "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
+      "integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
       "requires": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -40497,9 +44495,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
+      "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -40564,9 +44562,9 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -40662,6 +44660,11 @@
       "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
       "integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg=="
     },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -40687,6 +44690,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -40786,9 +44797,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.3.tgz",
+      "integrity": "sha512-0i77ZFLsb9U3DHi22WzmIngVzfoyxxbQcZRqlF3KoKmCJGq9nhFHoGi8FqBztN2rE8w6hURnZghetn0xpkVb6A==",
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
@@ -41061,13 +45072,13 @@
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "wrap-ansi": {
@@ -42323,13 +46334,13 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "type-fest": {
@@ -42782,6 +46793,144 @@
       "integrity": "sha512-KmxeBlRjwoqCnBBKGsihFtvsBHyUFlBxJPK4FzeYcIuBfdjv6jFys44JITAgSTbQD+vIdwMEfyZklsuQX0yI1Q==",
       "peer": true
     },
+    "jscodeshift": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.11.0.tgz",
+      "integrity": "sha512-SdRK2C7jjs4k/kT2mwtO07KJN9RnjxtKn03d9JVj6c3j9WwaLcFYsICYDnLAzY0hp+wG2nxl+Cm2jWLiNVYb8g==",
+      "peer": true,
+      "requires": {
+        "@babel/core": "^7.1.6",
+        "@babel/parser": "^7.1.6",
+        "@babel/plugin-proposal-class-properties": "^7.1.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.1.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.1.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+        "@babel/preset-flow": "^7.0.0",
+        "@babel/preset-typescript": "^7.1.0",
+        "@babel/register": "^7.0.0",
+        "babel-core": "^7.0.0-bridge.0",
+        "colors": "^1.1.2",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^3.1.10",
+        "neo-async": "^2.5.0",
+        "node-dir": "^0.1.17",
+        "recast": "^0.20.3",
+        "temp": "^0.8.1",
+        "write-file-atomic": "^2.3.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "peer": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "peer": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "peer": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "peer": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "peer": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "peer": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "peer": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "peer": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "peer": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
     "jsdom": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
@@ -42820,6 +46969,24 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
           "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
+        },
+        "tr46": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+          "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "whatwg-url": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+          "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+          "requires": {
+            "lodash": "^4.7.0",
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          }
         },
         "ws": {
           "version": "7.5.5",
@@ -42903,11 +47070,11 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
-      "integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
+      "integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
       "requires": {
-        "array-includes": "^3.1.2",
+        "array-includes": "^3.1.3",
         "object.assign": "^4.1.2"
       }
     },
@@ -43252,14 +47419,14 @@
           "peer": true
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "peer": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "wrap-ansi": {
@@ -43381,9 +47548,9 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
     "map-obj": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
-      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -43761,14 +47928,14 @@
           "peer": true
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "peer": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "wrap-ansi": {
@@ -44018,14 +48185,14 @@
           "peer": true
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "peer": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "wrap-ansi": {
@@ -44281,16 +48448,16 @@
       "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
     },
     "mime-db": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
+      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A=="
     },
     "mime-types": {
-      "version": "2.1.32",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+      "version": "2.1.33",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
+      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
       "requires": {
-        "mime-db": "1.49.0"
+        "mime-db": "1.50.0"
       }
     },
     "mimic-fn": {
@@ -44510,9 +48677,9 @@
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q=="
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.29.tgz",
+      "integrity": "sha512-dW2pUSGZ8ZnCFIlBIA31SV8huOGCHb6OwzVCc7A69rb/a+SgPBwfmLvK5TKQ3INPbRkcI8a/Owo0XbiTNH19wg=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -44602,10 +48769,22 @@
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q==",
       "peer": true
     },
+    "node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "peer": true,
+      "requires": {
+        "minimatch": "^3.0.2"
+      }
+    },
     "node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "node-forge": {
       "version": "0.10.0",
@@ -44702,9 +48881,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.75",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
+      "version": "1.1.77",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+      "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ=="
     },
     "node-sass": {
       "version": "6.0.1",
@@ -44843,9 +49022,9 @@
       }
     },
     "nth-check": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
-      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
       "requires": {
         "boolbase": "^1.0.0"
       }
@@ -44987,34 +49166,42 @@
       }
     },
     "object.entries": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
-      "integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.2"
+        "es-abstract": "^1.19.1"
       }
     },
     "object.fromentries": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.4.tgz",
-      "integrity": "sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
-        "has": "^1.0.3"
+        "es-abstract": "^1.19.1"
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz",
-      "integrity": "sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.3.tgz",
+      "integrity": "sha512-VdDoCwvJI4QdC6ndjpqFmoL3/+HxffFBbcJzKi5hwLLqqx3mdbedRpfZDdK0SrOSauj8X4GzBvnDZl4vTN7dOw==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2"
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
+      "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
       }
     },
     "object.pick": {
@@ -45026,13 +49213,13 @@
       }
     },
     "object.values": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
-      "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.2"
+        "es-abstract": "^1.19.1"
       }
     },
     "obuf": {
@@ -45422,6 +49609,11 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -45524,74 +49716,12 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.36",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-      "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
       "requires": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
       }
     },
     "postcss-attribute-case-insensitive": {
@@ -46441,12 +50571,12 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
-          "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+          "version": "8.3.9",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.9.tgz",
+          "integrity": "sha512-f/ZFyAKh9Dnqytx5X62jgjhhzttjZS7hMsohcI7HEI5tjELX/HxCy3EFhsRxyzGvrzFF+82XPvCS8T9TFleVJw==",
           "requires": {
-            "colorette": "^1.2.2",
-            "nanoid": "^3.1.23",
+            "nanoid": "^3.1.28",
+            "picocolors": "^0.2.1",
             "source-map-js": "^0.6.2"
           }
         }
@@ -46532,9 +50662,9 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "prettier": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.0.tgz",
-      "integrity": "sha512-DsEPLY1dE5HF3BxCRBmD4uYZ+5DCbvatnolqTqcxEgKVZnL2kUfyu7b8pPQ5+hTBkdhU9SLUmK0/pHb07RE4WQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -46560,12 +50690,12 @@
       }
     },
     "pretty-format": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.0.tgz",
-      "integrity": "sha512-KyJdmgBkMscLqo8A7K77omgLx5PWPiXJswtTtFV7XgVZv2+qPk6UivpXXO+5k6ZEbWIbLoKdx1pZ6ldINzbwTA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.4.tgz",
+      "integrity": "sha512-NUjw22WJHldzxyps2YjLZkUj6q1HvjqFezkB9Y2cklN8NtVZN/kZEXGZdFw4uny3oENzV5EEMESrkI0YDUH8vg==",
       "requires": {
-        "@jest/types": "^27.1.1",
-        "ansi-regex": "^5.0.0",
+        "@jest/types": "^27.2.4",
+        "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
@@ -46874,9 +51004,9 @@
       }
     },
     "react-bootstrap": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.3.tgz",
-      "integrity": "sha512-zsd4l0g68pusOmJ/R5LhTfofT+9RniCwcZsMMNFGJo97d1vT1H2nGlbhLWp/j/pfeXXj9zzR8ugUtKkadcoWnA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.4.tgz",
+      "integrity": "sha512-z3BhBD4bEZuLP8VrYqAD7OT7axdcSkkyvWBWnS2U/4MhyabUihrUyucPWkan7aMI1XIHbmH4LCpEtzWGfx/yfA==",
       "requires": {
         "@babel/runtime": "^7.14.0",
         "@restart/context": "^2.1.4",
@@ -47132,6 +51262,14 @@
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
           "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
         },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -47143,9 +51281,9 @@
       }
     },
     "react-devtools-core": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.18.0.tgz",
-      "integrity": "sha512-Kg/LhDkdt9J0ned1D1RfeuSdX4cKW83/valJLYswGdsYc0g2msmD0kfYozsaRacjDoZwcKlxGOES1wrkET5O6Q==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.19.1.tgz",
+      "integrity": "sha512-2wJiGffPWK0KggBjVwnTaAk+Z3MSxKInHmdzPTrBh1mAarexsa93Kw+WMX88+XjN+TtYgAiLe9xeTqcO5FfJTw==",
       "peer": true,
       "requires": {
         "shell-quote": "^1.6.1",
@@ -47172,9 +51310,9 @@
       }
     },
     "react-dropzone": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.4.0.tgz",
-      "integrity": "sha512-5NRpAN4ZmpEn0kvtkO18rPInE7n4eVjGeTLP/c0JcGAnV+5yrpr5QHdPH27M05SP2tsjkRoRf02DCK/4fxbsog==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.4.2.tgz",
+      "integrity": "sha512-ocYzYn7Qgp0tFc1gQtUTOaHHSzVTwhWHxxY+r7cj2jJTPfMTZB5GWSJHdIVoxsl+EQENpjJ/6Zvcw0BqKZQ+Eg==",
       "requires": {
         "attr-accept": "^2.2.1",
         "file-selector": "^0.2.2",
@@ -47202,9 +51340,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-native": {
-      "version": "0.65.1",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.65.1.tgz",
-      "integrity": "sha512-0UOVSnlssweQZjuaUtzViCifE/4tXm8oRbxwakopc8GavPu9vLulde145GOw6QVYiOy4iL50f+2XXRdX9NmMeQ==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.0.tgz",
+      "integrity": "sha512-m26TKwzsfHVdZ1hDG+7mZ4M4ftxFFZrhtiT0OXuwfBzmNtB3xhsJtYszPeizw33c9YNp8rvehKT3c4ldDCW6kA==",
       "peer": true,
       "requires": {
         "@jest/create-cache-key-function": "^27.0.1",
@@ -47213,12 +51351,12 @@
         "@react-native-community/cli-platform-ios": "^6.0.0",
         "@react-native/assets": "1.0.0",
         "@react-native/normalize-color": "1.0.0",
-        "@react-native/polyfills": "1.0.0",
+        "@react-native/polyfills": "2.0.0",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "base64-js": "^1.1.2",
         "event-target-shim": "^5.0.1",
-        "hermes-engine": "~0.8.1",
+        "hermes-engine": "~0.9.0",
         "invariant": "^2.2.4",
         "jsc-android": "^250230.2.1",
         "metro-babel-register": "0.66.2",
@@ -47229,7 +51367,8 @@
         "pretty-format": "^26.5.2",
         "promise": "^8.0.3",
         "prop-types": "^15.7.2",
-        "react-devtools-core": "^4.6.0",
+        "react-devtools-core": "^4.13.0",
+        "react-native-codegen": "^0.0.7",
         "react-refresh": "^0.4.0",
         "regenerator-runtime": "^0.13.2",
         "scheduler": "^0.20.2",
@@ -47279,6 +51418,17 @@
           "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
           "peer": true
         }
+      }
+    },
+    "react-native-codegen": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.0.7.tgz",
+      "integrity": "sha512-dwNgR8zJ3ALr480QnAmpTiqvFo+rDtq6V5oCggKhYFlRjzOmVSFn3YD41u8ltvKS5G2nQ8gCs2vReFFnRGLYng==",
+      "peer": true,
+      "requires": {
+        "flow-parser": "^0.121.0",
+        "jscodeshift": "^0.11.0",
+        "nullthrows": "^1.1.1"
       }
     },
     "react-native-get-random-values": {
@@ -47618,6 +51768,24 @@
         "picomatch": "^2.2.1"
       }
     },
+    "readline": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw=",
+      "peer": true
+    },
+    "recast": {
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
+      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
+      "peer": true,
+      "requires": {
+        "ast-types": "0.14.2",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tslib": "^2.0.1"
+      }
+    },
     "recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -47898,6 +52066,47 @@
         "source-map": "0.6.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
         "convert-source-map": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -47910,6 +52119,16 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
           "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "json5": {
           "version": "1.0.1",
@@ -47927,6 +52146,24 @@
             "big.js": "^5.2.2",
             "emojis-list": "^2.0.0",
             "json5": "^1.0.1"
+          }
+        },
+        "postcss": {
+          "version": "7.0.36",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -48614,9 +52851,9 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ=="
     },
     "simple-plist": {
       "version": "1.1.1",
@@ -49076,12 +53313,11 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
     "stack-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.4.tgz",
-      "integrity": "sha512-ERg+H//lSSYlZhBIUu+wJnqg30AbyBbpZlIhcshpn7BNzpoRODZgfyr9J+8ERf3ooC6af3u7Lcl01nleau7MrA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
       "requires": {
-        "escape-string-regexp": "^2.0.0",
-        "source-map-support": "^0.5.20"
+        "escape-string-regexp": "^2.0.0"
       },
       "dependencies": {
         "escape-string-regexp": {
@@ -49298,13 +53534,13 @@
       }
     },
     "string.prototype.matchall": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.5.tgz",
-      "integrity": "sha512-Z5ZaXO0svs0M2xd/6By3qpeKpLKd9mO4v4q3oMEQrk8Ck4xOD5d5XeBOOjGrmVZZ/AHB1S0CgG4N5r1G9N3E2Q==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
+      "integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.2",
+        "es-abstract": "^1.19.1",
         "get-intrinsic": "^1.1.1",
         "has-symbols": "^1.0.2",
         "internal-slot": "^1.0.3",
@@ -49341,11 +53577,11 @@
       }
     },
     "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-bom": {
@@ -49386,9 +53622,9 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
     "strnum": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.3.tgz",
-      "integrity": "sha512-GVoRjsqAYZkAH16GDzfTuafuwKxzKdaaCQyLaWf37gOP1e2PPbAKWoME1OmO+c4RCKMfNrrPRDLFCNBFU45N/A=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.4.tgz",
+      "integrity": "sha512-lMzNMfDpaQOLt4B2mEbfzYS0+T7dvCXeojnlGf6f1AygvWDMcWyXYaLbyICfjVu29sErR8fnRagQfBW/N/hGgw=="
     },
     "style-loader": {
       "version": "1.3.0",
@@ -49575,16 +53811,16 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "table": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
-      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
+      "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
       "requires": {
         "ajv": "^8.0.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0"
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
       },
       "dependencies": {
         "ajv": {
@@ -49629,13 +53865,13 @@
           }
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         }
       }
@@ -49835,9 +54071,9 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "terser": {
-          "version": "5.8.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.8.0.tgz",
-          "integrity": "sha512-f0JH+6yMpneYcRJN314lZrSwu9eKkUFEHLN/kNy8ceh8gaRiLgFPJqrB9HsXjhEGdv4e/ekjTOFxIlL6xlma8A==",
+          "version": "5.9.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
+          "integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
           "requires": {
             "commander": "^2.20.0",
             "source-map": "~0.7.2",
@@ -49978,12 +54214,9 @@
       }
     },
     "tr46": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
-      "requires": {
-        "punycode": "^2.1.1"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "trim-newlines": {
       "version": "3.0.1",
@@ -50320,14 +54553,14 @@
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
     },
     "uplot": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.13.tgz",
-      "integrity": "sha512-O5NHrZwetCUMUrYMN2/OG6v0poPXtlb68XBCERHqvvePFJvFPIuJI/SxdyZOygKzh0pAjMTX0xz3S0msAsPX0w=="
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.16.tgz",
+      "integrity": "sha512-Rh0WtFgtZdYk70Knu1VyZYbwlx5GuoIFBezZuHwlEUiREsIjOKpe3CXLXLaKc7/49Z7XhQ/bazgF/f1zercxgw=="
     },
     "uplot-react": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/uplot-react/-/uplot-react-1.1.0.tgz",
-      "integrity": "sha512-tU6noQZ7UbXWLEAMPPJyhHfoR1aDFYh8yo2hBHiFRcy7FtmupVXOKBfvyGhO8laMyM3G1v529KL9o3bDBJOtYg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/uplot-react/-/uplot-react-1.1.1.tgz",
+      "integrity": "sha512-zCvwyZVm4nfYDi+KjaK0FppqftGzga/x+u0h2baRWj1vXMB9/hfJ1qb9gXAdXMfp17C9Rk57HoZDE9MewNWLfg==",
       "requires": {}
     },
     "uri-js": {
@@ -51509,13 +55742,19 @@
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
     },
     "whatwg-url": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
-      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "requires": {
-        "lodash": "^4.7.0",
-        "tr46": "^2.1.0",
-        "webidl-conversions": "^6.1.0"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        }
       }
     },
     "which": {
@@ -51813,14 +56052,14 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "peer": true,
       "requires": {
+        "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
+        "signal-exit": "^3.0.2"
       }
     },
     "ws": {

--- a/hasher-matcher-actioner/webapp/package.json
+++ b/hasher-matcher-actioner/webapp/package.json
@@ -14,7 +14,6 @@
     "@types/react-dom": "^17.0.8",
     "aws-amplify": "^4.1.2",
     "axios": "^0.21.1",
-    "base64-arraybuffer": "^0.2.0",
     "bootstrap": "^4.6.0",
     "classnames": "^2.3.1",
     "clipboard-copy": "^4.0.1",
@@ -32,8 +31,8 @@
     "react-dropzone": "^11.4.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.3",
-    "uplot": "1.6.13",
-    "uplot-react": "1.1.0"
+    "uplot": "^1.6.13",
+    "uplot-react": "^1.1.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -47,18 +46,11 @@
       "react-app/jest"
     ]
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not op_mini all"
+  ],
   "devDependencies": {
     "@types/dompurify": "^2.2.3",
     "@types/react-router-dom": "^5.1.8",

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -62,14 +62,14 @@ async function apiDelete<T>(route: string, params = {}): Promise<T> {
 type MatchSummaries = {match_summaries: MatchDetails[]};
 
 export async function fetchAllMatches(): Promise<MatchSummaries> {
-  return apiGet('/matches/');
+  return apiGet('matches/');
 }
 
 export async function fetchMatchesFromSignal(
   signalSource: string,
   signalId: string,
 ): Promise<MatchSummaries> {
-  return apiGet('/matches/', {
+  return apiGet('matches/', {
     signal_q: signalId,
     signal_source: signalSource,
   });
@@ -78,7 +78,7 @@ export async function fetchMatchesFromSignal(
 export async function fetchMatchesFromContent(
   contentId: string,
 ): Promise<MatchSummaries> {
-  return apiGet('/matches/', {content_q: contentId});
+  return apiGet('matches/', {content_q: contentId});
 }
 
 export type MatchDetails = {
@@ -100,7 +100,7 @@ export type MatchDetails = {
 type Matches = {match_details: MatchDetails[]};
 
 export async function fetchMatchDetails(contentId: string): Promise<Matches> {
-  return apiGet('/matches/match/', {content_id: contentId});
+  return apiGet('matches/match/', {content_id: contentId});
 }
 
 export type HashDetails = {
@@ -111,13 +111,13 @@ export type HashDetails = {
 export async function fetchHashDetails(
   contentId: string,
 ): Promise<HashDetails> {
-  return apiGet('/content/hash/', {content_id: contentId});
+  return apiGet('content/hash/', {content_id: contentId});
 }
 
 export async function fetchPreviewURL(
   contentId: string,
 ): Promise<{preview_url: string}> {
-  return apiGet('/content/preview-url/', {content_id: contentId});
+  return apiGet('content/preview-url/', {content_id: contentId});
 }
 
 export type ContentActionHistoryRecord = {
@@ -132,7 +132,7 @@ type ContentActionHistoryRecords = {
 export async function fetchContentActionHistory(
   contentId: string,
 ): Promise<ContentActionHistoryRecords> {
-  return apiGet('/content/action-history/', {content_id: contentId});
+  return apiGet('content/action-history/', {content_id: contentId});
 }
 
 export type ContentDetails = {
@@ -152,7 +152,7 @@ export type ContentDetails = {
 export async function fetchContentDetails(
   contentId: string,
 ): Promise<ContentDetails> {
-  return apiGet('/content/', {
+  return apiGet('content/', {
     content_id: contentId,
   });
 }
@@ -170,7 +170,7 @@ type ContentPipelineProgress = {
 export async function fetchContentPipelineProgress(
   contentId: string,
 ): Promise<ContentPipelineProgress> {
-  return apiGet('/content/pipeline-progress/', {
+  return apiGet('content/pipeline-progress/', {
     content_id: contentId,
   });
 }
@@ -178,7 +178,7 @@ export async function fetchContentPipelineProgress(
 export async function fetchDashboardCardSummary(
   path: string,
 ): Promise<Response> {
-  return apiGet(`/${path}`);
+  return apiGet(`${path}`);
 }
 
 export type StatsCard = {
@@ -196,7 +196,7 @@ export async function fetchStats(
   statName: string,
   timeSpan: string,
 ): Promise<StatsResponse> {
-  return apiGet('/stats/', {stat_name: statName, time_span: timeSpan});
+  return apiGet('stats/', {stat_name: statName, time_span: timeSpan});
 }
 
 export async function requestSignalOpinionChange(
@@ -224,7 +224,7 @@ export async function submitContentViaURL(
   contentURL: string,
   forceResubmit: boolean,
 ): Promise<Response> {
-  return apiPost('/submit/url/', {
+  return apiPost('submit/url/', {
     content_id: contentId,
     content_type: contentType,
     additional_fields: additionalFields,
@@ -266,15 +266,15 @@ type DatasetSummariesResponse = {
   threat_exchange_datasets: Array<Dataset>;
 };
 export async function fetchAllDatasets(): Promise<DatasetSummariesResponse> {
-  return apiGet('/datasets/');
+  return apiGet('datasets/');
 }
 
 export async function syncAllDatasets(): Promise<{response: string}> {
-  return apiPost('/datasets/sync');
+  return apiPost('datasets/sync');
 }
 
 export async function deleteDataset(key: string): Promise<{response: string}> {
-  return apiPost(`/datasets/delete/${key}`);
+  return apiPost(`datasets/delete/${key}`);
 }
 
 type Dataset = {
@@ -295,7 +295,7 @@ export async function updateDataset(
   writeBack: boolean,
   matcherActive: boolean,
 ): Promise<Dataset> {
-  return apiPost('/datasets/update', {
+  return apiPost('datasets/update', {
     privacy_group_id: privacyGroupId,
     fetcher_active: fetcherActive,
     write_back: writeBack,
@@ -311,7 +311,7 @@ export async function createDataset(
   writeBack = false,
   matcherActive = true,
 ): Promise<{response: string}> {
-  return apiPost('/datasets/create', {
+  return apiPost('datasets/create', {
     privacy_group_id: privacyGroupId,
     privacy_group_name: privacyGroupName,
     description,
@@ -322,10 +322,8 @@ export async function createDataset(
 }
 
 export async function fetchHashCount(): Promise<Response> {
-  return apiGet('/hash-counts');
+  return apiGet('hash-counts');
 }
-
-// TODO remove the trailing slash from the API URL, then add back the leading slash for /actions/ and /action-rules/ endpoints.
 
 // This class should be kept in sync with python class ActionPerformer (hmalib.common.configs.actioner.ActionPerformer)
 type BackendActionPerformer = {
@@ -559,7 +557,7 @@ export async function fetchMediaUploadURL(
   mediaType: string,
   extension: string,
 ): Promise<MediaUploadURLResponse> {
-  return apiPost<MediaUploadURLResponse>('/banks/get-media-upload-url', {
+  return apiPost<MediaUploadURLResponse>('banks/get-media-upload-url', {
     media_type: mediaType,
     extension,
   });
@@ -572,7 +570,7 @@ export async function addBankMember(
   storageKey: string,
   notes: string,
 ): Promise<BankMember> {
-  return apiPost<BankMemberWithSerializedTypes>(`/banks/add-member/${bankId}`, {
+  return apiPost<BankMemberWithSerializedTypes>(`banks/add-member/${bankId}`, {
     content_type: contentType,
     storage_bucket: storageBucket,
     storage_key: storageKey,

--- a/hasher-matcher-actioner/webapp/src/App.tsx
+++ b/hasher-matcher-actioner/webapp/src/App.tsx
@@ -64,8 +64,11 @@ export default function App(): JSX.Element {
               <Route path="/banks/">
                 <ViewAllBanks />
               </Route>
-              <Route path="/">
+              <Route path="/dashboard/">
                 <Dashboard />
+              </Route>
+              <Route path="/">
+                <SubmitContent />
               </Route>
             </Switch>
           </main>

--- a/hasher-matcher-actioner/webapp/src/Sidebar.tsx
+++ b/hasher-matcher-actioner/webapp/src/Sidebar.tsx
@@ -22,7 +22,7 @@ export default function Sidebar(
         </a>
       </div>
       <ul className="navbar-nav mb-auto">
-        <li className="nav-item">
+        {/* <li className="nav-item">
           <NavLink
             exact
             activeClassName="text-white bg-secondary rounded"
@@ -30,7 +30,7 @@ export default function Sidebar(
             className="nav-link px-2">
             Dashboard
           </NavLink>
-        </li>
+        </li> */}
         <li className="nav-item">
           <NavLink
             activeClassName="text-white bg-secondary rounded"


### PR DESCRIPTION
Summary
---------

Builds off of #819 (so only the top three commits should be new with the two commit below that being fixes from 819)

Adds 3 new tfvars:
- `vpc_id` : id of vpc which to restrict the API.
-  `vpc_subnets` : list of private subnets to connect to the `aws_vpc_endpoint` used to access the private API
- `security_groups` : list of security groups to connect to the `aws_vpc_endpoint` used to access the private API

This also adds `examples/vpc_deploy/` to hma to make testing of these changes possible.

Test Plan
---------

Made sure deploy and unit tests still worked without passing in the new arguments. (i.e. does not break existing)
Also ran 30 min soak test that seemed to behave normally. 


Used `examples/vpc_deploy/terraform` + other steps documented in README.md to create a VPC and VPN 
passed output of that to the root terraform and made sure the API was only reachable within the VPN.
