### PR TITLE
[hma][ui] add support for setting custom pdq match thresholds on dataset settings page

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/datasets.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/datasets.py
@@ -317,10 +317,11 @@ def get_datasets_api(
         updated_config = hmaconfig.update_config(config).__dict__
         updated_config["privacy_group_id"] = updated_config["name"]
 
+        additional_config = AdditionalMatchSettingsConfig.get(
+            str(request.privacy_group_id)
+        )
         if request.pdq_match_threshold:
-            if additional_config := AdditionalMatchSettingsConfig.get(
-                str(request.privacy_group_id)
-            ):
+            if additional_config:
                 additional_config.pdq_match_threshold = int(request.pdq_match_threshold)
                 hmaconfig.update_config(additional_config)
             else:
@@ -328,6 +329,8 @@ def get_datasets_api(
                     str(request.privacy_group_id), int(request.pdq_match_threshold)
                 )
                 hmaconfig.create_config(additional_config)
+        elif additional_config:  # pdq_match_threshold was set and now should be removed
+            hmaconfig.delete_config(additional_config)
 
         return Dataset.from_dict(updated_config)
 

--- a/hasher-matcher-actioner/hmalib/lambdas/api/datasets.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/datasets.py
@@ -86,6 +86,7 @@ class UpdateDatasetRequest(DictParseable):
     fetcher_active: bool
     matcher_active: bool
     write_back: bool
+    pdq_match_threshold: str
 
     @classmethod
     def from_dict(cls, d: dict) -> "UpdateDatasetRequest":
@@ -94,6 +95,7 @@ class UpdateDatasetRequest(DictParseable):
             d["fetcher_active"],
             d["matcher_active"],
             d["write_back"],
+            d.get("pdq_match_threshold", ""),
         )
 
 
@@ -140,10 +142,15 @@ class ThreatExchangeDatasetSummary(Dataset):
 
     hash_count: int
     match_count: int
+    pdq_match_threshold: t.Optional[str]
 
     def to_json(self) -> t.Dict:
         dataset_json = super().to_json()
-        dataset_json.update(hash_count=self.hash_count, match_count=self.match_count)
+        dataset_json.update(
+            hash_count=self.hash_count,
+            match_count=self.match_count,
+            pdq_match_threshold=self.pdq_match_threshold,
+        )
 
         return dataset_json
 
@@ -238,26 +245,36 @@ def _get_threat_exchange_datasets(
         threat_exchange_data_folder,
     )
 
-    return [
-        ThreatExchangeDatasetSummary(
-            collab.privacy_group_id,
-            collab.privacy_group_name,
-            collab.description,
-            collab.fetcher_active,
-            collab.matcher_active,
-            collab.write_back,
-            collab.in_use,
-            hash_count=t.cast(
-                int,
-                hash_counts.get(
-                    collab.privacy_group_id,
-                    [-1, ""],
-                )[0],
-            ),
-            match_count=-1,  # fix will be based on new count system
+    summaries = []
+    for collab in collaborations:
+        if additional_config := AdditionalMatchSettingsConfig.get(
+            str(collab.privacy_group_id)
+        ):
+            pdq_match_threshold = str(additional_config.pdq_match_threshold)
+        else:
+            pdq_match_threshold = ""
+        summaries.append(
+            ThreatExchangeDatasetSummary(
+                collab.privacy_group_id,
+                collab.privacy_group_name,
+                collab.description,
+                collab.fetcher_active,
+                collab.matcher_active,
+                collab.write_back,
+                collab.in_use,
+                hash_count=t.cast(
+                    int,
+                    hash_counts.get(
+                        collab.privacy_group_id,
+                        [-1, ""],
+                    )[0],
+                ),
+                match_count=-1,  # fix will be based on new count system
+                pdq_match_threshold=pdq_match_threshold,
+            )
         )
-        for collab in collaborations
-    ]
+
+    return summaries
 
 
 def get_datasets_api(
@@ -299,6 +316,19 @@ def get_datasets_api(
         config.matcher_active = request.matcher_active
         updated_config = hmaconfig.update_config(config).__dict__
         updated_config["privacy_group_id"] = updated_config["name"]
+
+        if request.pdq_match_threshold:
+            if additional_config := AdditionalMatchSettingsConfig.get(
+                str(request.privacy_group_id)
+            ):
+                additional_config.pdq_match_threshold = int(request.pdq_match_threshold)
+                hmaconfig.update_config(additional_config)
+            else:
+                additional_config = AdditionalMatchSettingsConfig(
+                    str(request.privacy_group_id), int(request.pdq_match_threshold)
+                )
+                hmaconfig.create_config(additional_config)
+
         return Dataset.from_dict(updated_config)
 
     @datasets_api.post("/create", apply=[jsoninator(CreateDatasetRequest)])

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -287,6 +287,7 @@ export type PrivacyGroup = {
   localFetcherActive: boolean;
   localWriteBack: boolean;
   localMatcherActive: boolean;
+  localPDQMatchThreshold?: string;
 };
 
 type Dataset = {
@@ -299,6 +300,7 @@ type Dataset = {
   in_use: boolean;
   hash_count: number;
   match_count: number;
+  pdqMatchThreshold?: string;
 };
 
 export async function updateDataset(
@@ -306,12 +308,14 @@ export async function updateDataset(
   fetcherActive: boolean,
   writeBack: boolean,
   matcherActive: boolean,
+  pdqMatchThreshold?: string,
 ): Promise<Dataset> {
   return apiPost('datasets/update', {
     privacy_group_id: privacyGroupId,
     fetcher_active: fetcherActive,
     write_back: writeBack,
     matcher_active: matcherActive,
+    pdq_match_threshold: pdqMatchThreshold,
   });
 }
 

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -300,7 +300,7 @@ type Dataset = {
   in_use: boolean;
   hash_count: number;
   match_count: number;
-  pdqMatchThreshold?: string;
+  pdq_match_threshold?: string;
 };
 
 export async function updateDataset(

--- a/hasher-matcher-actioner/webapp/src/App.tsx
+++ b/hasher-matcher-actioner/webapp/src/App.tsx
@@ -3,12 +3,7 @@
  */
 
 import React from 'react';
-import {
-  BrowserRouter as Router,
-  Redirect,
-  Route,
-  Switch,
-} from 'react-router-dom';
+import {BrowserRouter as Router, Route, Switch} from 'react-router-dom';
 import {AmplifyAuthenticator, AmplifySignIn} from '@aws-amplify/ui-react';
 
 import './styles/_app.scss';

--- a/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.tsx
@@ -4,16 +4,9 @@
 
 import React, {useState} from 'react';
 import {IonIcon} from '@ionic/react';
-import {informationCircleOutline} from 'ionicons/icons';
+import {chevronUp, chevronDown} from 'ionicons/icons';
 
-import {
-  Col,
-  Button,
-  Form,
-  Card,
-  OverlayTrigger,
-  Popover,
-} from 'react-bootstrap';
+import {Accordion, Col, Button, Form, Card} from 'react-bootstrap';
 import DOMPurify from 'dompurify';
 import {CopyableTextField} from '../../utils/TextFieldsUtils';
 import {PrivacyGroup} from '../../Api';
@@ -45,6 +38,9 @@ export default function ThreatExchangePrivacyGroupCard({
   onSave,
   onDelete,
 }: ThreatExchangePrivacyGroupCardProps): JSX.Element {
+  const [showDescription, setShowDescription] = useState(false);
+  const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
+
   const [originalFetcherActive, setOriginalFetcherActive] =
     useState(fetcherActive);
   const [originalWriteBack, setOriginalWriteBack] = useState(writeBack);
@@ -65,90 +61,96 @@ export default function ThreatExchangePrivacyGroupCard({
 
   return (
     <>
-      <Col lg={4} sm={6} xs={12} className="mb-4">
-        <Card className="text-center">
-          <Card.Header
-            className={
-              inUse ? 'text-white bg-primary' : 'text-white bg-secondary'
-            }>
-            <h4 className="mb-0">
-              <CopyableTextField text={privacyGroupName} color="white" />
-              <OverlayTrigger
-                trigger="focus"
-                placement="bottom"
-                overlay={
-                  <Popover id={`popover-basic${privacyGroupId}`}>
-                    <Popover.Title as="h3">Information</Popover.Title>
-                    <Popover.Content>
-                      <div
-                        dangerouslySetInnerHTML={{
-                          __html: DOMPurify.sanitize(`${description}`, {
-                            ADD_ATTR: ['target'],
-                          }),
-                        }}
-                      />
-                    </Popover.Content>
-                  </Popover>
-                }>
-                <Button variant={inUse ? 'primary' : 'secondary'}>
-                  <IonIcon icon={informationCircleOutline} size="large" />
-                </Button>
-              </OverlayTrigger>
-            </h4>
+      <Col lg={4} sm={6}>
+        <Card className="mb-2">
+          <Card.Header className="mb-2 text-center">
+            {privacyGroupName}
           </Card.Header>
-          <Card.Subtitle className="mt-2 mb-2 text-muted">
-            Dataset ID: <CopyableTextField text={privacyGroupId} />
-          </Card.Subtitle>
-          <Card.Body className="text-left">
-            <Form>
-              <div>
-                <OverlayTrigger
-                  trigger="focus"
-                  placement="bottom"
-                  overlay={
-                    <Popover id={`popover-hashCount${privacyGroupId}`}>
-                      <Popover.Title as="h3">Hash Count</Popover.Title>
-                      <Popover.Content>{hashCount}</Popover.Content>
-                    </Popover>
-                  }>
-                  <Button variant="info">Hash Count</Button>
-                </OverlayTrigger>{' '}
-                <OverlayTrigger
-                  trigger="focus"
-                  placement="bottom"
-                  overlay={
-                    <Popover id={`popover-hashCount${privacyGroupId}`}>
-                      <Popover.Title as="h3">Match Count</Popover.Title>
-                      <Popover.Content>{matchCount}</Popover.Content>
-                    </Popover>
-                  }>
-                  <Button variant="info">Match Count</Button>
-                </OverlayTrigger>{' '}
-              </div>
-              <Form.Switch
-                onChange={onSwitchFetcherActive}
-                id={`fetcherActiveSwitch${privacyGroupId}`}
-                label="Fetcher Active"
-                checked={localFetcherActive}
-                disabled={!inUse}
-                style={{marginTop: 10}}
-              />
-              <Form.Switch
-                onChange={onSwitchMatcherActive}
-                id={`matcherSwitch${privacyGroupId}`}
-                label="Matcher Active"
-                checked={localMatcherActive}
-                disabled={!inUse}
-              />
-              <Form.Switch
-                onChange={onSwitchWriteBack}
-                id={`writeBackSwitch${privacyGroupId}`}
-                label="Writeback Seen"
-                checked={localWriteBack}
-                disabled={!inUse}
-              />
-            </Form>
-          </Card.Body>
+          <Card className="mx-2 mb-2">
+            <Card.Subtitle className="ml-3 my-2">
+              Dataset ID: <CopyableTextField text={privacyGroupId} />
+              <Accordion>
+                <Accordion.Toggle
+                  eventKey="0"
+                  as={Button}
+                  variant="outline-dark"
+                  size="sm"
+                  disabled={!description}
+                  onClick={() => setShowDescription(!showDescription)}
+                  className="my-2">
+                  Description
+                  <IonIcon
+                    className="inline-icon"
+                    icon={showDescription ? chevronDown : chevronUp}
+                  />
+                </Accordion.Toggle>
+                <Accordion.Collapse
+                  as={Card.Text}
+                  className="mt-2 mr-2 text-muted"
+                  eventKey="0">
+                  <div
+                    dangerouslySetInnerHTML={{
+                      __html: DOMPurify.sanitize(`${description}`, {
+                        ADD_ATTR: ['target'],
+                      }),
+                    }}
+                  />
+                </Accordion.Collapse>
+              </Accordion>
+            </Card.Subtitle>
+          </Card>
+          <Card className="mx-2 mb-2">
+            <Card.Body className="text-left">
+              {/* ToDo move to table based on signal type in own subcard. */}
+              <Card.Text>PDQ Hashes Available: {hashCount} </Card.Text>
+              <Form>
+                <Form.Switch
+                  onChange={onSwitchFetcherActive}
+                  id={`fetcherActiveSwitch${privacyGroupId}`}
+                  label="Fetcher Active"
+                  checked={localFetcherActive}
+                  disabled={!inUse}
+                />
+                <Form.Switch
+                  onChange={onSwitchMatcherActive}
+                  id={`matcherSwitch${privacyGroupId}`}
+                  label="Matcher Active"
+                  checked={localMatcherActive}
+                  disabled={!inUse}
+                />
+                <Form.Switch
+                  onChange={onSwitchWriteBack}
+                  id={`writeBackSwitch${privacyGroupId}`}
+                  label="Writeback Seen"
+                  checked={localWriteBack}
+                  disabled={!inUse}
+                />
+              </Form>
+            </Card.Body>
+          </Card>
+          <Card className="mx-2 mb-2 text-left">
+            <Accordion>
+              <Accordion.Toggle
+                eventKey="0"
+                as={Card.Header}
+                onClick={() => setShowAdvancedSettings(!showAdvancedSettings)}
+                variant="outline-dark"
+                size="sm"
+                className="mb-2 text-muted">
+                {!showAdvancedSettings
+                  ? 'Show Advanced Settings '
+                  : 'Hide Advanced Settings '}
+                <IonIcon
+                  className="inline-icon"
+                  icon={showAdvancedSettings ? chevronDown : chevronUp}
+                />
+              </Accordion.Toggle>
+              <Accordion.Collapse className="mt-2 mr-2 text-muted" eventKey="0">
+                <Card.Body>Comming Soon!</Card.Body>
+              </Accordion.Collapse>
+            </Accordion>
+          </Card>
+
           <Card.Footer>
             {localWriteBack === originalWriteBack &&
             localFetcherActive === originalFetcherActive &&

--- a/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.tsx
@@ -121,7 +121,7 @@ export default function ThreatExchangePrivacyGroupCard({
                   Description
                   <IonIcon
                     className="inline-icon"
-                    icon={showDescription ? chevronDown : chevronUp}
+                    icon={showDescription ? chevronUp : chevronDown}
                   />
                 </Accordion.Toggle>
                 <Accordion.Collapse
@@ -182,7 +182,7 @@ export default function ThreatExchangePrivacyGroupCard({
                   : 'Hide Advanced Settings '}
                 <IonIcon
                   className="inline-icon"
-                  icon={showAdvancedSettings ? chevronDown : chevronUp}
+                  icon={showAdvancedSettings ? chevronUp : chevronDown}
                 />
               </Accordion.Toggle>
               <Accordion.Collapse className="mt-2 mr-2" eventKey="0">

--- a/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ThreatExchangePrivacyGroupCard.tsx
@@ -40,7 +40,9 @@ export default function ThreatExchangePrivacyGroupCard({
   description,
   writeBack,
   hashCount,
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   matchCount,
+  /* eslint-enable @typescript-eslint/no-unused-vars */
   pdqMatchThreshold,
   onSave,
   onDelete,
@@ -78,7 +80,7 @@ export default function ThreatExchangePrivacyGroupCard({
         Number(values.pdqMatchThreshold) > 52)
     ) {
       errors.pdqMatchThreshold =
-        'Invalid: none empty values must be between 0 (only exact matches) and 52 (max threshold the libray supports)';
+        'Nonempty values must be between 0 (for only exact matches) and 52 (max threshold supported by index) inclusive';
     }
 
     return errors;
@@ -86,11 +88,14 @@ export default function ThreatExchangePrivacyGroupCard({
 
   const formik = useFormik({
     initialValues: {
-      pdqMatchThreshold: pdqMatchThreshold || '',
+      pdqMatchThreshold: pdqMatchThreshold ?? '',
     },
     validate,
-    onSubmit: values => {
-      console.log('shoudneverhappen');
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    onSubmit: _ => {
+      /* eslint-enable @typescript-eslint/no-unused-vars */
+      // https://github.com/jaredpalmer/formik/issues/2675
+      // this should never trigger but due to typing we can't just omit it.
     },
   });
 
@@ -191,7 +196,8 @@ export default function ThreatExchangePrivacyGroupCard({
                         isValid={
                           formik.touched.pdqMatchThreshold &&
                           !formik.errors.pdqMatchThreshold &&
-                          !!formik.values.pdqMatchThreshold
+                          formik.values.pdqMatchThreshold !==
+                            originalPDQMatchThreshold
                         }
                         isInvalid={
                           formik.touched.pdqMatchThreshold &&
@@ -199,7 +205,8 @@ export default function ThreatExchangePrivacyGroupCard({
                         }
                         onChange={formik.handleChange}
                         type="text"
-                        placeholder={pdqMatchThreshold ?? ''}
+                        value={formik.values.pdqMatchThreshold}
+                        placeholder="None"
                       />
                       {formik.touched.pdqMatchThreshold &&
                       formik.errors.pdqMatchThreshold ? (

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ActionRuleSettingsTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ActionRuleSettingsTab.tsx
@@ -17,7 +17,6 @@ import ActionRuleFormColumns, {
 } from '../../components/settings/ActionRuleFormColumns';
 import ActionRulesTableRow from '../../components/settings/ActionRulesTableRow';
 import '../../styles/_settings.scss';
-import FixedWidthCenterAlignedLayout from '../layouts/FixedWidthCenterAlignedLayout';
 import {addActionRule, deleteActionRule, updateActionRule} from '../../Api';
 import {ActionPerformer} from './ActionPerformerSettingsTab';
 import SettingsTabPane from './SettingsTabPane';

--- a/hasher-matcher-actioner/webapp/src/pages/settings/SettingsTabPane.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/SettingsTabPane.tsx
@@ -32,7 +32,7 @@ type SettingsTabPaneTitleProps = {
   children: string;
 };
 
-SettingsTabPane.Title = function ({
+SettingsTabPane.Title = function Title({
   children,
 }: SettingsTabPaneTitleProps): JSX.Element {
   return <h2>{children}</h2>;

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.tsx
@@ -182,6 +182,7 @@ export default function ThreatExchangeSettingsTab(): JSX.Element {
                   writeBack={dataset.write_back}
                   hashCount={dataset.hash_count}
                   matchCount={dataset.match_count}
+                  pdqMatchThreshold={dataset.pdq_match_threshold}
                   onSave={onPrivacyGroupSave}
                   onDelete={onPrivacyGroupDelete}
                 />

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.tsx
@@ -36,6 +36,7 @@ type Dataset = {
   write_back: boolean;
   hash_count: number;
   match_count: number;
+  pdq_match_threshold?: string;
 };
 
 export default function ThreatExchangeSettingsTab(): JSX.Element {
@@ -50,6 +51,7 @@ export default function ThreatExchangeSettingsTab(): JSX.Element {
       privacyGroup.localFetcherActive,
       privacyGroup.localWriteBack,
       privacyGroup.localMatcherActive,
+      privacyGroup.localPDQMatchThreshold,
     )
       .then(response => {
         setToastBody('Changes are saved!');

--- a/hasher-matcher-actioner/webapp/src/styles/_app.scss
+++ b/hasher-matcher-actioner/webapp/src/styles/_app.scss
@@ -31,6 +31,10 @@ div#root {
   color: white;
 }
 
+.inline-icon {
+  vertical-align: middle;
+}
+
 .table-action-button {
   display: block;
   margin: auto;


### PR DESCRIPTION
Summary
---------

This PR does a few things (as well as depending on #893). I'll leave it to the reviewer if you'd prefer reviewing by commit or not.

1) Stylist refactor of ThreatExchange Dataset setting page
  - remove match count (for now) as it is broken
  - have Hash count visible without needing to click a button
  - have description in drop down instead of harder to read tooltip
  - break up setting card in to set of subcards
 
2) Add closable Advanced Settings sub-card
  - includes form with validation via formik for `pdq_match_threshold`

3) API support for dataset object fetches to surface and existing update posts to mutate the adv match settings fields
  - limited to optional pdq_match_threshold at this time.


Test Plan
---------

Before:

https://user-images.githubusercontent.com/7664526/146214131-bbb7fbdf-27d0-4060-a8ec-14bb08c24810.mov



After:

https://user-images.githubusercontent.com/7664526/146214154-01663cdf-1457-4952-9f14-efc17837879b.mov


