### PR TITLE
Detached bank UI

### DIFF
--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -565,6 +565,7 @@ export async function fetchBankMembersPage(
       notes: member.notes,
       created_at: toDate(member.created_at)!,
       updated_at: toDate(member.updated_at)!,
+      is_media_unavailable: member.is_media_unavailable,
     })),
     response.continuation_token,
   ]);
@@ -594,6 +595,7 @@ export async function fetchBankMember(
     notes: member.notes,
     created_at: toDate(member.created_at)!,
     updated_at: toDate(member.updated_at)!,
+    is_media_unavailable: member.is_media_unavailable,
     signals: member.signals.map(signal => ({
       bank_id: signal.bank_id,
       bank_member_id: signal.bank_member_id,
@@ -643,6 +645,7 @@ export async function addBankMember(
     notes: response.notes,
     created_at: toDate(response.created_at)!,
     updated_at: toDate(response.updated_at)!,
+    is_media_unavailable: response.is_media_unavailable,
   }));
 }
 

--- a/hasher-matcher-actioner/webapp/src/components/ReturnTo.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/ReturnTo.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React from 'react';
+import {Button} from 'react-bootstrap';
+import {useHistory, Link} from 'react-router-dom';
+
+type ReturnToProps = {
+  to?: string;
+  children?: string | JSX.Element[];
+};
+
+/**
+ * A utility control that returns you to a page. Can either go back in history
+ * or to a specified page. Automatically provides the ← arrow.
+ */
+export default function ReturnTo({to, children}: ReturnToProps): JSX.Element {
+  const history = useHistory();
+
+  const fullText =
+    children === undefined || children.length === 0 ? 'Back' : children;
+
+  if (to) {
+    return <Link to={to}>&larr; {fullText}</Link>;
+  }
+  return (
+    <Button variant="link" onClick={() => history.goBack()}>
+      &larr; {fullText}
+    </Button>
+  );
+}
+
+ReturnTo.defaultProps = {
+  to: undefined,
+  children: [],
+};

--- a/hasher-matcher-actioner/webapp/src/messages/BankMessages.tsx
+++ b/hasher-matcher-actioner/webapp/src/messages/BankMessages.tsx
@@ -29,6 +29,7 @@ export type BankMember = {
   notes: string;
   created_at: Date;
   updated_at: Date;
+  is_media_unavailable: boolean;
 };
 
 export type BankMemberSignal = {

--- a/hasher-matcher-actioner/webapp/src/pages/ContentDetails.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/ContentDetails.tsx
@@ -3,7 +3,7 @@
  */
 
 import React, {useState, useEffect} from 'react';
-import {useHistory, useParams} from 'react-router-dom';
+import {useParams} from 'react-router-dom';
 import {Col, Row, Table, Button} from 'react-bootstrap';
 
 import {
@@ -20,13 +20,13 @@ import ContentMatchTable from '../components/ContentMatchTable';
 import ActionHistoryTable from '../components/ActionHistoryTable';
 import FixedWidthCenterAlignedLayout from './layouts/FixedWidthCenterAlignedLayout';
 import ContentPreview from '../components/ContentPreview';
+import ReturnTo from '../components/ReturnTo';
 
 type PageParam = {
   id: string;
 };
 
 export default function ContentDetailsSummary(): JSX.Element {
-  const history = useHistory();
   const {id} = useParams<PageParam>();
   const [contentDetails, setContentDetails] = useState<ContentDetails>();
   const [hashDetails, setHashDetails] = useState<HashDetails>();
@@ -70,9 +70,7 @@ export default function ContentDetailsSummary(): JSX.Element {
     <FixedWidthCenterAlignedLayout title="Summary">
       <Row>
         <Col className="mb-4">
-          <Button variant="link" href="#" onClick={() => history.goBack()}>
-            &larr; Back
-          </Button>
+          <ReturnTo />
         </Col>
       </Row>
       <Row

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/Members.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/Members.tsx
@@ -46,10 +46,20 @@ function EmptyState({onAdd}: EmptyStateProps): JSX.Element {
   );
 }
 
+export function MediaUnavailablePreview(): JSX.Element {
+  return (
+    <div className="p-4 bg-light" style={{borderBottom: '1px solid #6c757d'}}>
+      <p className="lead">Media Not Provided</p>
+      <p>Member was added without associated media.</p>
+    </div>
+  );
+}
+
 type MemberPreviewProps = {
   thumbnailSrc: string;
   lastUpdated: Date;
   type: ContentType;
+  isMediaUnavailable: boolean;
   bankMemberId: string;
 };
 
@@ -57,18 +67,24 @@ function MemberPreview({
   type,
   thumbnailSrc,
   lastUpdated,
+  isMediaUnavailable,
   bankMemberId,
 }: MemberPreviewProps): JSX.Element {
   return (
     <Col xs="4" className="mb-4">
       <Card>
-        <ResponsiveEmbed aspectRatio="16by9">
-          {type === ContentType.Video ? (
-            <BlurVideo src={thumbnailSrc} />
-          ) : (
-            <BlurImage src={thumbnailSrc} />
-          )}
-        </ResponsiveEmbed>
+        {isMediaUnavailable ? (
+          <MediaUnavailablePreview />
+        ) : (
+          <ResponsiveEmbed aspectRatio="16by9">
+            {type === ContentType.Video ? (
+              <BlurVideo src={thumbnailSrc} />
+            ) : (
+              <BlurImage src={thumbnailSrc} />
+            )}
+          </ResponsiveEmbed>
+        )}
+
         <Card.Body>
           <p className="text-small">
             <Link to={`/banks/member/${bankMemberId}`}>View Member</Link>
@@ -147,6 +163,7 @@ function BaseMembers({bankId, type}: BaseMembersProps): JSX.Element {
           <MemberPreview
             bankMemberId={member.bank_member_id}
             type={type}
+            isMediaUnavailable={member.is_media_unavailable}
             thumbnailSrc={member.preview_url!}
             lastUpdated={member.updated_at}
           />

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
@@ -24,6 +24,7 @@ import {
   CopyableHashField,
 } from '../../utils/TextFieldsUtils';
 import ReturnTo from '../../components/ReturnTo';
+import {MediaUnavailablePreview} from './Members';
 
 function NoSignalsYet() {
   return (
@@ -105,13 +106,17 @@ export default function ViewBankMember(): JSX.Element {
       ) : (
         <Row>
           <Col md={{span: 6}}>
-            <ResponsiveEmbed aspectRatio="4by3">
-              {member.content_type === ContentType.Video ? (
-                <BlurVideo src={member.preview_url!} />
-              ) : (
-                <BlurImage src={member.preview_url!} />
-              )}
-            </ResponsiveEmbed>
+            {member.is_media_unavailable ? (
+              <MediaUnavailablePreview />
+            ) : (
+              <ResponsiveEmbed aspectRatio="4by3">
+                {member.content_type === ContentType.Video ? (
+                  <BlurVideo src={member.preview_url!} />
+                ) : (
+                  <BlurImage src={member.preview_url!} />
+                )}
+              </ResponsiveEmbed>
+            )}
           </Col>
           <Col md={{span: 6}}>
             <Container>

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
@@ -14,10 +14,7 @@ import {
 import {useParams} from 'react-router-dom';
 
 import FixedWidthCenterAlignedLayout from '../layouts/FixedWidthCenterAlignedLayout';
-import {
-  BankMemberWithSignals,
-  BankMemberSignal,
-} from '../../messages/BankMessages';
+import {BankMemberWithSignals} from '../../messages/BankMessages';
 import Loader from '../../components/Loader';
 import {fetchBankMember} from '../../Api';
 import {ContentType} from '../../utils/constants';
@@ -26,6 +23,7 @@ import {
   CopyableTextField,
   CopyableHashField,
 } from '../../utils/TextFieldsUtils';
+import ReturnTo from '../../components/ReturnTo';
 
 function NoSignalsYet() {
   return (
@@ -80,8 +78,24 @@ export default function ViewBankMember(): JSX.Element {
     fetchBankMember(bankMemberId).then(setMember);
   }, [pollBuster]);
 
+  const returnURL = member
+    ? `/banks/bank/${member.bank_id}/${
+        member.content_type === ContentType.Video ? 'video' : 'photo'
+      }-memberships`
+    : '/';
+
   return (
-    <FixedWidthCenterAlignedLayout title="Bank Member">
+    <FixedWidthCenterAlignedLayout>
+      <Row>
+        <Col className="my-4">
+          <ReturnTo to={returnURL}>Back to Members</ReturnTo>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <h1>Bank Member</h1>
+        </Col>
+      </Row>
       {member === undefined ? (
         <Row>
           <Col>


### PR DESCRIPTION
Summary
---------
We have supported bank member signals that do not have media attached, (eg added via a fetcher), in ddb for a while. This PR adds:
a) an API to create such member signals
b) Ensure that the all-bank-members and single-bank-member pages both render correctly and show some information.

## Best reviewed commit by commit:
### [`4c15bf60`](https://github.com/facebook/ThreatExchange/pull/896/commits/4c15bf609ba0d0be754f9cec43cd259cc6a8c313) Add API to add detached-bank-member-signals [python only]

### [`8ca48bd7`](https://github.com/facebook/ThreatExchange/pull/896/commits/8ca48bd7dccb8cea895b8f6e001de1b1393100a9) [hma][ui] Show bank members whose media is unavailable [tsx only]

### [`06cc6f04`](https://github.com/facebook/ThreatExchange/pull/896/commits/06cc6f04200b524bdf72bfdd4077d27911d58bdd) [Bonus] Extract content-details's ← link into a component; use in ContentDetails & ViewBankMember [tsx only]


Test Plan
---------
black, mypy and py.test on local.

Added a few detached video members using postman.

**Screenshot 1: Single Bank Member page for a detached member signal**
<img width="1159" alt="Screen Shot 2021-12-15 at 23 02 44" src="https://user-images.githubusercontent.com/217056/146306475-b407dcce-c8d7-4914-af54-c3f2ecef7249.png">

**Screenshot 2: All Bank Members page with some detached member signals**
<img width="1161" alt="Screen Shot 2021-12-15 at 23 02 52" src="https://user-images.githubusercontent.com/217056/146306523-4cbcf6e9-6aa9-46d7-905d-1a92eea6985b.png">

