### PR TITLE
Make submit_events truly optional by making dashboard optional

### DIFF
--- a/hasher-matcher-actioner/terraform/dashboard/main.tf
+++ b/hasher-matcher-actioner/terraform/dashboard/main.tf
@@ -218,6 +218,9 @@ locals {
     }
   })
 
+  # Should we add the submit event widgets to the dashboard?
+  add_submit_event_widgets = var.submit_event_lambda_name != null
+
   submit_event_lambda_widget = jsonencode({
     height = 6,
     width  = 6,
@@ -238,7 +241,7 @@ locals {
     }
   })
 
-  submit_queue_widge = jsonencode({
+  submit_queue_widge = local.add_submit_event_widgets ? jsonencode({
     width = 6
     type  = "metric"
     properties = {
@@ -259,8 +262,7 @@ locals {
         [".", "ApproximateAgeOfOldestMessage", ".", ".", { yAxis = "right", label = "dlq-approx-age" }]
       ]
     }
-  })
-
+  }) : jsonencode({})
 
   dashboard_body = <<JSON
   {
@@ -280,11 +282,14 @@ locals {
       ${local.dynamodb_datastore_errors_widget},
 
       ${local.title_system_capacity},
-      ${local.total_concurrent_lambda},
+      ${local.total_concurrent_lambda}
 
+      %{if local.add_submit_event_widgets}
+      ,
       ${local.title_submit_event},
       ${local.submit_event_lambda_widget},
       ${local.submit_queue_widge}
+      %{endif}
       ]
   }
 JSON


### PR DESCRIPTION
Summary
---
Without `create_submit_event_sns_topic_and_handler` being true, terraform would refuse to apply because the dashboard module implicitly depends on resources existing.

Test Plan
---
Try `terraform apply` with and without
```hcl
create_submit_event_sns_topic_and_handler = true
```

## With `create_submit_event_sns_topic_and_handler = false`, note the dashboard ends without submit events widgets. 
<img width="1408" alt="Screen Shot 2021-10-27 at 15 03 17" src="https://user-images.githubusercontent.com/217056/139131123-3266a9dc-e999-4340-a256-655b78dc2ec6.png">


## With `create_submit_event_sns_topic_and_handler = true`, note the dashboard now has submit events widgets. 
<img width="1403" alt="Screen Shot 2021-10-27 at 15 06 34" src="https://user-images.githubusercontent.com/217056/139131109-817ed50f-8d7c-4625-b545-d9fdc18ba027.png">


