### PR TITLE
Fix content input from not resetting when selecting to submit another

### DIFF
--- a/hasher-matcher-actioner/webapp/src/pages/SubmitContent.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/SubmitContent.tsx
@@ -196,6 +196,7 @@ export default function SubmitContent(): JSX.Element {
                   name="content"
                   placeholder="url to content"
                   required
+                  value={inputs.content}
                 />
                 <Form.Text className="text-muted mt-0">
                   Currently behavior will store a copy of the content


### PR DESCRIPTION
Summary
---------

Selecting to "submit another" does not clear the content form, but it does clear what is stored in the state. It appears to the user that the content field is filled out, but if they submit again without modifying the input, it will actually send an empty string. Since the state get's reset, we just need to set the value of the input to the current state.

This use case probably never happens in practice since it would mean a user is submitting the same content URL multiple times with different IDs, but it happened to me when testing something else :). It may also be worthwhile to add a check for an empty content URL.

This is what would be added to dynamo if you reached this bug:
![image](https://user-images.githubusercontent.com/12033718/141019558-eaa82eca-9e79-4bff-8029-043a6593b723.png)

Test Plan
---------

Ran the UI with changes locally and confirmed that after clicking "Submit Another", the content URL is cleared.
