### PR TITLE
[py-tx] Interface for collab configuration

### DIFF
--- a/python-threatexchange/threatexchange/cli/cli_config.py
+++ b/python-threatexchange/threatexchange/cli/cli_config.py
@@ -1,0 +1,54 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import typing as t
+import pathlib
+import os
+
+from threatexchange.collab_config import CollaborationConfig
+
+"""
+Local storage and configuration for the CLI.
+
+The CLI and Hasher-Matcher-Actioner are roughly parallel, but this isn't a 
+scalable service running on AWS. Instead, we have all of our state in
+a file (likely ~/.threatexchange)
+"""
+
+FETCH_STATE_DIR_NAME = "fetched_state"
+COLLABORATION_CONFIG_DIR_NAME = "collaborations"
+INDEX_STATE_DIR_NAME = "index"
+CONFIG_FILENAME = "config.json"
+
+
+class CliState:
+    """
+    A wrapper around stateful information stored for the CLI.
+
+    Everything is just in a single file (usually ~/.threatexchange).
+    """
+
+    def __init__(self, dir: pathlib.Path):
+        assert dir.is_file
+        self._dir = dir
+
+    def get_collab_by_name(self, name: str) -> t.Optional[CollaborationConfig]:
+        """
+        Gets only a single stored collaboration config by its given name.
+        """
+        return None
+
+    def update_collab(self, collab: CollaborationConfig) -> None:
+        """Create or update a collaboration"""
+        pass
+
+    def delete_collab(self, name: str) -> None:
+        """Delete a collaboration"""
+        pass
+
+    def get_all_collabs(self) -> t.List[CollaborationConfig]:
+        """Get all collaborations"""
+        return []
+
+    def get_fetcher(self, something: t.Any) -> t.Any:
+        """Returns a fetcher, initialized from the CLI state"""
+        return None

--- a/python-threatexchange/threatexchange/cli/cli_config.py
+++ b/python-threatexchange/threatexchange/cli/cli_config.py
@@ -48,7 +48,3 @@ class CliState:
     def get_all_collabs(self) -> t.List[CollaborationConfig]:
         """Get all collaborations"""
         return []
-
-    def get_fetcher(self, something: t.Any) -> t.Any:
-        """Returns a fetcher, initialized from the CLI state"""
-        return None


### PR DESCRIPTION
Summary
---------

This will replace what is currently represented by:
1. txtoken
2. collab config files

And gives us the option to do multi-config fetching and so on.

A separate PR will contain the proposed interface for fetching.

Test Plan
---------

Uhhh... there were no squiggles in VSCode?
