### PR TITLE
[hma] Remove bank members from the UI

### DIFF
--- a/hasher-matcher-actioner/hmalib/banks/bank_operations.py
+++ b/hasher-matcher-actioner/hmalib/banks/bank_operations.py
@@ -57,6 +57,21 @@ def add_bank_member(
     return member
 
 
+def remove_bank_member(
+    banks_table: BanksTable,
+    bank_member_id: str,
+):
+    """
+    Remove bank member. Marks the member as removed and all its signals are
+    removed from the GSI used to build HMA indexes.
+
+    NOTE: If we ever start incremental updates to HMA indexes, removing bank
+    members will stop working.
+    """
+    banks_table.remove_bank_member_signals_to_process(bank_member_id=bank_member_id)
+    banks_table.remove_bank_member(bank_member_id=bank_member_id)
+
+
 def add_bank_member_signal(
     banks_table: BanksTable,
     bank_id: str,

--- a/hasher-matcher-actioner/hmalib/common/models/bank.py
+++ b/hasher-matcher-actioner/hmalib/common/models/bank.py
@@ -591,7 +591,12 @@ class BanksTable:
 
     def remove_bank_member_signals_to_process(self, bank_member_id: str):
         """
-        For a bank_member, remove all signals from the processing index.
+        For a bank_member, remove all signals from the
+        BankMemberSignalCursorIndex on this table.
+
+        All systems that want to "do" something with bank_member_signals use
+        this index. eg. building indexes, syncing signals to another
+        hash_exchange.
         """
         for signal in self.get_signals_for_bank_member(bank_member_id=bank_member_id):
             self._table.update_item(

--- a/hasher-matcher-actioner/hmalib/common/models/bank.py
+++ b/hasher-matcher-actioner/hmalib/common/models/bank.py
@@ -441,7 +441,6 @@ class BanksTable:
         content_type=t.Type[ContentType],
         exclusive_start_key: t.Optional[DynamoDBCursorKey] = None,
     ) -> PaginatedResponse[BankMember]:
-        # NOTE: This does not yet filter out is_removed bank_members
         PAGE_SIZE = 100
         expected_pk = BankMember.get_pk(bank_id=bank_id, content_type=content_type)
 
@@ -449,12 +448,14 @@ class BanksTable:
             result = self._table.query(
                 ScanIndexForward=False,
                 KeyConditionExpression=Key("PK").eq(expected_pk),
+                FilterExpression=Key("IsRemoved").eq(False),
                 Limit=PAGE_SIZE,
             )
         else:
             result = self._table.query(
                 ScanIndexForward=False,
                 KeyConditionExpression=Key("PK").eq(expected_pk),
+                FilterExpression=Key("IsRemoved").eq(False),
                 ExclusiveStartKey=exclusive_start_key,
                 Limit=PAGE_SIZE,
             )

--- a/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_member_removes.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_member_removes.py
@@ -1,0 +1,73 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import typing as t
+import unittest
+
+from threatexchange.content_type.video import VideoContent
+from threatexchange.signal_type.video_tmk_pdqf import VideoTmkPdqfSignal
+
+from hmalib.common.models.bank import BanksTable
+from hmalib.common.models.tests.test_signal_uniqueness import BanksTableTestBase
+
+
+class BankMemberRemovesTestCase(BanksTableTestBase, unittest.TestCase):
+    # Note: Table is defined in base class BanksTableTestBase
+
+    def _create_bank_and_bank_member(self) -> t.Tuple[str, str]:
+        table_manager = BanksTable(self.get_table())
+
+        bank = table_manager.create_bank("TEST_BANK", "Test bank description")
+        bank_member = table_manager.add_bank_member(
+            bank_id=bank.bank_id,
+            content_type=VideoContent,
+            raw_content=None,
+            storage_bucket="hma-test-media",
+            storage_key="irrrelevant",
+            notes="",
+        )
+
+        return (bank.bank_id, bank_member.bank_member_id)
+
+    def test_bank_member_removes(self):
+        with self.fresh_dynamodb():
+            table_manager = BanksTable(self.get_table())
+            bank_id, bank_member_id = self._create_bank_and_bank_member()
+
+            bank_member_signal_1 = table_manager.add_bank_member_signal(
+                bank_id=bank_id,
+                bank_member_id=bank_member_id,
+                signal_type=VideoTmkPdqfSignal,
+                signal_value="A VIDEO TMK PDQF SIGNAL. WILTY?",
+            )
+
+            bank_member_signal_2 = table_manager.add_bank_member_signal(
+                bank_id=bank_id,
+                bank_member_id=bank_member_id,
+                signal_type=VideoTmkPdqfSignal,
+                signal_value="ANOTHER VIDEO TMK PDQF SIGNAL. WILTY?",
+            )
+
+            bank_member_signal_3 = table_manager.add_bank_member_signal(
+                bank_id=bank_id,
+                bank_member_id=bank_member_id,
+                signal_type=VideoTmkPdqfSignal,
+                signal_value="An ANOTHER VIDEO TMK PDQF SIGNAL. WILTY?",
+            )
+
+            # expect this to now be available to process
+            to_process = table_manager.get_bank_member_signals_to_process_page(
+                signal_type=VideoTmkPdqfSignal
+            )
+
+            self.assertEqual(len(to_process.items), 3)
+
+            table_manager.remove_bank_member_signals_to_process(
+                bank_member_id=bank_member_id
+            )
+
+            # expect this to now be available to process
+            to_process = table_manager.get_bank_member_signals_to_process_page(
+                signal_type=VideoTmkPdqfSignal
+            )
+
+            self.assertEqual(len(to_process.items), 0)

--- a/hasher-matcher-actioner/hmalib/lambdas/api/bank.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/bank.py
@@ -290,4 +290,18 @@ def get_bank_api(
             **asdict(with_preview_url(member)), signals=signals
         )
 
+    @bank_api.post("/remove-bank-member/<bank_member_id>")
+    def remove_bank_member(bank_member_id: str):
+        """
+        Remove bank member signals from the processing index and mark
+        bank_member as is_removed=True.
+
+        Returns empty json object.
+        """
+        bank_ops.remove_bank_member(
+            banks_table=table_manager,
+            bank_member_id=bank_member_id,
+        )
+        return {}
+
     return bank_api

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -583,6 +583,7 @@ export async function fetchBankMembersPage(
       created_at: toDate(member.created_at)!,
       updated_at: toDate(member.updated_at)!,
       is_media_unavailable: member.is_media_unavailable,
+      is_removed: member.is_removed,
     })),
     response.continuation_token,
   ]);
@@ -613,6 +614,7 @@ export async function fetchBankMember(
     created_at: toDate(member.created_at)!,
     updated_at: toDate(member.updated_at)!,
     is_media_unavailable: member.is_media_unavailable,
+    is_removed: member.is_removed,
     signals: member.signals.map(signal => ({
       bank_id: signal.bank_id,
       bank_member_id: signal.bank_member_id,
@@ -663,7 +665,14 @@ export async function addBankMember(
     created_at: toDate(response.created_at)!,
     updated_at: toDate(response.updated_at)!,
     is_media_unavailable: response.is_media_unavailable,
+    is_removed: response.is_removed,
   }));
+}
+
+export async function removeBankMember(bankMemberId: string): Promise<void> {
+  return apiPost(`banks/remove-bank-member/${bankMemberId}`).then(
+    _ => undefined,
+  );
 }
 
 // Index APIs

--- a/hasher-matcher-actioner/webapp/src/messages/BankMessages.tsx
+++ b/hasher-matcher-actioner/webapp/src/messages/BankMessages.tsx
@@ -30,6 +30,7 @@ export type BankMember = {
   created_at: Date;
   updated_at: Date;
   is_media_unavailable: boolean;
+  is_removed: boolean;
 };
 
 export type BankMemberSignal = {

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
@@ -13,7 +13,7 @@ import {
   Modal,
   Alert,
 } from 'react-bootstrap';
-import {useParams} from 'react-router-dom';
+import {useParams, Link} from 'react-router-dom';
 
 import FixedWidthCenterAlignedLayout from '../layouts/FixedWidthCenterAlignedLayout';
 import {BankMemberWithSignals} from '../../messages/BankMessages';
@@ -163,6 +163,11 @@ export default function ViewBankMember(): JSX.Element {
                         This member is marked as removed. Signals from this
                         member are no longer going to be used for to find
                         similar content.
+                      </p>
+
+                      <p>
+                        You can add the member again from the{' '}
+                        <Link to={returnURL}>bank memberships</Link> page.
                       </p>
                     </Alert>
                   </Col>

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
@@ -10,13 +10,15 @@ import {
   Table,
   Button,
   Container,
+  Modal,
+  Alert,
 } from 'react-bootstrap';
 import {useParams} from 'react-router-dom';
 
 import FixedWidthCenterAlignedLayout from '../layouts/FixedWidthCenterAlignedLayout';
 import {BankMemberWithSignals} from '../../messages/BankMessages';
 import Loader from '../../components/Loader';
-import {fetchBankMember} from '../../Api';
+import {fetchBankMember, removeBankMember} from '../../Api';
 import {ContentType} from '../../utils/constants';
 import {BlurImage, BlurVideo} from '../../utils/MediaUtils';
 import {
@@ -71,6 +73,7 @@ function SignalDetails({
 
 export default function ViewBankMember(): JSX.Element {
   const {bankMemberId} = useParams<{bankMemberId: string}>();
+  const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
 
   const [member, setMember] = useState<BankMemberWithSignals>();
   const [pollBuster, setPollBuster] = useState<number>(1);
@@ -85,6 +88,13 @@ export default function ViewBankMember(): JSX.Element {
       }-memberships`
     : '/';
 
+  const removeMember = () => {
+    removeBankMember(bankMemberId).then(() => {
+      setShowConfirmModal(false);
+      setPollBuster(pollBuster + 1);
+    });
+  };
+
   return (
     <FixedWidthCenterAlignedLayout>
       <Row>
@@ -93,10 +103,27 @@ export default function ViewBankMember(): JSX.Element {
         </Col>
       </Row>
       <Row>
-        <Col>
-          <h1>Bank Member</h1>
+        <Col xs={{span: 8}}>
+          <h2>Bank Member</h2>
+        </Col>
+        <Col xs={{span: 4}} className="text-right">
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => setPollBuster(pollBuster + 1)}>
+            Refresh
+          </Button>{' '}
+          {member && !member.is_removed ? (
+            <Button
+              size="sm"
+              variant="danger"
+              onClick={() => setShowConfirmModal(true)}>
+              Delete Member
+            </Button>
+          ) : null}
         </Col>
       </Row>
+      <Row />
       {member === undefined ? (
         <Row>
           <Col>
@@ -121,18 +148,26 @@ export default function ViewBankMember(): JSX.Element {
           <Col md={{span: 6}}>
             <Container>
               <Row>
-                <Col xs={{span: 10}}>
+                <Col>
                   <h3>Member Details</h3>
                 </Col>
-                <Col xs={{span: 2}}>
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    onClick={() => setPollBuster(pollBuster + 1)}>
-                    Refresh
-                  </Button>
-                </Col>
               </Row>
+              {member.is_removed ? (
+                <Row>
+                  <Col>
+                    <Alert variant="warning">
+                      <Alert.Heading>
+                        Member is marked as removed!
+                      </Alert.Heading>
+                      <p>
+                        This member is marked as removed. Signals from this
+                        member are no longer going to be used for to find
+                        similar content.
+                      </p>
+                    </Alert>
+                  </Col>
+                </Row>
+              ) : null}
             </Container>
             <Table>
               <tbody>
@@ -169,6 +204,27 @@ export default function ViewBankMember(): JSX.Element {
           </Col>
         </Row>
       )}
+      <Modal show={showConfirmModal} onHide={() => setShowConfirmModal(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Remove the BankMember </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p>
+            Are you sure you want to remove this bank member? Once the index
+            rebuilds, HMA will stop matching against this member.
+          </p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            variant="secondary"
+            onClick={() => setShowConfirmModal(false)}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={removeMember}>
+            Yes, Remove this Member
+          </Button>
+        </Modal.Footer>
+      </Modal>
     </FixedWidthCenterAlignedLayout>
   );
 }


### PR DESCRIPTION
Summary
---------
As part of the 'banks-be-done' plan, we need to be able to remove banks members from the banks ui.

This PR allows that to be done. You can review commit by commit or at once. The key changes are:
* support marking is_removed = True for members in the API. This also removes the signals from the GSI used to build HMA indexes.
* in get_all_bank_members(), filter out is_removed members
* support removing bank members in the UI

Test Plan
---------
* py.test, black and mypy 

https://user-images.githubusercontent.com/217056/146830811-6a209dc7-43fd-46c5-9bae-4e305c02513c.mov


