### PR TITLE
[hma][cli] add sns support to storm cli command

### DIFF
--- a/hasher-matcher-actioner/scripts/submit_s3_bucket
+++ b/hasher-matcher-actioner/scripts/submit_s3_bucket
@@ -99,7 +99,7 @@ class S3BucketSubmitter:
     def run_one_iteration(self, executor):
         def submit_one(presigned_url: str):
             content_id = str(uuid.uuid4())
-            executor.submit(self.api.submit_via_external_url, presigned_url, content_id)
+            executor.submit(self.api.submit_via_external_url, content_id, presigned_url)
 
         self.map_object_presigned_urls(submit_one)
 


### PR DESCRIPTION
Summary
---------

This is an older change I meant to put up earlier. If you have AWS credentials this will allow hmacli to submit using an sns topic as well as the web interface for storm commands. This also gets us closer to consolidating scripts further


Test Plan
---------

Updated doc string with new order of args (in future PR I want to clarify and spilt up s3-object and s3-bucket)
```
$ hmacli storm -m "<filepath>" -c 100 -v upload
$ hmacli storm -m "<filepath>" -c 100 -v bytes
$ hmacli storm -m "<signed-url>" -c 100 -v url
$ hmacli storm -m "<bucket>:<key>" -c 100 -v s3
$ hmacli storm -m "<pdq-hash>" -c 100 -v hash
```
```
hmacli storm --media "<bucket>:<key>" -v --sns_topic arn:aws:sns:us-east-1:<acount-id>:<prefix>-submission2021102120070926530438200001 sns-s3

Started adding tasks to executor
1 requests prepared
Done adding tasks to executor
0 of 1 sent!! Current 200 chunk has QPS of 0.0
Sent all 1 submissions.
Percentiles in ms:
                    p75: 235
                    p95: 235
                    p99: 235
                
```