### PR TITLE
[hma][api][ui] update match details table to include signal bank details if present

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/models/bank.py
+++ b/hasher-matcher-actioner/hmalib/common/models/bank.py
@@ -729,3 +729,22 @@ class BanksTable:
                 Key={"PK": member_keys["PK"], "SK": member_keys["SK"]}
             )["Item"]
         )
+
+    def get_bank_member_signal_from_id(
+        self, signal_id: str
+    ) -> t.List[BankMemberSignal]:
+        """
+        Hacky (not efficient): we need to add an index entry or object
+        to change this look up to a query (not a scan) before we can
+        support very large banks.
+
+        This currently does not provide bank name, bank tags, or bank members tags to avoid
+        yet another look up. (we should find a way to avoid the scan before adding such options)
+        """
+        return [
+            BankMemberSignal.from_dynamodb_item(item)
+            for item in self._table.scan(
+                IndexName="BankMemberSignalCursorIndex",
+                FilterExpression=Key("SK").eq(BankMemberSignal.get_sk(signal_id)),
+            )["Items"]
+        ]

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -144,7 +144,7 @@ app.mount(
 app.mount(
     "/matches/",
     get_matches_api(
-        dynamodb_table=dynamodb.Table(DYNAMODB_TABLE),
+        datastore_table=dynamodb.Table(DYNAMODB_TABLE),
         hma_config_table=HMA_CONFIG_TABLE,
         indexes_bucket_name=INDEXES_BUCKET_NAME,
         writeback_queue_url=WRITEBACK_QUEUE_URL,

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -86,6 +86,18 @@ export async function fetchMatchesFromContent(
   return apiGet('matches/', {content_q: contentId});
 }
 
+type TESignalDetails = {
+  privacy_group_id: string;
+  tags: string[];
+  opinion: string;
+  pending_opinion_change: string;
+};
+
+type BankedSignalDetails = {
+  bank_member_id: string;
+  bank_id: string;
+};
+
 export type MatchDetails = {
   content_id: string;
   content_hash: string;
@@ -94,12 +106,8 @@ export type MatchDetails = {
   signal_source: string;
   signal_type: string;
   updated_at: string;
-  metadata: {
-    privacy_group_id: string;
-    tags: string[];
-    opinion: string;
-    pending_opinion_change: string;
-  }[];
+  te_signal_details: TESignalDetails[];
+  banked_signal_details: BankedSignalDetails[];
 };
 
 type Matches = {match_details: MatchDetails[]};

--- a/hasher-matcher-actioner/webapp/src/pages/ContentDetails.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/ContentDetails.tsx
@@ -4,7 +4,7 @@
 
 import React, {useState, useEffect} from 'react';
 import {useParams} from 'react-router-dom';
-import {Col, Row, Table, Button} from 'react-bootstrap';
+import {Col, Container, Row, Table} from 'react-bootstrap';
 
 import {
   HashDetails,
@@ -18,7 +18,7 @@ import {formatTimestamp} from '../utils/DateTimeUtils';
 import {getContentTypeForString} from '../utils/constants';
 import ContentMatchTable from '../components/ContentMatchTable';
 import ActionHistoryTable from '../components/ActionHistoryTable';
-import FixedWidthCenterAlignedLayout from './layouts/FixedWidthCenterAlignedLayout';
+import FullWidthLocalScrollingLeftAlignedLayout from './layouts/FullWidthLocalScrollingLeftAlignedLayout';
 import ContentPreview from '../components/ContentPreview';
 import ReturnTo from '../components/ReturnTo';
 
@@ -67,73 +67,78 @@ export default function ContentDetailsSummary(): JSX.Element {
   }, []);
 
   return (
-    <FixedWidthCenterAlignedLayout title="Summary">
-      <Row>
-        <Col className="mb-4">
-          <ReturnTo />
-        </Col>
-      </Row>
-      <Row
-        style={{
-          minHeight: '450px',
-        }}>
-        <Col md={6}>
-          <h3>Content Details</h3>
-          <Table>
-            <tbody>
-              <tr>
-                <td>Content ID:</td>
-                <td>{id}</td>
-              </tr>
-              <tr>
-                <td>Last Submitted:</td>
-                <td>
-                  {contentDetails && contentDetails.updated_at
-                    ? formatTimestamp(contentDetails.updated_at)
-                    : 'Unknown'}
-                </td>
-              </tr>
-              <tr>
-                <td>Additional Fields:</td>
-                <td>
-                  {contentDetails && contentDetails.additional_fields
-                    ? contentDetails.additional_fields.join(', ')
-                    : 'No additional fields provided'}
-                </td>
-              </tr>
-              <tr>
-                <td>Content Hash:</td>
-                <CopyableHashField
-                  text={
-                    hashDetails
-                      ? hashDetails.content_hash ?? 'Not found'
-                      : 'loading...'
-                  }
-                />
-              </tr>
-              <tr>
-                <td>Last Hashed on:</td>
-                <td>
-                  {hashDetails
-                    ? formatTimestamp(hashDetails.updated_at)
-                    : 'loading...'}
-                </td>
-              </tr>
-            </tbody>
-          </Table>
-          <ActionHistoryTable contentKey={id} />
-        </Col>
-        <Col className="pt-4" md={6}>
-          {img && contentDetails && contentDetails.content_type ? (
-            <ContentPreview
-              contentId={id}
-              contentType={getContentTypeForString(contentDetails.content_type)}
-              url={img}
-            />
-          ) : null}
-        </Col>
-      </Row>
-      <ContentMatchTable contentKey={id} />
-    </FixedWidthCenterAlignedLayout>
+    <FullWidthLocalScrollingLeftAlignedLayout title="Summary">
+      <Container className="h-100 v-100" fluid>
+        {/* ^ This container is everything below the header */}
+        <Row>
+          <Col className="mb-4">
+            <ReturnTo />
+          </Col>
+        </Row>
+        <Row
+          style={{
+            minHeight: '450px',
+          }}>
+          <Col md={6}>
+            <h3>Content Details</h3>
+            <Table>
+              <tbody>
+                <tr>
+                  <td>Content ID:</td>
+                  <td>{id}</td>
+                </tr>
+                <tr>
+                  <td>Last Submitted:</td>
+                  <td>
+                    {contentDetails && contentDetails.updated_at
+                      ? formatTimestamp(contentDetails.updated_at)
+                      : 'Unknown'}
+                  </td>
+                </tr>
+                <tr>
+                  <td>Additional Fields:</td>
+                  <td>
+                    {contentDetails && contentDetails.additional_fields
+                      ? contentDetails.additional_fields.join(', ')
+                      : 'No additional fields provided'}
+                  </td>
+                </tr>
+                <tr>
+                  <td>Content Hash:</td>
+                  <CopyableHashField
+                    text={
+                      hashDetails
+                        ? hashDetails.content_hash ?? 'Not found'
+                        : 'loading...'
+                    }
+                  />
+                </tr>
+                <tr>
+                  <td>Last Hashed on:</td>
+                  <td>
+                    {hashDetails
+                      ? formatTimestamp(hashDetails.updated_at)
+                      : 'loading...'}
+                  </td>
+                </tr>
+              </tbody>
+            </Table>
+            <ActionHistoryTable contentKey={id} />
+          </Col>
+          <Col className="pt-4" md={6}>
+            {img && contentDetails && contentDetails.content_type ? (
+              <ContentPreview
+                contentId={id}
+                contentType={getContentTypeForString(
+                  contentDetails.content_type,
+                )}
+                url={img}
+              />
+            ) : null}
+          </Col>
+        </Row>
+        <ContentMatchTable contentKey={id} />
+      </Container>
+    </FullWidthLocalScrollingLeftAlignedLayout>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/pages/ContentDetails.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/ContentDetails.tsx
@@ -18,7 +18,7 @@ import {formatTimestamp} from '../utils/DateTimeUtils';
 import {getContentTypeForString} from '../utils/constants';
 import ContentMatchTable from '../components/ContentMatchTable';
 import ActionHistoryTable from '../components/ActionHistoryTable';
-import FullWidthLocalScrollingLeftAlignedLayout from './layouts/FullWidthLocalScrollingLeftAlignedLayout';
+import FullWidthLeftAlignedLayout from './layouts/FullWidthLeftAlignedLayout';
 import ContentPreview from '../components/ContentPreview';
 import ReturnTo from '../components/ReturnTo';
 
@@ -67,7 +67,7 @@ export default function ContentDetailsSummary(): JSX.Element {
   }, []);
 
   return (
-    <FullWidthLocalScrollingLeftAlignedLayout title="Summary">
+    <FullWidthLeftAlignedLayout title="Summary">
       <Container className="h-100 v-100" fluid>
         {/* ^ This container is everything below the header */}
         <Row>
@@ -139,6 +139,6 @@ export default function ContentDetailsSummary(): JSX.Element {
         </Row>
         <ContentMatchTable contentKey={id} />
       </Container>
-    </FullWidthLocalScrollingLeftAlignedLayout>
+    </FullWidthLeftAlignedLayout>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/pages/layouts/FullWidthLeftAlignedLayout.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/layouts/FullWidthLeftAlignedLayout.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React from 'react';
+import {Container, Row, Col} from 'react-bootstrap';
+
+type FullWidthLeftAlignedLayoutProps = {
+  title?: string;
+  children: JSX.Element | JSX.Element[];
+};
+
+/**
+ * Uses a bootstrap container to put content in the center left aligned of the main area.
+ * Supports a title and any children.
+ *
+ * fluid version of FixedWidthCenterAlignedLayout (see that file for more details on usage)
+ */
+export default function FullWidthLeftAlignedLayout({
+  title,
+  children = [],
+}: FullWidthLeftAlignedLayoutProps): JSX.Element {
+  return (
+    <Container fluid>
+      {title !== undefined ? (
+        <Row>
+          <Col className="mt-4">
+            <h1>{title}</h1>
+          </Col>
+        </Row>
+      ) : null}
+      {children}
+    </Container>
+  );
+}
+
+FullWidthLeftAlignedLayout.defaultProps = {
+  title: undefined,
+};


### PR DESCRIPTION
Summary
---------

The content details page definitely had/has some cobwebs on it. This PR does a little clean up and updates the Matches table to show Bank and Dataset membership. 

This resulted in changing one of the fields returned from the `/matches/match/` endpoint
-  `te_signal_details` (instead of the ambiguous `metadata`)  
- and adding the new `banked_signal_details` 
  - which unfortunately at the moment is forced to be backed by an inefficient ddb scan (added warning comment)

Test Plan
---------

Befores:
<img width="1249" alt="Screen Shot 2022-01-28 at 12 02 03 PM" src="https://user-images.githubusercontent.com/7664526/152241790-939029f4-12d0-44d5-ab47-09ae00c01a5c.png">
<img width="1920" alt="Screen Shot 2022-02-02 at 4 13 41 PM" src="https://user-images.githubusercontent.com/7664526/152242241-68e95fbe-d26e-46a9-9303-e3a25e171c96.png">


Afters:

Now with Links!
<img width="1919" alt="Screen Shot 2022-02-02 at 4 13 54 PM" src="https://user-images.githubusercontent.com/7664526/152242026-dd4f152c-8bd1-46a9-9cfb-2b017f3d33d0.png">

https://user-images.githubusercontent.com/7664526/152242138-49fd27db-f2c2-41d9-bde6-63394a746771.mov

