### PR TITLE
Update PDQ README for  #868

### DIFF
--- a/pdq/README.md
+++ b/pdq/README.md
@@ -4,11 +4,8 @@
 
 This is the reference implementation for the PDQ hashing algorithm.
 
-Please see
-[LICENSE.txt](https://github.com/facebook/ThreatExchange/blob/main/pdq/LICENSE.txt)
-as well as
-[../hashing.pdf](https://github.com/facebook/ThreatExchange/blob/main/hashing/hashing.pdf)
-within this repository.
+Please see [../hashing.pdf](https://github.com/facebook/ThreatExchange/blob/main/hashing/hashing.pdf)
+within this repository for an explanation of the algorithm.
 
 See also https://newsroom.fb.com/news/2019/08/open-source-photo-video-matching for context.
 
@@ -17,5 +14,3 @@ As of November 2018 there are C++, PHP, and Java implementations.  Details are i
 ## Contact
 
 threatexchange@fb.com
-
-2017-10-09


### PR DESCRIPTION
Instead point to the top-level license, pending a deletion of the duplicate license files.

Summary
---------

I could have done this as part of the commit that deleted them, but preview is useful. I can probably delete files from the github UI, but am lazy. 

Test Plan
---------

Viewed preview, clicked on link.
