### PR TITLE
Allow incremental updates in threat-updates

### DIFF
--- a/python-threatexchange/tests/hashing/test_index_updates.py
+++ b/python-threatexchange/tests/hashing/test_index_updates.py
@@ -1,9 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from threatexchange.signal_type.signal_base import TrivialSignalTypeIndex
 import unittest
 import typing as t
 
+from threatexchange.signal_type.signal_base import TrivialSignalTypeIndex
 from threatexchange.signal_type.index import SignalTypeIndex
 from threatexchange.signal_type.pdq_index import PDQIndex
 

--- a/python-threatexchange/threatexchange/threat_updates.py
+++ b/python-threatexchange/threatexchange/threat_updates.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 """
@@ -343,7 +342,7 @@ class ThreatUpdatesStore:
                 delta.start <= self.checkpoint.fetch_checkpoint
             ), "gap in delta record"
             assert not self.stale, "attempted to apply stale delta"
-        assert delta.done, "delta was not fetched"
+
         # It's possible the fetch completed but has no records
         if delta.updates:
             self._apply_updates_impl(delta, post_apply_fn)


### PR DESCRIPTION
Summary
---
Attempting to do threat exchange fetches against a large dataset with a limit would error out. This prevented incremental updates in hma fetcher, so addressed it.

Verified that subsequent calls to threatexchange cli with a limit worked. Shown in the test plan.

Test Plan
---
### Before...

```
$ TX_ACCESS_TOKEN="<app>|<secret>" python -m threatexchange.cli.main fetch --limit=10000
Currently at 19 days 10h32m57s ago
Downloaded 501 updates. Currently at 19 days 10h33m01s ago
Downloaded 2501 updates. Currently at 19 days 10h33m32s ago
Downloaded 4501 updates. Currently at 19 days 10h33m58s ago
Downloaded 9001 updates. Currently at 19 days 10h34m13s ago
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/workspaces/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 198, in <module>
    main()
  File "/workspaces/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 194, in main
    execute_command(namespace)
  File "/workspaces/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 110, in execute_command
    command.execute(api, dataset)
  File "/workspaces/ThreatExchange/python-threatexchange/threatexchange/cli/fetch.py", line 118, in execute
    indicator_store.apply_updates(delta)
  File "/workspaces/ThreatExchange/python-threatexchange/threatexchange/threat_updates.py", line 346, in apply_updates
    assert delta.done, "delta was not fetched"
AssertionError: delta was not fetched
```

### AFTER
```
... First Run

$ TX_ACCESS_TOKEN="<app>|<secret>" python -m threatexchange.cli.main fetch --limit=1000
Currently at 19 days 10h26m19s ago
Downloaded 501 updates. Currently at 19 days 10h26m22s ago
Processed 1000 updates:
HASH_PDQ: +1000
Rebuilding match indices...

... Second Run

$ TX_ACCESS_TOKEN="<app>|<secret>" python -m threatexchange.cli.main fetch --limit=10000
Currently at 19 days 10h26m40s ago
Downloaded 501 updates. Currently at 19 days 10h26m44s ago
Downloaded 4001 updates. Currently at 19 days 10h27m01s ago
Downloaded 9501 updates. Currently at 19 days 10h27m12s ago
Processed 10000 updates:
HASH_PDQ: +9608
HASH_VIDEO_MD5: +392
Rebuilding match indices...

... Third Run

$ TX_ACCESS_TOKEN="<app>|<secret>" python -m threatexchange.cli.main fetch --limit=10000
Currently at 19 days 10h27m40s ago
Downloaded 501 updates. Currently at 19 days 10h27m52s ago
Downloaded 3501 updates. Currently at 19 days 10h28m14s ago
Downloaded 8501 updates. Currently at 19 days 10h28m28s ago
Processed 10000 updates:
HASH_PDQ: +8735
HASH_VIDEO_MD5: +1265
Rebuilding match indices...
```
