### PR TITLE
[HMA] Indexer sources hashes from banks as well as te data

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/messages/match.py
+++ b/hasher-matcher-actioner/hmalib/common/messages/match.py
@@ -36,7 +36,13 @@ class BankedSignal:
     bank_source: str
     classifications: t.Set[Label] = field(default_factory=set)
 
+    def __post_init__(self):
+        self.add_bank_classifications()
+
     def add_bank_classifications(self):
+        if len(self.classifications) != 0:
+            return
+
         self.classifications.add(BankSourceClassificationLabel(self.bank_source))
         self.classifications.add(BankIDClassificationLabel(self.bank_id))
         self.classifications.add(

--- a/hasher-matcher-actioner/hmalib/common/models/bank.py
+++ b/hasher-matcher-actioner/hmalib/common/models/bank.py
@@ -71,14 +71,12 @@ PK                SK                        Item
 PK                        SK            Item
 <bank_member_signal_id>   <bank_id>     KEYS_ONLY(BankMemberSignal)
 
-5. PendingBankMemberSignalsIndex
-   A sparse index. Only contains BankMemberSignalObjects that haven't yet been
-   processed into the index. Additions and Removals can both be processed. The
-   indexer must scan this index, for each entry, get the BankMember and
-   BankMemberSignal. As the indexer processes them in, it will remove them from
-   this sparse GSI.
-PK              SK              Item
-<signal_type>   <updated_at>    KEYS_ONLY(BankMemberSignal)
+5. BankMemberSignalCursorIndex
+   Contains BankMemberSignal Objects in the order they were updated. This can be
+   used by any system that needs to process bank member signals in order. eg.
+   indexer, TBD-component that can write a bank to threatexchange.
+PK              SK                                          Item
+<signal_type>   <updated_at>+<some-portion-of-signal-id>    ALL(BankMemberSignal)
 """
 
 
@@ -232,26 +230,6 @@ class BankMember(DynamoDBItem):
         return result
 
 
-class BankMemberSignalStatus(Enum):
-    """
-    Bank member signals are processed into the respective signal_type indexes.
-    This enum governs the possible states the BankMemberSignal object can be
-    in. This influences whether or not a BankMemberSignal object is present in
-    the PendingBankMemberSignalsIndex.
-    """
-
-    # Implies that this needs to be processed now.
-    PENDING = "PENDING"
-
-    # Has been processed into an index.
-    PROCESSED = "PROCESSED"
-
-    # State machine purists will note that we do not have a PROCESSING stage
-    # which will take a lock and prevent double processing for records. However,
-    # in our case, there is no cost to double processing as long as records are
-    # processed in order. i.e chronologically.
-
-
 @dataclass
 class BankMemberSignal(DynamoDBItem):
     """
@@ -265,17 +243,19 @@ class BankMemberSignal(DynamoDBItem):
     signal_type: t.Type[SignalType]
     signal_value: str
 
-    status: BankMemberSignalStatus
-
     updated_at: datetime
 
-    PENDING_BANK_MEMBER_SIGNALS_INDEX = "PendingBankMemberSignalIndex"
-    PENDING_BANK_MEMBER_SIGNALS_INDEX_SIGNAL_TYPE = (
-        f"{PENDING_BANK_MEMBER_SIGNALS_INDEX}-SignalType"
+    BANK_MEMBER_SIGNAL_CURSOR_INDEX = "BankMemberSignalCursorIndex"
+    BANK_MEMBER_SIGNAL_CURSOR_INDEX_SIGNAL_TYPE = (
+        f"{BANK_MEMBER_SIGNAL_CURSOR_INDEX}-SignalType"
     )
-    PENDING_BANK_MEMBER_SIGNALS_INDEX_UPDATED_AT = (
-        f"{PENDING_BANK_MEMBER_SIGNALS_INDEX}-UpdatedAt"
+    BANK_MEMBER_SIGNAL_CURSOR_INDEX_CHRONO_KEY = (
+        f"{BANK_MEMBER_SIGNAL_CURSOR_INDEX}-ChronoKey"
     )
+
+    # How many keys of the signal id to use to de-duplicate the chronological
+    # ordering key?
+    CHRONO_KEY_SIGNAL_ID_FRAGMENT_SIZE = 12
 
     @classmethod
     def get_pk(cls, bank_member_id):
@@ -284,6 +264,10 @@ class BankMemberSignal(DynamoDBItem):
     @classmethod
     def get_sk(cls, signal_id):
         return f"signal#{signal_id}"
+
+    @classmethod
+    def get_chrono_key(cls, updated_at: datetime, signal_id: str):
+        return f"{updated_at.isoformat()}:{signal_id[:cls.CHRONO_KEY_SIGNAL_ID_FRAGMENT_SIZE]}"
 
     def to_dynamodb_item(self) -> t.Dict:
         item = {
@@ -297,16 +281,11 @@ class BankMemberSignal(DynamoDBItem):
             "SignalType": self.signal_type.get_name(),
             "SignalValue": self.signal_value,
             "UpdatedAt": self.updated_at.isoformat(),
-            "Status": self.status.name,
+            self.BANK_MEMBER_SIGNAL_CURSOR_INDEX_SIGNAL_TYPE: self.signal_type.get_name(),
+            self.BANK_MEMBER_SIGNAL_CURSOR_INDEX_CHRONO_KEY: self.get_chrono_key(
+                self.updated_at, self.signal_id
+            ),
         }
-
-        if self.status == BankMemberSignalStatus.PENDING:
-            item.update(
-                **{
-                    self.PENDING_BANK_MEMBER_SIGNALS_INDEX_SIGNAL_TYPE: self.signal_type.get_name(),
-                    self.PENDING_BANK_MEMBER_SIGNALS_INDEX_UPDATED_AT: self.updated_at.isoformat(),
-                }
-            )
 
         return item
 
@@ -319,7 +298,6 @@ class BankMemberSignal(DynamoDBItem):
             signal_type=get_signal_types_by_name()[item["SignalType"]],
             signal_value=item["SignalValue"],
             updated_at=datetime.fromisoformat(item["UpdatedAt"]),
-            status=BankMemberSignalStatus(item["Status"]),
         )
 
     def to_json(self) -> t.Dict:
@@ -328,30 +306,8 @@ class BankMemberSignal(DynamoDBItem):
         result.update(
             signal_type=self.signal_type.get_name(),
             updated_at=self.updated_at.isoformat(),
-            status=self.status.value,
         )
         return result
-
-    @classmethod
-    def unmark(cls, table: Table, bank_member_id: str, signal_id: str):
-        """
-        Updates the status to processed, the updated_at value to now() and
-        removes from the PendingBankMemberSignalIndex.
-
-        To do this in a single ddb call, we use an update_item statement which
-        REMOVES the GSI values, thus removing them from the index.
-        """
-        table.update_item(
-            Key={
-                "PK": cls.get_pk(bank_member_id=bank_member_id),
-                "SK": cls.get_sk(signal_id=signal_id),
-            },
-            UpdateExpression=f"SET Status = :status, UpdatedAt = :updated_at  REMOVE {cls.PENDING_BANK_MEMBER_SIGNALS_INDEX_SIGNAL_TYPE}, {cls.PENDING_BANK_MEMBER_SIGNALS_INDEX_UPDATED_AT}",
-            ExpressionAttributeValues={
-                ":status": BankMemberSignalStatus.PROCESSED.value,
-                ":updated_at": datetime.now().isoformat(),
-            },
-        )
 
 
 @dataclass
@@ -590,7 +546,6 @@ class BanksTable:
             signal_type=signal_type,
             signal_value=signal_value,
             updated_at=datetime.now(),
-            status=BankMemberSignalStatus.PENDING,
         )
         member_signal.write_to_table(self._table)
         return member_signal
@@ -625,21 +580,13 @@ class BanksTable:
             signal_value=signal_value,
         )
 
-    def unmark_bank_member_signal(self, bank_member_id: str, signal_id: str):
-        """
-        Remove the bank-member-signal from the pending index.
-        """
-        BankMemberSignal.unmark(
-            self._table, bank_member_id=bank_member_id, signal_id=signal_id
-        )
-
     def get_bank_member_signals_to_process(
         self, signal_type: t.Type[SignalType], limit: int = 100
     ):
         return [
             BankMemberSignal.from_dynamodb_item(item)
             for item in self._table.query(
-                IndexName=BankMemberSignal.PENDING_BANK_MEMBER_SIGNALS_INDEX,
+                IndexName=BankMemberSignal.BANK_MEMBER_SIGNAL_CURSOR_INDEX,
                 KeyConditionExpression=Key("PK").eq(signal_type.get_name()),
                 Limit=limit,
             )["Items"]

--- a/hasher-matcher-actioner/hmalib/common/models/models_base.py
+++ b/hasher-matcher-actioner/hmalib/common/models/models_base.py
@@ -115,3 +115,12 @@ class PaginatedResponse(t.Generic[T]):
 
     last_evaluated_key: DynamoDBCursorKey
     items: t.List[T]
+
+    def has_next_page(self):
+        """
+        If query does not return last_evaluated_key, there are no more results
+        to return.
+
+        https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.Pagination.html
+        """
+        return self.last_evaluated_key != None

--- a/hasher-matcher-actioner/hmalib/common/models/tests/test_signal_uniqueness.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/test_signal_uniqueness.py
@@ -20,18 +20,22 @@ class BanksTableTestBase(DynamoDBTableTestBase):
         # TODO: Automate refresh of this using a commandline invocation
         return {
             "AttributeDefinitions": [
+                {
+                    "AttributeName": "BankMemberIdIndex-BankMemberId",
+                    "AttributeType": "S",
+                },
+                {
+                    "AttributeName": "BankMemberSignalCursorIndex-ChronoKey",
+                    "AttributeType": "S",
+                },
+                {
+                    "AttributeName": "BankMemberSignalCursorIndex-SignalType",
+                    "AttributeType": "S",
+                },
                 {"AttributeName": "BankNameIndex-BankId", "AttributeType": "S"},
                 {"AttributeName": "BankNameIndex-BankName", "AttributeType": "S"},
                 {"AttributeName": "PK", "AttributeType": "S"},
                 {"AttributeName": "SK", "AttributeType": "S"},
-                {
-                    "AttributeName": "PendingBankMemberSignalIndex-SignalType",
-                    "AttributeType": "S",
-                },
-                {
-                    "AttributeName": "PendingBankMemberSignalIndex-UpdatedAt",
-                    "AttributeType": "S",
-                },
             ],
             "TableName": table_name,
             "KeySchema": [
@@ -48,14 +52,24 @@ class BanksTableTestBase(DynamoDBTableTestBase):
                     "Projection": {"ProjectionType": "ALL"},
                 },
                 {
-                    "IndexName": "PendingBankMemberSignalIndex",
+                    "IndexName": "BankMemberIdIndex",
                     "KeySchema": [
                         {
-                            "AttributeName": "PendingBankMemberSignalIndex-SignalType",
+                            "AttributeName": "BankMemberIdIndex-BankMemberId",
+                            "KeyType": "HASH",
+                        }
+                    ],
+                    "Projection": {"ProjectionType": "KEYS_ONLY"},
+                },
+                {
+                    "IndexName": "BankMemberSignalCursorIndex",
+                    "KeySchema": [
+                        {
+                            "AttributeName": "BankMemberSignalCursorIndex-SignalType",
                             "KeyType": "HASH",
                         },
                         {
-                            "AttributeName": "PendingBankMemberSignalIndex-UpdatedAt",
+                            "AttributeName": "BankMemberSignalCursorIndex-ChronoKey",
                             "KeyType": "RANGE",
                         },
                     ],

--- a/hasher-matcher-actioner/hmalib/common/s3_adapters.py
+++ b/hasher-matcher-actioner/hmalib/common/s3_adapters.py
@@ -32,6 +32,10 @@ from hmalib.common.models.signal import (
 )
 from hmalib import metrics
 from hmalib.common.logging import get_logger
+from hmalib.indexers.metadata import (
+    BaseIndexMetadata,
+    ThreatExchangeIndicatorIndexMetadata,
+)
 
 logger = get_logger(__name__)
 
@@ -46,7 +50,14 @@ def get_s3_client():
     return boto3.client("s3")
 
 
-HashRowT = t.Tuple[str, t.Dict[str, t.Any]]
+# A hash row is a tuple of the hash_value and a sequence of metadata object.
+# Remember, a single hash may have multiple metadata objects. One from
+# threatexchange, one from banks, another one from threatexchange, but a
+# different privacy group.
+#
+# Use mutable sequence instead of list here because we need subclasses of
+# BaseIndexMetadata and t.List is not co-variant in mypy's grammar.
+HashRowT = t.Tuple[str, t.MutableSequence[BaseIndexMetadata]]
 
 # Signal types that s3_adapters should support
 KNOWN_SIGNAL_TYPES: t.List[t.Type[SignalType]] = [VideoMD5Signal, PdqSignal]
@@ -151,24 +162,21 @@ class ThreatExchangeS3Adapter:
         )
         self.last_modified[file_name] = data_file["LastModified"].isoformat()
         privacy_group = file_name.split("/")[-1].split(".")[0]
-        return [
-            (
-                row["hash"],
-                # Also add hash to metadata for easy look up on match
-                {
-                    "id": int(row["indicator_id"]),
-                    "hash": row["hash"],
-                    "source": self.config.SOURCE_STR,  # default for now to make downstream easier to generalize
-                    "privacy_groups": set(
-                        [privacy_group]
-                    ),  # read privacy group from key
-                    "tags": {privacy_group: row["tags"].split(" ")}
-                    if row["tags"]
-                    else {},  # note: these are the labels assigned by pytx in descriptor.py (NOT a 1-1 with tags on TE)
-                },
+
+        result: t.List[HashRowT] = []
+        for row in data_reader:
+            metadata = ThreatExchangeIndicatorIndexMetadata(
+                indicator_id=row["indicator_id"],
+                signal_value=row["hash"],
+                privacy_group=privacy_group,
             )
-            for row in data_reader
-        ]
+            if row["tags"]:
+                # note: these are the labels assigned by pytx in descriptor.py (NOT a 1-1 with tags on TE)
+                metadata.tags.update(row["tags"].split(" "))
+
+            result.append((row["hash"], [metadata]))
+
+        return result
 
 
 class ThreatExchangeS3PDQAdapter(ThreatExchangeS3Adapter):

--- a/hasher-matcher-actioner/hmalib/common/s3_adapters.py
+++ b/hasher-matcher-actioner/hmalib/common/s3_adapters.py
@@ -35,6 +35,7 @@ from hmalib.common.logging import get_logger
 from hmalib.indexers.metadata import (
     BaseIndexMetadata,
     ThreatExchangeIndicatorIndexMetadata,
+    THREAT_EXCHANGE_SOURCE_SHORT_CODE,
 )
 
 logger = get_logger(__name__)
@@ -66,7 +67,7 @@ KNOWN_SIGNAL_TYPES: t.List[t.Type[SignalType]] = [VideoMD5Signal, PdqSignal]
 @dataclass
 class S3ThreatDataConfig:
 
-    SOURCE_STR = "te"
+    SOURCE_STR = THREAT_EXCHANGE_SOURCE_SHORT_CODE
 
     threat_exchange_data_bucket_name: str
     threat_exchange_data_folder: str

--- a/hasher-matcher-actioner/hmalib/indexers/metadata.py
+++ b/hasher-matcher-actioner/hmalib/indexers/metadata.py
@@ -23,7 +23,11 @@ class BaseIndexMetadata:
         return asdict(self)
 
 
+# Note changing this value will change S3ThreatDataConfig.SOURCE_STR. Per my
+# lookup, this will not affect how data gets stored, only logs, but should
+# figure it out.
 THREAT_EXCHANGE_SOURCE_SHORT_CODE = "te"
+
 BANKS_SOURCE_SHORT_CODE = "bnk"
 
 

--- a/hasher-matcher-actioner/hmalib/indexers/metadata.py
+++ b/hasher-matcher-actioner/hmalib/indexers/metadata.py
@@ -1,0 +1,79 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Defines metadata objects that are indexed. All hash indexes allow querying for a
+hash. This hash can be of type PDQ, MD5, TLSH, etc. The index returns a list of
+IndexMatch objects. Classes exposed in this module define the 'type' of the
+metadata attribute of an IndexMatch object.
+
+This allows us to ensure that all IndexMatch.metadata objects have a common
+shape so we can write logic around it.
+"""
+
+import typing as t
+
+from dataclasses import asdict, dataclass, field
+
+
+class BaseIndexMetadata:
+    def get_source(self) -> str:
+        raise NotImplemented
+
+    def to_json(self) -> t.Dict[str, t.Any]:
+        return asdict(self)
+
+
+THREAT_EXCHANGE_SOURCE_SHORT_CODE = "te"
+BANKS_SOURCE_SHORT_CODE = "bnk"
+
+
+@dataclass
+class ThreatExchangeIndicatorIndexMetadata(BaseIndexMetadata):
+    """
+    A row of data returned from ThreatExchange. Should correspond to a single
+    descriptor.
+    """
+
+    # ThreatExchange Indicator ID.
+    indicator_id: str
+
+    # Actual value of the hash, use a string representation.
+    signal_value: str
+
+    # Which privacy groups report this indicator? Usually, will be a set of one,
+    # but because an indicator can be in multiple privacy_groups, using a set.
+    privacy_group: str
+
+    # Tags reported by threatexchange for this privacy group. Will not contain
+    # all tags, but a sub-set.
+    tags: t.Set[str] = field(default_factory=set)
+
+    def get_source(self):
+        return THREAT_EXCHANGE_SOURCE_SHORT_CODE
+
+    def to_json(self) -> t.Dict[str, t.Any]:
+        result = asdict(self)
+        result.update(tags=list(self.tags))
+        return result
+
+
+@dataclass
+class BankedSignalIndexMetadata(BaseIndexMetadata):
+    """
+    A row of data stored as a bank member signal. A more compact view so that we
+    can store along the index.
+    """
+
+    # Bank signal_id, this is roughly the same as an indicator id in
+    # ThreatExchange. Separate bank_members which hash to the same signal value
+    # will have the same signal_id.
+    signal_id: str
+
+    # Actual value of the hash, use a string representation.
+    signal_value: str
+
+    # Along with a signal_id, this should suffice as a uniqueness constraint.
+    bank_member_id: str
+
+    def get_source(self):
+        return BANKS_SOURCE_SHORT_CODE

--- a/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/actions/action_evaluator.py
@@ -85,7 +85,6 @@ def lambda_handler(event, context):
     for sqs_record in event["Records"]:
         # TODO research max # sqs records / lambda_handler invocation
         sqs_record_body = json.loads(sqs_record["body"])
-        logger.info("sqs record body %s", sqs_record["body"])
         match_message = MatchMessage.from_aws_json(sqs_record_body["Message"])
 
         logger.info("Evaluating match_message: %s", match_message)

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -148,6 +148,7 @@ app.mount(
         hma_config_table=HMA_CONFIG_TABLE,
         indexes_bucket_name=INDEXES_BUCKET_NAME,
         writeback_queue_url=WRITEBACK_QUEUE_URL,
+        bank_table=dynamodb.Table(BANKS_TABLE),
     ),
 )
 

--- a/hasher-matcher-actioner/hmalib/lambdas/unified_indexer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/unified_indexer.py
@@ -1,51 +1,95 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import os
-import json
 import typing as t
 import functools
-from collections import defaultdict
+import boto3
 
-from urllib.parse import unquote_plus
 from threatexchange.signal_type.md5 import VideoMD5Signal
 from threatexchange.signal_type.pdq import PdqSignal
-
 from threatexchange.signal_type.signal_base import SignalType
 
+from hmalib.common.models.bank import BanksTable
 from hmalib.common.s3_adapters import (
     HashRowT,
+    ThreatExchangeS3Adapter,
     ThreatExchangeS3PDQAdapter,
     ThreatExchangeS3VideoMD5Adapter,
-    ThreatUpdateS3Store,
     S3ThreatDataConfig,
 )
 from hmalib.common.logging import get_logger
 from hmalib import metrics
 from hmalib.common.mappings import INDEX_MAPPING
+from hmalib.indexers.metadata import BankedSignalIndexMetadata
 from hmalib.indexers.s3_indexers import (
     S3BackedInstrumentedIndexMixin,
 )
 
 logger = get_logger(__name__)
+dynamodb = boto3.resource("dynamodb")
 
 THREAT_EXCHANGE_DATA_BUCKET_NAME = os.environ["THREAT_EXCHANGE_DATA_BUCKET_NAME"]
 THREAT_EXCHANGE_DATA_FOLDER = os.environ["THREAT_EXCHANGE_DATA_FOLDER"]
 
 INDEXES_BUCKET_NAME = os.environ["INDEXES_BUCKET_NAME"]
+BANKS_TABLE = os.environ["BANKS_TABLE"]
 
 
-def merge_threat_exchange_files(
+def get_all_bank_hash_rows(
+    signal_type: t.Type[SignalType], banks_table: BanksTable
+) -> t.Iterable[HashRowT]:
+    """
+    Make repeated calls to banks table to get all hashes for a signal type.
+
+    Returns list[HashRowT]. HashRowT is a tuple of hash_value and some metadata
+    about the signal.
+    """
+
+    exclusive_start_key = None
+    hash_rows: t.List[HashRowT] = []
+
+    while True:
+        page = banks_table.get_bank_member_signals_to_process_page(
+            signal_type=signal_type, exclusive_start_key=exclusive_start_key
+        )
+
+        for bank_member_signal in page.items:
+            hash_rows.append(
+                (
+                    bank_member_signal.signal_value,
+                    [
+                        BankedSignalIndexMetadata(
+                            bank_member_signal.signal_id,
+                            bank_member_signal.signal_value,
+                            bank_member_signal.bank_member_id,
+                        ),
+                    ],
+                )
+            )
+
+        exclusive_start_key = page.last_evaluated_key
+        if not page.has_next_page():
+            break
+
+    logger.info(
+        f"Obtained {len(hash_rows)} hash records from banks for signal_type:{signal_type.get_name()}"
+    )
+
+    return hash_rows
+
+
+def merge_hash_rows_on_hash_value(
     accumulator: t.Dict[str, HashRowT], hash_row: HashRowT
 ) -> t.Dict[str, HashRowT]:
-    hash, meta_data = hash_row
+    hash, metadata = hash_row
     if hash not in accumulator.keys():
         # Add hash as new row
         accumulator[hash] = hash_row
     else:
-        # Add new privacy group to existing row
-        accumulator[hash][1]["privacy_groups"].update(meta_data["privacy_groups"])
-        # Add new 'tags' for privacy group to existing row
-        accumulator[hash][1]["tags"].update(meta_data["tags"])
+        # Append current metadata to existing row's metadata objects by
+        # replacing completely. Tuples can't be updated, so replace.
+        accumulator[hash] = (hash, list(metadata) + list(accumulator[hash][1]))
+
     return accumulator
 
 
@@ -53,7 +97,7 @@ def merge_threat_exchange_files(
 # ThreatExchangeS3Adapter is used to fetch all the data corresponding to a
 # signal_type. At some point, we must allow _updates_ to indexes rather than
 # rebuilding them all the time.
-_ADAPTER_MAPPING = {
+_ADAPTER_MAPPING: t.Dict[t.Type[SignalType], t.Type[ThreatExchangeS3Adapter]] = {
     PdqSignal: ThreatExchangeS3PDQAdapter,
     VideoMD5Signal: ThreatExchangeS3VideoMD5Adapter,
 }
@@ -85,20 +129,26 @@ def lambda_handler(event, context):
         threat_exchange_data_folder=THREAT_EXCHANGE_DATA_FOLDER,
     )
 
+    banks_table = BanksTable(dynamodb.Table(BANKS_TABLE))
+
     for signal_type in ALL_INDEXABLE_SIGNAL_TYPES:
         adapter_class = _ADAPTER_MAPPING[signal_type]
         data_files = adapter_class(
             config=s3_config, metrics_logger=metrics.names.indexer
         ).load_data()
 
+        bank_data = get_all_bank_hash_rows(signal_type, banks_table)
+
         with metrics.timer(metrics.names.indexer.merge_datafiles):
             logger.info(f"Merging {signal_type} Hash files")
+
+            # go from dict[filename, list<hash rows>] → list<hash rows>
             flattened_data = [
                 hash_row for file_ in data_files.values() for hash_row in file_
             ]
 
             merged_data = functools.reduce(
-                merge_threat_exchange_files, flattened_data, {}
+                merge_hash_rows_on_hash_value, flattened_data + bank_data, {}
             ).values()
 
         with metrics.timer(metrics.names.indexer.build_index):

--- a/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
+++ b/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
@@ -9,8 +9,6 @@ import datetime
 import functools
 
 from mypy_boto3_sns.client import SNSClient
-from hmalib.common.models.signal import ThreatExchangeSignalMetadata
-
 from mypy_boto3_dynamodb.service_resource import Table
 from threatexchange.signal_type.pdq import PdqSignal
 from hmalib.common.models.pipeline import MatchRecord
@@ -28,11 +26,22 @@ from hmalib.common.configs.fetcher import (
     ThreatExchangeConfig,
     AdditionalMatchSettingsConfig,
 )
+from hmalib.common.models.bank import BankMember, BanksTable
+from hmalib.common.models.signal import ThreatExchangeSignalMetadata
+from hmalib.indexers.metadata import (
+    BANKS_SOURCE_SHORT_CODE,
+    THREAT_EXCHANGE_SOURCE_SHORT_CODE,
+    BaseIndexMetadata,
+    BankedSignalIndexMetadata,
+)
 
 
 logger = get_logger(__name__)
 
 PG_CONFIG_CACHE_TIME_SECONDS = 300
+
+# This is clearly wrong, but will still work. Someone tell the correct value, please.
+MAX_PDQ_DISTANCE = 1000
 
 
 @functools.lru_cache(maxsize=128)
@@ -156,7 +165,7 @@ class Matcher:
 
     def match(
         self, signal_type: t.Type[SignalType], signal_value: str
-    ) -> t.List[IndexMatch]:
+    ) -> t.List[IndexMatch[BaseIndexMetadata]]:
         """
         Returns MatchMessage which can be directly published to a queue.
 
@@ -183,44 +192,33 @@ class Matcher:
         consider extending this class and implementing your own.
         """
 
-        filtered_results_based_on_active = []
+        filtered_results = []
         for match in results:
-            match.metadata["privacy_groups"] = list(
-                filter(
-                    lambda x: get_privacy_group_matcher_active(str(x)),
-                    match.metadata.get("privacy_groups", []),
-                )
-            )
-
-            if len(match.metadata["privacy_groups"]) != 0:
-                filtered_results_based_on_active.append(match)
-
-        # Also check and see if there is a custom threshold filter
-        filtered_results_based_on_threshold = []
-        for match in filtered_results_based_on_active:
-            filtered_privacy_groups = []
-            for privacy_group in match.metadata.get("privacy_groups", []):
-                if threshold := get_optional_privacy_group_matcher_pdq_theshold(
-                    str(privacy_group)
-                ):
-                    if match.distance >= threshold:
-                        logger.debug(
-                            "Match was found at %s distance but exceeds custom theshold of %s for pg, %s",
-                            match.distance,
-                            threshold,
-                            privacy_group,
+            match.metadata = [
+                metadata_obj
+                for metadata_obj in match.metadata
+                if metadata_obj.get_source() == BANKS_SOURCE_SHORT_CODE
+                or (
+                    # If metadata obj is from threatexchange (one privacy group
+                    # per metadata obj), check that it is active AND that its
+                    # distance is lesser than the optional pdq_threshold set for
+                    # that pg (or MAX_PDQ_DISTANCE).
+                    metadata_obj.get_source() == THREAT_EXCHANGE_SOURCE_SHORT_CODE
+                    and get_privacy_group_matcher_active(metadata_obj.privacy_group)
+                    and match.distance
+                    < (
+                        get_optional_privacy_group_matcher_pdq_theshold(
+                            str(metadata_obj.privacy_group)
                         )
-                    else:
-                        filtered_privacy_groups.append(privacy_group)
-                else:
-                    # no custom threshold found
-                    filtered_privacy_groups.append(privacy_group)
-            match.metadata["privacy_groups"] = filtered_privacy_groups
+                        or MAX_PDQ_DISTANCE
+                    )
+                )
+            ]
 
-            if len(match.metadata["privacy_groups"]) != 0:
-                filtered_results_based_on_threshold.append(match)
+            if len(match.metadata) != 0:
+                filtered_results.append(match)
 
-        return filtered_results_based_on_threshold
+        return filtered_results
 
     def write_match_record_for_result(
         self,
@@ -228,23 +226,50 @@ class Matcher:
         signal_type: t.Type[SignalType],
         content_hash: str,
         content_id: str,
-        match: IndexMatch,
+        match: IndexMatch[BaseIndexMetadata],
     ):
         """
         Write a match record to dynamodb. The content_id is not important to the
         matcher. So, the calling lambda is expected to pass on the content_id
         for match record calls.
         """
-        MatchRecord(
-            content_id=content_id,
-            signal_type=signal_type,
-            content_hash=content_hash,
-            updated_at=datetime.datetime.now(),
-            signal_id=str(match.metadata["id"]),
-            signal_source=match.metadata["source"],
-            signal_hash=match.metadata["hash"],
-            match_distance=int(match.distance),
-        ).write_to_table(table)
+        # Write one record for TE and one for banks.. I am sure the logic can be
+        # simplified. We can do filters instead of iterating with flags. But
+        # umm, we can fix that later?
+        bank_record_written = False
+        te_record_written = False
+
+        for metadata_obj in match.metadata:
+            match_record_attributes = {
+                "content_id": content_id,
+                "signal_type": signal_type,
+                "content_hash": content_hash,
+                "updated_at": datetime.datetime.now(),
+                "signal_source": metadata_obj.get_source(),
+                "match_distance": int(match.distance),
+            }
+
+            if (
+                metadata_obj.get_source() == THREAT_EXCHANGE_SOURCE_SHORT_CODE
+                and not te_record_written
+            ):
+                match_record_attributes.update(
+                    signal_id=metadata_obj.indicator_id,
+                    signal_hash=metadata_obj.signal_value,
+                )
+                te_record_written = True
+
+            elif (
+                metadata_obj.get_source() == BANKS_SOURCE_SHORT_CODE
+                and not bank_record_written
+            ):
+                match_record_attributes.update(
+                    signal_id=metadata_obj.signal_id,
+                    signal_hash=metadata_obj.signal_value,
+                )
+                bank_record_written = True
+
+            MatchRecord(**match_record_attributes).write_to_table(table)
 
     @classmethod
     def write_signal_if_not_found(
@@ -264,40 +289,35 @@ class Matcher:
         their own store. Perhaps the API could be useful when building local
         banks. Who knows! :)
         """
-        for signal in cls.get_metadata_objects_from_match(signal_type, match):
-            signal.write_to_table_if_not_found(table)
+        for signal in cls.get_te_metadata_objects_from_match(signal_type, match):
+            if hasattr(signal, "write_to_table_if_not_found"):
+                # only ThreatExchangeSignalMetadata has this method.
+                # mypy not smart enough to auto cast.
+                signal.write_to_table_if_not_found(table)  # type: ignore
 
     @classmethod
-    def get_metadata_objects_from_match(
+    def get_te_metadata_objects_from_match(
         cls,
         signal_type: t.Type[SignalType],
-        match: IndexMatch,
-    ) -> t.List[t.Union[ThreatExchangeSignalMetadata]]:
+        match: IndexMatch[BaseIndexMetadata],
+    ) -> t.List[ThreatExchangeSignalMetadata]:
         """
         See docstring of `write_signal_if_not_found` we will likely want to move
         this outside of Matcher. However while the MD5 expansion is still on going
         better to have it all in once place.
         Note: changes made here will have an effect on api.matches.get_match_for_hash
         """
-        if (
-            match.metadata["source"]
-            != ThreatExchangeSignalMetadata.SIGNAL_SOURCE_SHORTCODE
-        ):
-            logger.warn(
-                "Matched against signal that is not sourced from threatexchange. Not writing metadata object."
-            )
-            return []
-
         return [
             ThreatExchangeSignalMetadata(
-                signal_id=str(match.metadata["id"]),
-                privacy_group_id=privacy_group_id,
+                signal_id=str(match_object.indicator_id),
+                privacy_group_id=match_object.privacy_group,
                 updated_at=datetime.datetime.now(),
                 signal_type=signal_type,
-                signal_hash=match.metadata["hash"],
-                tags=match.metadata["tags"].get(privacy_group_id, []),
+                signal_hash=match_object.signal_value,
+                tags=list(match_object.tags),
             )
-            for privacy_group_id in match.metadata.get("privacy_groups", [])
+            for match_object in match.metadata
+            if match_object.get_source() == THREAT_EXCHANGE_SOURCE_SHORT_CODE
         ]
 
     def get_index(self, signal_type: t.Type[SignalType]) -> SignalTypeIndex:
@@ -361,17 +381,25 @@ class Matcher:
         banked_signals = []
 
         for match in matches:
-            for privacy_group_id in match.metadata.get("privacy_groups", []):
-                banked_signal = BankedSignal(
-                    str(match.metadata["id"]),
-                    str(privacy_group_id),
-                    str(match.metadata["source"]),
-                )
+            for metadata_obj in match.metadata:
+                if metadata_obj.get_source() == THREAT_EXCHANGE_SOURCE_SHORT_CODE:
+                    banked_signal = BankedSignal(
+                        str(metadata_obj.indicator_id),
+                        str(metadata_obj.privacy_group),
+                        str(metadata_obj.get_source()),
+                    )
+                    for tag in metadata_obj.tags:
+                        banked_signal.add_classification(tag)
 
-                for tag in match.metadata["tags"].get(privacy_group_id, []):
-                    banked_signal.add_classification(tag)
+                    banked_signals.append(banked_signal)
+                elif metadata_obj.get_source() == BANKS_SOURCE_SHORT_CODE:
+                    banked_signal = BankedSignal(
+                        metadata_obj.signal_id,
+                        metadata_obj.bank_member_id,
+                        metadata_obj.get_source(),
+                    )
 
-                banked_signals.append(banked_signal)
+                    banked_signals.append(banked_signal)
 
         match_message = MatchMessage(
             content_key=content_id,

--- a/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
+++ b/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
@@ -40,8 +40,7 @@ logger = get_logger(__name__)
 
 PG_CONFIG_CACHE_TIME_SECONDS = 300
 
-# This is clearly wrong, but will still work. Someone tell the correct value, please.
-MAX_PDQ_DISTANCE = 1000
+MAX_PDQ_DISTANCE = 256
 
 
 @functools.lru_cache(maxsize=128)
@@ -206,7 +205,7 @@ class Matcher:
                     metadata_obj.get_source() == THREAT_EXCHANGE_SOURCE_SHORT_CODE
                     and get_privacy_group_matcher_active(metadata_obj.privacy_group)
                     and match.distance
-                    < (
+                    <= (
                         get_optional_privacy_group_matcher_pdq_theshold(
                             str(metadata_obj.privacy_group)
                         )

--- a/hasher-matcher-actioner/terraform/datastore/main.tf
+++ b/hasher-matcher-actioner/terraform/datastore/main.tf
@@ -112,12 +112,12 @@ resource "aws_dynamodb_table" "hma_banks" {
   }
 
   attribute {
-    name = "PendingBankMemberSignalIndex-SignalType"
+    name = "BankMemberSignalCursorIndex-SignalType"
     type = "S"
   }
 
   attribute {
-    name = "PendingBankMemberSignalIndex-UpdatedAt"
+    name = "BankMemberSignalCursorIndex-ChronoKey"
     type = "S"
   }
 
@@ -152,9 +152,9 @@ resource "aws_dynamodb_table" "hma_banks" {
   }
 
   global_secondary_index {
-    name            = "PendingBankMemberSignalIndex"
-    hash_key        = "PendingBankMemberSignalIndex-SignalType"
-    range_key       = "PendingBankMemberSignalIndex-UpdatedAt"
+    name            = "BankMemberSignalCursorIndex"
+    hash_key        = "BankMemberSignalCursorIndex-SignalType"
+    range_key       = "BankMemberSignalCursorIndex-ChronoKey"
     projection_type = "ALL"
   }
 

--- a/hasher-matcher-actioner/terraform/indexer/main.tf
+++ b/hasher-matcher-actioner/terraform/indexer/main.tf
@@ -95,6 +95,8 @@ resource "aws_lambda_function" "indexer" {
       THREAT_EXCHANGE_DATA_FOLDER      = var.threat_exchange_data.data_folder
       INDEXES_BUCKET_NAME              = var.index_data_storage.bucket_name
       MEASURE_PERFORMANCE              = var.measure_performance ? "True" : "False"
+      HMA_CONFIG_TABLE                 = var.config_table.name
+      BANKS_TABLE                      = var.banks_datastore.name
     }
   }
   tags = merge(
@@ -158,6 +160,12 @@ data "aws_iam_policy_document" "indexer" {
     effect    = "Allow"
     actions   = ["s3:PutObject"]
     resources = ["arn:aws:s3:::${var.index_data_storage.bucket_name}/index/*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan", "dynamodb:PutItem", "dynamodb:UpdateItem"]
+    resources = ["${var.banks_datastore.arn}*"]
   }
   statement {
     effect = "Allow"

--- a/hasher-matcher-actioner/terraform/indexer/variables.tf
+++ b/hasher-matcher-actioner/terraform/indexer/variables.tf
@@ -51,3 +51,20 @@ variable "indexer_frequency" {
   description = "How frequently do we want indexing run? Must be an AWS Rate Expression. See here: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html"
   type        = string
 }
+
+
+variable "config_table" {
+  description = "The name and arn of the DynamoDB table used for persisting configs."
+  type = object({
+    arn  = string
+    name = string
+  })
+}
+
+variable "banks_datastore" {
+  description = "DynamoDB Table to store bank information into"
+  type = object({
+    name = string
+    arn  = string
+  })
+}

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -98,10 +98,14 @@ module "indexer" {
     index_folder_key = module.hashing_data.index_folder_info.key
   }
 
+  banks_datastore = module.datastore.banks_datastore
+
   log_retention_in_days = var.log_retention_in_days
   additional_tags       = merge(var.additional_tags, local.common_tags)
   measure_performance   = var.measure_performance
   indexer_frequency     = var.indexer_frequency
+  config_table          = local.config_table
+
 }
 
 module "counters" {


### PR DESCRIPTION
Summary
---------
### [`f961defb`](https://github.com/facebook/ThreatExchange/pull/887/commits/f961defbe981bc5329ad831b211787e3d172cbd0) [banks] PendingBankMemberSignalsIndex -> BankMemberSignalCursorIndex
Indexer is not the only consumer of bank member signals. So, the Pending index which was sparse worked out fine. However, there are two complications:
a) rebuilding is not going away, there needs to be a way to read all bank member signals. All of them even if there are writes between page reads. So sort_key needs to increment.  
b) other consumers (eg. publish bank to threatexchange) The pending index was meant for a single consumer only and for a one time use. We need something more durable.  

The new BankMemberSignalCursorIndex is durable. We don't remove items from it on successfully processing. Since the SK is monotonically increasing, there is no chance of missing out on keys.  Updates to existing signals (remove) will result in bringing the updated item to the end of the index because updated_at == current_time.  You can theoretically use this structure as a feed.  


### [`a70e42d6`](https://github.com/facebook/ThreatExchange/pull/887/commits/a70e42d6e83d09eaced6378417b34742dfd2d9dd)  Paginate bank_member_signal cursored query
Since we are no longer going to "mark" signals as procssed, we need to "seek" into the index. Which requires querying for pages.  


### [`b4e5c11d`](https://github.com/facebook/ThreatExchange/pull/887/commits/b4e5c11dec92db0505bc9c80415b593f3361310c) Add BaseIndexMetadata and subclasses for banks, threatexchange
Use the index with typed metadata objects so that downstream systems can 'expect' more than a dict.  Also ensures fetched data is converted into typed objects for indexer's convenience.  


### [`4a5870b8`](https://github.com/facebook/ThreatExchange/pull/887/commits/4a5870b8623a17547e706a49f82da973356869d2) Indexer pulls signals from banks and indexes them


### [`8fa98ba1`](https://github.com/facebook/ThreatExchange/pull/887/commits/8fa98ba1e329c87f797615cd1a44d86a25c79720) Matcher (for-hash API & lambda) supports Bank metadata objects in index


## Minor (ignorable)
### [`aa2f3fcd`](https://github.com/facebook/ThreatExchange/pull/887/commits/aa2f3fcde178a875344c9b25eb368069e5e9a08d) bug/improvement: legacy BankedSignal objects add source classification on init()


Test Plan
---------
Locally, `black`, `mypy` and `py.test`. 

Deployed to AWS.

Added a new member to bank. Waited (polling ddb console manually) for bank member to be hashed.
Ran indexer manually (using lambda console).

**Screenshot showing bank member**
<img width="1144" alt="Screen Shot 2021-12-10 at 11 59 25" src="https://user-images.githubusercontent.com/217056/145612410-dea099b6-3f6f-4fc3-9089-82a4bf08a20a.png">


Submitted an image after configuring an action rule to allow actioning for bank members.

**Screenshot showing the progress page of the submitted image**
<img width="1155" alt="Screen Shot 2021-12-10 at 12 00 52" src="https://user-images.githubusercontent.com/217056/145612579-2fd00b05-91b3-45e2-9ca1-c1726b97f308.png">

