### PR TITLE
[hma][make] update Makefile to not assume `prefix` & add command for hmacli install

### DIFF
--- a/hasher-matcher-actioner/Makefile
+++ b/hasher-matcher-actioner/Makefile
@@ -25,7 +25,7 @@ terraform/terraform.tfvars:
 	@echo ACTION REQUIRED: terraform/terraform.tfvars is needed to deploy and cannot be created automatically. 
 	@echo However as a staring point, you can copy the example:
 	@echo cp terraform/terraform.tfvars.example terraform/terraform.tfvars
-	@echo Here are the likely inital values for the first two vars:
+	@echo Here are the likely initial values for the first two vars:
 	@echo 'hma_lambda_docker_uri = "${DOCKER_URI}:${DOCKER_TAG}"'
 	@echo 'prefix = "${USER}"'
 	exit 1

--- a/hasher-matcher-actioner/Makefile
+++ b/hasher-matcher-actioner/Makefile
@@ -22,28 +22,34 @@ upload_docker:
 	DOCKER_TAG=${DOCKER_TAG} ./scripts/update_lambda_docker_image.sh
 
 terraform/terraform.tfvars:
-	echo 'hma_lambda_docker_uri = "${DOCKER_URI}:${DOCKER_TAG}"' > terraform/terraform.tfvars
+	@echo ACTION REQUIRED: terraform/terraform.tfvars is needed to deploy and cannot be created automatically. 
+	@echo However as a staring point, you can copy the example:
+	@echo cp terraform/terraform.tfvars.example terraform/terraform.tfvars
+	@echo Here are the likely inital values for the first two vars:
+	@echo 'hma_lambda_docker_uri = "${DOCKER_URI}:${DOCKER_TAG}"'
+	@echo 'prefix = "${USER}"'
+	exit 1
 
 terraform/backend.tf:
 	@echo terraform state will be stored locally unless a backend.tf file is configured. 
-	@echo Create a backend.tf? to use custom s3 bucket run: export TF_STATE_S3_BUCKET=bucket_name [y/N]
+	@echo Create a backend.tf? to use custom s3 bucket run this first: export TF_STATE_S3_BUCKET=bucket_name [y/N]
 	@read ans; if [ $$ans = "y" ]; then ./scripts/write_backend_config.sh > terraform/backend.tf; fi
 
 dev_create_configs: terraform/terraform.tfvars terraform/backend.tf
 
 dev_create_instance: dev_create_configs upload_docker
-	cd terraform/ && terraform init -var "prefix=${USER}"
-	cd terraform/ && terraform apply -var "prefix=${USER}"
+	terraform -chdir=terraform init 
+	terraform -chdir=terraform apply
 
 dev_destroy_instance:
-	cd terraform/ && terraform destroy -var "prefix=${USER}"
+	terraform -chdir=terraform destroy 
 
 dev_test_instance:
 	python3 hmalib/scripts/common/client_lib.py
 
-dev_clear_configs:
-	-rm terraform/terraform.tfvars terraform/backend.tf
-
 dev_apply_with_newest_docker_image:
-	@DIGEST=$(call shell-or-die, aws ecr describe-images --repository-name hma-lambda-dev --image-ids imageTag=${USER} | jq -r '.imageDetails[0].imageDigest'); \
+	@DIGEST=$(call shell-or-die, aws ecr describe-images --repository-name hma-lambda-dev --image-ids imageTag=${DOCKER_TAG} | jq -r '.imageDetails[0].imageDigest'); \
 	terraform -chdir=terraform apply -var "hma_lambda_docker_uri=${DOCKER_URI}@$${DIGEST}"
+
+dev_install_hmacli:
+	python3 -m pip install -r requirements-dev.txt

--- a/hasher-matcher-actioner/requirements-dev.txt
+++ b/hasher-matcher-actioner/requirements-dev.txt
@@ -1,4 +1,4 @@
--r requirements.txt
+.[all]
 pytest==6.2.1
 mypy==0.812
 black

--- a/hasher-matcher-actioner/terraform/terraform.tfvars.example
+++ b/hasher-matcher-actioner/terraform/terraform.tfvars.example
@@ -12,7 +12,7 @@ webapp_and_api_shared_user_pool_client_id = # "<webapp_and_api_shared_user_pool_
 integration_api_access_tokens             = # Optional_list_of_tokens e.g. ['<super_secret_token1>']
 
 # Fetching Signals:
-te_api_token = "<threat-exchange-api-token>"
+te_api_token = "" # "<threat-exchange-api-token>" Note: it is possible to test out HMA without TE access
 # fetch_frequency = <fetch_frequency> How long to wait between calls to ThreatExchange default "15 minutes"
 
 # Metrics and Logging:
@@ -21,8 +21,8 @@ measure_performance   = true # creates a dashboard and expands the set of logs
 log_retention_in_days = # DAYS to retain logs
 
 # Network and CDN:
-include_cloudfront_distribution = false 
-api_in_vpc = false # if true overrides `include_cloudfront_distribution` to false 
+include_cloudfront_distribution = false # Enables https connections to the HMA UI from a cloudfront domain
+api_in_vpc = false 
 vpc_id = "" # required to be nonempty if api_in_vpc = true. Note VPC must be in the same region that HMA is deployed in.
 vpc_subnets = [] # required to be nonempty if api_in_vpc = true
 security_groups = [] # required to be nonempty if api_in_vpc = true


### PR DESCRIPTION
Summary
---------

Our Makefile is designed to make using/deploying HMA a little easier however it was created back when `terraform.tfvars` was a lot simpler. We shouldn't assume 'prefix' and create the file automatically anymore. 

I changed the `terraform/terraform.tfvars` make target to instead just let the user know they need the file and exit if it can't find it. 

Also made a few minor changes to `terraform/terraform.tfvars.example` and added `dev_install_hmacli` to install the python cli via the Makefile.

Removed `dev_clear_configs` because it just deletes two files and is more likely to be used by mistake than be helpful.

Test Plan
---------

With terraform/terraform.tfvars not present
```
$ make terraform/terraform.tfvars
ACTION REQUIRED: terraform/terraform.tfvars is needed to deploy and cannot be created automatically.
However as a staring point, you can copy the example:
cp terraform/terraform.tfvars.example terraform/terraform.tfvars
Here are the likely initial values for the first two vars:
hma_lambda_docker_uri = "<reacted-id>.dkr.ecr.us-east-1.amazonaws.com/hma-lambda-dev:barrett"
prefix = "barrett"
exit 1
make: *** [Makefile:31: terraform/terraform.tfvars] Error 1
```

Before `dev_install_hmacli`

```
$ hmacli print-tfvars-example                                                                                                                                                                                                                                       [20:05:26] 
/workspaces/ThreatExchange/hasher-matcher-actioner/hmalib/scripts/cli/print_tfvars_example.py:70: UserWarning: Need hcl2 module installed. Try pip install -r requirements-dev.txt                                                                                                                                          
  warnings.warn(                                                                                                                                                                                                                                                                                                            
Traceback (most recent call last):                                                                                                                                                                                                                                                                                          
  File "/home/barrett/.local/bin/hmacli", line 33, in <module>                                                                                                                                                                                                                                                              
    sys.exit(load_entry_point('hmalib', 'console_scripts', 'hmacli')())                                                                                                                                                                                                                                                     
  File "/workspaces/ThreatExchange/hasher-matcher-actioner/hmalib/scripts/cli/main.py", line 168, in main                                                                                                                                                                                                                   
    execute_command(namespace)                                                                                                                                                                                                                                                                                              
  File "/workspaces/ThreatExchange/hasher-matcher-actioner/hmalib/scripts/cli/main.py", line 107, in execute_command                                                                                                                                                                                                        
    command.execute()                                                                                                                                                                                                                                                                                                       
  File "/workspaces/ThreatExchange/hasher-matcher-actioner/hmalib/scripts/cli/print_tfvars_example.py", line 73, in execute                                                                                                                                                                                                 
    raise ex                                                                                                                                                                                                                                                                                                                
  File "/workspaces/ThreatExchange/hasher-matcher-actioner/hmalib/scripts/cli/print_tfvars_example.py", line 68, in execute                                                                                                                                                                                                 
    import hcl2                                                                                                                                                                                                                                                                                                             
ModuleNotFoundError: No module named 'hcl2' 
```


After `dev_install_hmacli`
```
#  The URI for the docker image to use for the hma lambdas
hma_lambda_docker_uri = None

#  Prefix to use for resource names
prefix = hma

#  The name / acronym to use for resource names that must be globally unique (use only
#  lower case alpha a-z, and, optionally, hyphens)
organization = None

#  How long to retain cloudwatch logs for lambda functions in days
log_retention_in_days = 14
...
```
