### PR TITLE
Add a page showing bank members

### DIFF
--- a/hasher-matcher-actioner/webapp/src/App.tsx
+++ b/hasher-matcher-actioner/webapp/src/App.tsx
@@ -22,6 +22,7 @@ import SubmitContent from './pages/SubmitContent';
 import ContentDetailsWithStepper from './pages/ContentDetailsWithStepper';
 import ViewAllBanks from './pages/bank-management/ViewAllBanks';
 import ViewBank from './pages/bank-management/ViewBank';
+import ViewBankMember from './pages/bank-management/ViewBankMember';
 
 export default function App(): JSX.Element {
   return (
@@ -60,6 +61,9 @@ export default function App(): JSX.Element {
               </Route>
               <Route path="/banks/bank/:bankId/:tab">
                 <ViewBank />
+              </Route>
+              <Route path="/banks/member/:bankMemberId/">
+                <ViewBankMember />
               </Route>
               <Route path="/banks/">
                 <ViewAllBanks />

--- a/hasher-matcher-actioner/webapp/src/components/Loader.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/Loader.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React from 'react';
+import {Col, Spinner} from 'react-bootstrap';
+
+export default function Loader(): JSX.Element {
+  return (
+    <Col>
+      <h5>
+        <Spinner
+          style={{verticalAlign: 'middle'}}
+          className="mr-2"
+          animation="border"
+          variant="primary"
+        />
+        Loading...
+      </h5>
+    </Col>
+  );
+}

--- a/hasher-matcher-actioner/webapp/src/messages/BankMessages.tsx
+++ b/hasher-matcher-actioner/webapp/src/messages/BankMessages.tsx
@@ -30,3 +30,16 @@ export type BankMember = {
   created_at: Date;
   updated_at: Date;
 };
+
+export type BankMemberSignal = {
+  bank_id: string;
+  bank_member_id: string;
+  signal_id: string;
+  signal_type: string; // TODO: Convert to enum.
+  signal_value: string;
+  updated_at: Date;
+};
+
+export type BankMemberWithSignals = BankMember & {
+  signals: BankMemberSignal[];
+};

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/Members.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/Members.tsx
@@ -12,6 +12,7 @@ import {
   Spinner,
   ResponsiveEmbed,
 } from 'react-bootstrap';
+import {Link} from 'react-router-dom';
 import {fetchBank, fetchBankMembersPage} from '../../Api';
 import {BankMember} from '../../messages/BankMessages';
 import {ContentType} from '../../utils/constants';
@@ -49,12 +50,14 @@ type MemberPreviewProps = {
   thumbnailSrc: string;
   lastUpdated: Date;
   type: ContentType;
+  bankMemberId: string;
 };
 
 function MemberPreview({
   type,
   thumbnailSrc,
   lastUpdated,
+  bankMemberId,
 }: MemberPreviewProps): JSX.Element {
   return (
     <Col xs="4" className="mb-4">
@@ -67,6 +70,9 @@ function MemberPreview({
           )}
         </ResponsiveEmbed>
         <Card.Body>
+          <p className="text-small">
+            <Link to={`/banks/member/${bankMemberId}`}>View Member</Link>
+          </p>
           <p className="text-small">Updated: {timeAgoForDate(lastUpdated)}</p>
         </Card.Body>
       </Card>
@@ -139,6 +145,7 @@ function BaseMembers({bankId, type}: BaseMembersProps): JSX.Element {
         ) : null}
         {members.map(member => (
           <MemberPreview
+            bankMemberId={member.bank_member_id}
             type={type}
             thumbnailSrc={member.preview_url!}
             lastUpdated={member.updated_at}

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/Members.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/Members.tsx
@@ -16,7 +16,7 @@ import {fetchBank, fetchBankMembersPage} from '../../Api';
 import {BankMember} from '../../messages/BankMessages';
 import {ContentType} from '../../utils/constants';
 import {timeAgoForDate} from '../../utils/DateTimeUtils';
-
+import Loader from '../../components/Loader';
 import {BlurImage, BlurVideo} from '../../utils/MediaUtils';
 import AddBankMemberModal from './AddBankMemberModal';
 
@@ -25,22 +25,6 @@ export type BankTabProps = {
 };
 
 type OptionalString = string | undefined;
-
-function Loader(): JSX.Element {
-  return (
-    <Col>
-      <h5>
-        <Spinner
-          style={{verticalAlign: 'middle'}}
-          className="mr-2"
-          animation="border"
-          variant="primary"
-        />
-        Loading...
-      </h5>
-    </Col>
-  );
-}
 
 type EmptyStateProps = {
   onAdd: () => void;

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React, {useState, useEffect} from 'react';
+import {
+  Row,
+  Col,
+  ResponsiveEmbed,
+  Table,
+  Button,
+  Container,
+} from 'react-bootstrap';
+import {useParams} from 'react-router-dom';
+
+import FixedWidthCenterAlignedLayout from '../layouts/FixedWidthCenterAlignedLayout';
+import {
+  BankMemberWithSignals,
+  BankMemberSignal,
+} from '../../messages/BankMessages';
+import Loader from '../../components/Loader';
+import {fetchBankMember} from '../../Api';
+import {ContentType} from '../../utils/constants';
+import {BlurImage, BlurVideo} from '../../utils/MediaUtils';
+import {
+  CopyableTextField,
+  CopyableHashField,
+} from '../../utils/TextFieldsUtils';
+
+function NoSignalsYet() {
+  return (
+    <Container>
+      <Row>
+        <Col>
+          <p className="lead">
+            No signals have been extracted or provided for this member yet.
+          </p>
+        </Col>
+      </Row>
+    </Container>
+  );
+}
+
+type SignalDetailsProps = {
+  signalId: string;
+  signalType: string;
+  signalValue: string;
+};
+
+function SignalDetails({
+  signalId,
+  signalType,
+  signalValue,
+}: SignalDetailsProps): JSX.Element {
+  return (
+    <div>
+      <Table>
+        <tbody>
+          <tr>
+            <td>Signal Type:</td>
+            <td>{signalType}</td>
+          </tr>
+          <tr>
+            <td>Signal Value:</td>
+            <CopyableHashField text={signalValue} />
+          </tr>
+        </tbody>
+      </Table>
+    </div>
+  );
+}
+
+export default function ViewBankMember(): JSX.Element {
+  const {bankMemberId} = useParams<{bankMemberId: string}>();
+
+  const [member, setMember] = useState<BankMemberWithSignals>();
+  const [pollBuster, setPollBuster] = useState<number>(1);
+
+  useEffect(() => {
+    fetchBankMember(bankMemberId).then(setMember);
+  }, [pollBuster]);
+
+  return (
+    <FixedWidthCenterAlignedLayout title="Bank Member">
+      {member === undefined ? (
+        <Row>
+          <Col>
+            <Loader />
+          </Col>
+        </Row>
+      ) : (
+        <Row>
+          <Col md={{span: 6}}>
+            <ResponsiveEmbed aspectRatio="4by3">
+              {member.content_type === ContentType.Video ? (
+                <BlurVideo src={member.preview_url!} />
+              ) : (
+                <BlurImage src={member.preview_url!} />
+              )}
+            </ResponsiveEmbed>
+          </Col>
+          <Col md={{span: 6}}>
+            <Container>
+              <Row>
+                <Col xs={{span: 10}}>
+                  <h3>Member Details</h3>
+                </Col>
+                <Col xs={{span: 2}}>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => setPollBuster(pollBuster + 1)}>
+                    Refresh
+                  </Button>
+                </Col>
+              </Row>
+            </Container>
+            <Table>
+              <tbody>
+                <tr>
+                  <td>Member ID:</td>
+                  <td>
+                    <CopyableTextField text={member.bank_member_id} />
+                  </td>
+                </tr>
+                <tr>
+                  <td>Notes:</td>
+                  <td>{member.notes}</td>
+                </tr>
+              </tbody>
+            </Table>
+            <Container>
+              <Row>
+                <Col>
+                  <h3>Signals</h3>
+                </Col>
+              </Row>
+            </Container>
+            {member.signals.length === 0 ? (
+              <NoSignalsYet />
+            ) : (
+              member.signals.map(signal => (
+                <SignalDetails
+                  signalId={signal.signal_id}
+                  signalType={signal.signal_type}
+                  signalValue={signal.signal_value}
+                />
+              ))
+            )}
+          </Col>
+        </Row>
+      )}
+    </FixedWidthCenterAlignedLayout>
+  );
+}


### PR DESCRIPTION
Summary
---------
When adding new members, I found myself looking at the dynamodb items page to see if a hash had been generated yet. This page makes this process simpler.

Test Plan
---------
Add a new bank member, click on its link to go to its new page and use the 'refresh' button on the new page to see signals loading.

**Screenshot showing the new 'View Member' link on the all members page**
<img width="870" alt="Screen Shot 2021-12-11 at 15 26 09" src="https://user-images.githubusercontent.com/217056/145690755-cbf4654d-7125-4693-90db-132b430922d8.png">

**Screenshot showing the new 'View Member' page. Notice the 'refresh' button**
<img width="1177" alt="Screen Shot 2021-12-11 at 15 26 19" src="https://user-images.githubusercontent.com/217056/145690772-562b193f-ce40-4e23-be7e-1a127ba2f23f.png">


