### PR TITLE
Use parameterized counts for the HMADataStore stream counter

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/ddb_stream_counter.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/ddb_stream_counter.py
@@ -89,12 +89,22 @@ class PipelineTableStreamCounter(BaseTableStreamCounter):
             # TODO These should maybe have a strong connection to the objects instead of class constants
             # otherwise changes to the object might not correctly update these count checks
             if sk == ContentObject.CONTENT_STATIC_SK:
-                count_buffer.inc_aggregate(AggregateCount.PipelineNames.submits)
+                content_type = record["dynamodb"]["NewImage"]["ContentType"]["S"]
+                count_buffer.inc_parameterized(
+                    AggregateCount.PipelineNames.submits, "content_type", content_type
+                )
             elif sk.startswith(DynamoDBItem.TYPE_PREFIX):
                 # note hashes should always match submits (submits == hashes)
-                count_buffer.inc_aggregate(AggregateCount.PipelineNames.hashes)
+                signal_type = record["dynamodb"]["NewImage"]["SignalType"]["S"]
+                count_buffer.inc_parameterized(
+                    AggregateCount.PipelineNames.hashes, "signal_type", signal_type
+                )
             elif sk.startswith(DynamoDBItem.SIGNAL_KEY_PREFIX):
-                count_buffer.inc_aggregate(AggregateCount.PipelineNames.matches)
+                signal_source = record["dynamodb"]["NewImage"]["SignalSource"]["S"]
+                signal_id = sk.split("#")[-1]
+                count_buffer.inc_parameterized(
+                    AggregateCount.PipelineNames.matches, signal_source, signal_id
+                )
 
         count_buffer.flush()
 

--- a/hasher-matcher-actioner/hmalib/lambdas/ddb_stream_counter.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/ddb_stream_counter.py
@@ -85,25 +85,28 @@ class PipelineTableStreamCounter(BaseTableStreamCounter):
 
             pk: str = record["dynamodb"]["Keys"]["PK"]["S"]
             sk: str = record["dynamodb"]["Keys"]["SK"]["S"]
+            # The raw stream values have a different schema than what is returned by boto3 meaning
+            # they can't be deserialized into one of the HMA datamodels using existing functionality.
+            inserted_record = record["dynamodb"]["NewImage"]
 
             # TODO These should maybe have a strong connection to the objects instead of class constants
             # otherwise changes to the object might not correctly update these count checks
             if sk == ContentObject.CONTENT_STATIC_SK:
                 count_buffer.inc_aggregate(AggregateCount.PipelineNames.submits)
-                content_type = record["dynamodb"]["NewImage"]["ContentType"]["S"]
+                content_type = inserted_record["ContentType"]["S"]
                 count_buffer.inc_parameterized(
                     AggregateCount.PipelineNames.submits, "content_type", content_type
                 )
             elif sk.startswith(DynamoDBItem.TYPE_PREFIX):
                 # note hashes should always match submits (submits == hashes)
                 count_buffer.inc_aggregate(AggregateCount.PipelineNames.hashes)
-                signal_type = record["dynamodb"]["NewImage"]["SignalType"]["S"]
+                signal_type = inserted_record["SignalType"]["S"]
                 count_buffer.inc_parameterized(
                     AggregateCount.PipelineNames.hashes, "signal_type", signal_type
                 )
             elif sk.startswith(DynamoDBItem.SIGNAL_KEY_PREFIX):
                 count_buffer.inc_aggregate(AggregateCount.PipelineNames.matches)
-                signal_source = record["dynamodb"]["NewImage"]["SignalSource"]["S"]
+                signal_source = inserted_record["SignalSource"]["S"]
                 signal_id = sk.split("#")[-1]
                 count_buffer.inc_parameterized(
                     AggregateCount.PipelineNames.matches, signal_source, signal_id

--- a/hasher-matcher-actioner/hmalib/lambdas/ddb_stream_counter.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/ddb_stream_counter.py
@@ -89,17 +89,20 @@ class PipelineTableStreamCounter(BaseTableStreamCounter):
             # TODO These should maybe have a strong connection to the objects instead of class constants
             # otherwise changes to the object might not correctly update these count checks
             if sk == ContentObject.CONTENT_STATIC_SK:
+                count_buffer.inc_aggregate(AggregateCount.PipelineNames.submits)
                 content_type = record["dynamodb"]["NewImage"]["ContentType"]["S"]
                 count_buffer.inc_parameterized(
                     AggregateCount.PipelineNames.submits, "content_type", content_type
                 )
             elif sk.startswith(DynamoDBItem.TYPE_PREFIX):
                 # note hashes should always match submits (submits == hashes)
+                count_buffer.inc_aggregate(AggregateCount.PipelineNames.hashes)
                 signal_type = record["dynamodb"]["NewImage"]["SignalType"]["S"]
                 count_buffer.inc_parameterized(
                     AggregateCount.PipelineNames.hashes, "signal_type", signal_type
                 )
             elif sk.startswith(DynamoDBItem.SIGNAL_KEY_PREFIX):
+                count_buffer.inc_aggregate(AggregateCount.PipelineNames.matches)
                 signal_source = record["dynamodb"]["NewImage"]["SignalSource"]["S"]
                 signal_id = sk.split("#")[-1]
                 count_buffer.inc_parameterized(

--- a/hasher-matcher-actioner/hmalib/lambdas/ddb_stream_counter.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/ddb_stream_counter.py
@@ -93,24 +93,32 @@ class PipelineTableStreamCounter(BaseTableStreamCounter):
             # otherwise changes to the object might not correctly update these count checks
             if sk == ContentObject.CONTENT_STATIC_SK:
                 count_buffer.inc_aggregate(AggregateCount.PipelineNames.submits)
-                content_type = inserted_record["ContentType"]["S"]
-                count_buffer.inc_parameterized(
-                    AggregateCount.PipelineNames.submits, "content_type", content_type
-                )
+                if (
+                    content_type := inserted_record.get("ContentType", {}).get("S")
+                ) is not None:
+                    count_buffer.inc_parameterized(
+                        AggregateCount.PipelineNames.submits,
+                        "content_type",
+                        content_type,
+                    )
             elif sk.startswith(DynamoDBItem.TYPE_PREFIX):
                 # note hashes should always match submits (submits == hashes)
                 count_buffer.inc_aggregate(AggregateCount.PipelineNames.hashes)
-                signal_type = inserted_record["SignalType"]["S"]
-                count_buffer.inc_parameterized(
-                    AggregateCount.PipelineNames.hashes, "signal_type", signal_type
-                )
+                if (
+                    signal_type := inserted_record.get("SignalType", {}).get("S")
+                ) is not None:
+                    count_buffer.inc_parameterized(
+                        AggregateCount.PipelineNames.hashes, "signal_type", signal_type
+                    )
             elif sk.startswith(DynamoDBItem.SIGNAL_KEY_PREFIX):
                 count_buffer.inc_aggregate(AggregateCount.PipelineNames.matches)
-                signal_source = inserted_record["SignalSource"]["S"]
-                signal_id = sk.split("#")[-1]
-                count_buffer.inc_parameterized(
-                    AggregateCount.PipelineNames.matches, signal_source, signal_id
-                )
+                if (
+                    signal_source := inserted_record.get("SignalSource", {}).get("S")
+                ) is not None:
+                    signal_id = sk.split("#")[-1]
+                    count_buffer.inc_parameterized(
+                        AggregateCount.PipelineNames.matches, signal_source, signal_id
+                    )
 
         count_buffer.flush()
 


### PR DESCRIPTION
Summary
---------

Adds the parameterized count to the HMADataStore stream counter.

Test Plan
---------

Updated my lambda function to use these code changes and testing submitting a photo and video.

Test data added (images/videos were uploaded via the HMA UI, the match was added to dynamo manually):
![image](https://user-images.githubusercontent.com/12033718/141014693-65bbedcc-9fa9-43e7-8232-a5f56dedeb1a.png)

Resulting counts:
![image](https://user-images.githubusercontent.com/12033718/141015415-89086be0-df18-4de0-addc-55f95b1a5d82.png)
