### PR TITLE
[pytx] quick fix of benchmark script - pdq index requires custom ids

### DIFF
--- a/python-threatexchange/benchmarks/benchmark_pdq_faiss_matchers.py
+++ b/python-threatexchange/benchmarks/benchmark_pdq_faiss_matchers.py
@@ -48,13 +48,6 @@ parser.add_argument(
     help="PDQ similarity threshold values to benchmark with",
 )
 parser.add_argument("--seed", type=int, help="seed for random number generator")
-parser.add_argument(
-    "--use-custom-ids",
-    dest="use_custom_ids",
-    action="store_true",
-    help="whether to use custom ids in the index",
-)
-parser.set_defaults(use_custom_ids=False)
 
 args = parser.parse_args()
 
@@ -121,10 +114,8 @@ def generate_random_hash_with_hamming_distance(original_hash, desired_hamming_di
 
 dataset = [generate_random_hash() for _ in range(args.dataset_size)]
 
-if args.use_custom_ids:
-    custom_ids = [i + 100_000_000_000_000 for i in range(args.dataset_size)]
-else:
-    custom_ids = None
+
+custom_ids = [i + 100_000_000_000_000 for i in range(args.dataset_size)]
 
 start_build_flat_hash_index = time.time()
 flat_index = PDQFlatHashIndex()


### PR DESCRIPTION
Summary
---------

PR merged awhile go [made `custom_ids` required](https://github.com/facebook/ThreatExchange/pull/811/files#diff-d150baf7a027ad595b5696c7b16f8e4fc7d99da4a83fe1ababeae118384b548bR133) 

This change has `benchmark_pdq_faiss_matchers.py` respect this change

Test Plan
---------

Before:
```
$ python3 benchmarks/benchmark_pdq_faiss_matchers.py --dataset-size 100000
 ....
Traceback (most recent call last):
  File "benchmarks/benchmark_pdq_faiss_matchers.py", line 131, in <module>
    flat_index.add(dataset, custom_ids=custom_ids)
  File "/Users/barrett/dev/github/ThreatExchange/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py", line 143, in add
    i64_ids = list(map(uint64_to_int64, custom_ids))
TypeError: 'NoneType' object is not iterable
```

After:
```
$ python3 benchmarks/benchmark_pdq_faiss_matchers.py --dataset-size 100000                                                                                                                                         [11:48:04]
Benchmark: PDQ Faiss Matcher Comparison

Options:
         faiss_threads :  1
         dataset_size :  100000
         num_queries :  1000
         thresholds :  [0, 15, 31, 47]
         seed :  None

using random seed of  1638377287787902000
use --seed  1638377287787902000  to rerun with same random values

Building Stats:
        PDQFlatHashIndex: time to build (s):  0.3279421329498291
        PDQFlatHashIndex: approximate size: 3,906KB
        PDQMultiHashIndex: time to build (s):  1.1916327476501465
        PDQMultiHashIndex: approximate size: 10,531KB

Benchmarks for threshold:  0
        PDQFlatHashIndex - Total Time to search  (s):  0.32317328453063965
        PDQMultiHashIndex - Total Time to search  (s):  0.027163982391357422
        PDQFlatHashIndex - Precent of targets found:  100.0
        PDQMultiHashIndex - Precent of targets found:  100.0

Benchmarks for threshold:  15
        PDQFlatHashIndex - Total Time to search  (s):  0.30727410316467285
        PDQMultiHashIndex - Total Time to search  (s):  0.02283501625061035
        PDQFlatHashIndex - Precent of targets found:  100.0
        PDQMultiHashIndex - Precent of targets found:  100.0

Benchmarks for threshold:  31
        PDQFlatHashIndex - Total Time to search  (s):  0.3049619197845459
        PDQMultiHashIndex - Total Time to search  (s):  0.18273687362670898
        PDQFlatHashIndex - Precent of targets found:  100.0
        PDQMultiHashIndex - Precent of targets found:  100.0

Benchmarks for threshold:  47
        PDQFlatHashIndex - Total Time to search  (s):  0.3089599609375
        PDQMultiHashIndex - Total Time to search  (s):  1.5262069702148438
        PDQFlatHashIndex - Precent of targets found:  100.0
        PDQMultiHashIndex - Precent of targets found:  100.0
```
