### PR TITLE
Add padding to the popover for <CopyableTextField>

### DIFF
--- a/hasher-matcher-actioner/webapp/src/utils/TextFieldsUtils.tsx
+++ b/hasher-matcher-actioner/webapp/src/utils/TextFieldsUtils.tsx
@@ -50,7 +50,11 @@ export function CopyableTextField({
       // @BarrettOlson. UpdatingPopover is really, really hard to type in
       // typescript. Let's discuss what it was helping with and if it is
       // necessary.
-      overlay={<Popover id="copy-me">{message}</Popover>}>
+      overlay={
+        <Popover id="copy-me">
+          <div className="p-2">{message}</div>
+        </Popover>
+      }>
       <button
         type="button"
         role="link"


### PR DESCRIPTION
Summary
---
This was something that had annoyed me for a while. It just looks unprofessional.

Testing
---
**Before**
<img width="216" alt="Screen Shot 2021-12-15 at 16 12 39" src="https://user-images.githubusercontent.com/217056/146266076-8e9b2b03-42f7-47d6-a495-139ced57fd40.png">


**After**
<img width="306" alt="Screen Shot 2021-12-15 at 16 12 15" src="https://user-images.githubusercontent.com/217056/146266093-9743f108-3b30-489d-a25c-d11a0bd930f0.png">

