### PR TITLE
[py-tx] Fetcher API interface

### DIFF
--- a/python-threatexchange/threatexchange/fetcher/__init__.py
+++ b/python-threatexchange/threatexchange/fetcher/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/python-threatexchange/threatexchange/fetcher/fetch_api.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_api.py
@@ -4,7 +4,7 @@
 """
 The fetcher is the component that talks to external APIs to get and put signals
 
-@see Fetcher
+@see SignalExchangeAPI
 """
 
 
@@ -63,7 +63,7 @@ class SignalExchangeAPI:
         raise NotImplementedError
 
     def report_seen(
-        self, s_type: SignalType, signal: str, metadata: state.FetchMetadata
+        self, s_type: SignalType, signal: str, metadata: state.FetchedSignalData
     ) -> None:
         """Report that this signal was observed on your platform"""
         raise NotImplementedError

--- a/python-threatexchange/threatexchange/fetcher/fetch_api.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_api.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+The fetcher is the component that talks to external APIs to get and put signals
+
+@see Fetcher
+"""
+
+
+import typing as t
+
+from threatexchange.collab_config import CollaborationConfig
+from threatexchange.signal_type.signal_base import SignalType
+from . import fetch_state_base as state
+
+
+class SignalExchangeAPI:
+    """
+    An external APIs to get and maybe put signals
+
+    Fetchers ideally can checkpoint their progress, so that they can tail
+    updates from the server.
+
+    Is assumed that fetched signals have some metadata attached to them,
+    which is unique to that API. Additionally, it a assumed that there
+    might be multiple contributors to signals inside of an API.
+
+    The Fetcher can assume it is stateful, and
+    """
+
+    @classmethod
+    def name(cls) -> str:
+        """
+        A string name unique to all SignalExchangeAPIs
+
+        This will get stored for lookup from a map of supported APIs
+        keyed str: API
+        """
+        return cls.__name__
+
+    def resolve_owner(self, id: int) -> str:
+        """
+        Convert an owner ID into a human readable name (if available)
+
+        If empty is returned, its assumed that the collaboration name itself
+        is good enough to describe this content.
+        """
+        return ""
+
+    def get_own_owner_id(self) -> int:
+        """
+        Return the owner ID of this caller. Opinions with that ID are "ours"
+        """
+        return -1
+
+    def fetch_once(
+        self, collab: CollaborationConfig, checkpoint: t.Any
+    ) -> state.FetchDelta:
+        """
+        Call out to external resources, pulling down one "batch" of content.
+        """
+        raise NotImplementedError
+
+    def report_seen(
+        self, s_type: SignalType, signal: str, metadata: state.FetchMetadata
+    ) -> None:
+        """Report that this signal was observed on your platform"""
+        raise NotImplementedError
+
+    def report_opinion(
+        self,
+        collab: CollaborationConfig,
+        s_type: t.Type[SignalType],
+        signal: str,
+        opinion: state.SignalOpinion,
+    ) -> None:
+        """
+        Weigh in on a signal for this collaboration.
+
+        Most implementations will want a full replacement specialization, but this
+        allows a common interface for all uploads for the simplest usecases.
+        """
+        raise NotImplementedError
+
+    def report_true_positive(
+        self,
+        s_type: t.Type[SignalType],
+        signal: str,
+        metadata: state.FetchedSignalData,
+    ) -> None:
+        """Report that a previously seen signal was a true positive"""
+        raise NotImplementedError
+
+    def report_false_positive(
+        self,
+        s_type: t.Type[SignalType],
+        signal: str,
+        metadata: state.FetchedSignalData,
+    ) -> None:
+        """Report that a previously seen signal is a false positive"""
+        raise NotImplementedError

--- a/python-threatexchange/threatexchange/fetcher/fetch_state_base.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_state_base.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 """
@@ -41,6 +40,10 @@ class SignalOpinion:
     Certain APIs won't have any concept of owner, category, or tags,
     in which case owner=0, category=TRUE_POSITIVE, tags=[] is reasonable
     default.
+
+    Some implementations may extend this to store additional API-specific data
+
+    @see threatexchange.fetch_api.SignalExchangeAPI
     """
 
     owner: int
@@ -52,9 +55,14 @@ class SignalOpinion:
 class FetchedSignalData:
     """
     Metadata to make decisions on matches and power feedback on the fetch API.
+
+    You likely need to extend this for your API to include enough context for
+    SignalExchangeAPI.report_seen() and others.
+
+    If your API supports multiple databases or collections, you likely
+    will need to store that here.
     """
 
-    collab_name: str  # Corresponds to the collab config that fetched it
     opinions: t.List[SignalOpinion]
 
 
@@ -62,7 +70,8 @@ class FetchDelta:
     """
     Contains the result of a fetch.
 
-    Needs only to be interpretable by FetchedState
+    You'll need to extend this, but it only to be interpretable by your
+    API's version of FetchedState
     """
 
     def record_count(self) -> int:
@@ -70,15 +79,26 @@ class FetchDelta:
         return 1
 
     def next_checkpoint(self) -> TFetchStateCheckpoint:
-        """
-        A serializable checkpoint for fetch
-        """
+        """A serializable checkpoint for fetch."""
         raise NotImplementedError
 
 
+# TODO t.Generic[TFetchDelta, TFetchedSignalData]
+#      to help keep track of the expected subclasses for an impl
 class FetchedState:
     """
     An interface to previously fetched or persisted state.
+
+    You will need to extend this for your API, but even worse, there
+    might need to be multiple versions for a single API if it's being
+    used by Hasher-Matcher-Actioner, since that might want to specialcase
+    for AWS components.
+
+    = A Note on Metadata ID =
+    It's assumed that the storage will be split into a scheme that allows
+    addressing individual IDs. Depending on the implementation, you may
+    have to invent IDs during merge() which will also need to be persisted,
+    since they need to be consistent between instanciation
     """
 
     def get_checkpoint(self) -> TFetchStateCheckpoint:
@@ -87,9 +107,9 @@ class FetchedState:
         """
         raise NotImplementedError
 
-    def merge(self, subsequent: FetchDelta) -> None:
+    def merge(self, delta: FetchDelta) -> None:
         """
-        Merge a subsequent FetchDelta into this one.
+        Merge a FetchDelta into the state.
 
         At the implementation's discretion, it may call flush() or the
         equivalent work.
@@ -102,15 +122,18 @@ class FetchedState:
 
         This should also persist the checkpoint.
         """
-        return None
+        raise NotImplementedError
 
-    def get_as_signals(self) -> t.Dict[t.Type[SignalType], t.List[t.Tuple[str, str]]]:
+    # TODO - if sticking with this signature, convert to t.NamedTuple
+    def get_as_signals(self) -> t.Dict[str, t.List[t.Tuple[str, int]]]:
         """
         Get as a map of SignalType.name() => (signal, MetataData ID).
 
+        If the underlying API doesn't support IDs, one solution
+
         It's assumed that signal is unique (all merging has already taken place).
 
-        Note - this currently implies that you are going to load the entire dataset
+        TODO this currently implies that you are going to load the entire dataset
         into memory, which once we start getting huge amounts of data, might not make
         sense.
         """
@@ -118,6 +141,6 @@ class FetchedState:
 
     def get_metadata_from_id(self, metadata_id: int) -> FetchedSignalData:
         """
-        Returns additional metadata from a match
+        Fetch the metadata from an ID
         """
         raise NotImplementedError

--- a/python-threatexchange/threatexchange/fetcher/fetch_state_base.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_state_base.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Base classes for passing data between SignalExchangeAPIs and other interfaces.
+
+Many implementations will choose to extend these to add additional metadata
+needed to power API features.
+"""
+
+
+from dataclasses import dataclass
+from enum import Enum
+import typing as t
+
+from threatexchange.signal_type.signal_base import SignalType
+
+
+TFetchStateCheckpoint = t.TypeVar("TFetchStateCheckpoint")  # TODO for now
+
+
+class SignalOpinionCategory(Enum):
+    """
+    What the opinion on a signal is.
+
+    Some APIs may not support all of these, but each of these should influence
+    what action you might take as a result of matching, otherwise it might
+    make more sense as a tag
+    """
+
+    FALSE_POSITIVE = 0  # Signal generates false positives
+    WORTH_INVESTIGATING = 1  # Indirect indicator
+    TRUE_POSITIVE = 2  # Confirmed meets category
+
+
+@dataclass
+class SignalOpinion:
+    """
+    The metadata of a single signal upload.
+
+    Certain APIs won't have any concept of owner, category, or tags,
+    in which case owner=0, category=TRUE_POSITIVE, tags=[] is reasonable
+    default.
+    """
+
+    owner: int
+    category: SignalOpinionCategory
+    tags: t.List[str]
+
+
+@dataclass
+class FetchedSignalData:
+    """
+    Metadata to make decisions on matches and power feedback on the fetch API.
+    """
+
+    collab_name: str  # Corresponds to the collab config that fetched it
+    opinions: t.List[SignalOpinion]
+
+
+class FetchDelta:
+    """
+    Contains the result of a fetch.
+
+    Needs only to be interpretable by FetchedState
+    """
+
+    def record_count(self) -> int:
+        """Helper for --limit"""
+        return 1
+
+    def next_checkpoint(self) -> TFetchStateCheckpoint:
+        """
+        A serializable checkpoint for fetch
+        """
+        raise NotImplementedError
+
+
+class FetchedState:
+    """
+    An interface to previously fetched or persisted state.
+    """
+
+    def get_checkpoint(self) -> TFetchStateCheckpoint:
+        """
+        Returns the last checkpoint passed to merge() after a flush()
+        """
+        raise NotImplementedError
+
+    def merge(self, subsequent: FetchDelta) -> None:
+        """
+        Merge a subsequent FetchDelta into this one.
+
+        At the implementation's discretion, it may call flush() or the
+        equivalent work.
+        """
+        raise NotImplementedError
+
+    def flush(self) -> None:
+        """
+        Finish writing the results of previous merges to persistant state.
+
+        This should also persist the checkpoint.
+        """
+        return None
+
+    def get_as_signals(self) -> t.Dict[t.Type[SignalType], t.List[t.Tuple[str, str]]]:
+        """
+        Get as a map of SignalType.name() => (signal, MetataData ID).
+
+        It's assumed that signal is unique (all merging has already taken place).
+
+        Note - this currently implies that you are going to load the entire dataset
+        into memory, which once we start getting huge amounts of data, might not make
+        sense.
+        """
+        raise NotImplementedError
+
+    def get_metadata_from_id(self, metadata_id: int) -> FetchedSignalData:
+        """
+        Returns additional metadata from a match
+        """
+        raise NotImplementedError


### PR DESCRIPTION
Summary
---------

Third time's the charm? This is an attempt to both generalize the fetch interface, and to delete mistakes of the past with the threat_updates API. 

It's basically the threat_updates API again, except with less weird intermediate translations via function as arguments.

# What's in this PR
A simple interface that represents fetch APIs, which should cover all 5 fetch approaches I am tracking:
1. ThreatExchange tagged_objects
2. ThreatExchange threat_updates
3. StopNCII.org 
4. NCMEC Industry Hash DB
5. A hardcoded set of signals

It also contains a simple interface for storage that I think should work for both HMA and py-te, in line with goals of aligning them.

# What the end of this road hopefully contains (3w of coding + debugging, which probably means 6w in real time)
1. py-te CLI handles multiple APIs/collabs
2. py-te state moves to .threatexchange (since its now a lot more complicated)
3. py-te uses Fetcher API => SQL Lite Storage Impl => SignalTypeIndex, which would be very close to HMA
4. ThreatExchange fetch by tags is deleted because I'm too lazy to preserve it
5. Hardcoded sample data signal fetcher source, threat_updates, NCII API, NCMEC API
6. The whole thing is stable enough to fetch ~200k range signals


Test Plan
---------

Pending
