### PR TITLE
[hma][api] add s3 api submit support

### DIFF
--- a/hasher-matcher-actioner/hmalib/scripts/common/utils.py
+++ b/hasher-matcher-actioner/hmalib/scripts/common/utils.py
@@ -130,6 +130,31 @@ class HasherMatcherActionerAPI:
         )
         response.raise_for_status()
 
+    def submit_via_s3_object(
+        self,
+        content_id: str,
+        bucket_name: str,
+        object_key: str,
+        content_type: str = "photo",
+        additional_fields: t.List[str] = [],
+    ):
+        """
+        Submit to the API using a s3 object that api_root is authorized to read from
+        """
+        payload = {
+            "content_id": content_id,
+            "content_type": content_type,
+            "additional_fields": additional_fields,
+            "bucket_name": bucket_name,
+            "object_key": object_key,
+        }
+        api_path: str = "submit/s3/"
+        response = self.session.post(
+            self._get_request_url(api_path),
+            data=json.dumps(payload).encode(),
+        )
+        response.raise_for_status()
+
     def submit_hash(
         self,
         content_id: str,

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -501,7 +501,7 @@ data "aws_iam_policy_document" "hma_api_gw_in_vpc" {
 # Connect partner s3 buckets to api_root 
 
 resource "aws_lambda_permission" "allow_bucket" {
-  count = length(var.partner_image_buckets)
+  count = var.enable_partner_upload_notification ? length(var.partner_image_buckets) : 0
 
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
@@ -511,7 +511,7 @@ resource "aws_lambda_permission" "allow_bucket" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  count = length(var.partner_image_buckets)
+  count = var.enable_partner_upload_notification ? length(var.partner_image_buckets) : 0
 
   bucket = var.partner_image_buckets[count.index].name
 

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -143,6 +143,12 @@ variable "partner_image_buckets" {
   }))
 }
 
+variable "enable_partner_upload_notification" {
+  description = "Enable the upload notfication of partner buckets if given."
+  type        = bool
+  default     = false
+}
+
 variable "banks_media_storage" {
   description = "Name and arn where we store bank media."
   type = object({

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -470,7 +470,8 @@ module "api" {
     url = aws_sqs_queue.submissions_queue.id,
     arn = aws_sqs_queue.submissions_queue.arn
   }
-  partner_image_buckets = var.partner_image_buckets
+  partner_image_buckets              = var.partner_image_buckets
+  enable_partner_upload_notification = var.enable_partner_upload_notification
 
   api_in_vpc      = var.api_in_vpc
   vpc_id          = var.vpc_id

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -90,7 +90,6 @@ variable "partner_image_buckets" {
     params = map(string)
   }))
   default = []
-
   # Ensure only correct params are used
   validation {
     condition = alltrue(
@@ -109,6 +108,11 @@ variable "partner_image_buckets" {
 
     error_message = "The only accepted params are 'prefix' to specify a prefix/folder/path string where only uploads with that prefix should be sent to HMA and 'suffix' to restrict uploads to only files with a specific extension."
   }
+}
+variable "enable_partner_upload_notification" {
+  description = "Enable the upload notfication of partner buckets if given."
+  type        = bool
+  default     = false
 }
 
 variable "integration_api_access_tokens" {


### PR DESCRIPTION
Summary
---------

Along with `submit/hash/` `submit/url/` etc. this adds an `submit/s3/` endpoint to submit content from an s3 bucket the HMA has been given access to via `partner_image_buckets` in `terraform.tfvars` (I also disable bucket notifications by default for the old s3 integration, they now require `enable_partner_upload_notification = true`

Will update docs after merge for now here is an example/how to use:

Example tf vars arg:
```
partner_image_buckets = [{
  "name" : "example-bucket-name-with-test-media",
  "arn" : "arn:aws:s3:::example-bucket-name-with-test-media",
  "params" : {}
}]
```

Example submit using changes to `hmalib/scripts/common/utils.py` payload:
```python
api.submit_via_s3_object(
            content_id="barrett-test-s3-object-submit-1",
            bucket_name="example-bucket-name-with-test-media",
            object_key="images/originals/4210454325132514.jpg",
            additional_fields=["submitted_via_python_script"],
)
# resulting payload sent to HMA
payload = {
    "content_id": "barrett-test-s3-object-submit-1",
    "content_type": "photo",
    "additional_fields": ["submitted_via_python_script"],
    "bucket_name": "example-bucket-name-with-test-media",
    "object_key": "images/originals/4210454325132514.jpg",
}
```


Test Plan
---------

`make dev_test_instance` & and example of the new command above to confirms submit for s3 works and will trigger a match. 

Thanks!