### PR TITLE
Update README for #868

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,9 @@ We welcome contributions! See [CONTRIBUTING](https://github.com/facebook/ThreatE
 
 ## License
 
-Please see `./LICENSE`.
+All projects in this repository are under the BSD license - see [./LICENSE](https://github.com/facebook/ThreatExchange/blob/main/LICENSE). However, there are some exceptions for files that were included for demonstration purposes, and their alternative licenses are noted at the top of the files themselves.
+
+As of 12/9/2021, this is the complete list of exceptions:
+* pdq/cpp/CImg.h
+
+


### PR DESCRIPTION
Summary
---------

Add some more context about license of repository.

Test Plan
---------

`grep -ri license` to look for any other files that might have been missed. Found a bunch of reference to missing files in api-examples, but nothing that looked like CImg.h's issue. 
