### PR TITLE
[pytx] update faiss_matcher to have option to return distance & add PDQFlatIndex

### DIFF
--- a/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
+++ b/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
@@ -106,7 +106,6 @@ class PDQHashIndex(ABC):
         queries: t.Sequence[PDQ_HASH_TYPE],
         threshhold: int,
         return_as_ids: bool = False,
-        **kwargs
     ):
         query_vectors = [
             numpy.frombuffer(binascii.unhexlify(q), dtype=numpy.uint8) for q in queries
@@ -239,9 +238,23 @@ class PDQMultiHashIndex(PDQHashIndex):
             return faiss.downcast_IndexBinary(self.faiss_index.index)
         return self.faiss_index
 
-    def search(self, queries: t.Sequence[PDQ_HASH_TYPE], threshhold: int, **kwargs):
+    def search(
+        self,
+        queries: t.Sequence[PDQ_HASH_TYPE],
+        threshhold: int,
+        return_as_ids: bool = False,
+    ):
         self.mih_index.nflip = threshhold // self.mih_index.nhash
-        return super().search(queries, threshhold, **kwargs)
+        return super().search(queries, threshhold, return_as_ids)
+
+    def search_with_distance(
+        self,
+        queries: t.Sequence[PDQ_HASH_TYPE],
+        threshhold: int,
+        return_as_ids: bool = False,
+    ):
+        self.mih_index.nflip = threshhold // self.mih_index.nhash
+        return super().search_with_distance(queries, threshhold, return_as_ids)
 
     def hash_at(self, idx: int):
         i64_id = uint64_to_int64(idx)

--- a/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
+++ b/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
@@ -103,7 +103,7 @@ class PDQHashIndex(ABC):
 
     def search_with_distance_in_result(
         self,
-        queries: t.Sequence[PDQ_HASH_TYPE],
+        queries: t.Sequence[str],
         threshhold: int,
     ):
         """
@@ -256,7 +256,7 @@ class PDQMultiHashIndex(PDQHashIndex):
 
     def search_with_distance_in_result(
         self,
-        queries: t.Sequence[PDQ_HASH_TYPE],
+        queries: t.Sequence[str],
         threshhold: int,
     ):
         self.mih_index.nflip = threshhold // self.mih_index.nhash

--- a/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
+++ b/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
@@ -107,6 +107,23 @@ class PDQHashIndex(ABC):
         threshhold: int,
         return_as_ids: bool = False,
     ):
+        """
+        Same as search however instead of returning only sequence of matches per query
+        it returns a mapping from query strings to a list of matched hashes (or ids) and distances
+        e.g.
+        result = {
+            "000000000000000000000000000000000000000000000000000000000000FFFF": [
+                ("00000000000000000000000000000000000000000000000000000000FFFFFFFF", 16.0)
+            ]
+        }
+        or if return_as_ids=True
+        result_with_as_ids = {
+            "000000000000000000000000000000000000000000000000000000000000FFFF": [
+                (12345678901, 16.0)
+            ]
+        }
+        """
+
         query_vectors = [
             numpy.frombuffer(binascii.unhexlify(q), dtype=numpy.uint8) for q in queries
         ]

--- a/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
+++ b/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
@@ -132,14 +132,14 @@ class PDQHashIndex(ABC):
         output_fn: t.Callable[[int], t.Any] = int64_to_uint64
 
         result = {}
-        for i in range(len(queries)):
+        for i, query in enumerate(queries):
             match_tuples = []
             matches = [idx.item() for idx in I[limits[i] : limits[i + 1]]]
             distances = [idx for idx in similarities[limits[i] : limits[i + 1]]]
             for match, distance in zip(matches, distances):
                 # (Id, Hash, Distance)
                 match_tuples.append((output_fn(match), self.hash_at(match), distance))
-            result[queries[i]] = match_tuples
+            result[query] = match_tuples
         return result
 
     def __getstate__(self):

--- a/python-threatexchange/threatexchange/signal_type/pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_index.py
@@ -23,12 +23,11 @@ class PDQIndex(SignalTypeIndex):
     Wrapper around the pdq faiss index lib using PDQMultiHashIndex
     """
 
-    PDQ_CONFIDENT_MATCH_THRESHOLD = 31
     T = IndexT
 
     @classmethod
     def get_match_threshold(cls):
-        return cls.PDQ_CONFIDENT_MATCH_THRESHOLD
+        return 31  # PDQ_CONFIDENT_MATCH_THRESHOLD
 
     @classmethod
     def _get_empty_index(cls) -> PDQHashIndex:
@@ -49,12 +48,12 @@ class PDQIndex(SignalTypeIndex):
         """
 
         # query takes a signal hash but index supports batch queries hence [hash]
-        results = self.index.search_with_distance(
-            [hash], self.get_match_threshold(), return_as_ids=True
+        results = self.index.search_with_distance_in_result(
+            [hash], self.get_match_threshold()
         )
 
         matches = []
-        for id, distance in results[hash]:
+        for id, _, distance in results[hash]:
             matches.append(IndexMatch(distance, self.local_id_to_entry[id][1]))
         return matches
 
@@ -96,11 +95,9 @@ class PDQFlatIndex(PDQIndex):
     possibly as the cost of precision.
     """
 
-    PDQ_MATCH_THRESHOLD = 52
-
     @classmethod
     def get_match_threshold(cls):
-        return cls.PDQ_MATCH_THRESHOLD
+        return 52  # larger PDQ_MATCH_THRESHOLD for flatindexes
 
     @classmethod
     def _get_empty_index(cls) -> PDQHashIndex:

--- a/python-threatexchange/threatexchange/signal_type/pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_index.py
@@ -36,15 +36,14 @@ class PDQIndex(SignalTypeIndex):
         Look up entries against the index, up to the max supported distance.
         """
 
-        # query takes a signal hash but index supports banch quries hence [hash]
-        results = self.index.search(
+        # query takes a signal hash but index supports batch queries hence [hash]
+        results = self.index.search_with_distance(
             [hash], self.PDQ_CONFIDENT_MATCH_THRESHOLD, return_as_ids=True
         )
+
         matches = []
-        for result_ids in results:
-            for id in result_ids:
-                # distance = -1 (index does not currently support distance)
-                matches.append(IndexMatch(-1, self.local_id_to_entry[id][1]))
+        for id, distance in results[hash]:
+            matches.append(IndexMatch(distance, self.local_id_to_entry[id][1]))
         return matches
 
     def add(self, entries: t.Iterable[t.Tuple[str, T]]) -> None:

--- a/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index.py
@@ -88,7 +88,7 @@ class TestPDQIndex(unittest.TestCase):
 
         # Convert expected to distance -> set of metadata map
         distance_to_expected_items_map: t.Dict[int, t.Set[t.Dict]] = functools.reduce(
-            quality_indexed_dict_reducer, result, dict()
+            quality_indexed_dict_reducer, expected, dict()
         )
 
         assert len(distance_to_expected_items_map) == len(
@@ -106,7 +106,7 @@ class TestPDQIndex(unittest.TestCase):
         result = self.index.query(entry_hash)
         self.assertEqualPDQIndexMatchResults(
             result,
-            [IndexMatch(-1, test_entries[1][1]), IndexMatch(-1, test_entries[0][1])],
+            [IndexMatch(0, test_entries[1][1]), IndexMatch(16, test_entries[0][1])],
         )
 
     def test_search_index_with_no_match(self):
@@ -130,5 +130,5 @@ class TestPDQIndex(unittest.TestCase):
         result = reconstructed_index.query(query)
         self.assertEqualPDQIndexMatchResults(
             result,
-            [IndexMatch(-1, test_entries[1][1]), IndexMatch(-1, test_entries[0][1])],
+            [IndexMatch(0, test_entries[1][1]), IndexMatch(16, test_entries[0][1])],
         )


### PR DESCRIPTION
Summary
---------

To support variable threshold in HMA ideally each match returned can be paired with its distance.
Though since `python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py` has been around for over a year I added a new `search_with_distance` instead of changing the results given form `search` 

I also added a PDQFlatIndex to `python-threatexchange/threatexchange/signal_type/pdq_index.py` so that index type can be used in HMA as well.

Test Plan
---------
fixed a bug in pytest so it now checks the distance for matches for `PDQIndex`