### PR TITLE
[pytx] mypy supportand fixes

### DIFF
--- a/.github/workflows/python-threatexchange-ci.yaml
+++ b/.github/workflows/python-threatexchange-ci.yaml
@@ -18,25 +18,29 @@ defaults:
     working-directory: python-threatexchange
 
 jobs:
-  lint:
+  lint-and-types:
+    name: Lint and Type-Check python
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.8"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black
+          python3 -m pip install -e .[all]
       - name: Check code format
         run: |
           black --check .
+      - name: Check python types
+        run: |
+          python -m mypy threatexchange
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python ${{ matrix.python-version }}

--- a/python-threatexchange/mypy.ini
+++ b/python-threatexchange/mypy.ini
@@ -1,0 +1,19 @@
+[mypy]
+
+[mypy-PIL.*]
+ignore_missing_imports = True
+
+[mypy-Levenshtein.*]
+ignore_missing_imports = True
+
+[mypy-pytesseract.*]
+ignore_missing_imports = True
+
+[mypy-pdqhash.*]
+ignore_missing_imports = True
+
+[mypy-pdfminer.*]
+ignore_missing_imports = True
+
+[mypy-tlsh.*]
+ignore_missing_imports = True

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -38,6 +38,7 @@ all_extras = set(sum(extras_require.values(), []))
 extras_require["test"] = sorted({"pytest"} | all_extras)
 extras_require["package"] = ["wheel"]
 extras_require["lint"] = ["black"]
+extras_require["types"] = ["mypy"]
 extras_require["all"] = sorted(set(sum(extras_require.values(), [])))
 
 setup(

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -38,7 +38,7 @@ all_extras = set(sum(extras_require.values(), []))
 extras_require["test"] = sorted({"pytest"} | all_extras)
 extras_require["package"] = ["wheel"]
 extras_require["lint"] = ["black"]
-extras_require["types"] = ["mypy"]
+extras_require["types"] = ["mypy", "types-python-dateutil", "types-requests"]
 extras_require["all"] = sorted(set(sum(extras_require.values(), [])))
 
 setup(

--- a/python-threatexchange/threatexchange/api_representations.py
+++ b/python-threatexchange/threatexchange/api_representations.py
@@ -31,7 +31,7 @@ class ThreatPrivacyGroup:
     def __eq__(self, other) -> bool:
         return self.id == other.id
 
-    def __hash__(self) -> bool:
+    def __hash__(self) -> int:
         return hash(self.id)
 
     @classmethod

--- a/python-threatexchange/threatexchange/cli/command_base.py
+++ b/python-threatexchange/threatexchange/cli/command_base.py
@@ -66,7 +66,7 @@ class Command:
     @classmethod
     def get_description(self) -> str:
         """The long help of the command"""
-        return self.__doc__
+        return self.__doc__ or ""
 
     @classmethod
     def get_help(cls) -> str:

--- a/python-threatexchange/threatexchange/cli/dataset/simple_serialization.py
+++ b/python-threatexchange/threatexchange/cli/dataset/simple_serialization.py
@@ -49,8 +49,9 @@ class CliIndicatorSerialization(threat_updates.ThreatUpdateSerialization):
     def te_threat_updates_fields(cls):
         return SimpleDescriptorRollup.te_threat_updates_fields()
 
+    # ToDo this violates Liskov but is already used in Prod and will require a larger refactor
     @classmethod
-    def store(
+    def store(  # type: ignore
         cls, state_dir: pathlib.Path, contents: t.Iterable["CliIndicatorSerialization"]
     ) -> t.List[pathlib.Path]:
         # Stores in multiple files split by indicator type
@@ -68,9 +69,7 @@ class CliIndicatorSerialization(threat_updates.ThreatUpdateSerialization):
         return ret
 
     @classmethod
-    def load(
-        cls, state_dir: pathlib.Path
-    ) -> t.List["threat_updates.ThreatUpdateSerialization"]:
+    def load(cls, state_dir: pathlib.Path) -> t.Iterable["CliIndicatorSerialization"]:
         """Load this serialization from the state directory"""
         ret = []
         pattern = r"simple\.([^.]+)" + re.escape(Dataset.EXTENSION)
@@ -139,9 +138,7 @@ class HMASerialization(CliIndicatorSerialization):
         )
 
     @classmethod
-    def load(
-        cls, state_dir: pathlib.Path
-    ) -> t.List["threat_updates.ThreatUpdateSerialization"]:
+    def load(cls, state_dir: pathlib.Path) -> t.Iterable["HMASerialization"]:
         """Load this serialization from the state directory"""
         ret = []
         pattern = r"simple\.([^.]+)" + re.escape(Dataset.EXTENSION)
@@ -172,7 +169,7 @@ if __name__ == "__main__":
         indicator_id,
         SimpleDescriptorRollup(first_descriptor_id, added_on, labels),
     )
-    serdeser = HMASerialization.from_csv_row(ser.as_csv_row(), "HASH_PDQ")
+    serdeser = HMASerialization.from_csv_row(list(ser.as_csv_row()), "HASH_PDQ")
 
     if ser.as_csv_row() == serdeser.as_csv_row():
         print("Serialization worked correctly")

--- a/python-threatexchange/threatexchange/cli/fetch.py
+++ b/python-threatexchange/threatexchange/cli/fetch.py
@@ -74,7 +74,7 @@ class FetchCommand(command_base.Command):
         # Print first update after 5 seconds
         self.last_update_printed = time.time() - self.PROGRESS_PRINT_INTERVAL_SEC + 5
         self.processed = 0
-        self.counts = collections.Counter()
+        self.counts: t.Dict[str, int] = collections.Counter()
 
     def execute(self, api: ThreatExchangeAPI, dataset: Dataset) -> None:
         privacy_groups = dataset.config.privacy_groups

--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -14,7 +14,7 @@ from ..api import ThreatExchangeAPI
 from ..content_type import meta
 from ..dataset import Dataset
 from ..descriptor import ThreatDescriptor
-from ..signal_type.signal_base import FileHasher, StrHasher
+from ..signal_type.signal_base import FileHasher, StrHasher, SignalType
 from . import command_base, fetch
 
 
@@ -67,7 +67,7 @@ class HashCommand(command_base.Command):
         content_type: str,
         signal_type: t.Optional[str],
         as_text: bool,
-        content: t.List[str],
+        content: t.Union[t.List[str], t.TextIO],
     ) -> None:
         self.content_type = [
             c for c in meta.get_all_content_types() if c.get_name() == content_type
@@ -103,7 +103,7 @@ class HashCommand(command_base.Command):
 
         for inp in self.input_generator:
             hash_fn = lambda s, t: s.hash_from_file(t)
-            signal_types = file_hashers
+            signal_types: t.List[t.Any] = file_hashers
             if isinstance(inp, str):
                 hash_fn = lambda s, t: s.hash_from_str(t)
                 signal_types = str_hashers

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -122,7 +122,7 @@ def get_app_token(cli_option: str = None) -> str:
     file_loc = pathlib.Path("~/.txtoken").expanduser()
     environment_var = "TX_ACCESS_TOKEN"
     token = ""
-    source = ""
+    source: t.Union[pathlib.Path, str] = ""
     if cli_option:
         source = "cli argument"
         token = cli_option

--- a/python-threatexchange/threatexchange/cli/match.py
+++ b/python-threatexchange/threatexchange/cli/match.py
@@ -119,11 +119,11 @@ class MatchCommand(command_base.Command):
             tok: str,
         ) -> t.Generator[t.Union[str, pathlib.Path], None, None]:
             if force_input_to_text:
-                return tok
+                yield tok
             path = pathlib.Path(token)
             if path.exists():
-                return path
-            return tok
+                yield path
+            yield tok
 
         for token in input_:
             token = token.rstrip()
@@ -141,7 +141,7 @@ class MatchCommand(command_base.Command):
                     no_stderr=True,
                 )
             else:
-                yield parsed
+                yield from parsed
 
     def execute(self, api: ThreatExchangeAPI, dataset: Dataset) -> None:
         if dataset.is_cache_empty:
@@ -155,7 +155,9 @@ class MatchCommand(command_base.Command):
         )
 
         file_matchers = [s for s in all_signal_types if isinstance(s, FileMatcher)]
-        str_matchers = [s for s in all_signal_types if isinstance(s, StrMatcher)]
+        str_matchers: t.List[t.Any] = [
+            s for s in all_signal_types if isinstance(s, StrMatcher)
+        ]
 
         match_str = lambda s, t: s.match(t)
         if self.as_hashes:

--- a/python-threatexchange/threatexchange/collab_config.py
+++ b/python-threatexchange/threatexchange/collab_config.py
@@ -68,7 +68,7 @@ class CollaborationConfig:
             json.dump(out, f, indent=4)
 
     @classmethod
-    def get_example_config(cls) -> "CollabConfig":
+    def get_example_config(cls) -> "CollaborationConfig":
         """
         Get a config to access the public sample data under media_priority_samples
         """

--- a/python-threatexchange/threatexchange/common.py
+++ b/python-threatexchange/threatexchange/common.py
@@ -72,6 +72,4 @@ def normalize_url(url: str) -> bytes:
     # https://www.facebook.com => www.facebook.com
     url = parsed.geturl().replace(scheme, "", 1)
     # Ensure URL is utf-8 encoded
-    encoded_url = url.encode("utf-8")
-
-    return encoded_url
+    return url.encode("utf-8")

--- a/python-threatexchange/threatexchange/common.py
+++ b/python-threatexchange/threatexchange/common.py
@@ -54,11 +54,11 @@ def normalize_string(s: str) -> str:
     return s
 
 
-def normalize_url(url: str) -> str:
+def normalize_url(url: str) -> bytes:
     """
     Normalize the URL and strip the scheme from the URL to make matching more effective.
 
-    Urls will be normalized to lowercase and the initial sche
+    Urls will be normalized to lowercase and the initial scheme removed as well as "utf-8" encoded.
     """
     # Lowercase
     # HtTPs://wWw.faCeBook.cOM => https://www.facebook.com
@@ -72,6 +72,6 @@ def normalize_url(url: str) -> str:
     # https://www.facebook.com => www.facebook.com
     url = parsed.geturl().replace(scheme, "", 1)
     # Ensure URL is utf-8 encoded
-    url = url.encode("utf-8")
+    encoded_url = url.encode("utf-8")
 
-    return url
+    return encoded_url

--- a/python-threatexchange/threatexchange/content_type/content_base.py
+++ b/python-threatexchange/threatexchange/content_type/content_base.py
@@ -20,5 +20,5 @@ class ContentType:
         return common.class_name_to_human_name(cls.__name__, "Content")
 
     @classmethod
-    def get_signal_types() -> t.List[t.Type[signal_base.SignalType]]:
+    def get_signal_types(cls) -> t.List[t.Type[signal_base.SignalType]]:
         raise NotImplementedError

--- a/python-threatexchange/threatexchange/content_type/meta.py
+++ b/python-threatexchange/threatexchange/content_type/meta.py
@@ -25,19 +25,18 @@ def get_all_content_types() -> t.List[t.Type[content_base.ContentType]]:
 
 
 @functools.lru_cache(1)
-def get_content_types_by_name() -> t.Dict[str, content_base.ContentType]:
+def get_content_types_by_name() -> t.Dict[str, t.Type[content_base.ContentType]]:
     return {c.get_name(): c for c in get_all_content_types()}
 
 
 @functools.lru_cache(1)
 def get_all_signal_types() -> t.Set[t.Type[signal_base.SignalType]]:
     """Returns all signal_type implementations for commands"""
-    ret = set()
     return {s for c in get_all_content_types() for s in c.get_signal_types()}
 
 
 @functools.lru_cache(1)
-def get_signal_types_by_name() -> t.Dict[str, signal_base.SignalType]:
+def get_signal_types_by_name() -> t.Dict[str, t.Type[signal_base.SignalType]]:
     return {s.get_name(): s for s in get_all_signal_types()}
 
 

--- a/python-threatexchange/threatexchange/dataset.py
+++ b/python-threatexchange/threatexchange/dataset.py
@@ -129,4 +129,4 @@ class Dataset:
         if not path.exists():
             return None
         with path.open("rb") as fin:
-            return signal_type.get_index_cls.deserialize(fin)
+            return signal_type.get_index_cls().deserialize(fin)

--- a/python-threatexchange/threatexchange/descriptor.py
+++ b/python-threatexchange/threatexchange/descriptor.py
@@ -31,18 +31,18 @@ class ThreatDescriptor(t.NamedTuple):
 
     # TODO - do something smarter than this - static
     #        class variable problematic, currently set in main.py
-    MY_APP_ID = -1
+    MY_APP_ID = -1  # type: ignore
 
     # You declared the indicator was in the collaboration label set
-    TRUE_POSITIVE = "true_positive"
+    TRUE_POSITIVE = "true_positive"  # type: ignore
     # You declared the indicator was not in the collaboration label set
-    FALSE_POSITIVE = "false_positive"
+    FALSE_POSITIVE = "false_positive"  # type: ignore
     # Someone declared the indicator was not in the collaboration label set
-    DISPUTED = "disputed"
+    DISPUTED = "disputed"  # type: ignore
 
     # Special tags to mark whether you (or someone else)
     # has weighed in on the indicator
-    SPECIAL_TAGS = frozenset((TRUE_POSITIVE, FALSE_POSITIVE, DISPUTED))
+    SPECIAL_TAGS = frozenset((TRUE_POSITIVE, FALSE_POSITIVE, DISPUTED))  # type: ignore
 
     id: int
     raw_indicator: str
@@ -53,7 +53,7 @@ class ThreatDescriptor(t.NamedTuple):
     added_on: str
 
     @classmethod
-    def from_te_json(cls, my_app_id: int, td_json) -> "ThreatDescriptor":
+    def from_te_json(cls, my_app_id: t.Union[str, int], td_json) -> "ThreatDescriptor":
         # Hack for now, but nearly refactored out of cls state
         cls.MY_APP_ID = my_app_id
         owner_id_str = td_json["owner"]["id"]
@@ -62,7 +62,7 @@ class ThreatDescriptor(t.NamedTuple):
         # does a transform, but other locations do not
         if isinstance(tags, dict):
             tags = sorted(tag["text"] for tag in tags["data"])
-        td = cls(
+        td = cls(  # type: ignore
             id=int(td_json["id"]),
             raw_indicator=td_json["raw_indicator"],
             indicator_type=td_json["type"],
@@ -133,7 +133,7 @@ class SimpleDescriptorRollup:
 
     @classmethod
     def from_descriptor(cls, descriptor: ThreatDescriptor) -> "SimpleDescriptorRollup":
-        return cls(descriptor.id, descriptor.added_on, descriptor.tags)
+        return cls(descriptor.id, descriptor.added_on, set(descriptor.tags))
 
     @classmethod
     def from_descriptors(
@@ -155,7 +155,7 @@ class SimpleDescriptorRollup:
         if descriptor.is_mine:
             self.added_on = self.IS_MY_OPINION
             self.first_descriptor_id = descriptor.id
-            self.labels = descriptor.tags
+            self.labels = set(descriptor.tags)
             return
         # My descriptor beats my reactions, and I don't want
         # to take anyone else's opinion
@@ -165,7 +165,7 @@ class SimpleDescriptorRollup:
         elif descriptor.is_false_positive:
             self.added_on = self.IS_MY_OPINION
             self.first_descriptor_id = descriptor.id
-            self.labels = descriptor.tags
+            self.labels = set(descriptor.tags)
             return
         # Else merge the labels together
         self.added_on, self.first_descriptor_id = min(
@@ -179,12 +179,12 @@ class SimpleDescriptorRollup:
         return self.first_descriptor_id, self.added_on, " ".join(self.labels)
 
     @classmethod
-    def from_row(cls, row: t.Iterable) -> "SimpleDescriptorRollup":
+    def from_row(cls, row: t.List) -> "SimpleDescriptorRollup":
         """Simple conversion from CSV row"""
         labels = []
         if row[2]:
             labels = row[2].split(" ")
-        return cls(int(row[0]), row[1], labels)
+        return cls(int(row[0]), row[1], set(labels))
 
     @classmethod
     def from_threat_updates_json(

--- a/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
+++ b/python-threatexchange/threatexchange/hashing/pdq_faiss_matcher.py
@@ -92,7 +92,7 @@ class PDQHashIndex(ABC):
             # for custom ids, we understood them initially as uint64 numbers and then coerced them internally to be signed
             # int64s, so we need to reverse this before returning them back to the caller. For non custom ids, this will
             # effectively return the same result
-            output_fn = int64_to_uint64
+            output_fn: t.Callable[[int], t.Any] = int64_to_uint64
         else:
             output_fn = self.hash_at
 
@@ -250,9 +250,14 @@ class PDQMultiHashIndex(PDQHashIndex):
             return faiss.downcast_IndexBinary(self.faiss_index.index)
         return self.faiss_index
 
-    def search(self, queries: t.Sequence[PDQ_HASH_TYPE], threshhold: int, **kwargs):
+    def search(
+        self,
+        queries: t.Sequence[PDQ_HASH_TYPE],
+        threshhold: int,
+        return_as_ids: bool = False,
+    ):
         self.mih_index.nflip = threshhold // self.mih_index.nhash
-        return super().search(queries, threshhold, **kwargs)
+        return super().search(queries, threshhold, return_as_ids)
 
     def search_with_distance_in_result(
         self,

--- a/python-threatexchange/threatexchange/signal_type/pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_index.py
@@ -23,8 +23,6 @@ class PDQIndex(SignalTypeIndex):
     Wrapper around the pdq faiss index lib using PDQMultiHashIndex
     """
 
-    T = IndexT
-
     @classmethod
     def get_match_threshold(cls):
         return 31  # PDQ_CONFIDENT_MATCH_THRESHOLD
@@ -33,7 +31,7 @@ class PDQIndex(SignalTypeIndex):
     def _get_empty_index(cls) -> PDQHashIndex:
         return PDQMultiHashIndex()
 
-    def __init__(self, entries: t.Iterable[t.Tuple[str, T]]) -> None:
+    def __init__(self, entries: t.Iterable[t.Tuple[str, IndexT]]) -> None:
         super().__init__()
         self.local_id_to_entry: t.OrderedDict = collections.OrderedDict()
         self.index: PDQHashIndex = self._get_empty_index()
@@ -42,7 +40,7 @@ class PDQIndex(SignalTypeIndex):
     def __len__(self) -> int:
         return len(self.local_id_to_entry)
 
-    def query(self, hash: str) -> t.List[IndexMatch[T]]:
+    def query(self, hash: str) -> t.List[IndexMatch[IndexT]]:
         """
         Look up entries against the index, up to the max supported distance.
         """
@@ -57,7 +55,7 @@ class PDQIndex(SignalTypeIndex):
             matches.append(IndexMatch(distance, self.local_id_to_entry[id][1]))
         return matches
 
-    def add(self, entries: t.Iterable[t.Tuple[str, T]]) -> None:
+    def add(self, entries: t.Iterable[t.Tuple[str, IndexT]]) -> None:
         hashes = []
 
         for i, entry in enumerate(entries):
@@ -67,7 +65,9 @@ class PDQIndex(SignalTypeIndex):
         self.index.add(hashes, self.local_id_to_entry.keys())
 
     @classmethod
-    def build(cls, entries: t.Iterable[t.Tuple[str, T]]) -> "SignalTypeIndex[T]":
+    def build(
+        cls, entries: t.Iterable[t.Tuple[str, IndexT]]
+    ) -> "SignalTypeIndex[IndexT]":
         """
         Build an PDQ index from a set of entries.
         """
@@ -80,11 +80,11 @@ class PDQIndex(SignalTypeIndex):
         fout.write(pickle.dumps(self))
 
     @classmethod
-    def deserialize(cls, fin: t.BinaryIO) -> "SignalTypeIndex[T]":
+    def deserialize(cls, fin: t.BinaryIO) -> "SignalTypeIndex[IndexT]":
         """
-        Instanciate an index from a previous call to serialize
+        Instantiate an index from a previous call to serialize
         """
-        return pickle.loads(fin)
+        return pickle.loads(fin.read())
 
 
 class PDQFlatIndex(PDQIndex):

--- a/python-threatexchange/threatexchange/signal_type/raw_text.py
+++ b/python-threatexchange/threatexchange/signal_type/raw_text.py
@@ -30,7 +30,7 @@ class RawTextSignal(signal_base.SimpleSignalType, signal_base.StrMatcher):
 
     def __init__(self) -> None:
         super().__init__()
-        self.normal_to_raw = {}
+        self.normal_to_raw: t.Dict[str, str] = {}
 
     def match(self, content: str) -> t.List[signal_base.SignalMatch]:
         return self.match_hash(content)

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -103,7 +103,7 @@ class SignalType:
 
     ##########################################################################
     # TODO - Remove  these methods after refactor
-    def process_descriptor(self, descriptor) -> bool:
+    def process_descriptor(self, descriptor: ThreatDescriptor) -> bool:
         """
         Add ThreatDescriptor to the state of this type, if it is for this type.
 

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -103,7 +103,7 @@ class SignalType:
 
     ##########################################################################
     # TODO - Remove  these methods after refactor
-    def process_descriptor(self, descriptor: t.Dict[str, t.Any]) -> bool:
+    def process_descriptor(self, descriptor) -> bool:
         """
         Add ThreatDescriptor to the state of this type, if it is for this type.
 
@@ -214,7 +214,7 @@ class SimpleSignalType(SignalType, HashMatcher):
     Assumes that the signal type can easily merge on a string.
     """
 
-    INDICATOR_TYPE: t.Union[str, t.Tuple[str]] = ()
+    INDICATOR_TYPE: t.Union[str, t.Tuple[str, ...]] = ()
     TYPE_TAG: t.Optional[str] = None
 
     @classmethod

--- a/python-threatexchange/threatexchange/signal_type/trend_query.py
+++ b/python-threatexchange/threatexchange/signal_type/trend_query.py
@@ -58,7 +58,7 @@ class TrendQuerySignal(signal_base.SignalType, signal_base.StrMatcher):
     """
 
     def __init__(self) -> None:
-        self.state: t.Dict[str, (TrendQuery, SimpleDescriptorRollup)] = {}
+        self.state: t.Dict[str, t.Tuple[TrendQuery, SimpleDescriptorRollup]] = {}
 
     def process_descriptor(self, descriptor: ThreatDescriptor) -> bool:
         """
@@ -78,7 +78,9 @@ class TrendQuerySignal(signal_base.SignalType, signal_base.StrMatcher):
             self.state[descriptor.raw_indicator] = (
                 TrendQuery(query_json),
                 SimpleDescriptorRollup(
-                    descriptor.id, descriptor.added_on, descriptor.tags
+                    descriptor.id,
+                    descriptor.added_on,
+                    set(descriptor.tags),
                 ),
             )
         else:


### PR DESCRIPTION
Summary
---------

This is the remaining pieces from break up #873 and is mostly just around fixing types.

I would recommend reviewing commit by commit. 

### [`aec21f10`](https://github.com/facebook/ThreatExchange/pull/878/commits/aec21f10e2778c1b18a7c23ac7fff0c0b08af3c5) add simple type hints
- no logic changes
### [`304b9340`](https://github.com/facebook/ThreatExchange/pull/878/commits/304b9340b9bfa077b6858e30290f83ba57407048) add typing and simple fixes to threatexchange cli commands
- minor fixes + typing
### [`34a63fce`](https://github.com/facebook/ThreatExchange/pull/878/commits/34a63fcebb2d916280d9d52ed7dc76cbf65743fa) adds typing, ignores, list-to-set, and null checks on threat_update utils and descriptor.py
- type + some logic fixes / casting

### [`e7221b8c`](https://github.com/facebook/ThreatExchange/pull/878/commits/e7221b8cc8bdb5eead51bb59b978ee1b7c926905) update type hints and add set to list casts for serialization classes
- threat_update specific typing

### [`da27f81d`](https://github.com/facebook/ThreatExchange/pull/878/commits/da27f81db20b6707795afe2c400e8c4645c8449d) add mypy checks to CLI
- adds stuff to github actions

### [`06afe107`](https://github.com/facebook/ThreatExchange/pull/878/commits/06afe1073cf0dcb4d627271688130d64e2064e20) final typing fixes in pdq_index and faiss files
- typing fixes needed from files in #875 

### [`0ecc14c5`](https://github.com/facebook/ThreatExchange/pull/878/commits/0ecc14c563616ccc1b3863614cfe5942bb535b5e) add typestubs to make ci happy



Test Plan
---------

Repeat of #873 testing after rebase
