### PR TITLE
[hma] add support for PDQ match threshold >31

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/mappings.py
+++ b/hasher-matcher-actioner/hmalib/common/mappings.py
@@ -28,31 +28,10 @@ from hmalib.indexers.s3_indexers import (
     S3BackedInstrumentedIndexMixin,
 )
 
-# Maps from signal type → index to use for that signal type.
+# Maps from signal type → [index] i.e. list of indexes the can be use for that signal type.
 INDEX_MAPPING: t.Dict[
     t.Type[SignalType], t.List[t.Type[S3BackedInstrumentedIndexMixin]]
 ] = {
     PdqSignal: [S3BackedPDQIndex, S3BackedPDQFlatIndex],
     VideoMD5Signal: [S3BackedMD5Index],
 }
-
-
-def get_index_for_signal_type_matching(
-    signal_type: t.Type[SignalType], max_custom_threshold: int = 0
-):
-    indexes = INDEX_MAPPING[signal_type]
-    # disallow empty list
-    assert indexes
-    if len(indexes) == 1:
-        # if we only have one option just return
-        return indexes[0]
-
-    indexes.sort(key=lambda i: i.get_index_max_distance())
-
-    for index in indexes:
-        if max_custom_threshold <= index.get_index_max_distance():
-            return index
-
-    # if we don't have an index that supports max threshold
-    # just return the one if the highest possible max distance
-    return indexes[-1]

--- a/hasher-matcher-actioner/hmalib/common/mappings.py
+++ b/hasher-matcher-actioner/hmalib/common/mappings.py
@@ -24,11 +24,35 @@ from threatexchange.signal_type.signal_base import SignalType
 from hmalib.indexers.s3_indexers import (
     S3BackedMD5Index,
     S3BackedPDQIndex,
+    S3BackedPDQFlatIndex,
     S3BackedInstrumentedIndexMixin,
 )
 
 # Maps from signal type → index to use for that signal type.
-INDEX_MAPPING: t.Dict[t.Type[SignalType], t.Type[S3BackedInstrumentedIndexMixin]] = {
-    PdqSignal: S3BackedPDQIndex,
-    VideoMD5Signal: S3BackedMD5Index,
+INDEX_MAPPING: t.Dict[
+    t.Type[SignalType], t.List[t.Type[S3BackedInstrumentedIndexMixin]]
+] = {
+    PdqSignal: [S3BackedPDQIndex, S3BackedPDQFlatIndex],
+    VideoMD5Signal: [S3BackedMD5Index],
 }
+
+
+def get_index_for_signal_type_matching(
+    signal_type: t.Type[SignalType], max_custom_threshold: int = 0
+):
+    indexes = INDEX_MAPPING[signal_type]
+    # disallow empty list
+    assert indexes
+    if len(indexes) == 1:
+        # if we only have one option just return
+        return indexes[0]
+
+    indexes.sort(key=lambda i: i.get_index_max_distance())
+
+    for index in indexes:
+        if max_custom_threshold <= index.get_index_max_distance():
+            return index
+
+    # if we don't have an index that supports max threshold
+    # just return the one if the highest possible max distance
+    return indexes[-1]

--- a/hasher-matcher-actioner/hmalib/indexers/s3_indexers.py
+++ b/hasher-matcher-actioner/hmalib/indexers/s3_indexers.py
@@ -14,7 +14,7 @@ import functools
 from mypy_boto3_s3.service_resource import Bucket
 from mypy_boto3_s3.type_defs import MetricsAndOperatorTypeDef
 from threatexchange.signal_type.signal_base import TrivialSignalTypeIndex
-from threatexchange.signal_type.pdq_index import PDQIndex
+from threatexchange.signal_type.pdq_index import PDQIndex, PDQFlatIndex
 
 from hmalib.common.logging import get_logger
 from hmalib import metrics
@@ -54,6 +54,20 @@ class S3BackedInstrumentedIndexMixin:
             )
             return pickle.loads(index_file_bytes)
 
+    def get_index_class_name(self) -> str:
+        """
+        Name to help identify the index being used in HMA logs.
+        """
+        return self.__class__.__name__
+
+    @classmethod
+    def get_index_max_distance(cls) -> int:
+        """
+        Helper to distinguish if the next should be used based on configured thersholds.
+        Defaults to zero (i.e. only exact matches supported)
+        """
+        return 0
+
     @classmethod
     def _get_index_s3_key(cls):
         """
@@ -92,3 +106,17 @@ class S3BackedPDQIndex(PDQIndex, S3BackedInstrumentedIndexMixin):
     """
 
     pass
+
+    @classmethod
+    def get_index_max_distance(cls) -> int:
+        return cls.get_match_threshold()
+
+
+class S3BackedPDQFlatIndex(PDQFlatIndex, S3BackedInstrumentedIndexMixin):
+    """
+    DO NOT OVERRIDE __init__(). Let PDQFlatIndex provide that.
+    """
+
+    @classmethod
+    def get_index_max_distance(cls) -> int:
+        return cls.get_match_threshold()

--- a/hasher-matcher-actioner/hmalib/lambdas/unified_indexer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/unified_indexer.py
@@ -103,11 +103,14 @@ def lambda_handler(event, context):
 
         with metrics.timer(metrics.names.indexer.build_index):
             logger.info(f"Rebuilding {signal_type} Index")
-            index_class = INDEX_MAPPING[signal_type]
-            index: S3BackedInstrumentedIndexMixin = index_class.build(merged_data)
 
-            logger.info(f"Putting {signal_type} index in S3")
-            index.save(bucket_name=INDEXES_BUCKET_NAME)
+            for index_class in INDEX_MAPPING[signal_type]:
+                index: S3BackedInstrumentedIndexMixin = index_class.build(merged_data)
+
+                logger.info(
+                    f"Putting {signal_type} index in S3 for index {index.get_index_class_name()}"
+                )
+                index.save(bucket_name=INDEXES_BUCKET_NAME)
             metrics.flush()
 
     logger.info("Index updates complete")

--- a/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
+++ b/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
@@ -301,8 +301,11 @@ class Matcher:
         ]
 
     def get_index(self, signal_type: t.Type[SignalType]) -> SignalTypeIndex:
-        # If cached, return an index instance for the signal_type. If not, build
-        # one, cache and return.
+        """
+        If cached, return an index instance for the signal_type. If not, build
+        one, cache and return.
+        """
+
         max_custom_threshold = (
             get_max_threshold_of_active_privacy_groups_for_signal_type(signal_type)
         )
@@ -310,6 +313,8 @@ class Matcher:
             signal_type, max_custom_threshold
         )
 
+        # Check for signal_type in cache AND confirm said index class type is
+        # still correct for the given [optional] max_custom_threshold
         if not signal_type in self._cached_indexes or not isinstance(
             self._cached_indexes[signal_type], index_cls
         ):

--- a/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
+++ b/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
@@ -22,7 +22,7 @@ from threatexchange.signal_type.signal_base import SignalType
 
 from hmalib import metrics
 from hmalib.common.logging import get_logger
-from hmalib.common.mappings import INDEX_MAPPING
+from hmalib.common.mappings import get_index_for_signal_type_matching
 from hmalib.common.messages.match import BankedSignal, MatchMessage
 from hmalib.common.configs.fetcher import (
     ThreatExchangeConfig,
@@ -56,6 +56,49 @@ def get_privacy_group_matcher_active(privacy_group_id: str) -> bool:
     return _get_privacy_group_matcher_active(
         privacy_group_id, time.time() // PG_CONFIG_CACHE_TIME_SECONDS
     )
+
+
+@functools.lru_cache(maxsize=128)
+def _get_all_matcher_active_privacy_groups(cache_buster) -> t.List[str]:
+    configs = ThreatExchangeConfig.get_all()
+    return list(
+        map(
+            lambda c: c.name,
+            filter(
+                lambda c: c.matcher_active,
+                configs,
+            ),
+        )
+    )
+
+
+@functools.lru_cache(maxsize=128)
+def _get_all_privacy_group_active_matcher_pdq_theshold(
+    cache_buster,
+) -> t.Dict[str, int]:
+    active_pg_names = _get_all_matcher_active_privacy_groups(cache_buster)
+    if not active_pg_names:
+        return {}
+    return {
+        config.name: config.pdq_match_threshold
+        for config in AdditionalMatchSettingsConfig.get_all()
+        if config.name in active_pg_names
+    }
+
+
+def get_max_threshold_of_active_privacy_groups_for_signal_type(
+    signal_type: t.Type[SignalType],
+) -> int:
+    if signal_type == PdqSignal:
+        pg_to_pdq_threshold = _get_all_privacy_group_active_matcher_pdq_theshold(
+            time.time() // PG_CONFIG_CACHE_TIME_SECONDS
+        )
+        # no custom threshold set/active
+        if not pg_to_pdq_threshold:
+            return 0
+        return max(pg_to_pdq_threshold.values())
+    else:
+        return 0
 
 
 @functools.lru_cache(maxsize=128)
@@ -123,7 +166,8 @@ class Matcher:
         index = self.get_index(signal_type)
 
         with metrics.timer(metrics.names.indexer.search_index):
-            match_results: t.List[IndexMatch] = index.query(signal_value)
+            match_results: t.List[IndexMatch] = []
+            match_results.extend(index.query(signal_value))
 
         if not match_results:
             # No matches found in the index
@@ -261,12 +305,16 @@ class Matcher:
         # If cached, return an index instance for the signal_type. If not, build
         # one, cache and return.
         if not signal_type in self._cached_indexes:
-            index_cls = INDEX_MAPPING[signal_type]
+            max_custom_threshold = (
+                get_max_threshold_of_active_privacy_groups_for_signal_type(signal_type)
+            )
 
+            index_cls = get_index_for_signal_type_matching(
+                signal_type, max_custom_threshold
+            )
             with metrics.timer(metrics.names.indexer.download_index):
-                self._cached_indexes[signal_type] = index_cls.load(
-                    bucket_name=self.index_bucket_name
-                )
+                index = index_cls.load(bucket_name=self.index_bucket_name)
+                self._cached_indexes[signal_type] = index
 
         return self._cached_indexes[signal_type]
 

--- a/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
+++ b/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
@@ -304,14 +304,16 @@ class Matcher:
     def get_index(self, signal_type: t.Type[SignalType]) -> SignalTypeIndex:
         # If cached, return an index instance for the signal_type. If not, build
         # one, cache and return.
-        if not signal_type in self._cached_indexes:
-            max_custom_threshold = (
-                get_max_threshold_of_active_privacy_groups_for_signal_type(signal_type)
-            )
+        max_custom_threshold = (
+            get_max_threshold_of_active_privacy_groups_for_signal_type(signal_type)
+        )
+        index_cls = get_index_for_signal_type_matching(
+            signal_type, max_custom_threshold
+        )
 
-            index_cls = get_index_for_signal_type_matching(
-                signal_type, max_custom_threshold
-            )
+        if not signal_type in self._cached_indexes or not isinstance(
+            self._cached_indexes[signal_type], index_cls
+        ):
             with metrics.timer(metrics.names.indexer.download_index):
                 index = index_cls.load(bucket_name=self.index_bucket_name)
                 self._cached_indexes[signal_type] = index

--- a/hasher-matcher-actioner/terraform/matcher/main.tf
+++ b/hasher-matcher-actioner/terraform/matcher/main.tf
@@ -99,7 +99,7 @@ data "aws_iam_policy_document" "matcher_lambda" {
   }
   statement {
     effect    = "Allow"
-    actions   = ["dynamodb:GetItem"]
+    actions   = ["dynamodb:GetItem", "dynamodb:Scan"]
     resources = [var.config_table.arn]
   }
   statement {


### PR DESCRIPTION
Summary
---------

1) Updates indexer to build new PDQFlatIndex and store it in s3
2) Updates matcher_base to consider configured thresholds when picking matcher have a choice between  
- PDQIndex (31 max)
- PDQFlatIndex (52 max) 
  - limits based on hardcoded value in python-threatexchange (possible to make dynamic as well) 

What is missing but plan to leave for next PR (if it is alright with reviewer):
- tf variable for enable disable FlatIndex usage
- UI support

Test Plan
---------
(Gave live demo of postman tests)
Tested e2e by submitting hashes of variable distance from given sample set hash and making sure matcher we found or not found accordingly when thresholds were configured for various distances. 
`hmacli storm  --media "ffffffffffffff4f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22" --verbose -c 1 hash`
