### PR TITLE
Bank action evaluation fixups

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/models/bank.py
+++ b/hasher-matcher-actioner/hmalib/common/models/bank.py
@@ -132,7 +132,7 @@ class Bank(DynamoDBItem):
             # is_active is True by default.
             is_active=item.get("IsActive", True),
             # tags default to empty set
-            bank_tags=cls.dynamodb_attribute_to_set(item.get("BankTags", {})),
+            bank_tags=cls.dynamodb_attribute_to_set(item.get("BankTags", set())),
         )
 
     def to_json(self) -> t.Dict:
@@ -234,7 +234,7 @@ class BankMember(DynamoDBItem):
             is_media_unavailable=item["IsMediaUnavailable"],
             # tags default to empty set
             bank_member_tags=cls.dynamodb_attribute_to_set(
-                item.get("BankMemberTags", {})
+                item.get("BankMemberTags", set())
             ),
         )
 

--- a/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
+++ b/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
@@ -245,7 +245,7 @@ class Matcher:
         self,
         content_id: str,
         content_hash: str,
-        matches: t.List[IndexMatch],
+        matches: t.List[IndexMatch[t.List[BaseIndexMetadata]]],
         sns_client: SNSClient,
         topic_arn: str,
     ):
@@ -268,13 +268,14 @@ class Matcher:
 
                     banked_signals.append(banked_signal)
                 elif metadata_obj.get_source() == BANKS_SOURCE_SHORT_CODE:
-                    banked_signal = BankedSignal(
-                        metadata_obj.signal_id,
-                        metadata_obj.bank_member_id,
-                        metadata_obj.get_source(),
-                    )
                     bank_member = self.banks_table.get_bank_member(
                         bank_member_id=metadata_obj.bank_member_id
+                    )
+
+                    banked_signal = BankedSignal(
+                        metadata_obj.bank_member_id,
+                        bank_member.bank_id,
+                        metadata_obj.get_source(),
                     )
 
                     # TODO: This would do good with caching.


### PR DESCRIPTION
Summary
---------
When writing out the [WIP wiki page](https://github.com/facebook/ThreatExchange/wiki/Creating-and-Managing-Banks) for banks, I realized that configuring actions to be taken when match.bank == foo was not possible. This was because of a mistake I made in one of my earlier commits.

This PR fixes that. Moving forward, the match message properties (as in action rules) will be like:
```
Label(key='BankIDClassification', value='<bank_id>'), 
Label(key='BankSourceClassification', value='bnk'), 
Label(key='BankedContentIDClassification', value='<bank_member_id>'), 
Label(key='Classification', value='<bank or bank_member tags>'), 
...
Label(key='Classification', value='<more bank or bank_member tags>'), 
```

Bonus: Also fixes a bug which used the wrong literal for sets (`{}` instead of `set()`) when filling out bank_tags and bank_member_tags for older banks and members.

Test Plan
---------

Locally, mypy, py.test, black.

Deployed a new docker image. Ran  a matching image through the pipeline, verified the match message:

```
MatchMessage(
	content_key='d1bfbefb-c3bf-440c-a0a8-2d5c928df71c', 
	content_hash='09c91924995ba646a32635ae79aef6b4ecb9da5d64f5d4d45b462a46262b059b', 
	matching_banked_signals=[
		BankedSignal(
			banked_content_id='e65881a0-0718-4f5c-8274-784d44cbf7d9', 
			bank_id='e99e3128-ba89-4d15-afcc-8fd130fcfca3', 
			bank_source='bnk', 
			classifications={
				Label(key='BankIDClassification', value='e99e3128-ba89-4d15-afcc-8fd130fcfca3'), 
				Label(key='BankSourceClassification', value='bnk'), 
				Label(key='BankedContentIDClassification', value='e65881a0-0718-4f5c-8274-784d44cbf7d9'), 
				Label(key='Classification', value='tag1'), 
				Label(key='Classification', value='tag2'), 
				Label(key='Classification', value='tag3')
			})])
```

The `Label` objects correspond correctly to the bank_id and bank_member_id.