### PR TITLE
[hma] record match distance in match record and surface on API

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/models/pipeline.py
+++ b/hasher-matcher-actioner/hmalib/common/models/pipeline.py
@@ -268,6 +268,7 @@ class _MatchRecord(PipelineRecordBase):
     signal_id: str
     signal_source: str
     signal_hash: str
+    match_distance: t.Optional[int] = None
 
 
 @dataclass
@@ -300,6 +301,7 @@ class MatchRecord(PipelineRecordDefaultsBase, _MatchRecord):
                 "GSI1-SK": self.get_dynamodb_content_key(self.content_id),
                 "HashType": self.signal_type.get_name(),
                 "GSI2-PK": self.get_dynamodb_type_key(self.__class__.__name__),
+                "MatchDistance": self.match_distance,
             },
         )
 
@@ -399,6 +401,7 @@ class MatchRecord(PipelineRecordDefaultsBase, _MatchRecord):
                 signal_specific_attributes=cls.deserialize_signal_specific_attributes(
                     item
                 ),
+                match_distance=item.get("MatchDistance"),
             )
             for item in items
         ]

--- a/hasher-matcher-actioner/hmalib/common/models/tests/test_pipeline_models.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/test_pipeline_models.py
@@ -47,6 +47,7 @@ DATASTORE_TABLE_DEF = {
                     "SignalSource",
                     "HashType",
                     "SignalType",
+                    "MatchDistance",
                 ],
             },
         },
@@ -64,6 +65,7 @@ DATASTORE_TABLE_DEF = {
                     "SignalSource",
                     "HashType",
                     "SignalType",
+                    "MatchDistance",
                 ],
             },
         },
@@ -114,7 +116,6 @@ class TestPDQModels(DynamoDBTableTestBase, unittest.TestCase):
             TestPDQModels.TEST_SIGNAL_ID,
             TestPDQModels.TEST_SIGNAL_SOURCE,
             signal_hash,
-            {"Distance": "29"},
         )
 
     @staticmethod

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -96,6 +96,7 @@ class MatchDetail(JSONifiable):
     signal_source: str
     signal_type: str
     updated_at: str
+    match_distance: t.Optional[int]
     metadata: t.List[ThreatExchangeMatchDetailMetadata]
 
     def to_json(self) -> t.Dict:
@@ -135,6 +136,9 @@ def get_match_details(table: Table, content_id: str) -> t.List[MatchDetail]:
             signal_source=record.signal_source,
             signal_type=record.signal_type.get_name(),
             updated_at=record.updated_at.isoformat(),
+            match_distance=int(record.match_distance)
+            if record.match_distance is not None
+            else None,
             metadata=get_signal_details(table, record.signal_id, record.signal_source),
         )
         for record in records

--- a/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
+++ b/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
@@ -139,6 +139,7 @@ class Matcher:
             signal_id=str(match.metadata["id"]),
             signal_source=match.metadata["source"],
             signal_hash=match.metadata["hash"],
+            match_distance=int(match.distance),
         ).write_to_table(table)
 
     @classmethod


### PR DESCRIPTION
Summary
---------

Now that the PDQIndex provides distance for matches why not record it in match record and surface them on the API?
Note: All video_md5 matches recorded at 0 (as expected)

Test Plan
---------
Deployed and took a hash from `sample_data/holidays-jpg1-pdq-hashes.csv` e.g. `431dfd4204ad7b54ec6203bdfd42033fbfa5ec42033dfcc4033bf631dccc031c`

Modified it slightly and ran (after setting auth token):
`hmacli storm  --media "431dfd4204ad7b54ec6203bdfd42033fbfa5ec42033dfcc4033bf631dccc0310" --verbose -c 1 hash`  

Checked results in postman (with auth token in header):
GET `https://{{api_id}}.execute-api.us-east-1.amazonaws.com/api/matches/match/?content_id=<id-of-match-ui>`
```JSON
{
    "match_details": [
        {
            "content_id": "<id-of-match-ui>",
            "content_hash": "431dfd4204ad7b54ec6203bdfd42033fbfa5ec42033dfcc4033bf631dccc0310",
            "signal_id": "<id>",
            "signal_hash": "431dfd4204ad7b54ec6203bdfd42033fbfa5ec42033dfcc4033bf631dccc031c",
            "signal_source": "te",
            "signal_type": "pdq",
            "updated_at": "2021-12-09T20:42:21.489901",
            "match_distance": 2,
            "metadata": ["..."]
        }
    ]
}
```

Checked that match record created before deploying changes return `"match_distance": null,`
