### PR TITLE
Move Delete button into Edit view for ActionRules tab

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionRulesTableRow.tsx
@@ -136,12 +136,6 @@ export default function ActionRulesTableRow({
             onClick={() => setEditing(true)}>
             <IonIcon icon={pencil} size="large" color="white" />
           </Button>{' '}
-          <Button
-            variant="secondary"
-            className="table-action-button"
-            onClick={() => setShowDeleteActionRuleConfirmation(true)}>
-            <IonIcon icon={trashBin} size="large" className="white" />
-          </Button>
           <Modal
             show={showDeleteActionRuleConfirmation}
             onHide={() => setShowDeleteActionRuleConfirmation(false)}>
@@ -189,6 +183,13 @@ export default function ActionRulesTableRow({
               }
             }}>
             <IonIcon icon={checkmark} size="large" color="white" />
+          </Button>{' '}
+          <Button
+            variant="secondary"
+            className="mb-2 table-action-button"
+            onClick={() => setShowDeleteActionRuleConfirmation(true)}
+            disabled={!editing}>
+            <IonIcon icon={trashBin} size="large" className="white" />
           </Button>{' '}
           <Button
             variant="outline-secondary"


### PR DESCRIPTION
Summary
---------
Feedback says it's too easy to delete ActionRules in the HMA UI. This moves the delete button from the top level of the ActionRules tab view into the Edit view. You have to start editing an ActionRule before you can delete it,

Test Plan
---------
Before:

After:
<img width="1781" alt="AR_002" src="https://user-images.githubusercontent.com/3166948/150024329-7212c89c-0414-4fab-a49b-0e74941a3b55.png">
<img width="1772" alt="AR_003" src="https://user-images.githubusercontent.com/3166948/150024371-912a708d-a4d6-4ac2-bc27-133f1311ee4d.png">