### PR TITLE
Upgrade Node to v16, v15 is no longer supported

### DIFF
--- a/hasher-matcher-actioner/.devcontainer/Dockerfile
+++ b/hasher-matcher-actioner/.devcontainer/Dockerfile
@@ -22,11 +22,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
 ARG unixname
 RUN echo "$unixname ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-# [Install node] Node.js version: 15 only. Stolen from: https://github.com/nodejs/docker-node/blob/main/15/buster/Dockerfile
+# [Install node] Node.js version: 16 only. Stolen from: https://github.com/nodejs/docker-node/blob/main/16/buster/Dockerfile
 RUN groupadd --gid 1001 node \
   && useradd --uid 1001 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 15.14.0
+ENV NODE_VERSION 16.13.2
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -53,9 +53,8 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   108F52B48DB57BB0CC439B2997B01419BD92F80A \
   B9E2F5981AA6E0CD28160D9FF13993A75599653C \
   ; do \
-  gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://keys.openpgp.org --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
   done \
   && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
   && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
@@ -68,15 +67,14 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && node --version \
   && npm --version
 
-ENV YARN_VERSION 1.22.5
+ENV YARN_VERSION 1.22.15
 
 RUN set -ex \
   && for key in \
   6A010C5166006599AA17F08146C2130DFD2497F5 \
   ; do \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
   done \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \

--- a/hasher-matcher-actioner/.devcontainer/devcontainer.json.example
+++ b/hasher-matcher-actioner/.devcontainer/devcontainer.json.example
@@ -49,7 +49,7 @@
     "python.analysis.extraPaths": [
       // Unless we do this, pylance is not able to resolve imports
       "~/.local/lib/python3.9/site-packages"
-    ]
+    ],
     "[javascriptreact]": {
       "editor.defaultFormatter": "rvest.vs-code-prettier-eslint"
     },


### PR DESCRIPTION
## Summary
v15 is no longer supported and it is advised to not use odd number releases in production.
Additionally:
- remove sks keyservers when installing yarn
- fix missing comma in devcontainer example

## Test plan
- rebuild container without cache (installs node, installs dependencies)
- webapp build (npm start) browser opens
