### PR TITLE
[hma] add hma_extension entry point for custom impl of ActionPerformer

### DIFF
--- a/hasher-matcher-actioner/Dockerfile
+++ b/hasher-matcher-actioner/Dockerfile
@@ -11,3 +11,4 @@ RUN pip install -e .
 # the python path complications from arising.
 # 1: https://hub.docker.com/r/amazon/aws-lambda-python
 COPY hmalib ${LAMBDA_TASK_ROOT}/hmalib
+COPY hmalib_extensions ${LAMBDA_TASK_ROOT}/hmalib_extensions

--- a/hasher-matcher-actioner/hmalib/common/extensions.py
+++ b/hasher-matcher-actioner/hmalib/common/extensions.py
@@ -1,0 +1,32 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import sys
+import functools
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata as importlib_metadata
+else:
+    import importlib_metadata
+
+
+@functools.lru_cache(maxsize=None)
+def importlib_metadata_get(group: str):
+    ep = importlib_metadata.entry_points()
+    if hasattr(ep, "select"):
+        return ep.select(group=group)  # type: ignore # method checked manually.
+    else:
+        return ep.get(group, ())
+
+
+# 5 is arbitrary (seems unlikely >5 custom impl used together)
+@functools.lru_cache(maxsize=5)
+def load_extension_impl(entry_point_name: str):
+    """
+    Attempts to load an entry point from the `hmalib_extensions`
+    group specifed in setup.py
+    TODO more typing and validation should be done here. for now:
+    ONLY USE THIS OR MAKE CHANGES IF YOU KNOW WHAT YOU ARE DOING. :)
+    """
+    for ep in importlib_metadata_get(group="hmalib_extensions"):
+        if ep.name == entry_point_name:
+            return ep.load()
+    return None

--- a/hasher-matcher-actioner/hmalib/scripts/common/utils.py
+++ b/hasher-matcher-actioner/hmalib/scripts/common/utils.py
@@ -242,7 +242,7 @@ class HasherMatcherActionerAPI:
             "matcher_active": matcher_active,
             "write_back": write_back,
         }
-        self.session.post(
+        return self.session.post(
             self._get_request_url(api_path),
             data=json.dumps(payload).encode(),
         )
@@ -266,7 +266,7 @@ class HasherMatcherActionerAPI:
             "config_subtype": config_subtype,
             "fields": fields,
         }
-        self.session.post(
+        return self.session.post(
             self._get_request_url(api_path),
             data=json.dumps(payload).encode(),
         )
@@ -276,7 +276,7 @@ class HasherMatcherActionerAPI:
         action_name: str,
         api_path: str = "actions/",
     ):
-        self.session.delete(self._get_request_url(api_path + action_name))
+        return self.session.delete(self._get_request_url(api_path + action_name))
 
     def get_action_rules(
         self,
@@ -293,7 +293,7 @@ class HasherMatcherActionerAPI:
         payload = {
             "action_rule": action_rule,
         }
-        self.session.post(
+        return self.session.post(
             self._get_request_url(api_path),
             data=json.dumps(payload).encode(),
         )
@@ -303,7 +303,7 @@ class HasherMatcherActionerAPI:
         action_rule_name: str,
         api_path: str = "action-rules/",
     ):
-        self.session.delete(self._get_request_url(api_path + action_rule_name))
+        return self.session.delete(self._get_request_url(api_path + action_rule_name))
 
     def get_matches_for_hash(
         self,

--- a/hasher-matcher-actioner/hmalib_extensions/main.py
+++ b/hasher-matcher-actioner/hmalib_extensions/main.py
@@ -1,0 +1,30 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+This file holds simple hma_extension implementations. 
+Primary as an example for incorporating others.
+
+To use an extention you must specific a new entry point in 
+setup.py 's entry_points group "hmalib_extensions"
+
+For example the `print_arg` method below has been added to setup.py as
+  "echo = hmalib_extensions.main:print_arg"
+
+Once added hmalib can load these extentions via
+`hmalib.common.extensions.load_extension_impl` 
+e.g. 
+```python3
+from hmalib.common.extensions import load_extension_impl
+
+fn = load_extension_impl("echo")
+
+fn("Hello World!")
+>> Hello World
+
+```
+"""
+
+
+def print_arg(arg):
+    """Example method use could use to test basic hma_extension support"""
+    print(arg)

--- a/hasher-matcher-actioner/setup.py
+++ b/hasher-matcher-actioner/setup.py
@@ -30,5 +30,8 @@ setup(
         "requests>=2.25.1",
     ],
     extras_require=extras_require,
-    entry_points={"console_scripts": ["hmacli = hmalib.scripts.cli.main:main"]},
+    entry_points={
+        "console_scripts": ["hmacli = hmalib.scripts.cli.main:main"],
+        "hmalib_extensions": ["echo = hmalib_extensions.main:print_arg"],
+    },
 )

--- a/hasher-matcher-actioner/terraform/actions/outputs.tf
+++ b/hasher-matcher-actioner/terraform/actions/outputs.tf
@@ -15,6 +15,10 @@ output "action_performer_function_name" {
   value = aws_lambda_function.action_performer.function_name
 }
 
+output "action_performer_iam_role_arn" {
+  value = aws_iam_role.action_performer.arn
+}
+
 output "writebacker_function_name" {
   value = aws_lambda_function.writebacker.function_name
 }

--- a/hasher-matcher-actioner/terraform/outputs.tf
+++ b/hasher-matcher-actioner/terraform/outputs.tf
@@ -35,3 +35,6 @@ output "ui_url" {
 output "submit_topic_arn" {
   value = var.create_submit_event_sns_topic_and_handler ? module.submit_events[0].submit_topic_arn : ""
 }
+output "action_performer_iam_role_arn" {
+  value = module.actions.action_performer_iam_role_arn
+}


### PR DESCRIPTION
Summary
---------

Create the initial structure such that custom code written outside of hmalib can be used and run by hmalib lambda's in this first case `hmalib/lambdas/actions/action_performer.py`

More typing, documenting, etc are in the works but want to get input on this approach now.


Test Plan
---------

### Test locally:
```python3
from hmalib.common.extensions import load_extension_impl

fn = load_extension_impl("echo")

fn("Hello World!")
>> Hello World
```

### Test Deploy:
```bash
make upload_docker 
make dev_apply_with_newest_docker_image
``` 
then
Manually created an ActionPerformer & ActionRule in my <prefix>-HMAConfig table:

ConfigType | ConfigName | action_label | config_subtype | entry_point_name | must_have_labels | must_not_have_labels
-- | -- | -- | -- | -- | -- | --
ActionPerformer | CustomImplAction1 |   | CustomImplActionPerformer | echo |   |   |  
ActionRule | trigger-on-tag-holidays_jpg1_dataset-custom | {"value":{"S":"CustomImplAction1"},"key":{"S":"Action"}} |   |   | [{"M":{"value":{"S":"holidays_jpg1_dataset"},"key":{"S":"Classification"}}}] | [] |  

Submitted the b.jpg photo the triggers match and manually created action.

Made sure the ActionPerformer lambda cloudwatch logs have the result of the echo extension printed along with the action history record for the content_id.

Note: right now manually creating this action will break the UI settings page for actions. 




Updates since publish
---------
- action_performer_iam_role_arn now part of tf outputs
- add some missing returns to `hmalib/scripts/common/utils.py` post requests
- `hmalib/common/configs/actioner.py` was incorrectly typed to handle`MatchMessage` even though action_eval sends its child class `ActionMessage` fixed this.
- Added kwargs field to new action type. 
(repeated test plan after changes) 
