### PR TITLE
[HMA] Make threatexchange token optional and allow updates from the UI

### DIFF
--- a/hasher-matcher-actioner/hmalib/aws_secrets.py
+++ b/hasher-matcher-actioner/hmalib/aws_secrets.py
@@ -14,6 +14,9 @@ from hmalib.common.logging import get_logger
 logger = get_logger(__name__)
 
 
+THREAT_EXCHANGE_API_TOKEN_SECRET_NAME = "THREAT_EXCHANGE_API_TOKEN_SECRET_NAME"
+
+
 class AWSSecrets:
     """
     A class for reading secrets stored in aws
@@ -25,16 +28,17 @@ class AWSSecrets:
         session = boto3.session.Session()
         self.secrets_client = session.client(service_name="secretsmanager")
 
-    def te_api_key(self) -> str:
         """
-        get the ThreatExchange API Key.
-        Requires THREAT_EXCHANGE_API_TOKEN_SECRET_NAME be present in environ
+    def te_api_token(self) -> str:
+        f"""
+        get the ThreatExchange API Token.
+        Requires {THREAT_EXCHANGE_API_TOKEN_SECRET_NAME} be present in environ
         else returns empty string.
         """
-        secret_name = os.environ.get("THREAT_EXCHANGE_API_TOKEN_SECRET_NAME")
+        secret_name = os.environ.get(THREAT_EXCHANGE_API_TOKEN_SECRET_NAME)
         if not secret_name:
             logger.warning(
-                "Unable to load THREAT_EXCHANGE_API_TOKEN_SECRET_NAME from env"
+                f"Unable to load {THREAT_EXCHANGE_API_TOKEN_SECRET_NAME} from env"
             )
             return ""
         api_key = self._get_str_secret(secret_name)

--- a/hasher-matcher-actioner/hmalib/aws_secrets.py
+++ b/hasher-matcher-actioner/hmalib/aws_secrets.py
@@ -28,7 +28,16 @@ class AWSSecrets:
         session = boto3.session.Session()
         self.secrets_client = session.client(service_name="secretsmanager")
 
+    def update_te_api_token(self, token: str):
+        f"""
+        Sets the value of the ThreatExchange API Token in AWS Secrets. Requires
+        {THREAT_EXCHANGE_API_TOKEN_SECRET_NAME} be defined in os.environ.
+
+        Raises KeyError if environment variable is not defined.
         """
+        secret_name = os.environ[THREAT_EXCHANGE_API_TOKEN_SECRET_NAME]
+        self._update_str_secret(secret_name, token)
+
     def te_api_token(self) -> str:
         f"""
         get the ThreatExchange API Token.
@@ -81,3 +90,11 @@ class AWSSecrets:
             SecretId=secret_name
         )
         return get_secret_value_response
+
+    def _update_str_secret(self, secret_name: str, secret_value: str):
+        """
+        Update secret_value as the value for secret_name only if it exists.
+        """
+        self.secrets_client.update_secret(
+            SecretId=secret_name, SecretString=secret_value
+        )

--- a/hasher-matcher-actioner/hmalib/common/threatexchange_config.py
+++ b/hasher-matcher-actioner/hmalib/common/threatexchange_config.py
@@ -3,13 +3,15 @@
 """
 Helpers for sync privacy groups between ThreatExchange and DynamoDB
 """
+from botocore.exceptions import ClientError
+from requests.exceptions import HTTPError
+
+from threatexchange.api import ThreatExchangeAPI
 
 from hmalib.aws_secrets import AWSSecrets
-from threatexchange.api import ThreatExchangeAPI
 from hmalib.common.logging import get_logger
 from hmalib.common import config as hmaconfig
 from hmalib.common.configs.fetcher import ThreatExchangeConfig
-from botocore.exceptions import ClientError
 
 logger = get_logger(__name__)
 
@@ -90,3 +92,25 @@ def update_privacy_groups_in_use(priavcy_group_id_in_use: set) -> None:
         if str(collab.privacy_group_id) not in priavcy_group_id_in_use:
             collab.in_use = False
             hmaconfig.update_config(collab)
+
+
+def try_api_token(api_token: str) -> bool:
+    """
+    Try the new API token to make a get_privacy_groups member call. If
+    successful, return True, else False.
+
+    Some doctests to choose from:
+    >>> from hmalib.common.threatexchange_config import try_api_token
+    >>> try_api_token("<valid token>")
+    True
+    >>> try_api_token("<blank_string>")
+    False
+    >>> try_api_token("<invalid_token>")
+    False
+    """
+    api = ThreatExchangeAPI(api_token)
+    try:
+        api.get_threat_privacy_groups_member()
+        return True
+    except (ValueError, HTTPError):
+        return False

--- a/hasher-matcher-actioner/hmalib/common/threatexchange_config.py
+++ b/hasher-matcher-actioner/hmalib/common/threatexchange_config.py
@@ -55,8 +55,8 @@ def create_privacy_group_if_not_exists(
 
 
 def sync_privacy_groups():
-    api_key = AWSSecrets().te_api_key()
-    api = ThreatExchangeAPI(api_key)
+    api_token = AWSSecrets().te_api_token()
+    api = ThreatExchangeAPI(api_token)
     privacy_group_member_list = api.get_threat_privacy_groups_member()
     privacy_group_owner_list = api.get_threat_privacy_groups_owner()
     unique_privacy_groups = set(privacy_group_member_list + privacy_group_owner_list)

--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -148,8 +148,8 @@ def lambda_handler(_event, _context):
     data = f"Triggered at time {current_time}, found {len(collabs)} collabs: {', '.join(names)}"
     logger.info(data)
 
-    api_key = AWSSecrets().te_api_key()
-    api = ThreatExchangeAPI(api_key)
+    api_token = AWSSecrets().te_api_token()
+    api = ThreatExchangeAPI(api_token)
 
     for collab in collabs:
         logger.info(

--- a/hasher-matcher-actioner/hmalib/writebacker/writebacker_base.py
+++ b/hasher-matcher-actioner/hmalib/writebacker/writebacker_base.py
@@ -157,8 +157,8 @@ class ThreatExchangeWritebacker(Writebacker):
         mock_te_api = os.environ.get("MOCK_TE_API")
         if mock_te_api == "True":
             return MockedThreatExchangeAPI()
-        api_key = AWSSecrets().te_api_key()
-        return ThreatExchangeAPI(api_key)
+        api_token = AWSSecrets().te_api_token()
+        return ThreatExchangeAPI(api_token)
 
     def my_descriptor_from_all_descriptors(
         self, all_descriptors: t.List[t.Dict[str, t.Any]]

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -151,7 +151,7 @@ data "aws_iam_policy_document" "api_root" {
 
   statement {
     effect    = "Allow"
-    actions   = ["secretsmanager:GetSecretValue"]
+    actions   = ["secretsmanager:GetSecretValue", "secretsmanager:UpdateSecret"]
     resources = [var.te_api_token_secret.arn]
   }
 

--- a/hasher-matcher-actioner/terraform/variables.tf
+++ b/hasher-matcher-actioner/terraform/variables.tf
@@ -50,6 +50,7 @@ variable "te_api_token" {
   description = "The secret token used to authenticate your access to ThreatExchange. You can find this by navigating to https://developers.facebook.com/tools/accesstoken/. Leave blank if you would not like to fetch from ThreatExchange"
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "fetch_frequency" {

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -341,6 +341,23 @@ export async function fetchHashCount(): Promise<Response> {
   return apiGet('hash-counts');
 }
 
+/**
+ * Update ThreatExchange token to a new value. Backend will check whether the
+ * token has appropriate access and only then succeed.
+ *
+ * Invalid token will return Promise(False); while valid token when set will
+ * return Promise(True);
+ *
+ * @param token The new Token for access to ThreatExchange.
+ */
+export async function updateThreatExchangeAPIToken(
+  token: string,
+): Promise<boolean> {
+  return apiPost('datasets/update-threatexchange-token', {token})
+    .then(() => true)
+    .catch(() => false);
+}
+
 // This class should be kept in sync with python class ActionPerformer (hmalib.common.configs.actioner.ActionPerformer)
 type BackendActionPerformer = {
   name: string;

--- a/hasher-matcher-actioner/webapp/src/components/HolidaysDatasetInformationBlock.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/HolidaysDatasetInformationBlock.tsx
@@ -32,8 +32,9 @@ export function HolidaysDatasetInformationBlock({
   };
 
   return (
-    <Card bg="light" body style={{maxWidth: '720px'}}>
-      <h2>Test Photos</h2>
+    // <Card bg="light" body style={{maxWidth: '720px'}}>
+    <>
+      <h3>Test Photos</h3>
       <p>
         In addition to ThreatExchange data, HMA also comes with a set of image
         hashes baked in. The images are from a dataset called the INRIA Holidays
@@ -70,7 +71,7 @@ export function HolidaysDatasetInformationBlock({
           </Button>
         </li>
       </ul>
-    </Card>
+    </>
   );
 }
 

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.tsx
@@ -25,6 +25,29 @@ import {
   deleteDataset,
 } from '../../Api';
 import {NotificationsContext} from '../../AppWithNotifications';
+import SettingsTabPane from './SettingsTabPane';
+import ThreatExchangeTokenEditor from './ThreatExchangeTokenEditor';
+
+/**
+ * Empty state when no datasets are found in the backend.
+ */
+function EmptyState(): JSX.Element {
+  return (
+    <Col xs={{offset: 2, span: 8}} className="py-4">
+      <div className="h-100" style={{textAlign: 'center'}}>
+        <p className="lead">No ThreatExchange Datasets found.</p>
+        <p>
+          Datasets map to{' '}
+          <a href="https://developers.facebook.com/docs/threat-exchange/reference/apis/threat-privacy-group/v12.0">
+            Threat Privacy Groups
+          </a>{' '}
+          on ThreatExchange. Use the sync button to fetch all privacy groups you
+          have access to.
+        </p>
+      </div>
+    </Col>
+  );
+}
 
 type Dataset = {
   privacy_group_id: string;
@@ -120,17 +143,21 @@ export default function ThreatExchangeSettingsTab(): JSX.Element {
     refreshDatasets();
   }, []);
   return (
-    <>
-      <Card.Header>
-        <Row className="mt-3">
-          <h2 className="mt-2">ThreatExchange Datasets </h2>
+    <SettingsTabPane>
+      <Row className="mt-3">
+        <Col xs={{span: 8}}>
+          <h3>ThreatExchange Datasets </h3>
+        </Col>
+        <Col xs={{span: 4}} className="text-right">
           <OverlayTrigger
             key="syncButton"
-            placement="right"
+            placement="left"
             overlay={
-              <Tooltip id="tooltip-right">
-                Read PrivacyGroup metatdata from ThreatExchange to build new
-                Datasets
+              <Tooltip id="sync-info" className="p-2">
+                <p style={{textAlign: 'left'}}>
+                  Get information on all PrivacyGroups that you have access to.
+                  These will be used to fetch datasets of hashes.
+                </p>
               </Tooltip>
             }>
             <Button
@@ -152,47 +179,76 @@ export default function ThreatExchangeSettingsTab(): JSX.Element {
               Sync
             </Button>
           </OverlayTrigger>
-        </Row>
-      </Card.Header>
-      <Card.Body>
-        <Row className="mt-3">
-          <Spinner hidden={!loading} animation="border" role="status">
-            <span className="sr-only">Loading...</span>
-          </Spinner>
-          {!datasets || datasets.length === 0
-            ? null
-            : datasets.map(dataset => (
-                <ThreatExchangePrivacyGroupCard
-                  key={dataset.privacy_group_id}
-                  privacyGroupName={dataset.privacy_group_name}
-                  description={dataset.description}
-                  fetcherActive={dataset.fetcher_active}
-                  matcherActive={dataset.matcher_active}
-                  inUse={dataset.in_use}
-                  privacyGroupId={dataset.privacy_group_id}
-                  writeBack={dataset.write_back}
-                  hashCount={dataset.hash_count}
-                  matchCount={dataset.match_count}
-                  pdqMatchThreshold={dataset.pdq_match_threshold}
-                  onSave={onPrivacyGroupSave}
-                  onDelete={onPrivacyGroupDelete}
-                />
-              ))}
-        </Row>
-      </Card.Body>
-      <Col className="mx-1" md="6">
-        <HolidaysDatasetInformationBlock
-          samplePGExists={
-            datasets
-              ? datasets.some(
-                  (ds: {privacy_group_id: string}) =>
-                    ds.privacy_group_id === SAMPLE_PG_ID,
-                )
-              : false
-          }
-          refresh={refreshDatasets}
-        />
-      </Col>
-    </>
+        </Col>
+      </Row>
+      <Row className="mt-3">
+        {loading ? (
+          <Col>
+            <Spinner animation="border" role="status">
+              <span className="sr-only">Loading...</span>
+            </Spinner>
+          </Col>
+        ) : null}
+
+        {!loading && (!datasets || datasets.length === 0) ? (
+          <EmptyState />
+        ) : (
+          datasets.map(dataset => (
+            <ThreatExchangePrivacyGroupCard
+              key={dataset.privacy_group_id}
+              privacyGroupName={dataset.privacy_group_name}
+              description={dataset.description}
+              fetcherActive={dataset.fetcher_active}
+              matcherActive={dataset.matcher_active}
+              inUse={dataset.in_use}
+              privacyGroupId={dataset.privacy_group_id}
+              writeBack={dataset.write_back}
+              hashCount={dataset.hash_count}
+              matchCount={dataset.match_count}
+              pdqMatchThreshold={dataset.pdq_match_threshold}
+              onSave={onPrivacyGroupSave}
+              onDelete={onPrivacyGroupDelete}
+            />
+          ))
+        )}
+      </Row>
+      <Row>
+        <Col>
+          <hr />
+        </Col>
+      </Row>
+
+      <Row className="mt-3">
+        <Col>
+          <h3>ThreatExchange Configuration</h3>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={{span: 8}}>
+          <ThreatExchangeTokenEditor />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <hr />
+        </Col>
+      </Row>
+
+      <Row className="mt-3">
+        <Col className="mx-1" md="8">
+          <HolidaysDatasetInformationBlock
+            samplePGExists={
+              datasets
+                ? datasets.some(
+                    (ds: {privacy_group_id: string}) =>
+                      ds.privacy_group_id === SAMPLE_PG_ID,
+                  )
+                : false
+            }
+            refresh={refreshDatasets}
+          />
+        </Col>
+      </Row>
+    </SettingsTabPane>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeTokenEditor.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeTokenEditor.tsx
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+import React, {useState, useContext} from 'react';
+import {Accordion, Button, Card, Form} from 'react-bootstrap';
+import {IonIcon} from '@ionic/react';
+import {chevronUp, chevronDown} from 'ionicons/icons';
+import {useFormik} from 'formik';
+import {updateThreatExchangeAPIToken} from '../../Api';
+import {NotificationsContext} from '../../AppWithNotifications';
+
+type TETokenFormFields = {
+  token: string;
+};
+
+/**
+ * This never fetches the te token from the backend, only updates it if
+ * something changed. Applies string validations on the frontend and uses an
+ * actual query on the backend before setting it as the value on the backend.
+ */
+export default function ThreatExchangeTokenEditor(): JSX.Element {
+  const [showEditor, setShowEditor] = useState<boolean>(false);
+  const notifications = useContext(NotificationsContext);
+
+  const onSubmit = (token: string) => {
+    updateThreatExchangeAPIToken(token).then(result => {
+      if (result) {
+        notifications.success({message: 'ThreatExchange API Token updated!'});
+      } else {
+        notifications.error({
+          message:
+            'Malformed or unauthorized API Token. Did not update ThreatExchange API Token.',
+        });
+      }
+    });
+  };
+
+  const validateTEToken = (values: TETokenFormFields) => {
+    const errors: Partial<TETokenFormFields> = {};
+
+    if (values.token && values.token.indexOf('|') === -1) {
+      errors.token =
+        'Not a ThreatExchange App Token. Copy one from the link below.';
+    }
+
+    if (values.token === '') {
+      errors.token = 'ThreatExchange App Token cannot be empty';
+    }
+
+    return errors;
+  };
+
+  const formik = useFormik({
+    initialValues: {
+      token: '',
+    },
+    validate: validateTEToken,
+    validateOnChange: true,
+    onSubmit: () => undefined,
+  });
+
+  return (
+    <Card>
+      <Accordion>
+        <Accordion.Toggle
+          eventKey="0"
+          as={Card.Header}
+          onClick={() => setShowEditor(!showEditor)}
+          style={{cursor: 'pointer'}}
+          variant="outline-dark">
+          Change ThreatExchange Access Token &nbsp;
+          <IonIcon
+            className="inline-icon"
+            icon={showEditor ? chevronUp : chevronDown}
+          />
+        </Accordion.Toggle>
+        <Accordion.Collapse eventKey="0">
+          <Card.Body>
+            <Form>
+              <Form.Group>
+                <Form.Label>Enter new ThreatExchange Token</Form.Label>
+                <Form.Control
+                  id="token"
+                  onBlur={formik.handleBlur}
+                  isValid={formik.values.token !== '' && !formik.errors.token}
+                  isInvalid={!!formik.errors.token}
+                  onChange={formik.handleChange}
+                  type="text"
+                  value={formik.values.token}
+                />
+                {formik.errors.token ? (
+                  <Form.Control.Feedback type="invalid">
+                    {formik.errors.token}
+                  </Form.Control.Feedback>
+                ) : null}
+                <Form.Text muted>
+                  You can obtain your threatexchange access tokens at{' '}
+                  <a href="https://developers.facebook.com/tools/accesstoken/">
+                    https://developers.facebook.com/tools/accesstoken/
+                  </a>
+                  . Note that using a token for a different app might change the
+                  privacy groups you have access to.
+                </Form.Text>
+              </Form.Group>
+
+              <Button
+                variant="primary"
+                onClick={_ => onSubmit(formik.values.token)}
+                disabled={formik.values.token === '' || !!formik.errors.token}>
+                Update
+              </Button>
+            </Form>
+          </Card.Body>
+        </Accordion.Collapse>
+      </Accordion>
+    </Card>
+  );
+}


### PR DESCRIPTION
Summary
---------
### [`23708ca5`](https://github.com/facebook/ThreatExchange/pull/898/commits/23708ca5eb2e77d1a4ab2d2bc32f597c5be7df55) Change api_key → api_token, consistent with the tf variable name

### [`a962d715`](https://github.com/facebook/ThreatExchange/pull/898/commits/a962d7158441d6983fccb30f42cd407f949851a6) Add an API to update the te_api_token value, also make it an optional tfvar
- includes webapp API method too  
### [`12a665e5`](https://github.com/facebook/ThreatExchange/pull/898/commits/12a665e5d9156f0a89a33cbcb4a5bf4934da7e98) Allow updating TE Token from ThreatExchange settings page
- includes empty state for when privacy groups have not been synced. - removes card border around the test dataset because it looked weird as we added more settings - Uses <SettingsTabPane> at par with most other settings pages  

Test Plan
---------
* Cleared all ThreatExchangeConfig manually to see empty state.
<img width="1372" alt="Screen Shot 2021-12-19 at 11 08 43" src="https://user-images.githubusercontent.com/217056/146781393-2505773d-e3a4-4c40-8d6f-b1409595ae78.png">

* Used the token editor to supply a malformed token
<img width="756" alt="Screen Shot 2021-12-20 at 09 20 49" src="https://user-images.githubusercontent.com/217056/146781736-9ba187c2-e69a-4629-b9be-810ff1888231.png">

* Used the token to supply a well-formed but invalid token

<img width="749" alt="Screen Shot 2021-12-20 at 09 20 59" src="https://user-images.githubusercontent.com/217056/146781809-611a570f-1da8-47e5-ac89-c42c9a6f2b59.png">

* Upon submitting this well-formed but invalid token
<img width="2202" alt="Screen Shot 2021-12-20 at 09 21 06" src="https://user-images.githubusercontent.com/217056/146781815-9a3bd66c-8742-4422-9ba7-4f4fb1b5c66a.png">

* Now, submit a valid token (not showing the token for security)
<img width="585" alt="Screen Shot 2021-12-20 at 09 21 34" src="https://user-images.githubusercontent.com/217056/146781896-0e193f88-2505-45c5-b819-dfa38e54b323.png">

* Used the sync button to get privacy groups back
<img width="869" alt="Screen Shot 2021-12-20 at 09 23 13" src="https://user-images.githubusercontent.com/217056/146782043-5dc172e7-accb-4050-b834-b93f2730fff0.png">

