### PR TITLE
[hma][api] AdditionalMatchSettingsConfig adjustable from API and match distance in /for-hash/ results

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -196,22 +196,22 @@ class MatchesForHashRequest(DictParseable):
 
 
 @dataclass
-class MatchesForHashResponse(JSONifiable):
-    matches: t.List[ThreatExchangeSignalMetadata]
-    signal_value: str
+class MatchesForHash(JSONifiable):
+    match_distance: int
+    matched_signal_fields: ThreatExchangeSignalMetadata  # or matches signal from other sources
 
     UNSUPPORTED_FIELDS = ["updated_at", "pending_opinion_change"]
 
     def to_json(self) -> t.Dict:
         return {
-            "matches": [
-                self._remove_unsupported_fields(match.to_json())
-                for match in self.matches
-            ]
+            "match_distance": self.match_distance,
+            "matched_signal_fields": self._remove_unsupported_fields(
+                self.matched_signal_fields.to_json()
+            ),
         }
 
     @classmethod
-    def _remove_unsupported_fields(cls, match_dict: t.Dict) -> t.Dict:
+    def _remove_unsupported_fields(cls, signal_fields: t.Dict) -> t.Dict:
         """
         ThreatExchangeSignalMetadata is used to store metadata in dynamodb
         and handle opinion changes on said signal. However the request this object
@@ -220,10 +220,19 @@ class MatchesForHashResponse(JSONifiable):
         """
         for field in cls.UNSUPPORTED_FIELDS:
             try:
-                del match_dict[field]
+                del signal_fields[field]
             except KeyError:
                 pass
-        return match_dict
+        return signal_fields
+
+
+@dataclass
+class MatchesForHashResponse(JSONifiable):
+    matches: t.List[MatchesForHash]
+    signal_value: str
+
+    def to_json(self) -> t.Dict:
+        return {"matches": [match.to_json() for match in self.matches]}
 
 
 def get_matches_api(
@@ -347,11 +356,19 @@ def get_matches_api(
             request.signal_type, request.signal_value
         )
 
-        match_objects: t.List[ThreatExchangeSignalMetadata] = []
+        match_objects: t.List[MatchesForHash] = []
 
         for match in matches:
             match_objects.extend(
-                Matcher.get_metadata_objects_from_match(request.signal_type, match)
+                [
+                    MatchesForHash(
+                        match_distance=int(match.distance),
+                        matched_signal_fields=signal_metadata,
+                    )
+                    for signal_metadata in Matcher.get_metadata_objects_from_match(
+                        request.signal_type, match
+                    )
+                ]
             )
 
         return MatchesForHashResponse(match_objects, request.signal_value)

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -198,20 +198,20 @@ class MatchesForHashRequest(DictParseable):
 @dataclass
 class MatchesForHash(JSONifiable):
     match_distance: int
-    matched_signal_fields: ThreatExchangeSignalMetadata  # or matches signal from other sources
+    matched_signal: ThreatExchangeSignalMetadata  # or matches signal from other sources
 
     UNSUPPORTED_FIELDS = ["updated_at", "pending_opinion_change"]
 
     def to_json(self) -> t.Dict:
         return {
             "match_distance": self.match_distance,
-            "matched_signal_fields": self._remove_unsupported_fields(
-                self.matched_signal_fields.to_json()
+            "matched_signal": self._remove_unsupported_fields(
+                self.matched_signal.to_json()
             ),
         }
 
     @classmethod
-    def _remove_unsupported_fields(cls, signal_fields: t.Dict) -> t.Dict:
+    def _remove_unsupported_fields(cls, matched_signal: t.Dict) -> t.Dict:
         """
         ThreatExchangeSignalMetadata is used to store metadata in dynamodb
         and handle opinion changes on said signal. However the request this object
@@ -220,10 +220,10 @@ class MatchesForHash(JSONifiable):
         """
         for field in cls.UNSUPPORTED_FIELDS:
             try:
-                del signal_fields[field]
+                del matched_signal[field]
             except KeyError:
                 pass
-        return signal_fields
+        return matched_signal
 
 
 @dataclass
@@ -363,7 +363,7 @@ def get_matches_api(
                 [
                     MatchesForHash(
                         match_distance=int(match.distance),
-                        matched_signal_fields=signal_metadata,
+                        matched_signal=signal_metadata,
                     )
                     for signal_metadata in Matcher.get_metadata_objects_from_match(
                         request.signal_type, match


### PR DESCRIPTION
Summary
---------

Depends on #885 and #883 (and has their commits)

Take the distance recorded in #883 and also adds it to `/for-hash/`

Provides endpoints on the `/datasets/` path for 
- listing all     
  - GET `/datasets/match-settings`
- listing one
  - GET `/datasets/match-settings/<key>`
- creating/updating 
  - POST `/datasets/match-settings` `{  "privacy_group_id": <key>, "pdq_match_threshold": <val>}`
- deleting
  - DELETE `/datasets/match-settings/<key>`

Test Plan
---------
Tested all new dataset endpoints and new response format for `/matches/for-hash/`

`https://{{api_id}}.execute-api.us-east-1.amazonaws.com/api/matches/for-hash/?signal_type=pdq&signal_value=f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22`
```json
{
    "matches": [
        {
            "match_distance": 0,
            "matched_signal_fields": {
                "signal_id": "4109214869142910",
                "privacy_group_id": "inria-holidays-test",
                "signal_type": "pdq",
                "signal_hash": "f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22",
                "tags": [
                    "test_pdq_samples",
                    "holidays_jpg1_dataset",
                    "but_not_really_it_is_an_extra_photo_see_b_jpg",
                    "disputed"
                ]
            }
        }
    ]
}
```
