### PR TITLE
Parse variables.tf into a neat little .tfvars example friendly output

### DIFF
--- a/hasher-matcher-actioner/hmalib/scripts/cli/main.py
+++ b/hasher-matcher-actioner/hmalib/scripts/cli/main.py
@@ -19,7 +19,7 @@ import hmalib.scripts.common.utils as utils
 import hmalib.scripts.cli.command_base as base
 import hmalib.scripts.cli.soak as soak
 import hmalib.scripts.cli.shell as shell
-from hmalib.scripts.cli import run_api, run_lambda
+from hmalib.scripts.cli import run_api, run_lambda, write_terraform_example
 
 TERRAFORM_OUTPUTS_CACHE = "/tmp/hma-terraform-outputs.json"
 
@@ -30,6 +30,7 @@ def get_subcommands() -> t.List[t.Type[base.Command]]:
         shell.ShellCommand,
         run_lambda.RunLambdaCommand,
         run_api.RunAPICommand,
+        write_terraform_example.WriteTerraformExampleConfigCommand,
     ]
 
 
@@ -95,6 +96,11 @@ def execute_command(namespace) -> None:
         elif issubclass(command_cls, base.NeedsTerraformOutputs):
             tf_outputs = get_terraform_outputs(namespace.refresh_tf_outputs)
             command.execute(tf_outputs)
+        else:
+            # Command does not seem to require injection of any specific
+            # arguments. Just execute it.
+            command.execute()
+
     except base.CommandError as ce:
         print(ce, file=sys.stderr)
         sys.exit(ce.returncode)

--- a/hasher-matcher-actioner/requirements-dev.txt
+++ b/hasher-matcher-actioner/requirements-dev.txt
@@ -6,3 +6,4 @@ moto
 pandas
 WebTest==2.0.35
 Pillow==8.3.2
+python-hcl2==3.0.1


### PR DESCRIPTION
Summary
---
Makes it easy to have single point of maintenance. Will defer to @BarrettOlson on actually using this script in CI / during release.

Test
---
```
/hasher-matcher-actioner$ hmacli write-terraform-example
```

Output
```
#  The URI for the docker image to use for the hma lambdas
hma_lambda_docker_uri = None

#  Prefix to use for resource names
prefix = hma

#  The name / acronym to use for resource names that must be globally unique (use only
#  lower case alpha a-z, and, optionally, hyphens)
organization = None

#  How long to retain cloudwatch logs for lambda functions in days
log_retention_in_days = 14

#  Send metrics to cloudwatch and build a dashboard. Useful for benchmarking, but can
#  incur costs. Set to string True for this to work.
measure_performance = False

#  Cloudwatch namespace for metrics.
metrics_namespace = ThreatExchange/HMA

#  Additional resource tags. Will be applied to ALL resources created.
additional_tags = {}

#  Indicates whether a CloudFront distribution is included
include_cloudfront_distribution = False

#  The secret token used to authenticate your access to ThreatExchange. You can find
#  this by navigating to https://developers.facebook.com/tools/accesstoken/. Leave blank
#  if you would not like to fetch from ThreatExchange
te_api_token = None

#  How long to wait between calls to ThreatExcahnge. Must be an AWS Rate Expression.
#  See here: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html

fetch_frequency = 15 minutes

#  Indicates if the web app and api will use a shared user pool (generally true for
#  developers / engineers sandbox environments, otherwise false)
use_shared_user_pool = False

#  The id of the shared user pool. Used in conjunction with use_shared_user_pool set
#  to true. Generate by running terraform init & apply from /authentication-shared.

webapp_and_api_shared_user_pool_id =

#  The id of the shared user pool app client. Used in conjunction with use_shared_user_pool
#  set to true. Generate by running terraform init & apply from /authentication-shared.

webapp_and_api_shared_user_pool_client_id =

#  The system's SQS Queues have a batch_size and timeout window configured for a production
#  use case. If this var is set to true those values will be overridden and set to the
#  minimum (helpful for fast one off testing).
set_sqs_windows_to_min = False

#  Names and arns of s3 buckets to consider as inputs to HMA. All images uploaded to
#  these buckets will be processed by the hasher
partner_image_buckets = []

#  Enable the upload notfication of partner buckets if given.
enable_partner_upload_notification = False

#  Access tokens checked for in authorizer api as an alternative to cognito user tokens.

integration_api_access_tokens = []

#  Should the API gateway used with HMA be made private behind a VPC. (Either way API
#  will also require authorization)
api_in_vpc = None

#  vpc that locks down the API and UI to the specfic vpc_subnets and security_groups.
#  Required if api_in_vpc = true. Note VPC must be in the same region that HMA is deployed
#  in.
vpc_id =

#  Subnet ids of the vpc given in for vpc_id. Required if api_in_vpc = true
vpc_subnets = []

#  Security group ids to be used with the vpc given in for vpc_id. Required if api_in_vpc
#  = true
security_groups = []
```
