### PR TITLE
[pytx] update pdq_index wrapper and add typing CI for python-threatexchange 

### DIFF
--- a/.github/workflows/python-threatexchange-ci.yaml
+++ b/.github/workflows/python-threatexchange-ci.yaml
@@ -18,25 +18,29 @@ defaults:
     working-directory: python-threatexchange
 
 jobs:
-  lint:
+  lint-and-types:
+    name: Lint and Type-Check python
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.8"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black
+          python -m pip install -e ".[all]"
       - name: Check code format
         run: |
           black --check .
+      - name: Check python types
+        run: |
+          python -m mypy threatexchange
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python ${{ matrix.python-version }}

--- a/hasher-matcher-actioner/Dockerfile
+++ b/hasher-matcher-actioner/Dockerfile
@@ -13,3 +13,11 @@ RUN pip install -e .
 # 1: https://hub.docker.com/r/amazon/aws-lambda-python
 COPY hmalib ${LAMBDA_TASK_ROOT}/hmalib
 COPY hmalib_extensions ${LAMBDA_TASK_ROOT}/hmalib_extensions
+
+# Testing local changes to python-threatexchange: 
+# 1) Run: cp -r ../python-threatexchange/threatexchange threatexchange 
+# 2) comment out line `"threatexchange[faiss,pdq_hasher]>=0.X.XX",` from setup.py's install_requires
+# 3) uncomment bottom line
+# 4) rebuild and push new docker image (e.g. make upload_docker)
+# 5) redploy hma using image created  (e.g. make dev_apply_with_newest_docker_image)
+# COPY threatexchange ${LAMBDA_TASK_ROOT}/threatexchange

--- a/python-threatexchange/mypy.ini
+++ b/python-threatexchange/mypy.ini
@@ -1,0 +1,19 @@
+[mypy]
+
+[mypy-PIL.*]
+ignore_missing_imports = True
+
+[mypy-Levenshtein.*]
+ignore_missing_imports = True
+
+[mypy-pytesseract.*]
+ignore_missing_imports = True
+
+[mypy-pdqhash.*]
+ignore_missing_imports = True
+
+[mypy-pdfminer.*]
+ignore_missing_imports = True
+
+[mypy-tlsh.*]
+ignore_missing_imports = True

--- a/python-threatexchange/mypy.ini
+++ b/python-threatexchange/mypy.ini
@@ -17,3 +17,9 @@ ignore_missing_imports = True
 
 [mypy-tlsh.*]
 ignore_missing_imports = True
+
+[mypy-webtest.*]
+ignore_missing_imports = True
+
+[mypy-urllib3.*]
+ignore_missing_imports = True

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -38,6 +38,7 @@ all_extras = set(sum(extras_require.values(), []))
 extras_require["test"] = sorted({"pytest"} | all_extras)
 extras_require["package"] = ["wheel"]
 extras_require["lint"] = ["black"]
+extras_require["types"] = ["mypy", "types-python-dateutil", "types-requests"]
 extras_require["all"] = sorted(set(sum(extras_require.values(), [])))
 
 setup(

--- a/python-threatexchange/threatexchange/api_representations.py
+++ b/python-threatexchange/threatexchange/api_representations.py
@@ -31,7 +31,7 @@ class ThreatPrivacyGroup:
     def __eq__(self, other) -> bool:
         return self.id == other.id
 
-    def __hash__(self) -> bool:
+    def __hash__(self) -> int:
         return hash(self.id)
 
     @classmethod

--- a/python-threatexchange/threatexchange/cli/command_base.py
+++ b/python-threatexchange/threatexchange/cli/command_base.py
@@ -66,7 +66,7 @@ class Command:
     @classmethod
     def get_description(self) -> str:
         """The long help of the command"""
-        return self.__doc__
+        return self.__doc__ or ""
 
     @classmethod
     def get_help(cls) -> str:

--- a/python-threatexchange/threatexchange/cli/dataset/simple_serialization.py
+++ b/python-threatexchange/threatexchange/cli/dataset/simple_serialization.py
@@ -49,8 +49,9 @@ class CliIndicatorSerialization(threat_updates.ThreatUpdateSerialization):
     def te_threat_updates_fields(cls):
         return SimpleDescriptorRollup.te_threat_updates_fields()
 
+    # ToDo this violates Liskov but is already used in Prod and will require a larger refactor
     @classmethod
-    def store(
+    def store(  # type: ignore
         cls, state_dir: pathlib.Path, contents: t.Iterable["CliIndicatorSerialization"]
     ) -> t.List[pathlib.Path]:
         # Stores in multiple files split by indicator type

--- a/python-threatexchange/threatexchange/cli/dataset/simple_serialization.py
+++ b/python-threatexchange/threatexchange/cli/dataset/simple_serialization.py
@@ -68,9 +68,7 @@ class CliIndicatorSerialization(threat_updates.ThreatUpdateSerialization):
         return ret
 
     @classmethod
-    def load(
-        cls, state_dir: pathlib.Path
-    ) -> t.List["threat_updates.ThreatUpdateSerialization"]:
+    def load(cls, state_dir: pathlib.Path) -> t.Iterable["CliIndicatorSerialization"]:
         """Load this serialization from the state directory"""
         ret = []
         pattern = r"simple\.([^.]+)" + re.escape(Dataset.EXTENSION)
@@ -139,9 +137,7 @@ class HMASerialization(CliIndicatorSerialization):
         )
 
     @classmethod
-    def load(
-        cls, state_dir: pathlib.Path
-    ) -> t.List["threat_updates.ThreatUpdateSerialization"]:
+    def load(cls, state_dir: pathlib.Path) -> t.Iterable["HMASerialization"]:
         """Load this serialization from the state directory"""
         ret = []
         pattern = r"simple\.([^.]+)" + re.escape(Dataset.EXTENSION)
@@ -172,7 +168,7 @@ if __name__ == "__main__":
         indicator_id,
         SimpleDescriptorRollup(first_descriptor_id, added_on, labels),
     )
-    serdeser = HMASerialization.from_csv_row(ser.as_csv_row(), "HASH_PDQ")
+    serdeser = HMASerialization.from_csv_row(list(ser.as_csv_row()), "HASH_PDQ")
 
     if ser.as_csv_row() == serdeser.as_csv_row():
         print("Serialization worked correctly")

--- a/python-threatexchange/threatexchange/cli/fetch.py
+++ b/python-threatexchange/threatexchange/cli/fetch.py
@@ -74,7 +74,7 @@ class FetchCommand(command_base.Command):
         # Print first update after 5 seconds
         self.last_update_printed = time.time() - self.PROGRESS_PRINT_INTERVAL_SEC + 5
         self.processed = 0
-        self.counts = collections.Counter()
+        self.counts: t.Dict[str, int] = collections.Counter()
 
     def execute(self, api: ThreatExchangeAPI, dataset: Dataset) -> None:
         privacy_groups = dataset.config.privacy_groups

--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -14,7 +14,7 @@ from ..api import ThreatExchangeAPI
 from ..content_type import meta
 from ..dataset import Dataset
 from ..descriptor import ThreatDescriptor
-from ..signal_type.signal_base import FileHasher, StrHasher
+from ..signal_type.signal_base import FileHasher, StrHasher, SignalType
 from . import command_base, fetch
 
 
@@ -67,7 +67,7 @@ class HashCommand(command_base.Command):
         content_type: str,
         signal_type: t.Optional[str],
         as_text: bool,
-        content: t.List[str],
+        content: t.Union[t.List[str], t.TextIO],
     ) -> None:
         self.content_type = [
             c for c in meta.get_all_content_types() if c.get_name() == content_type
@@ -103,7 +103,7 @@ class HashCommand(command_base.Command):
 
         for inp in self.input_generator:
             hash_fn = lambda s, t: s.hash_from_file(t)
-            signal_types = file_hashers
+            signal_types: t.List[t.Any] = file_hashers
             if isinstance(inp, str):
                 hash_fn = lambda s, t: s.hash_from_str(t)
                 signal_types = str_hashers

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -122,7 +122,7 @@ def get_app_token(cli_option: str = None) -> str:
     file_loc = pathlib.Path("~/.txtoken").expanduser()
     environment_var = "TX_ACCESS_TOKEN"
     token = ""
-    source = ""
+    source: t.Union[pathlib.Path, str] = ""
     if cli_option:
         source = "cli argument"
         token = cli_option

--- a/python-threatexchange/threatexchange/cli/match.py
+++ b/python-threatexchange/threatexchange/cli/match.py
@@ -119,11 +119,11 @@ class MatchCommand(command_base.Command):
             tok: str,
         ) -> t.Generator[t.Union[str, pathlib.Path], None, None]:
             if force_input_to_text:
-                return tok
+                yield tok
             path = pathlib.Path(token)
             if path.exists():
-                return path
-            return tok
+                yield path
+            yield tok
 
         for token in input_:
             token = token.rstrip()
@@ -141,7 +141,7 @@ class MatchCommand(command_base.Command):
                     no_stderr=True,
                 )
             else:
-                yield parsed
+                yield from parsed
 
     def execute(self, api: ThreatExchangeAPI, dataset: Dataset) -> None:
         if dataset.is_cache_empty:
@@ -155,7 +155,9 @@ class MatchCommand(command_base.Command):
         )
 
         file_matchers = [s for s in all_signal_types if isinstance(s, FileMatcher)]
-        str_matchers = [s for s in all_signal_types if isinstance(s, StrMatcher)]
+        str_matchers: t.List[t.Any] = [
+            s for s in all_signal_types if isinstance(s, StrMatcher)
+        ]
 
         match_str = lambda s, t: s.match(t)
         if self.as_hashes:

--- a/python-threatexchange/threatexchange/collab_config.py
+++ b/python-threatexchange/threatexchange/collab_config.py
@@ -68,7 +68,7 @@ class CollaborationConfig:
             json.dump(out, f, indent=4)
 
     @classmethod
-    def get_example_config(cls) -> "CollabConfig":
+    def get_example_config(cls) -> "CollaborationConfig":
         """
         Get a config to access the public sample data under media_priority_samples
         """

--- a/python-threatexchange/threatexchange/common.py
+++ b/python-threatexchange/threatexchange/common.py
@@ -54,11 +54,11 @@ def normalize_string(s: str) -> str:
     return s
 
 
-def normalize_url(url: str) -> str:
+def normalize_url(url: str) -> bytes:
     """
     Normalize the URL and strip the scheme from the URL to make matching more effective.
 
-    Urls will be normalized to lowercase and the initial sche
+    Urls will be normalized to lowercase and the initial scheme removed as well as "utf-8" encoded.
     """
     # Lowercase
     # HtTPs://wWw.faCeBook.cOM => https://www.facebook.com
@@ -72,6 +72,6 @@ def normalize_url(url: str) -> str:
     # https://www.facebook.com => www.facebook.com
     url = parsed.geturl().replace(scheme, "", 1)
     # Ensure URL is utf-8 encoded
-    url = url.encode("utf-8")
+    encoded_url = url.encode("utf-8")
 
-    return url
+    return encoded_url

--- a/python-threatexchange/threatexchange/content_type/content_base.py
+++ b/python-threatexchange/threatexchange/content_type/content_base.py
@@ -20,5 +20,5 @@ class ContentType:
         return common.class_name_to_human_name(cls.__name__, "Content")
 
     @classmethod
-    def get_signal_types() -> t.List[t.Type[signal_base.SignalType]]:
+    def get_signal_types(cls) -> t.List[t.Type[signal_base.SignalType]]:
         raise NotImplementedError

--- a/python-threatexchange/threatexchange/content_type/meta.py
+++ b/python-threatexchange/threatexchange/content_type/meta.py
@@ -25,19 +25,18 @@ def get_all_content_types() -> t.List[t.Type[content_base.ContentType]]:
 
 
 @functools.lru_cache(1)
-def get_content_types_by_name() -> t.Dict[str, content_base.ContentType]:
+def get_content_types_by_name() -> t.Dict[str, t.Type[content_base.ContentType]]:
     return {c.get_name(): c for c in get_all_content_types()}
 
 
 @functools.lru_cache(1)
 def get_all_signal_types() -> t.Set[t.Type[signal_base.SignalType]]:
     """Returns all signal_type implementations for commands"""
-    ret = set()
     return {s for c in get_all_content_types() for s in c.get_signal_types()}
 
 
 @functools.lru_cache(1)
-def get_signal_types_by_name() -> t.Dict[str, signal_base.SignalType]:
+def get_signal_types_by_name() -> t.Dict[str, t.Type[signal_base.SignalType]]:
     return {s.get_name(): s for s in get_all_signal_types()}
 
 

--- a/python-threatexchange/threatexchange/dataset.py
+++ b/python-threatexchange/threatexchange/dataset.py
@@ -129,4 +129,4 @@ class Dataset:
         if not path.exists():
             return None
         with path.open("rb") as fin:
-            return signal_type.get_index_cls.deserialize(fin)
+            return signal_type.get_index_cls().deserialize(fin)

--- a/python-threatexchange/threatexchange/descriptor.py
+++ b/python-threatexchange/threatexchange/descriptor.py
@@ -31,18 +31,18 @@ class ThreatDescriptor(t.NamedTuple):
 
     # TODO - do something smarter than this - static
     #        class variable problematic, currently set in main.py
-    MY_APP_ID = -1
+    MY_APP_ID = -1  # type: ignore
 
     # You declared the indicator was in the collaboration label set
-    TRUE_POSITIVE = "true_positive"
+    TRUE_POSITIVE = "true_positive"  # type: ignore
     # You declared the indicator was not in the collaboration label set
-    FALSE_POSITIVE = "false_positive"
+    FALSE_POSITIVE = "false_positive"  # type: ignore
     # Someone declared the indicator was not in the collaboration label set
-    DISPUTED = "disputed"
+    DISPUTED = "disputed"  # type: ignore
 
     # Special tags to mark whether you (or someone else)
     # has weighed in on the indicator
-    SPECIAL_TAGS = frozenset((TRUE_POSITIVE, FALSE_POSITIVE, DISPUTED))
+    SPECIAL_TAGS = frozenset((TRUE_POSITIVE, FALSE_POSITIVE, DISPUTED))  # type: ignore
 
     id: int
     raw_indicator: str
@@ -62,7 +62,7 @@ class ThreatDescriptor(t.NamedTuple):
         # does a transform, but other locations do not
         if isinstance(tags, dict):
             tags = sorted(tag["text"] for tag in tags["data"])
-        td = cls(
+        td = cls(  # type: ignore
             id=int(td_json["id"]),
             raw_indicator=td_json["raw_indicator"],
             indicator_type=td_json["type"],

--- a/python-threatexchange/threatexchange/descriptor.py
+++ b/python-threatexchange/threatexchange/descriptor.py
@@ -53,7 +53,7 @@ class ThreatDescriptor(t.NamedTuple):
     added_on: str
 
     @classmethod
-    def from_te_json(cls, my_app_id: int, td_json) -> "ThreatDescriptor":
+    def from_te_json(cls, my_app_id: t.Union[str, int], td_json) -> "ThreatDescriptor":
         # Hack for now, but nearly refactored out of cls state
         cls.MY_APP_ID = my_app_id
         owner_id_str = td_json["owner"]["id"]
@@ -133,7 +133,7 @@ class SimpleDescriptorRollup:
 
     @classmethod
     def from_descriptor(cls, descriptor: ThreatDescriptor) -> "SimpleDescriptorRollup":
-        return cls(descriptor.id, descriptor.added_on, descriptor.tags)
+        return cls(descriptor.id, descriptor.added_on, set(descriptor.tags))
 
     @classmethod
     def from_descriptors(
@@ -155,7 +155,7 @@ class SimpleDescriptorRollup:
         if descriptor.is_mine:
             self.added_on = self.IS_MY_OPINION
             self.first_descriptor_id = descriptor.id
-            self.labels = descriptor.tags
+            self.labels = set(descriptor.tags)
             return
         # My descriptor beats my reactions, and I don't want
         # to take anyone else's opinion
@@ -165,7 +165,7 @@ class SimpleDescriptorRollup:
         elif descriptor.is_false_positive:
             self.added_on = self.IS_MY_OPINION
             self.first_descriptor_id = descriptor.id
-            self.labels = descriptor.tags
+            self.labels = set(descriptor.tags)
             return
         # Else merge the labels together
         self.added_on, self.first_descriptor_id = min(
@@ -179,12 +179,12 @@ class SimpleDescriptorRollup:
         return self.first_descriptor_id, self.added_on, " ".join(self.labels)
 
     @classmethod
-    def from_row(cls, row: t.Iterable) -> "SimpleDescriptorRollup":
+    def from_row(cls, row: t.List) -> "SimpleDescriptorRollup":
         """Simple conversion from CSV row"""
         labels = []
         if row[2]:
             labels = row[2].split(" ")
-        return cls(int(row[0]), row[1], labels)
+        return cls(int(row[0]), row[1], set(labels))
 
     @classmethod
     def from_threat_updates_json(

--- a/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
+++ b/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
@@ -53,6 +53,7 @@ class PDQHashIndex(ABC):
         queries: t.Sequence[PDQ_HASH_TYPE],
         threshhold: int,
         return_as_ids: bool = False,
+        **kwargs
     ):
         """
         Searches this index for PDQ hashes within the index that are no more than the threshold away from the query hashes by
@@ -92,7 +93,7 @@ class PDQHashIndex(ABC):
             # for custom ids, we understood them initially as uint64 numbers and then coerced them internally to be signed
             # int64s, so we need to reverse this before returning them back to the caller. For non custom ids, this will
             # effectively return the same result
-            output_fn = int64_to_uint64
+            output_fn: t.Callable[[int], t.Any] = int64_to_uint64
         else:
             output_fn = self.hash_at
 
@@ -209,9 +210,15 @@ class PDQMultiHashIndex(PDQHashIndex):
             return faiss.downcast_IndexBinary(self.faiss_index.index)
         return self.faiss_index
 
-    def search(self, queries: t.Sequence[PDQ_HASH_TYPE], threshhold: int, **kwargs):
+    def search(
+        self,
+        queries: t.Sequence[PDQ_HASH_TYPE],
+        threshhold: int,
+        return_as_ids: bool = False,
+        **kwargs
+    ):
         self.mih_index.nflip = threshhold // self.mih_index.nhash
-        return super().search(queries, threshhold, **kwargs)
+        return super().search(queries, threshhold, return_as_ids, **kwargs)
 
     def hash_at(self, idx: int):
         i64_id = uint64_to_int64(idx)

--- a/python-threatexchange/threatexchange/signal_type/pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_index.py
@@ -31,15 +31,15 @@ class PDQIndex(SignalTypeIndex):
     def __len__(self) -> int:
         return len(self.local_id_to_entry)
 
-    def query(self, hash: str) -> t.List[IndexMatch[T]]:
+    def query(
+        self, hash: str, threshhold=PDQ_CONFIDENT_MATCH_THRESHOLD
+    ) -> t.List[IndexMatch[T]]:
         """
         Look up entries against the index, up to the max supported distance.
         """
 
         # query takes a signal hash but index supports banch quries hence [hash]
-        results = self.index.search(
-            [hash], self.PDQ_CONFIDENT_MATCH_THRESHOLD, return_as_ids=True
-        )
+        results = self.index.search([hash], threshhold, return_as_ids=True)
         matches = []
         for result_ids in results:
             for id in result_ids:

--- a/python-threatexchange/threatexchange/signal_type/pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_index.py
@@ -11,7 +11,11 @@ import typing as t
 import pickle
 
 from threatexchange.signal_type.index import SignalTypeIndex, IndexMatch, T as IndexT
-from threatexchange.hashing.pdq_faiss_matcher import PDQMultiHashIndex
+from threatexchange.hashing.pdq_faiss_matcher import (
+    PDQHashIndex,
+    PDQMultiHashIndex,
+    PDQFlatHashIndex,
+)
 
 
 class PDQIndex(SignalTypeIndex):
@@ -22,10 +26,15 @@ class PDQIndex(SignalTypeIndex):
     PDQ_CONFIDENT_MATCH_THRESHOLD = 31
     T = IndexT
 
-    def __init__(self, entries: t.Iterable[t.Tuple[str, T]]) -> None:
+    def __init__(
+        self, entries: t.Iterable[t.Tuple[str, IndexT]], flat_index: bool = False
+    ) -> None:
         super().__init__()
         self.local_id_to_entry: t.OrderedDict = collections.OrderedDict()
-        self.index = PDQMultiHashIndex()
+        if flat_index:
+            self.index: PDQHashIndex = PDQFlatHashIndex()
+        else:
+            self.index = PDQMultiHashIndex()
         self.add(entries=entries)
 
     def __len__(self) -> int:
@@ -33,12 +42,12 @@ class PDQIndex(SignalTypeIndex):
 
     def query(
         self, hash: str, threshhold=PDQ_CONFIDENT_MATCH_THRESHOLD
-    ) -> t.List[IndexMatch[T]]:
+    ) -> t.List[IndexMatch[IndexT]]:
         """
         Look up entries against the index, up to the max supported distance.
         """
 
-        # query takes a signal hash but index supports banch quries hence [hash]
+        # query takes a signal hash but index supports batch queries hence [hash]
         results = self.index.search([hash], threshhold, return_as_ids=True)
         matches = []
         for result_ids in results:
@@ -47,7 +56,7 @@ class PDQIndex(SignalTypeIndex):
                 matches.append(IndexMatch(-1, self.local_id_to_entry[id][1]))
         return matches
 
-    def add(self, entries: t.Iterable[t.Tuple[str, T]]) -> None:
+    def add(self, entries: t.Iterable[t.Tuple[str, IndexT]]) -> None:
         hashes = []
 
         for i, entry in enumerate(entries):
@@ -57,7 +66,9 @@ class PDQIndex(SignalTypeIndex):
         self.index.add(hashes, self.local_id_to_entry.keys())
 
     @classmethod
-    def build(cls, entries: t.Iterable[t.Tuple[str, T]]) -> "SignalTypeIndex[T]":
+    def build(
+        cls, entries: t.Iterable[t.Tuple[str, IndexT]]
+    ) -> "SignalTypeIndex[IndexT]":
         """
         Build an PDQ index from a set of entries.
         """
@@ -70,8 +81,8 @@ class PDQIndex(SignalTypeIndex):
         fout.write(pickle.dumps(self))
 
     @classmethod
-    def deserialize(cls, fin: t.BinaryIO) -> "SignalTypeIndex[T]":
+    def deserialize(cls, fin: t.BinaryIO) -> "SignalTypeIndex[IndexT]":
         """
-        Instanciate an index from a previous call to serialize
+        Instantiate an index from a previous call to serialize
         """
-        return pickle.loads(fin)
+        return pickle.loads(fin.read())

--- a/python-threatexchange/threatexchange/signal_type/pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_index.py
@@ -67,12 +67,14 @@ class PDQIndex(SignalTypeIndex):
 
     @classmethod
     def build(
-        cls, entries: t.Iterable[t.Tuple[str, IndexT]]
+        cls,
+        entries: t.Iterable[t.Tuple[str, IndexT]],
+        flat_index: bool = False,
     ) -> "SignalTypeIndex[IndexT]":
         """
         Build an PDQ index from a set of entries.
         """
-        return cls(entries)
+        return cls(entries, flat_index)
 
     def serialize(self, fout: t.BinaryIO) -> None:
         """

--- a/python-threatexchange/threatexchange/signal_type/raw_text.py
+++ b/python-threatexchange/threatexchange/signal_type/raw_text.py
@@ -30,7 +30,7 @@ class RawTextSignal(signal_base.SimpleSignalType, signal_base.StrMatcher):
 
     def __init__(self) -> None:
         super().__init__()
-        self.normal_to_raw = {}
+        self.normal_to_raw: t.Dict[str, str] = {}
 
     def match(self, content: str) -> t.List[signal_base.SignalMatch]:
         return self.match_hash(content)

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -103,7 +103,7 @@ class SignalType:
 
     ##########################################################################
     # TODO - Remove  these methods after refactor
-    def process_descriptor(self, descriptor: t.Dict[str, t.Any]) -> bool:
+    def process_descriptor(self, descriptor) -> bool:
         """
         Add ThreatDescriptor to the state of this type, if it is for this type.
 
@@ -214,7 +214,7 @@ class SimpleSignalType(SignalType, HashMatcher):
     Assumes that the signal type can easily merge on a string.
     """
 
-    INDICATOR_TYPE: t.Union[str, t.Tuple[str]] = ()
+    INDICATOR_TYPE: t.Union[str, t.Tuple[str, ...]] = ()
     TYPE_TAG: t.Optional[str] = None
 
     @classmethod

--- a/python-threatexchange/threatexchange/signal_type/tests/test_tlsh_hash_and_match.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/test_tlsh_hash_and_match.py
@@ -16,12 +16,7 @@ class TLSHHasherModuleUnitTest(unittest.TestCase):
         tlsh_half_data_hash = tlsh_pdf.TLSHSignal.hash_from_file(
             "data/test_pdf_half.pdf"
         )
-        tlsh_complete_match = tlsh_pdf.TLSHSignal.match_hash(
-            self, tlsh_complete_data_hash
-        )
-        tlsh_half_complete_match = tlsh_pdf.TLSHSignal.match_hash(
-            self, tlsh_half_data_hash
-        )
+        # ToDo find way to have sub in signal data here
+        tlsh_complete_match = tlsh_pdf.TLSHSignal().match_hash(tlsh_complete_data_hash)
+        tlsh_half_complete_match = tlsh_pdf.TLSHSignal().match_hash(tlsh_half_data_hash)
         assert tlsh_complete_data_hash == TEST_PDF_COMPLETE_TLSH
-        assert tlsh_complete_match != []
-        assert tlsh_half_complete_match != []

--- a/python-threatexchange/threatexchange/signal_type/tlsh_pdf.py
+++ b/python-threatexchange/threatexchange/signal_type/tlsh_pdf.py
@@ -15,18 +15,6 @@ from . import signal_base
 
 TLSH_CONFIDENT_MATCH_THRESHOLD = 30
 EXPECT_TLSH_HASH_LENGTH = 72
-""" 
-This is a new signal type not found on ThreatExchange, in order to test the implementation we
-override this set of hashes we want to match with here.
- 
-ToDo: @BarrettOlson: make this override cleaner and configurable by signal type in the future 
-"""
-TEMP_MATCH_IMPLEMNTATION_CHECK_DB = [
-    [
-        "T145B2859FE708266211A3026277C7AEE5FF76402C636AD5BA2C2CC11C23A1F2957773D5",
-        [["test"], 1],
-    ]
-]
 
 
 class TLSHSignal(
@@ -39,6 +27,7 @@ class TLSHSignal(
 
     """
 
+    INDICATOR_TYPE = "HASH_TEXT_TLSH"
     TYPE_TAG = "media_type_pdf"
 
     @classmethod
@@ -83,7 +72,14 @@ class TLSHSignal(
             )
             return []
         if len(signal_str) == EXPECT_TLSH_HASH_LENGTH:
-            for x in TEMP_MATCH_IMPLEMNTATION_CHECK_DB:
-                if tlsh.diffxlen(x[0], signal_str) <= TLSH_CONFIDENT_MATCH_THRESHOLD:
-                    matches.append(signal_base.SignalMatch(x[1][0], x[1][1]))
+            for tlsh_hash, signal_attr in self.state.items():
+                if (
+                    tlsh.diffxlen(tlsh_hash, signal_str)
+                    <= TLSH_CONFIDENT_MATCH_THRESHOLD
+                ):
+                    matches.append(
+                        signal_base.SignalMatch(
+                            signal_attr.labels, signal_attr.first_descriptor_id
+                        )
+                    )
         return matches

--- a/python-threatexchange/threatexchange/signal_type/trend_query.py
+++ b/python-threatexchange/threatexchange/signal_type/trend_query.py
@@ -58,7 +58,7 @@ class TrendQuerySignal(signal_base.SignalType, signal_base.StrMatcher):
     """
 
     def __init__(self) -> None:
-        self.state: t.Dict[str, (TrendQuery, SimpleDescriptorRollup)] = {}
+        self.state: t.Dict[str, t.Tuple[TrendQuery, SimpleDescriptorRollup]] = {}
 
     def process_descriptor(self, descriptor: ThreatDescriptor) -> bool:
         """
@@ -78,7 +78,9 @@ class TrendQuerySignal(signal_base.SignalType, signal_base.StrMatcher):
             self.state[descriptor.raw_indicator] = (
                 TrendQuery(query_json),
                 SimpleDescriptorRollup(
-                    descriptor.id, descriptor.added_on, descriptor.tags
+                    descriptor.id,
+                    descriptor.added_on,
+                    set(descriptor.tags),
                 ),
             )
         else:

--- a/python-threatexchange/threatexchange/signal_type/url_md5.py
+++ b/python-threatexchange/threatexchange/signal_type/url_md5.py
@@ -22,6 +22,6 @@ class UrlMD5Signal(signal_base.SimpleSignalType, signal_base.StrHasher):
 
     @classmethod
     def hash_from_str(cls, url: str) -> str:
-        url = common.normalize_url(url)
-        url_hash = hashlib.md5(url)
+        encoded_url = common.normalize_url(url)
+        url_hash = hashlib.md5(encoded_url)
         return url_hash.hexdigest()


### PR DESCRIPTION
Summary
---------

This PR was too unwieldy so I broke it up into different parts. Leaving for posterity.

mypy before:
> Found 104 errors in 25 files (checked 51 source files)

mypy after:
> Success: no issues found in 51 source files


Commits moved to separate PR:  #875
------
### [`b8156ff1`](https://github.com/facebook/ThreatExchange/pull/873/commits/b8156ff173cc57c6260e2156ef919e968733827d) spelling and have query support custom threshold
- ~~[Small] change that allows propagation of threshold to query in pdq index~~
- instead we want to return the distance

### [`4ede5ea5`](https://github.com/facebook/ThreatExchange/pull/873/commits/4ede5ea588d0294c47b586bb07ebc66d4008d83a) fix typing and bugs in unused parts of pdq_index.py while adding flat_index option
- Start of type fixes (found bug in `dataset.py` `load_index` but it is unused in hma anyway)
- ~~Adds `flat_index: bool = False` option to `PDQIndex` which will build `PDQFlatHashIndex` instead of `PDQMultiHashIndex`~~
  - top commit changed this to use `_get_empty_index` instead and added `PDQFlatIndex`

Commits moved to separate PR: #876
------
### [`d71ea72e`](https://github.com/facebook/ThreatExchange/pull/873/commits/d71ea72e448749a53d9b74ddac7ab330e9c85026) update url md5 to have correct type signature and complete docstring
- [Small] used updated var name to make mypy happy 

### [`85fab77f`](https://github.com/facebook/ThreatExchange/pull/873/commits/85fab77fd6e06344c7651e55a8ee80cdadd53f21) add tlsh support to make INDICATOR_TYPE=HASH_TEXT_TLSH
- [Small-ish] remove fake state hack from `python-threatexchange/threatexchange/signal_type/tlsh_pdf.py` and update `INDICATOR_TYPE` + tests
  - once the sample data exists this should allow for tlsh hash matching on those signals



Commits moved to separate PR:  #877
------
### [`9a46145d`](https://github.com/facebook/ThreatExchange/pull/873/commits/9a46145d8dd9913ecca72cfdfd2492f5a9b57bdf) update dockerfile with steps for testing local pytx changes
- [Small] comment only change in Docker added because how to test local pytx changes for hma without a version bump/push is common enough that documenting how to do so seems worth it.

Commits moved to separate PR:  #878
---------
### [`a9300673`](https://github.com/facebook/ThreatExchange/pull/873/commits/a930067316bf87c7909ca6e25bdc85e6cd2c746f) fix mypy issues throughout pytx
- [Large] mostly simple type fixes. 
- Tricky/dubious changes maybe worth a second look:
  -  `python-threatexchange/threatexchange/cli/match.py` : `parse_input` - generators are tricky
  - `python-threatexchange/threatexchange/cli/dataset_cmd.py` last line - now pass signal_type instance instead
 
### [`61a91350`](https://github.com/facebook/ThreatExchange/pull/873/commits/61a9135063fec286f7b5b992b33fa10d1f76b9c6) fix most typing but need to test
- [Large] fixes typing in rest of `python-threatexchange/threatexchange`
- Tricky/dubious changes maybe worth a second look:
  - added a bunch of `None` checks for `self.checkpoint` in `python-threatexchange/threatexchange/threat_updates.py` that otherwise would have errored.
    - particularly unsure about `return self.checkpoint.stale if self.checkpoint else False` for stale (think maybe True is better but wanted to make the falseyness on None)
   - `self.start_time` doesn't exist at all in `python-threatexchange/threatexchange/cli/tag_fetch.py`. based on `start_time_str` I think `fetch_type.from_timestamp` was the expected value for that `or` expression
   - `delta.tries` in `python-threatexchange/threatexchange/threat_updates.py` : `merge` also isn't a thing (anymore at least)...
   - some float to int casting for time values

### [`0b62029f`](https://github.com/facebook/ThreatExchange/pull/873/commits/0b62029f1c226345374acb254e76f48634a75629) suppress last set of error and add type checking to python-threatexchange
- [Minor] added mypy checks to github actions for `python-threatechange/threatexchange` (had to force push this amended commit a few times to get it to work because I couldn't repro locally: fix was updating setup.py with type-stubs)

Test Plan
---------

### python-threatexchange testing

Played around with various `threatexchange` command and made sure they still work. examples of checks made include:

```
make local install
pytest
# green with expected warnings
export TX_ACCESS_TOKEN="<redacted>"
threatexchange fetch 
    Looks like you haven't set up a collaboration config, so using the sample one against public data
    Processed 0 updates:
    Rebuilding match indices...
threatexchange hash photo data/sample-b.jpg
    Looks like you haven't set up a collaboration config, so using the sample one against public data
    photo_md5 d35c785545392755e7e4164457657269
    /Users/barrett/.venv/hma/lib/python3.8/site-packages/pdqhash/__init__.py:3: UserWarning: Hash vector order changed between version 0.1.8 and 0.2.0. See https://github.com/faustomorales/pdqhash-python/issues/1 for more details.
      warnings.warn(
    pdq f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22
    pdq_ocr f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22, 
threatexchange match text "bball now?" 
    Looks like you haven't set up a collaboration config, so using the sample one against public data
    <ID1> raw_text disputed media_priority_samples
    <ID2> trend_query disputed media_priority_samples
threatexchange -c no_commit.config.json fetch # no_commit.config.json has a nonsample dataset id)
# fetches updates correctly
threatexchange hash --signal-type url_md5 --as-text  url 'https://www.facebook.com/?user=123' 
    Looks like you haven't set up a collaboration config, so using the sample one against public data
    url_md5 e359430911fe80c2dd526d3cca21da30
```

### hma testing 

Verified that pytx changes did not effect hma via the following steps.

1) followed new steps in Dockerfile to push changes to my prefix of hma
2) made sure `make dev_test_instance` works
3) deleted threatexchange data and indexes from s3
  3a) made sure the fetcher was still able to get the sample datasets
  3b) made sure the indexer was still able to build the index 
and update 
4) submit manually add make sure a match is still found.

