### PR TITLE
[hmalib][script] add hmalib_extensions/ to gitignore and small changes to client_lib.py 

### DIFF
--- a/hasher-matcher-actioner/.gitignore
+++ b/hasher-matcher-actioner/.gitignore
@@ -41,4 +41,9 @@ dist/
 # Ignore files for local lambda testing.
 lambda_local.py
 main.py.zip
-settings.py
+
+# see settings.py.example for an example in source control
+settings.py 
+# __init__.py and one other file are commited as an example. 
+# all other files added are expected to be third party additions/custom implementations. 
+hmalib_extensions/

--- a/hasher-matcher-actioner/.gitignore
+++ b/hasher-matcher-actioner/.gitignore
@@ -44,6 +44,6 @@ main.py.zip
 
 # see settings.py.example for an example in source control
 settings.py 
-# __init__.py and one other file are commited as an example. 
+# __init__.py and one other file are committed as an example. 
 # all other files added are expected to be third party additions/custom implementations. 
 hmalib_extensions/


### PR DESCRIPTION
Summary
---------

`hmalib_extensions/` should be ignored by git, `__init__.py` and one other file are committed as an example but all other files added are expected to be third party additions/custom implementations. 

Test Plan
---------

```
cp settings.py.example
make upload_docker
make dev_apply_with_newest_docker_image
# comment out lines in `hmalib/scripts/common/client_lib.py`
make dev_test_instance
```
