### PR TITLE
[hma] Add a settings pane for getting index last modified and rebuilding on demand

### DIFF
--- a/hasher-matcher-actioner/hmalib/indexers/s3_indexers.py
+++ b/hasher-matcher-actioner/hmalib/indexers/s3_indexers.py
@@ -58,9 +58,9 @@ class S3BackedInstrumentedIndexMixin:
             return pickle.loads(index_file_bytes)
 
     @classmethod
-    def get_oldest_last_modified(cls, bucket_name: str) -> datetime:
+    def get_latest_last_modified(cls, bucket_name: str) -> datetime:
         """
-        Get the update time of the oldest index.
+        Get the update time of the newest index.
         """
         objects = get_s3_client().list_objects_v2(
             Bucket=bucket_name, Prefix=cls.INDEXES_PREFIX

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -17,6 +17,7 @@ from hmalib.lambdas.api.action_rules import get_action_rules_api
 from hmalib.lambdas.api.actions import get_actions_api
 from hmalib.lambdas.api.content import get_content_api
 from hmalib.lambdas.api.datasets import get_datasets_api
+from hmalib.lambdas.api.indexes import get_indexes_api
 from hmalib.lambdas.api.matches import get_matches_api
 from hmalib.lambdas.api.stats import get_stats_api
 from hmalib.lambdas.api.submit import (
@@ -49,6 +50,7 @@ SUBMISSIONS_QUEUE_URL = os.environ["SUBMISSIONS_QUEUE_URL"]
 HASHES_QUEUE_URL = os.environ["HASHES_QUEUE_URL"]
 
 INDEXES_BUCKET_NAME = os.environ["INDEXES_BUCKET_NAME"]
+INDEXER_FUNCTION_NAME = os.environ["INDEXER_FUNCTION_NAME"]
 WRITEBACK_QUEUE_URL = os.environ["WRITEBACKS_QUEUE_URL"]
 
 # Override common errors codes to return json instead of bottle's default html
@@ -192,6 +194,14 @@ app.mount(
         bank_table=dynamodb.Table(BANKS_TABLE),
         bank_user_media_bucket=BANKS_MEDIA_BUCKET_NAME,
         submissions_queue_url=SUBMISSIONS_QUEUE_URL,
+    ),
+)
+
+app.mount(
+    "/indexes/",
+    get_indexes_api(
+        indexes_bucket_name=INDEXES_BUCKET_NAME,
+        indexer_function_name=INDEXER_FUNCTION_NAME,
     ),
 )
 

--- a/hasher-matcher-actioner/hmalib/lambdas/api/indexes.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/indexes.py
@@ -1,0 +1,59 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import functools
+import boto3
+import typing as t
+import bottle
+import datetime
+from dataclasses import dataclass
+
+from mypy_boto3_lambda.client import LambdaClient
+
+from hmalib.indexers.s3_indexers import S3BackedInstrumentedIndexMixin
+from hmalib.lambdas.api.middleware import SubApp, jsoninator
+
+
+@functools.lru_cache(maxsize=None)
+def _get_lambda_client() -> LambdaClient:
+    return boto3.client("lambda")
+
+
+@dataclass
+class IndexesLastModifiedResponse:
+    last_modified: datetime.datetime
+
+    def to_json(self) -> t.Dict[str, str]:
+        return {
+            "last_modified": self.last_modified.isoformat(),
+        }
+
+
+def get_indexes_api(
+    indexes_bucket_name: str, indexer_function_name: str
+) -> bottle.Bottle:
+    indexes_api = SubApp()
+
+    @indexes_api.get("/last-modified", apply=[jsoninator])
+    def all_indexes_last_modified() -> IndexesLastModifiedResponse:
+        """
+        Returns the max of last_modified time of all indexes. Read as: when was
+        the latest index rebuilt.
+        """
+        return IndexesLastModifiedResponse(
+            S3BackedInstrumentedIndexMixin.get_oldest_last_modified(
+                bucket_name=indexes_bucket_name
+            )
+        )
+
+    @indexes_api.post("/rebuild-all")
+    def rebuild_all_indexes():
+        """
+        Well, it rebuilds all your indexes. Async operation. Just triggers, does
+        not wait.
+        """
+        response = _get_lambda_client().invoke(
+            FunctionName=indexer_function_name,
+            InvocationType="Event",
+        )
+
+    return indexes_api

--- a/hasher-matcher-actioner/hmalib/lambdas/api/indexes.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/indexes.py
@@ -40,7 +40,7 @@ def get_indexes_api(
         the latest index rebuilt.
         """
         return IndexesLastModifiedResponse(
-            S3BackedInstrumentedIndexMixin.get_oldest_last_modified(
+            S3BackedInstrumentedIndexMixin.get_latest_last_modified(
                 bucket_name=indexes_bucket_name
             )
         )

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -48,6 +48,7 @@ resource "aws_lambda_function" "api_root" {
       SUBMISSIONS_QUEUE_URL                 = var.submissions_queue.url
       HASHES_QUEUE_URL                      = var.hashes_queue.url
       BANKS_MEDIA_BUCKET_NAME               = var.banks_media_storage.bucket_name
+      INDEXER_FUNCTION_NAME                 = var.indexer_function_name
     }
   }
   tags = merge(
@@ -164,6 +165,12 @@ data "aws_iam_policy_document" "api_root" {
     effect    = "Allow"
     actions   = ["lambda:GetFunctionConfiguration"]
     resources = [aws_lambda_function.api_root.arn]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["lambda:InvokeAsync", "lambda:InvokeFunction"]
+    resources = [var.indexer_function_arn]
   }
 }
 

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -183,3 +183,13 @@ variable "security_groups" {
   type        = list(string)
   default     = []
 }
+
+variable "indexer_function_name" {
+  description = "Name of the lambda function that does indexing."
+  type        = string
+}
+
+variable "indexer_function_arn" {
+  description = "ARN of the lambda function that does indexing."
+  type        = string
+}

--- a/hasher-matcher-actioner/terraform/indexer/outputs.tf
+++ b/hasher-matcher-actioner/terraform/indexer/outputs.tf
@@ -4,3 +4,6 @@
 output "indexer_function_name" {
   value = aws_lambda_function.indexer.function_name
 }
+output "indexer_function_arn" {
+  value = aws_lambda_function.indexer.arn
+}

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -476,7 +476,9 @@ module "api" {
   te_api_token_secret          = aws_secretsmanager_secret.te_api_token
   hma_api_access_tokens_secret = aws_secretsmanager_secret.hma_api_tokens
 
-  writebacks_queue = module.actions.writebacks_queue
+  writebacks_queue      = module.actions.writebacks_queue
+  indexer_function_name = module.indexer.indexer_function_name
+  indexer_function_arn  = module.indexer.indexer_function_arn
   hashes_queue = {
     url = aws_sqs_queue.hashes_queue.id,
     arn = aws_sqs_queue.hashes_queue.arn

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -601,3 +601,19 @@ export async function addBankMember(
     updated_at: toDate(response.updated_at)!,
   }));
 }
+
+// Index APIs
+
+type IndexLastModifiedResponse = {
+  last_modified: string;
+};
+
+export async function fetchIndexesLastModified(): Promise<Date> {
+  return apiGet<IndexLastModifiedResponse>('indexes/last-modified').then(
+    response => toDate(response.last_modified)!,
+  );
+}
+
+export async function rebuildAllIndexes(): Promise<undefined> {
+  return apiPost('indexes/rebuild-all').then();
+}

--- a/hasher-matcher-actioner/webapp/src/App.tsx
+++ b/hasher-matcher-actioner/webapp/src/App.tsx
@@ -52,11 +52,8 @@ export default function App(): JSX.Element {
               <Route path="/submit">
                 <SubmitContent />
               </Route>
-              <Route path="/settings/:tab">
+              <Route path="/settings/:tab?">
                 <Settings />
-              </Route>
-              <Route path="/settings">
-                <Redirect to="/settings/signals" />
               </Route>
               <Route path="/banks/bank/:bankId/:tab">
                 <ViewBank />

--- a/hasher-matcher-actioner/webapp/src/pages/Settings.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Settings.tsx
@@ -20,7 +20,7 @@ import ThreatExchangeSettingsTab from './settings/ThreatExchangeSettingsTab';
 const tabEventKeys = ['threatexchange', 'actions', 'action-rules'];
 
 export default function Settings(): JSX.Element {
-  const {tab} = useParams<{tab: string}>();
+  const {tab = tabEventKeys[0]} = useParams<{tab: string}>();
   const history = useHistory();
   const [actions, setActions] = useState<ActionPerformer[]>([]);
   const [actionRules, setActionRules] = useState<ActionRule[]>([]);
@@ -37,9 +37,6 @@ export default function Settings(): JSX.Element {
     });
   }, []);
 
-  if (tab === undefined || !tab || !tabEventKeys.includes(tab)) {
-    window.location.href = '/settings/threatexchange';
-  }
   return (
     <>
       <Tabs

--- a/hasher-matcher-actioner/webapp/src/pages/Settings.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Settings.tsx
@@ -14,6 +14,7 @@ import ActionPerformerSettingsTab, {
   ActionPerformer,
 } from './settings/ActionPerformerSettingsTab';
 import ThreatExchangeSettingsTab from './settings/ThreatExchangeSettingsTab';
+import IndexSettingsTab from './settings/IndexSettingsTab';
 
 // This array must include the eventKey attribute value of any Tab in Tabs as
 // a part of the implementation to give each tab its own route.
@@ -61,6 +62,9 @@ export default function Settings(): JSX.Element {
             actionRules={actionRules}
             setActionRules={setActionRules}
           />
+        </Tab>
+        <Tab eventKey="index" title="Indexes">
+          <IndexSettingsTab />
         </Tab>
       </Tabs>
     </>

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ActionRuleSettingsTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ActionRuleSettingsTab.tsx
@@ -20,6 +20,7 @@ import '../../styles/_settings.scss';
 import FixedWidthCenterAlignedLayout from '../layouts/FixedWidthCenterAlignedLayout';
 import {addActionRule, deleteActionRule, updateActionRule} from '../../Api';
 import {ActionPerformer} from './ActionPerformerSettingsTab';
+import SettingsTabPane from './SettingsTabPane';
 
 export type Label = {
   key: string;
@@ -247,7 +248,12 @@ export default function ActionRuleSettingsTab({
   ));
 
   return (
-    <FixedWidthCenterAlignedLayout title="Action Rules">
+    <SettingsTabPane>
+      <Row>
+        <Col>
+          <SettingsTabPane.Title>Action Rules</SettingsTabPane.Title>
+        </Col>
+      </Row>
       <Row className="mt-3">
         <Col>
           <p>
@@ -325,6 +331,6 @@ export default function ActionRuleSettingsTab({
           <Toast.Body>{toastMessage}</Toast.Body>
         </Toast>
       </div>
-    </FixedWidthCenterAlignedLayout>
+    </SettingsTabPane>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/pages/settings/IndexSettingsTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/IndexSettingsTab.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React, {useEffect, useState} from 'react';
+import {Col, Row, Button} from 'react-bootstrap';
+import {fetchIndexesLastModified, rebuildAllIndexes} from '../../Api';
+import {timeAgoForDate} from '../../utils/DateTimeUtils';
+import SettingsTabPane from './SettingsTabPane';
+
+export default function IndexSettingsTab(): JSX.Element {
+  const [lastModified, setLastModified] = useState<Date>();
+  const [rebuilding, setRebuilding] = useState<boolean>(false);
+  const [pollBuster, setPollBuster] = useState<number>(0);
+
+  useEffect(() => {
+    fetchIndexesLastModified().then(setLastModified);
+  }, [pollBuster]);
+
+  const rebuild = () => {
+    setRebuilding(true);
+    rebuildAllIndexes().then(() => {
+      setRebuilding(false);
+      // Trigger refresh of page contents.
+      setPollBuster(pollBuster + 1);
+    });
+  };
+
+  return (
+    <SettingsTabPane>
+      <Row>
+        <Col>
+          <SettingsTabPane.Title>Indexes</SettingsTabPane.Title>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          Indexes are how your content is quickly matched against sources. They
+          are frequently rebuilt automatically. However, if you want to
+          force-update the index, you can do that here.
+        </Col>
+      </Row>
+
+      <Row>
+        <Col className="mt-4">
+          <p>
+            <b>Index Last Built: </b>
+            {lastModified ? timeAgoForDate(lastModified) : <i>Loading...</i>}
+          </p>
+          <Button disabled={rebuilding} onClick={rebuild}>
+            Rebuild Indexes
+          </Button>
+        </Col>
+      </Row>
+    </SettingsTabPane>
+  );
+}

--- a/hasher-matcher-actioner/webapp/src/pages/settings/SettingsTabPane.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/SettingsTabPane.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React from 'react';
+import {Container} from 'react-bootstrap';
+
+type SettingsTabPaneProps = {
+  children: JSX.Element | JSX.Element[];
+};
+
+/**
+ * Wrap settings pages in this class. Allows you to change their properties
+ * together. And allows you to left align the page while retaining fixed-width
+ * properties.
+ *
+ * @returns
+ */
+export default function SettingsTabPane({
+  children = [],
+}: SettingsTabPaneProps): JSX.Element {
+  return (
+    <Container
+      className="mt-4"
+      style={{marginLeft: 'unset', marginRight: 'unset'}}>
+      {children}
+    </Container>
+  );
+}
+
+type SettingsTabPaneTitleProps = {
+  children: string;
+};
+
+SettingsTabPane.Title = function ({
+  children,
+}: SettingsTabPaneTitleProps): JSX.Element {
+  return <h2>{children}</h2>;
+};


### PR DESCRIPTION
Summary
---------
With banks, indexing runs on a pre-determined frequency. This may not be fast enough for our users when they are demoing something or need to test changes out.

This shows the last_modified times of the current set of indexes on the 'settings' portion of the HMA UI and allows a user to trigger an async rebuild of the index.

Test Plan
---------
mypy, black, py.test on local.

**Screenshot 1: the new UI pane with the rebuild button**
<img width="499" alt="Screen Shot 2021-12-13 at 22 37 58" src="https://user-images.githubusercontent.com/217056/145929222-85d317bb-b210-424b-88a6-ff7eb71e97d5.png">

**Screenshot 2: logs of indexer when the rebuild button was clicked**
<img width="1114" alt="Screen Shot 2021-12-13 at 22 38 10" src="https://user-images.githubusercontent.com/217056/145929253-5e9eddf7-aa6b-4683-8d6d-b674d6e19971.png">

