### PR TITLE
Toast UI infra

### DIFF
--- a/hasher-matcher-actioner/webapp/src/App.tsx
+++ b/hasher-matcher-actioner/webapp/src/App.tsx
@@ -18,6 +18,7 @@ import ContentDetailsWithStepper from './pages/ContentDetailsWithStepper';
 import ViewAllBanks from './pages/bank-management/ViewAllBanks';
 import ViewBank from './pages/bank-management/ViewBank';
 import ViewBankMember from './pages/bank-management/ViewBankMember';
+import {AppWithNotifications} from './AppWithNotifications';
 
 export default function App(): JSX.Element {
   return (
@@ -29,46 +30,48 @@ export default function App(): JSX.Element {
         />
       </div>
       <Router>
-        <div className="row">
-          <Sidebar className="col-md-2 bg-light sidebar" />
-          <main
-            role="main"
-            className="col-md-10 px-0 main"
-            style={{overflow: 'auto'}}>
-            <Switch>
-              <Route path="/matches/:id">
-                <ContentDetailsSummary />
-              </Route>
-              <Route path="/pipeline-progress/:id">
-                <ContentDetailsWithStepper />
-              </Route>
-              <Route path="/matches">
-                <Matches />
-              </Route>
-              <Route path="/submit">
-                <SubmitContent />
-              </Route>
-              <Route path="/settings/:tab?">
-                <Settings />
-              </Route>
-              <Route path="/banks/bank/:bankId/:tab">
-                <ViewBank />
-              </Route>
-              <Route path="/banks/member/:bankMemberId/">
-                <ViewBankMember />
-              </Route>
-              <Route path="/banks/">
-                <ViewAllBanks />
-              </Route>
-              <Route path="/dashboard/">
-                <Dashboard />
-              </Route>
-              <Route path="/">
-                <SubmitContent />
-              </Route>
-            </Switch>
-          </main>
-        </div>
+        <AppWithNotifications>
+          <div className="row">
+            <Sidebar className="col-md-2 bg-light sidebar" />
+            <main
+              role="main"
+              className="col-md-10 px-0 main"
+              style={{overflow: 'auto'}}>
+              <Switch>
+                <Route path="/matches/:id">
+                  <ContentDetailsSummary />
+                </Route>
+                <Route path="/pipeline-progress/:id">
+                  <ContentDetailsWithStepper />
+                </Route>
+                <Route path="/matches">
+                  <Matches />
+                </Route>
+                <Route path="/submit">
+                  <SubmitContent />
+                </Route>
+                <Route path="/settings/:tab?">
+                  <Settings />
+                </Route>
+                <Route path="/banks/bank/:bankId/:tab">
+                  <ViewBank />
+                </Route>
+                <Route path="/banks/member/:bankMemberId/">
+                  <ViewBankMember />
+                </Route>
+                <Route path="/banks/">
+                  <ViewAllBanks />
+                </Route>
+                <Route path="/dashboard/">
+                  <Dashboard />
+                </Route>
+                <Route path="/">
+                  <SubmitContent />
+                </Route>
+              </Switch>
+            </main>
+          </div>
+        </AppWithNotifications>
       </Router>
     </AmplifyAuthenticator>
   );

--- a/hasher-matcher-actioner/webapp/src/AppWithNotifications.tsx
+++ b/hasher-matcher-actioner/webapp/src/AppWithNotifications.tsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React, {useState} from 'react';
+import {Toast} from 'react-bootstrap';
+
+// How long to wait before
+const AUTOHIDE_DELAY = 5000;
+
+/**
+ * If you decide to expand the set of arguments a notification needs, remember
+ * to make them backwards compatible, or you'll need to update all callsites.
+ */
+type NotificationProps = {
+  message: string;
+  header?: string;
+};
+
+type ToastMessage = NotificationProps & {
+  level: 'info' | 'success' | 'warn' | 'error';
+  id: string;
+};
+
+type AppWithNotificationsProps = {
+  children: JSX.Element | JSX.Element[];
+};
+
+export const NotificationsContext = React.createContext({
+  /* eslint-disable @typescript-eslint/no-empty-function */
+  info: ({message, header}: NotificationProps) => {},
+  success: ({message, header}: NotificationProps) => {},
+  warn: ({message, header}: NotificationProps) => {},
+  error: ({message, header}: NotificationProps) => {},
+  /* eslint-enable @typescript-eslint/no-empty-function */
+});
+
+let counter = 0;
+
+export function AppWithNotifications({children}: AppWithNotificationsProps) {
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+
+  const appendToast = (toast: Omit<ToastMessage, 'id'>) => {
+    // autoincrementing counter for toast ids.
+    counter += 1;
+    const id = `${counter}`;
+
+    setToasts(toasts.concat([{...toast, id}]));
+  };
+
+  const inAppNotify = {
+    info: ({message, header}: NotificationProps) => {
+      appendToast({level: 'info', message, header});
+    },
+    success: ({message, header}: NotificationProps) => {
+      appendToast({level: 'success', message, header});
+    },
+    warn: ({message, header}: NotificationProps) => {
+      appendToast({level: 'warn', message, header});
+    },
+    error: ({message, header}: NotificationProps) => {
+      appendToast({level: 'error', message, header});
+    },
+  };
+
+  const removeToast = (id: string) => () => {
+    setToasts(toasts.filter(x => x.id !== id));
+  };
+
+  return (
+    <NotificationsContext.Provider value={inAppNotify}>
+      {children}
+      <div className="toast-container">
+        {toasts &&
+          toasts.map(toast => (
+            <Toast
+              key={toast.id}
+              className={toast.level}
+              autohide
+              onClose={removeToast(toast.id)}
+              delay={AUTOHIDE_DELAY}>
+              {toast.header ? (
+                <Toast.Header>{toast.header}</Toast.Header>
+              ) : null}
+              <Toast.Body>{toast.message}</Toast.Body>
+            </Toast>
+          ))}
+      </div>
+    </NotificationsContext.Provider>
+  );
+}

--- a/hasher-matcher-actioner/webapp/src/components/ContentMatchTable.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/ContentMatchTable.tsx
@@ -2,8 +2,8 @@
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  */
 
-import React, {useState, useEffect} from 'react';
-import {Col, Collapse, Row, Table, Toast} from 'react-bootstrap';
+import React, {useState, useEffect, useContext} from 'react';
+import {Col, Collapse, Row, Table} from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import Spinner from 'react-bootstrap/Spinner';
 
@@ -12,6 +12,7 @@ import {CopyableHashField, CopyableTextField} from '../utils/TextFieldsUtils';
 import {formatTimestamp} from '../utils/DateTimeUtils';
 
 import OpinionTableCell from './OpinionTableCell';
+import {NotificationsContext} from '../AppWithNotifications';
 
 export default function ContentMatchTable({
   contentKey,
@@ -19,33 +20,19 @@ export default function ContentMatchTable({
   contentKey: string;
 }): JSX.Element {
   const [matchDetails, setMatchDetails] = useState<MatchDetails[]>();
+  const notifications = useContext(NotificationsContext);
+
   useEffect(() => {
     fetchMatchDetails(contentKey).then(matches => {
       setMatchDetails(matches.match_details);
     });
   }, [contentKey]);
 
-  const [showToast, setShowToast] = useState(false);
   return (
     <>
       <Spinner hidden={matchDetails !== null} animation="border" role="status">
         <span className="sr-only">Loading...</span>
       </Spinner>
-      <div className="feedback-toast-container">
-        <Toast
-          onClose={() => setShowToast(false)}
-          show={showToast}
-          delay={5000}
-          autohide>
-          <Toast.Header>
-            <strong className="mr-auto">Submitted</strong>
-            <small>Thanks!</small>
-          </Toast.Header>
-          <Toast.Body>
-            Please wait for the requested change to propagate
-          </Toast.Body>
-        </Toast>
-      </div>
       <Collapse in={matchDetails !== null}>
         <Row>
           <Col md={12}>
@@ -97,7 +84,13 @@ export default function ContentMatchTable({
                             pendingOpinionChange={
                               metadata.pending_opinion_change
                             }
-                            setShowToast={setShowToast}
+                            setShowToast={() =>
+                              notifications.success({
+                                header: 'Submitted',
+                                message:
+                                  'Please wait for the requested change to propagate',
+                              })
+                            }
                           />
                         </td>
                         <td>{metadata.tags.join(', ')}</td>

--- a/hasher-matcher-actioner/webapp/src/pages/Settings.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Settings.tsx
@@ -39,8 +39,9 @@ export default function Settings(): JSX.Element {
   }, []);
 
   return (
-    <>
+    <div className="pt-4">
       <Tabs
+        className="pl-3"
         activeKey={tab}
         id="setting-tabs"
         onSelect={key => {
@@ -67,6 +68,6 @@ export default function Settings(): JSX.Element {
           <IndexSettingsTab />
         </Tab>
       </Tabs>
-    </>
+    </div>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ActionPerformerSettingsTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ActionPerformerSettingsTab.tsx
@@ -2,18 +2,18 @@
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  */
 
-import React, {useState} from 'react';
+import React, {useContext, useState} from 'react';
 import Card from 'react-bootstrap/Card';
 import Table from 'react-bootstrap/Table';
 import Button from 'react-bootstrap/Button';
-import Toast from 'react-bootstrap/Toast';
 import {IonIcon} from '@ionic/react';
-import {add, checkmark, close} from 'ionicons/icons';
+import {add, checkmark, close, notificationsOutline} from 'ionicons/icons';
 import {updateAction, createAction, deleteAction} from '../../Api';
 import ActionPerformerColumns from '../../components/settings/ActionPerformer/ActionPerformerColumns';
 import ActionPerformerRows from '../../components/settings/ActionPerformer/ActionPerformerRows';
 import {ActionRule} from './ActionRuleSettingsTab';
 import {ActionPerformerType} from '../../utils/constants';
+import {NotificationsContext} from '../../AppWithNotifications';
 
 type Input = {
   actions: ActionPerformer[];
@@ -74,14 +74,10 @@ export default function ActionPerformerSettingsTab({
 }: Input): JSX.Element {
   const [adding, setAdding] = useState(false);
   const [newAction, setNewAction] = useState(defaultAction);
-  const [showToast, setShowToast] = useState(false);
-  const [toastMessage, setToastMessage] = useState('');
+  const notifications = useContext(NotificationsContext);
+
   const resetForm = () => {
     setNewAction(defaultAction);
-  };
-  const displayToast = (message: string) => {
-    setToastMessage(message);
-    setShowToast(true);
   };
   const onActionUpdate = (
     old_name: string,
@@ -97,22 +93,22 @@ export default function ActionPerformerSettingsTab({
           return action;
         });
         setActions(updatedActions);
-        displayToast(
-          `${response.response} (Manual refresh maybe necessary to see changes.)`,
-        );
+        notifications.success({
+          message: `${response.response} (Manual refresh maybe necessary to see changes.)`,
+        });
       })
       .catch(e => {
-        displayToast(
-          `Errors when updating the action. Please try again later\n${e.message}`,
-        );
+        notifications.error({
+          message: `Errors when updating the action. Please try again later\n${e.message}`,
+        });
       });
   };
   const onActionCreate = () => {
     createAction(removeUnexpectedParams(newAction))
       .then(response => {
-        displayToast(
-          `${response.response} (Manual refresh maybe necessary to see changes.)`,
-        );
+        notifications.success({
+          message: `${response.response} (Manual refresh maybe necessary to see changes.)`,
+        });
         const newActions = actions;
         newActions.unshift(newAction);
         setActions(newActions);
@@ -120,9 +116,9 @@ export default function ActionPerformerSettingsTab({
         setAdding(false);
       })
       .catch(e => {
-        displayToast(
-          `Errors when creating the action. Please try again later\n${e.message}`,
-        );
+        notifications.error({
+          message: `Errors when creating the action. Please try again later\n${e.message}`,
+        });
       });
   };
   const onActionDelete = (actionToDelete: ActionPerformer) => {
@@ -132,12 +128,12 @@ export default function ActionPerformerSettingsTab({
           (action: ActionPerformer) => action.name !== actionToDelete.name,
         );
         setActions(filteredActions);
-        displayToast(`${response.response}`);
+        notifications.success({message: `${response.response}`});
       })
       .catch(e => {
-        displayToast(
-          `Errors when deleting the action. Please try again later\n${e.message}`,
-        );
+        notifications.error({
+          message: `Errors when deleting the action. Please try again later\n${e.message}`,
+        });
       });
   };
 
@@ -154,15 +150,6 @@ export default function ActionPerformerSettingsTab({
             that you can review the Content and, if it is truly a cat, remove it
             for violating your Platform&apos;s Community Standards.
           </p>
-          <div className="feedback-toast-container">
-            <Toast
-              onClose={() => setShowToast(false)}
-              show={showToast}
-              delay={5000}
-              autohide>
-              <Toast.Body>{toastMessage}</Toast.Body>
-            </Toast>
-          </div>
         </Card.Header>
         <Card.Body>
           <Table striped bordered hover>

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ActionRuleSettingsTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ActionRuleSettingsTab.tsx
@@ -6,10 +6,9 @@
 
 import Button from 'react-bootstrap/Button';
 import Col from 'react-bootstrap/Col';
-import React, {useState} from 'react';
+import React, {useContext, useState} from 'react';
 import Row from 'react-bootstrap/Row';
 import Table from 'react-bootstrap/Table';
-import Toast from 'react-bootstrap/Toast';
 import {IonIcon} from '@ionic/react';
 import {add, checkmark, close} from 'ionicons/icons';
 import ActionRuleFormColumns, {
@@ -20,6 +19,7 @@ import '../../styles/_settings.scss';
 import {addActionRule, deleteActionRule, updateActionRule} from '../../Api';
 import {ActionPerformer} from './ActionPerformerSettingsTab';
 import SettingsTabPane from './SettingsTabPane';
+import {NotificationsContext} from '../../AppWithNotifications';
 
 export type Label = {
   key: string;
@@ -146,8 +146,7 @@ export default function ActionRuleSettingsTab({
   const [adding, setAdding] = useState(false);
   const [newActionRule, setNewActionRule] = useState(defaultActionRule);
   const [showErrors, setShowErrors] = useState(false);
-  const [showToast, setShowToast] = useState(false);
-  const [toastMessage, setToastMessage] = useState('');
+  const notifications = useContext(NotificationsContext);
 
   const onNewActionRuleChange = (
     update_name: 'name' | 'action_name' | 'classification_conditions',
@@ -195,11 +194,6 @@ export default function ActionRuleSettingsTab({
     setNewActionRule(defaultActionRule);
   };
 
-  const displayToast = (message: string) => {
-    setToastMessage(message);
-    setShowToast(true);
-  };
-
   const onAddActionRule = (actionRule: ActionRule, addToUIOnly: boolean) => {
     actionRules.push(actionRule);
     actionRules.sort((a, b) =>
@@ -208,7 +202,9 @@ export default function ActionRuleSettingsTab({
     setActionRules([...actionRules]);
     if (!addToUIOnly) {
       addActionRule(actionRule);
-      displayToast('A new action rule was added successfully.');
+      notifications.success({
+        message: 'A new action rule was added successfully.',
+      });
     }
   };
 
@@ -220,7 +216,9 @@ export default function ActionRuleSettingsTab({
     setActionRules([...actionRules]);
     if (!deleteFromUIOnly) {
       deleteActionRule(name);
-      displayToast('The action rule was deleted successfully.');
+      notifications.success({
+        message: 'The action rule was deleted successfully.',
+      });
     }
   };
 
@@ -231,7 +229,9 @@ export default function ActionRuleSettingsTab({
     onDeleteActionRule(oldName, true); // deleteFromUIOnly
     onAddActionRule(updatedActionRule, true); // addToUIOnly
     updateActionRule(oldName, updatedActionRule);
-    displayToast('The action rule was updated successfully.');
+    notifications.success({
+      message: 'The action rule was updated successfully.',
+    });
   };
 
   const actionRulesTableRows = actionRules.map(actionRule => (
@@ -321,15 +321,6 @@ export default function ActionRuleSettingsTab({
           </Table>
         </Col>
       </Row>
-      <div className="feedback-toast-container">
-        <Toast
-          onClose={() => setShowToast(false)}
-          show={showToast}
-          delay={5000}
-          autohide>
-          <Toast.Body>{toastMessage}</Toast.Body>
-        </Toast>
-      </div>
     </SettingsTabPane>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/styles/_app.scss
+++ b/hasher-matcher-actioner/webapp/src/styles/_app.scss
@@ -4,6 +4,7 @@
 
 @import '_variables';
 @import './themed-form';
+@import 'node_modules/bootstrap/scss/variables';
 
 div#root {
   display: flex;
@@ -40,9 +41,32 @@ div#root {
   margin: auto;
 }
 
-.feedback-toast-container {
+.toast-container {
   position: fixed;
-  top: 0;
-  right: 0;
-  padding: 25px;
+  z-index: 2;
+  top: 20px;
+  right: 20px;
+  width: 350px; // Toasts are max 350px wide.
+
+  & > .toast {
+    padding: 8px;
+    border-left-width: 5px;
+    border-left-style: solid;
+
+    &.info {
+      border-left-color: $blue;
+    }
+
+    &.success {
+      border-left-color: $green;
+    }
+
+    &.warn {
+      border-left-color: $yellow;
+    }
+
+    &.error {
+      border-left-color: $red;
+    }
+  }
 }


### PR DESCRIPTION
# Summary

### [`67542384`](https://github.com/facebook/ThreatExchange/pull/897/commits/675423848ffb23aa35453f21cdca3385bee87243) [tiny] Add some breathing room for the navbar on settings

**Screenshot: Before**
<img width="910" alt="Screen Shot 2021-12-18 at 23 15 25" src="https://user-images.githubusercontent.com/217056/146663648-ad6e14b7-8898-4427-81f7-edc3005d3c6c.png">

**Screenshot: After**
<img width="929" alt="Screen Shot 2021-12-18 at 23 15 33" src="https://user-images.githubusercontent.com/217056/146663662-bc952219-79dd-4712-8561-2d7090e45d64.png">


### [`778ba1a2`](https://github.com/facebook/ThreatExchange/pull/897/commits/778ba1a2dbb3275bff29d5d35d2fa345993efad8) [hma][ui] Consolidate toasts across the app and control them with useContext

While adding a new error toast, I realized: 
-  our toasts were not typed. You only had one type of toast. No failure, success etc. 
- also, all pages declared their own containers which made styling impossible and violated DRY  

This changeset uses React's [`useContext`](https://reactjs.org/docs/hooks-reference.html#usecontext) to provide interested components an _option_ to simply fire-and-forget notifications. The styling is centrally managed and so is the markup.  This allows you to stack notifications, and centrally control them. 

Also, you need not pass props around. Because this is context and not props, any interested component can gain access without requiring the tree to be stirred..

Test Plan 
--- 
tried some actions which trigger toasts, and npm build.  Here are screenshots in a collage. Left is before, right is after.

<img width="1792" alt="Screen Shot 2021-12-18 at 23 13 24" src="https://user-images.githubusercontent.com/217056/146663701-1fe7500d-7881-4ad9-a4ad-407d683bda34.png">

