### PR TITLE
[pytx] hot fix - fetch of sample data to use tag_fetch renamed in (#744)

### DIFF
--- a/python-threatexchange/threatexchange/cli/match.py
+++ b/python-threatexchange/threatexchange/cli/match.py
@@ -15,7 +15,7 @@ from ..content_type import meta
 from ..dataset import Dataset
 from ..descriptor import ThreatDescriptor
 from ..signal_type.signal_base import FileMatcher, HashMatcher, StrMatcher
-from . import command_base, fetch
+from . import command_base, tag_fetch
 
 
 class MatchCommand(command_base.Command):
@@ -148,7 +148,7 @@ class MatchCommand(command_base.Command):
             self.stderr(
                 "Looks like you are running this for the first time. Fetching some sample data."
             )
-            fetch.TagFetchCommand(sample=True).execute(api, dataset)
+            tag_fetch.TagFetchCommand(sample=True).execute(api, dataset)
 
         all_signal_types = dataset.load_cache(
             s() for s in self.content_type.get_signal_types()


### PR DESCRIPTION
Summary
---------

If you don't have a `threatexchange_samples` folder and run something `threatexchange match text "example"`

The cli match command will try and fetch, however it still needs to use the tag_fetch version that was renamed but missed in #744. 

Test Plan
---------
Before:
```
#with `threatexchange_samples` folder deleted
python-threatexchange $ threatexchange match text "example"                                                                                                                                                                                                                                                                                                                                                   
 ...
AttributeError: module 'threatexchange.cli.fetch' has no attribute 'TagFetchCommand'
```
After:
```
$ threatexchange match text "example"                   
# match command print out signal type and count from successful fetch (given correct auth token)                
```                                                                                                                                                                                                                                                                                                                 