### PR TITLE
BankMember tags are not editable

### DIFF
--- a/hasher-matcher-actioner/webapp/src/components/PillBox.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/PillBox.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  */
 
-import React, {useState, KeyboardEvent, FormEvent} from 'react';
+import React, {useState, KeyboardEvent} from 'react';
 import {Button, Form, InputGroup} from 'react-bootstrap';
 
 import {IonIcon} from '@ionic/react';
@@ -14,23 +14,30 @@ type PillBoxProps = {
   pills: string[];
   handleNewTagAdd: (tag: string) => void;
   handleTagDelete: (tag: string) => void;
+  readOnly?: boolean;
 };
 
 type PillProps = {
   tag: string;
   onDelete: () => void;
+  readOnly: boolean;
 };
 
-function Pill({tag, onDelete}: PillProps) {
+function Pill({tag, onDelete, readOnly = true}: PillProps) {
   return (
     <span className="pill">
       <div className="pill-internal">
         <span className="expand has-label">{tag}</span>
-        <span className="fixed">
-          <Button onClick={onDelete} size="sm" variant="secondary">
-            <IonIcon icon={close} />
-          </Button>
-        </span>
+        {readOnly ? (
+          // To ensure padding is equal on both sides.
+          <span className="fixed">&nbsp;</span>
+        ) : (
+          <span className="fixed">
+            <Button onClick={onDelete} size="sm" variant="secondary">
+              <IonIcon icon={close} />
+            </Button>
+          </span>
+        )}
       </div>
     </span>
   );
@@ -44,6 +51,7 @@ export default function PillBox({
   pills,
   handleNewTagAdd,
   handleTagDelete,
+  readOnly,
 }: PillBoxProps) {
   const [newTagValue, setNewTagValue] = useState<string>('');
 
@@ -58,30 +66,40 @@ export default function PillBox({
   return (
     <div>
       {pills.map(pill => (
-        <Pill tag={pill} onDelete={() => handleTagDelete(pill)} />
-      ))}
-      <InputGroup size="sm">
-        <Form.Control
-          type="text"
-          value={newTagValue}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setNewTagValue(e.target.value)
-          }
-          onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
-            if (e.keyCode === 13) {
-              e.stopPropagation();
-              e.preventDefault();
-              handleNewTagAddInner();
-            }
-          }}
-          placeholder="Add new tag"
+        <Pill
+          readOnly={!!readOnly}
+          tag={pill}
+          onDelete={() => handleTagDelete(pill)}
         />
-        <InputGroup.Append>
-          <Button onClick={handleNewTagAddInner} variant="secondary">
-            Add
-          </Button>
-        </InputGroup.Append>
-      </InputGroup>
+      ))}
+      {readOnly ? null : (
+        <InputGroup size="sm">
+          <Form.Control
+            type="text"
+            value={newTagValue}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setNewTagValue(e.target.value)
+            }
+            onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+              if (e.keyCode === 13) {
+                e.stopPropagation();
+                e.preventDefault();
+                handleNewTagAddInner();
+              }
+            }}
+            placeholder="Add new tag"
+          />
+          <InputGroup.Append>
+            <Button onClick={handleNewTagAddInner} variant="secondary">
+              Add
+            </Button>
+          </InputGroup.Append>
+        </InputGroup>
+      )}
     </div>
   );
 }
+
+PillBox.defaultProps = {
+  readOnly: false,
+};

--- a/hasher-matcher-actioner/webapp/src/forms/BankMemberForm.tsx
+++ b/hasher-matcher-actioner/webapp/src/forms/BankMemberForm.tsx
@@ -15,6 +15,8 @@ type BankMemberFormProps = {
   uploadProgress: number; // Between 0 and 100 implies upload not started, 100 implies uploaded and anything in between is shown in progress bar
 };
 
+const ARE_BANK_MEMBER_TAGS_EDITABLE = false;
+
 function renderProgressBar(uploadProgress: number): JSX.Element | null {
   if (uploadProgress === 0) {
     return null;
@@ -82,26 +84,32 @@ export default function BankMemberForm({
           </Form.Control.Feedback>
         ) : null}
 
-        <Form.Label>Tags</Form.Label>
-
-        <PillBox
-          handleNewTagAdd={tag => {
-            const alreadyExists = formik.values.tags.indexOf(tag) !== -1;
-            if (!alreadyExists) {
-              formik.setFieldValue('tags', formik.values.tags.concat([tag]));
-            }
-          }}
-          handleTagDelete={tag => {
-            const alreadyExists = formik.values.tags.indexOf(tag) !== -1;
-            if (alreadyExists) {
-              formik.setFieldValue(
-                'tags',
-                formik.values.tags.filter(x => x !== tag),
-              );
-            }
-          }}
-          pills={formik.values.tags}
-        />
+        {ARE_BANK_MEMBER_TAGS_EDITABLE ? (
+          <>
+            <Form.Label>Tags</Form.Label>
+            <PillBox
+              handleNewTagAdd={tag => {
+                const alreadyExists = formik.values.tags.indexOf(tag) !== -1;
+                if (!alreadyExists) {
+                  formik.setFieldValue(
+                    'tags',
+                    formik.values.tags.concat([tag]),
+                  );
+                }
+              }}
+              handleTagDelete={tag => {
+                const alreadyExists = formik.values.tags.indexOf(tag) !== -1;
+                if (alreadyExists) {
+                  formik.setFieldValue(
+                    'tags',
+                    formik.values.tags.filter(x => x !== tag),
+                  );
+                }
+              }}
+              pills={formik.values.tags}
+            />
+          </>
+        ) : null}
       </Form.Group>
       <Button type="submit" variant="primary" disabled={saving}>
         {ctaLabel}

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
@@ -120,6 +120,7 @@ function BankMemberEditableAttributesForm({
         <td>Tags:</td>
         <td>
           <PillBox
+            readOnly
             handleNewTagAdd={tag => {
               const alreadyExists = formik.values.tags.indexOf(tag) !== -1;
               if (!alreadyExists) {


### PR DESCRIPTION
Summary
---------
Editing bank member tags can potentially lead to partners overusing them. We want banks to be the unit of classification rules. Until we discuss this more, disallowing edits to bank member tags when creating and editing them.

Test Plan
---------
<img width="1160" alt="Screen Shot 2022-02-01 at 22 18 14" src="https://user-images.githubusercontent.com/217056/152088363-6f268f8d-a865-44bc-acd4-e3fb2b35c52d.png">
<img width="813" alt="Screen Shot 2022-02-01 at 22 19 11" src="https://user-images.githubusercontent.com/217056/152088370-2c0c9421-b444-4e40-b90f-b366400267ec.png">
<img width="616" alt="Screen Shot 2022-02-01 at 22 20 12" src="https://user-images.githubusercontent.com/217056/152088378-714ecca4-3aa6-4b1e-80e7-114b8a7cec20.png">

