### PR TITLE
Run indexer on a schedule instead of on events

### DIFF
--- a/hasher-matcher-actioner/terraform/fetcher/main.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/main.tf
@@ -176,7 +176,7 @@ data "aws_iam_policy_document" "fetcher_trigger_assume_role" {
 data "aws_iam_policy_document" "fetcher_trigger" {
   statement {
     actions   = ["lambda:InvokeFunction"]
-    resources = ["*"]
+    resources = [aws_lambda_function.fetcher.arn]
     effect    = "Allow"
     condition {
       test     = "ArnLike"

--- a/hasher-matcher-actioner/terraform/indexer/main.tf
+++ b/hasher-matcher-actioner/terraform/indexer/main.tf
@@ -2,7 +2,7 @@
 
 # First define the Indexing Schedule
 resource "aws_cloudwatch_event_rule" "indexing_trigger" {
-  name                = "${var.prefix}-HMA_IndexingTrigger"
+  name                = "${var.prefix}-RecurringIndexBuild"
   description         = "Rebuild Index on a regular cadence"
   schedule_expression = "rate(${var.indexer_frequency})"
   role_arn            = aws_iam_role.indexing_trigger.arn

--- a/hasher-matcher-actioner/terraform/indexer/main.tf
+++ b/hasher-matcher-actioner/terraform/indexer/main.tf
@@ -1,5 +1,66 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+# First define the Indexing Schedule
+resource "aws_cloudwatch_event_rule" "indexing_schedule" {
+  name                = "${var.prefix}HMA_IndexingSchedule"
+  description         = "Rebuild Index on a regular cadence"
+  schedule_expression = "rate(${var.indexer_frequency})"
+  role_arn            = aws_iam_role.indexing_schedule.arn
+}
+
+resource "aws_iam_role" "indexing_schedule" {
+  name_prefix        = "${var.prefix}_indexing_schedule"
+  assume_role_policy = data.aws_iam_policy_document.indexing_schedule_assume_role.json
+
+  tags = merge(
+    var.additional_tags,
+    {
+      Name = "FetcherLambdaTriggerRole"
+    }
+  )
+}
+
+data "aws_iam_policy_document" "indexing_schedule_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+## Define a policy document to asign to the role
+data "aws_iam_policy_document" "indexing_schedule" {
+  statement {
+    actions   = ["lambda:InvokeFunction"]
+    resources = ["*"]
+    effect    = "Allow"
+    condition {
+      test     = "ArnLike"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudwatch_event_rule.indexing_schedule.arn]
+    }
+  }
+}
+
+## Create a permission policy from policy document
+resource "aws_iam_policy" "indexing_schedule" {
+  name_prefix = "${var.prefix}_indexing_schedule_role_policy"
+  description = "Permissions for Indexing Schedule"
+  policy      = data.aws_iam_policy_document.indexing_schedule.json
+}
+
+## Attach a permission policy to the fetech trigger role
+resource "aws_iam_role_policy_attachment" "indexing_schedule" {
+  role       = aws_iam_role.indexing_schedule.name
+  policy_arn = aws_iam_policy.indexing_schedule.arn
+}
+
+
+
+# Then define the Indexing Function / Lambda etc.
 data "aws_iam_policy_document" "lambda_assume_role" {
   statement {
     effect  = "Allow"
@@ -10,8 +71,6 @@ data "aws_iam_policy_document" "lambda_assume_role" {
     }
   }
 }
-
-#  Indexer
 
 resource "aws_lambda_function" "indexer" {
   function_name = "${var.prefix}_indexer"
@@ -113,19 +172,6 @@ resource "aws_iam_role_policy_attachment" "indexer" {
   policy_arn = aws_iam_policy.indexer.arn
 }
 
-resource "aws_sns_topic_subscription" "indexer" {
-  topic_arn = var.threat_exchange_data.notification_topic
-  protocol  = "lambda"
-  endpoint  = aws_lambda_function.indexer.arn
-}
-
-resource "aws_lambda_permission" "indexer" {
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.indexer.function_name
-  principal     = "sns.amazonaws.com"
-  source_arn    = var.threat_exchange_data.notification_topic
-}
-
 resource "null_resource" "provide_sample_pdq_data_holidays" {
   # To force-update on existing deployment, taint and apply terraform again
   # $ terraform taint module.indexer.null_resource.provide_sample_pdq_data_holidays
@@ -134,8 +180,6 @@ resource "null_resource" "provide_sample_pdq_data_holidays" {
   # To get a sensible privacy group value, we reverse engineer the filename split at
   # hmalib.common.s3_adapters.ThreatExchangeS3Adapter._parse_file at line 118
   depends_on = [
-    aws_lambda_permission.indexer,
-    aws_sns_topic_subscription.indexer,
     aws_lambda_function.indexer
   ]
 

--- a/hasher-matcher-actioner/terraform/indexer/main.tf
+++ b/hasher-matcher-actioner/terraform/indexer/main.tf
@@ -2,7 +2,7 @@
 
 # First define the Indexing Schedule
 resource "aws_cloudwatch_event_rule" "indexing_schedule" {
-  name                = "${var.prefix}HMA_IndexingSchedule"
+  name                = "${var.prefix}-HMA_IndexingSchedule"
   description         = "Rebuild Index on a regular cadence"
   schedule_expression = "rate(${var.indexer_frequency})"
   role_arn            = aws_iam_role.indexing_schedule.arn
@@ -56,6 +56,12 @@ resource "aws_iam_policy" "indexing_schedule" {
 resource "aws_iam_role_policy_attachment" "indexing_schedule" {
   role       = aws_iam_role.indexing_schedule.name
   policy_arn = aws_iam_policy.indexing_schedule.arn
+}
+
+## Connect rule to function invocation
+resource "aws_cloudwatch_event_target" "indexer" {
+  arn  = aws_lambda_function.indexer.arn
+  rule = aws_cloudwatch_event_rule.indexing_schedule.name
 }
 
 

--- a/hasher-matcher-actioner/terraform/indexer/main.tf
+++ b/hasher-matcher-actioner/terraform/indexer/main.tf
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "indexing_trigger_assume_role" {
 data "aws_iam_policy_document" "indexing_trigger" {
   statement {
     actions   = ["lambda:InvokeFunction"]
-    resources = ["*"]
+    resources = [aws_lambda_function.indexer.arn]
     effect    = "Allow"
     condition {
       test     = "ArnLike"

--- a/hasher-matcher-actioner/terraform/indexer/main.tf
+++ b/hasher-matcher-actioner/terraform/indexer/main.tf
@@ -105,6 +105,14 @@ resource "aws_lambda_function" "indexer" {
   )
 }
 
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  statement_id  = "${var.prefix}AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.indexer.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.indexing_schedule.arn
+}
+
 resource "aws_cloudwatch_log_group" "indexer" {
   name              = "/aws/lambda/${aws_lambda_function.indexer.function_name}"
   retention_in_days = var.log_retention_in_days

--- a/hasher-matcher-actioner/terraform/indexer/variables.tf
+++ b/hasher-matcher-actioner/terraform/indexer/variables.tf
@@ -24,9 +24,8 @@ variable "measure_performance" {
 variable "threat_exchange_data" {
   description = "Configuration information for the S3 Bucket that will hold ThreatExchange Data"
   type = object({
-    bucket_name        = string
-    notification_topic = string
-    data_folder        = string
+    bucket_name = string
+    data_folder = string
   })
 }
 
@@ -46,4 +45,9 @@ variable "lambda_docker_info" {
       indexer = string
     })
   })
+}
+
+variable "indexer_frequency" {
+  description = "How frequently do we want indexing run? Must be an AWS Rate Expression. See here: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html"
+  type        = string
 }

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -101,6 +101,7 @@ module "indexer" {
   log_retention_in_days = var.log_retention_in_days
   additional_tags       = merge(var.additional_tags, local.common_tags)
   measure_performance   = var.measure_performance
+  indexer_frequency     = var.indexer_frequency
 }
 
 module "counters" {

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -58,6 +58,12 @@ variable "fetch_frequency" {
   default     = "15 minutes"
 }
 
+variable "indexer_frequency" {
+  description = "How frequently do we want indexing run? Must be an AWS Rate Expression. See here: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html"
+  type        = string
+  default     = "15 minutes"
+}
+
 variable "use_shared_user_pool" {
   description = "Indicates if the web app and api will use a shared user pool (generally true for developers / engineers sandbox environments, otherwise false)"
   type        = bool


### PR DESCRIPTION
Banks will not emit update events for every member added/removed. Instead indexer will run on a schedule and:
a) if rebuilding, get all datafiles for TE and all members for banks.
b) if updating, get updated datafiles for TE and updated members for banks.

Note, this PR only reads existing s3 datafiles on a schedule. The banks related things will happen as part of a later PR.

To ensure we don't develop what is unnecessary, we'll start off with the rebuilding arc, do some performance tests to see at what data size rebuilding is ineffective and then work on delta updates.

Test Plan
---
1. Deployed to my instance.
2. Deleted index/ prefix objects in the s3 bucket
3. Manually ran the indexer
4. Verified that the index was re-created
