### PR TITLE
[hma] pytx version bump and keyword arg name fix in matcher_base

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/matcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/matcher.py
@@ -84,7 +84,7 @@ def lambda_handler(event, context):
             matcher.write_match_record_for_result(
                 table=table,
                 signal_type=hash_record.signal_type,
-                signal_value=hash_record.content_hash,
+                content_hash=hash_record.content_hash,
                 content_id=hash_record.content_id,
                 match=match,
             )

--- a/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
+++ b/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
@@ -122,7 +122,7 @@ class Matcher:
         self,
         table: Table,
         signal_type: t.Type[SignalType],
-        signal_value: str,
+        content_hash: str,
         content_id: str,
         match: IndexMatch,
     ):
@@ -132,13 +132,13 @@ class Matcher:
         for match record calls.
         """
         MatchRecord(
-            content_id,
-            signal_type,
-            signal_value,
-            datetime.datetime.now(),
-            str(match.metadata["id"]),
-            match.metadata["source"],
-            match.metadata["hash"],
+            content_id=content_id,
+            signal_type=signal_type,
+            content_hash=content_hash,
+            updated_at=datetime.datetime.now(),
+            signal_id=str(match.metadata["id"]),
+            signal_source=match.metadata["source"],
+            signal_hash=match.metadata["hash"],
         ).write_to_table(table)
 
     @classmethod

--- a/hasher-matcher-actioner/setup.py
+++ b/hasher-matcher-actioner/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         "boto3",
         "boto3-stubs[essential,sns,dynamodbstreams]==1.17.14.0",
-        "threatexchange[faiss,pdq_hasher]>=0.0.27",
+        "threatexchange[faiss,pdq_hasher]>=0.0.29",
         "bottle",
         "apig_wsgi",
         "pyjwt[crypto]==2.1.0",


### PR DESCRIPTION
Summary
---------

I been testing 0.29 for ThreatExchange on HMA in my next PR and it works. Would rather keep main-hma on most recent version as soon as we are ~confident it won't break.

Also saw that a method incorrectly referred to a `content_hash` as a `signal_value` when creating `MatchRecord` wanted to address ASAP to avoid the confusion spreading. Also updated call site in matcher lambda to avoid this happening again there.

Test Plan
---------

`make upload_docker`
`make dev_apply_with_newest_docker_image`  
`make dev_test_instance`