### PR TITLE
[hma] check if fetcher is active in lambda

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -162,6 +162,12 @@ def lambda_handler(_event, _context):
             )
             continue
 
+        if not collab.fetcher_active:
+            logger.info(
+                f"Fetch skipped because configs has `fetcher_active` set to false for privacy_group_id({collab.privacy_group_id})"
+            )
+            continue
+
         indicator_store = ThreatUpdateS3Store(
             int(collab.privacy_group_id),
             api.app_id,


### PR DESCRIPTION
Summary
---------

see title.

Test Plan
---------
`make upload_docker`
`make make dev_apply_with_newest_docker_image` # with access token that has PGs access 

open UI go to settings hit `sync`
trigger fetcher manually or wait for it to trigger
make sure those in the fetch_active = false state are skipped 
- s3 objects aren't updated
- logs that the skip is occurring are taking place 