### PR TITLE
[pytx] Fix various bugs with threat_updates and CLI fetch

### DIFF
--- a/python-threatexchange/threatexchange/cli/dataset/simple_serialization.py
+++ b/python-threatexchange/threatexchange/cli/dataset/simple_serialization.py
@@ -61,9 +61,10 @@ class CliIndicatorSerialization(threat_updates.ThreatUpdateSerialization):
         for threat_type, items in row_by_type.items():
             path = state_dir / f"simple.{threat_type}{Dataset.EXTENSION}"
             ret.append(path)
-            with path.open("w") as f:
+            with path.open("w", encoding="utf-8", newline="") as f:
                 writer = csv.writer(f)
-                writer.writerows(item.as_csv_row() for item in items)
+                for item in items:
+                    writer.writerow(item.as_csv_row())
         return ret
 
     @classmethod
@@ -80,7 +81,7 @@ class CliIndicatorSerialization(threat_updates.ThreatUpdateSerialization):
             indicator_type = match.group(1)
             # Violate your warranty with class state! Not threadsafe!
             csv.field_size_limit(path.stat().st_size)  # dodge field size problems
-            with path.open("r", newline="") as f:
+            with path.open("r", encoding="utf-8", newline="") as f:
                 for row in csv.reader(f):
                     ret.append(
                         cls(

--- a/python-threatexchange/threatexchange/descriptor.py
+++ b/python-threatexchange/threatexchange/descriptor.py
@@ -190,7 +190,10 @@ class SimpleDescriptorRollup:
     def from_threat_updates_json(
         cls, my_app_id: int, te_json: t.Dict[str, t.Any]
     ) -> t.Optional["SimpleDescriptorRollup"]:
-        if te_json["should_delete"] or not te_json["descriptors"]["data"]:
+        if te_json["should_delete"]:
+            return None
+        # https://github.com/facebook/ThreatExchange/issues/834
+        if not te_json.get("descriptors", {}).get("data"):
             return None
         descriptors = []
         for descriptor_json in te_json["descriptors"]["data"]:

--- a/python-threatexchange/threatexchange/threat_updates.py
+++ b/python-threatexchange/threatexchange/threat_updates.py
@@ -63,7 +63,9 @@ class ThreatUpdateJSON(ThreatUpdateSerialization):
     @property
     def should_delete(self) -> bool:
         """This record is a tombstone, and we should delete our copy"""
-        return self.raw_json["should_delete"]
+        # This should just be should_delete only, but see
+        # https://github.com/facebook/ThreatExchange/issues/834
+        return self.raw_json["should_delete"] or "descriptors" not in self.raw_json
 
     @property
     def key(self):


### PR DESCRIPTION
Summary
---------

This the result of trying to run `threatexchange fetch` on one of the new collections for a few hours, and just fixing whatever thing came up.

At least one of them is actually a bug with the Facebook API, but we can work around it on the client side for now.

I now regret many stupid choices about how I set up serialization, and fetching, with the root of all evil being not choosing SQLite as the base storage layer.

Should fix #844 

Test Plan
---------

```
$ threatexchange fetch  # Completes on a big test collaboration
```
