### PR TITLE
url md5 hashing and normalization added

### DIFF
--- a/python-threatexchange/threatexchange/common.py
+++ b/python-threatexchange/threatexchange/common.py
@@ -53,6 +53,7 @@ def normalize_string(s: str) -> str:
     s = re.sub("[\W_]", "", s)
     return s
 
+
 def normalize_url(url: str) -> str:
     """
     Normalize the URL and strip the scheme from the URL to make matching more effective.
@@ -64,13 +65,13 @@ def normalize_url(url: str) -> str:
     url = url.lower()
     # parse the Url into it's consituent parts
     parsed = urlparse(url)
-    #identify the scheme and trailing punctuation
-    #e.g. scheme = "http://"
+    # identify the scheme and trailing punctuation
+    # e.g. scheme = "http://"
     scheme = "%s://" % parsed.scheme
-    #Remove the scheme from the full url
+    # Remove the scheme from the full url
     # https://www.facebook.com => www.facebook.com
-    url = parsed.geturl().replace(scheme, '', 1)
-    #Ensure URL is utf-8 encoded
-    url=url.encode('utf-8')
+    url = parsed.geturl().replace(scheme, "", 1)
+    # Ensure URL is utf-8 encoded
+    url = url.encode("utf-8")
 
     return url

--- a/python-threatexchange/threatexchange/content_type/meta.py
+++ b/python-threatexchange/threatexchange/content_type/meta.py
@@ -15,7 +15,13 @@ from ..signal_type import signal_base
 @functools.lru_cache(1)
 def get_all_content_types() -> t.List[t.Type[content_base.ContentType]]:
     """Returns all content_type implementations for commands"""
-    return [text.TextContent, video.VideoContent, photo.PhotoContent, pdf.PDFContent, url.URL]
+    return [
+        text.TextContent,
+        video.VideoContent,
+        photo.PhotoContent,
+        pdf.PDFContent,
+        url.URL,
+    ]
 
 
 @functools.lru_cache(1)

--- a/python-threatexchange/threatexchange/content_type/url.py
+++ b/python-threatexchange/threatexchange/content_type/url.py
@@ -10,6 +10,7 @@ from ..signal_type import url_md5
 from ..signal_type.signal_base import SignalType
 from .content_base import ContentType
 
+
 class URL(ContentType):
     """
     URLs are often used to point specific files and specific locations online.

--- a/python-threatexchange/threatexchange/signal_type/tests/test_url_md5_hash.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/test_url_md5_hash.py
@@ -8,9 +8,14 @@ URL_TEST = "www.facebook.com/?user=123"
 FULL_URL_TEST = "https://www.facebook.com/?user=123"
 URL_TEST_MD5 = "e359430911fe80c2dd526d3cca21da30"
 
+
 class UrlMD5SignalTestCase(unittest.TestCase):
     def test_can_hash_simple_url(self):
-        assert URL_TEST_MD5 == UrlMD5Signal.hash_from_str(URL_TEST), "MD5 hash does not match"
+        assert URL_TEST_MD5 == UrlMD5Signal.hash_from_str(
+            URL_TEST
+        ), "MD5 hash does not match"
 
     def test_can_hash_full_url(self):
-        assert URL_TEST_MD5 == UrlMD5Signal.hash_from_str(FULL_URL_TEST), "MD5 hash does not match"
+        assert URL_TEST_MD5 == UrlMD5Signal.hash_from_str(
+            FULL_URL_TEST
+        ), "MD5 hash does not match"

--- a/python-threatexchange/threatexchange/signal_type/url_md5.py
+++ b/python-threatexchange/threatexchange/signal_type/url_md5.py
@@ -11,7 +11,8 @@ from ..descriptor import SimpleDescriptorRollup, ThreatDescriptor
 from . import signal_base
 from .. import common
 
-class UrlMD5Signal( signal_base.SimpleSignalType, signal_base.StrHasher):
+
+class UrlMD5Signal(signal_base.SimpleSignalType, signal_base.StrHasher):
     """
     Simple signal type for URL MD5s.
     """
@@ -20,7 +21,7 @@ class UrlMD5Signal( signal_base.SimpleSignalType, signal_base.StrHasher):
     TYPE_TAG = "media_type_url"
 
     @classmethod
-    def hash_from_str(cls,url: str) -> str:
+    def hash_from_str(cls, url: str) -> str:
         url = common.normalize_url(url)
         url_hash = hashlib.md5(url)
         return url_hash.hexdigest()


### PR DESCRIPTION
Summary
---------

Added Url content type and Url_MD5_Hash signal type along with necessary utilities to normalize urls before hashing.

Test Plan
---------

Added 2 tests of the Url_MD5_Hash signal type to validate that it correctly creates hashes from a normalized url and a that it correctly normalizes Urls prior to hashing. These have been run and passed locally on sample URLs (see test file for example)
