### PR TITLE
Infra for confirmations; dedicated empty state component

### DIFF
--- a/hasher-matcher-actioner/webapp/src/App.tsx
+++ b/hasher-matcher-actioner/webapp/src/App.tsx
@@ -19,6 +19,7 @@ import ViewAllBanks from './pages/bank-management/ViewAllBanks';
 import ViewBank from './pages/bank-management/ViewBank';
 import ViewBankMember from './pages/bank-management/ViewBankMember';
 import {AppWithNotifications} from './AppWithNotifications';
+import {AppWithConfirmations} from './AppWithConfirmations';
 
 export default function App(): JSX.Element {
   return (
@@ -31,46 +32,48 @@ export default function App(): JSX.Element {
       </div>
       <Router>
         <AppWithNotifications>
-          <div className="row">
-            <Sidebar className="col-md-2 bg-light sidebar" />
-            <main
-              role="main"
-              className="col-md-10 px-0 main"
-              style={{overflow: 'auto'}}>
-              <Switch>
-                <Route path="/matches/:id">
-                  <ContentDetailsSummary />
-                </Route>
-                <Route path="/pipeline-progress/:id">
-                  <ContentDetailsWithStepper />
-                </Route>
-                <Route path="/matches">
-                  <Matches />
-                </Route>
-                <Route path="/submit">
-                  <SubmitContent />
-                </Route>
-                <Route path="/settings/:tab?">
-                  <Settings />
-                </Route>
-                <Route path="/banks/bank/:bankId/:tab">
-                  <ViewBank />
-                </Route>
-                <Route path="/banks/member/:bankMemberId/">
-                  <ViewBankMember />
-                </Route>
-                <Route path="/banks/">
-                  <ViewAllBanks />
-                </Route>
-                <Route path="/dashboard/">
-                  <Dashboard />
-                </Route>
-                <Route path="/">
-                  <SubmitContent />
-                </Route>
-              </Switch>
-            </main>
-          </div>
+          <AppWithConfirmations>
+            <div className="row">
+              <Sidebar className="col-md-2 bg-light sidebar" />
+              <main
+                role="main"
+                className="col-md-10 px-0 main"
+                style={{overflow: 'auto'}}>
+                <Switch>
+                  <Route path="/matches/:id">
+                    <ContentDetailsSummary />
+                  </Route>
+                  <Route path="/pipeline-progress/:id">
+                    <ContentDetailsWithStepper />
+                  </Route>
+                  <Route path="/matches">
+                    <Matches />
+                  </Route>
+                  <Route path="/submit">
+                    <SubmitContent />
+                  </Route>
+                  <Route path="/settings/:tab?">
+                    <Settings />
+                  </Route>
+                  <Route path="/banks/bank/:bankId/:tab">
+                    <ViewBank />
+                  </Route>
+                  <Route path="/banks/member/:bankMemberId/">
+                    <ViewBankMember />
+                  </Route>
+                  <Route path="/banks/">
+                    <ViewAllBanks />
+                  </Route>
+                  <Route path="/dashboard/">
+                    <Dashboard />
+                  </Route>
+                  <Route path="/">
+                    <SubmitContent />
+                  </Route>
+                </Switch>
+              </main>
+            </div>
+          </AppWithConfirmations>
         </AppWithNotifications>
       </Router>
     </AmplifyAuthenticator>

--- a/hasher-matcher-actioner/webapp/src/AppWithConfirmations.tsx
+++ b/hasher-matcher-actioner/webapp/src/AppWithConfirmations.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React, {useState} from 'react';
+import {Button, Modal} from 'react-bootstrap';
+
+type ConfirmationMessage = {
+  message: string;
+  ctaText: string;
+  ctaVariant: 'primary' | 'success' | 'danger'; // Figure out how to refer to bootstrap variants
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+type AppWithConfirmationsProps = {
+  children: JSX.Element | JSX.Element[];
+};
+
+export const ConfirmationsContext = React.createContext({
+  /* eslint-disable @typescript-eslint/no-empty-function */
+  confirm: ({
+    message,
+    ctaText,
+    ctaVariant,
+    onConfirm,
+    onCancel,
+  }: ConfirmationMessage) => {},
+  /* eslint-enable @typescript-eslint/no-empty-function */
+});
+
+export function AppWithConfirmations({children}: AppWithConfirmationsProps) {
+  const [confirmation, setConfirmation] = useState<
+    ConfirmationMessage | undefined
+  >(undefined);
+
+  const inAppConfirmations = {
+    confirm: ({
+      message,
+      ctaText,
+      ctaVariant,
+      onConfirm,
+      onCancel,
+    }: ConfirmationMessage) => {
+      setConfirmation({message, ctaText, ctaVariant, onConfirm, onCancel});
+    },
+  };
+
+  const handleConfirm = () => {
+    setConfirmation(undefined);
+    confirmation?.onConfirm();
+  };
+
+  const handleCancel = () => {
+    setConfirmation(undefined);
+    confirmation?.onCancel();
+  };
+
+  return (
+    <ConfirmationsContext.Provider value={inAppConfirmations}>
+      {children}
+      <Modal show={!!confirmation}>
+        <Modal.Body>{confirmation?.message}</Modal.Body>
+        <Modal.Footer>
+          <Button onClick={handleConfirm} variant={confirmation?.ctaVariant}>
+            {confirmation?.ctaText}
+          </Button>
+          <Button onClick={handleCancel} variant="light">
+            Cancel
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </ConfirmationsContext.Provider>
+  );
+}

--- a/hasher-matcher-actioner/webapp/src/Sidebar.tsx
+++ b/hasher-matcher-actioner/webapp/src/Sidebar.tsx
@@ -2,10 +2,11 @@
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  */
 
-import React, {useState} from 'react';
+import React, {useState, useContext} from 'react';
 import {Modal, Container, Row, Col, Button} from 'react-bootstrap';
 import {NavLink} from 'react-router-dom';
 import {Auth} from 'aws-amplify';
+import {ConfirmationsContext} from './AppWithConfirmations';
 import './styles/_sidebar.scss';
 
 type SidebarProps = {
@@ -15,8 +16,16 @@ type SidebarProps = {
 export default function Sidebar(
   {className}: SidebarProps = {className: 'sidebar'},
 ): JSX.Element {
-  const [showLogoutModal, setShowLogoutModal] = useState(false);
-
+  const confirmations = useContext(ConfirmationsContext);
+  const showLogoutModal = () => {
+    confirmations.confirm({
+      message: 'Are you sure you want to sign out?',
+      ctaText: 'Yes. Sign me out.',
+      ctaVariant: 'primary',
+      onCancel: () => undefined,
+      onConfirm: () => Auth.signOut(),
+    });
+  };
   return (
     <div className={`${className} d-flex flex-column`}>
       <div className="px-2 pt-2 pb-4Right">
@@ -73,31 +82,11 @@ export default function Sidebar(
           <Button
             variant="link"
             className="nav-link px-1"
-            onClick={() => setShowLogoutModal(true)}>
+            onClick={showLogoutModal}>
             Sign Out
           </Button>
         </li>
       </ul>
-      <Modal show={showLogoutModal} size="lg" centered>
-        <Modal.Header closeButton onHide={() => setShowLogoutModal(false)}>
-          <Modal.Title>Logout</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <Container>
-            <Row>
-              <Col>
-                <p>Are you sure you want to sign out?</p>
-                <Button
-                  variant="primary"
-                  onClick={() => Auth.signOut()}
-                  href="/">
-                  Yes. Sign me out.
-                </Button>
-              </Col>
-            </Row>
-          </Container>
-        </Modal.Body>
-      </Modal>
     </div>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/components/EmptyState.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/EmptyState.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React from 'react';
+import {Col, Button} from 'react-bootstrap';
+
+type HasChildrenOnlyProps = {
+  children: string | JSX.Element | JSX.Element[];
+};
+
+/**
+ * Use within a bootstrap row to create a thematically consistent empty state
+ * across pages.
+ *
+ * Usage:
+ * <EmptyState>
+ *   <EmptyState.Lead>What you want the empty state to say</EmptyState.Lead>
+ *   <EmptyState.CTA onClick={}>Do the thing!</EmptyState.CTA>
+ * </EmptyState>
+ */
+export default function EmptyState({
+  children,
+}: HasChildrenOnlyProps): JSX.Element {
+  return (
+    <Col xs={{offset: 2, span: 8}} className="py-4">
+      <div className="h-100" style={{textAlign: 'center', paddingTop: '40%)'}}>
+        {children}
+      </div>
+    </Col>
+  );
+}
+
+EmptyState.Lead = function ({children}: HasChildrenOnlyProps): JSX.Element {
+  return <p className="lead">{children}</p>;
+};
+
+type CTAProps = HasChildrenOnlyProps & {
+  onClick: () => void;
+};
+
+EmptyState.CTA = function ({children, onClick}: CTAProps): JSX.Element {
+  return (
+    <p className="text-center">
+      <Button variant="success" size="lg" onClick={onClick}>
+        {children}
+      </Button>
+    </p>
+  );
+};

--- a/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/settings/ActionPerformer/ActionPerformerRows.tsx
@@ -4,9 +4,10 @@
 
 import {IonIcon} from '@ionic/react';
 import {checkmark, trashBin, pencil, close} from 'ionicons/icons';
-import React, {useState} from 'react';
+import React, {useContext, useState} from 'react';
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
+import {ConfirmationsContext} from '../../../AppWithConfirmations';
 import {ActionPerformer} from '../../../pages/settings/ActionPerformerSettingsTab';
 import ActionPerformerColumns from './ActionPerformerColumns';
 
@@ -24,12 +25,32 @@ export default function ActionPerformerRows({
   canNotDeleteOrUpdateName,
 }: ActionPerformerRowsProps): JSX.Element {
   const [editing, setEditing] = useState(false);
-  const [showDeleteActionConfirmation, setShowDeleteActionConfirmation] =
-    useState(false);
-  const [showUpdateActionConfirmation, setShowUpdateActionConfirmation] =
-    useState(false);
   const newAction = {...action};
   const [updatedAction, setUpdatedAction] = useState(newAction);
+
+  const confirmations = useContext(ConfirmationsContext);
+  const showDeleteActionConfirmation = () => {
+    confirmations.confirm({
+      message: `Please confirm you want to delete the action named "${action.name}"`,
+      ctaText: 'Yes. Delete this Action.',
+      ctaVariant: 'danger',
+      onCancel: () => undefined,
+      onConfirm: () => deleteAction(action),
+    });
+  };
+
+  const showUpdateActionConfirmation = () => {
+    confirmations.confirm({
+      message: `Please confirm you want to update the action named ${action.name}`,
+      ctaVariant: 'primary',
+      ctaText: 'Yes. Update this Action.',
+      onCancel: () => undefined,
+      onConfirm: () => {
+        setEditing(false);
+        saveAction(updatedAction);
+      },
+    });
+  };
 
   const resetForm = () => {
     setUpdatedAction(action);
@@ -49,38 +70,10 @@ export default function ActionPerformerRows({
             variant="secondary"
             className="table-action-button"
             disabled={canNotDeleteOrUpdateName}
-            onClick={() => setShowDeleteActionConfirmation(true)}>
+            onClick={showDeleteActionConfirmation}>
             <IonIcon icon={trashBin} size="large" color="white" />
           </Button>
           <br />
-          <Modal
-            show={showDeleteActionConfirmation}
-            onHide={() => setShowDeleteActionConfirmation(false)}>
-            <Modal.Header closeButton>
-              <Modal.Title>Confirm Action Delete</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
-              <p>
-                Please confirm you want to delete the action named{' '}
-                <strong>{action.name}</strong>.
-              </p>
-            </Modal.Body>
-            <Modal.Footer>
-              <Button
-                variant="secondary"
-                onClick={() => setShowDeleteActionConfirmation(false)}>
-                Cancel
-              </Button>
-              <Button
-                variant="primary"
-                onClick={() => {
-                  deleteAction(action);
-                  setShowDeleteActionConfirmation(false);
-                }}>
-                Yes, Delete This Action
-              </Button>
-            </Modal.Footer>
-          </Modal>
         </td>
         <ActionPerformerColumns
           action={updatedAction}
@@ -94,9 +87,7 @@ export default function ActionPerformerRows({
           <Button
             variant="outline-primary"
             className="mb-2 table-action-button"
-            onClick={() => {
-              setShowUpdateActionConfirmation(true);
-            }}>
+            onClick={showUpdateActionConfirmation}>
             <IonIcon icon={checkmark} size="large" color="white" />
           </Button>
           <br />
@@ -109,35 +100,6 @@ export default function ActionPerformerRows({
             }}>
             <IonIcon icon={close} size="large" />
           </Button>
-          <Modal
-            show={showUpdateActionConfirmation}
-            onHide={() => setShowUpdateActionConfirmation(false)}>
-            <Modal.Header closeButton>
-              <Modal.Title>Confirm Action Update</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
-              <p>
-                Please confirm you want to update the action named{' '}
-                <strong>{action.name}</strong>.
-              </p>
-            </Modal.Body>
-            <Modal.Footer>
-              <Button
-                variant="secondary"
-                onClick={() => setShowUpdateActionConfirmation(false)}>
-                Cancel
-              </Button>
-              <Button
-                variant="primary"
-                onClick={() => {
-                  setEditing(false);
-                  saveAction(updatedAction);
-                  setShowUpdateActionConfirmation(false);
-                }}>
-                Yes, Update This Action
-              </Button>
-            </Modal.Footer>
-          </Modal>
         </td>
         <ActionPerformerColumns
           action={updatedAction}

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/Members.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/Members.tsx
@@ -20,31 +20,13 @@ import {timeAgoForDate} from '../../utils/DateTimeUtils';
 import Loader from '../../components/Loader';
 import {BlurImage, BlurVideo} from '../../utils/MediaUtils';
 import AddBankMemberModal from './AddBankMemberModal';
+import EmptyState from '../../components/EmptyState';
 
 export type BankTabProps = {
   bankId: string;
 };
 
 type OptionalString = string | undefined;
-
-type EmptyStateProps = {
-  onAdd: () => void;
-};
-
-function EmptyState({onAdd}: EmptyStateProps): JSX.Element {
-  return (
-    <Col xs={{offset: 2, span: 8}} className="py-4">
-      <div className="h-100 text-center mt-4">
-        <p className="lead">You have not added any members to this bank yet!</p>
-        <p className="text-center">
-          <Button variant="success" size="lg" onClick={onAdd}>
-            Add Member
-          </Button>
-        </p>
-      </div>
-    </Col>
-  );
-}
 
 export function MediaUnavailablePreview(): JSX.Element {
   return (
@@ -157,7 +139,14 @@ function BaseMembers({bankId, type}: BaseMembersProps): JSX.Element {
       <Row>
         {neverFetched ? <Loader /> : null}
         {empty ? (
-          <EmptyState onAdd={() => setShowAddMemberModal(true)} />
+          <EmptyState>
+            <EmptyState.Lead>
+              You have not added any members to this bank yet!
+            </EmptyState.Lead>
+            <EmptyState.CTA onClick={() => setShowAddMemberModal(true)}>
+              Add Member
+            </EmptyState.CTA>
+          </EmptyState>
         ) : null}
         {members.map(member => (
           <MemberPreview

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewAllBanks.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewAllBanks.tsx
@@ -6,13 +6,13 @@ import React, {useEffect, useState} from 'react';
 import {Row, Col, Card, Button} from 'react-bootstrap';
 import {generatePath, useHistory} from 'react-router-dom';
 import {fetchAllBanks} from '../../Api';
+import EmptyState from '../../components/EmptyState';
 import Loader from '../../components/Loader';
 import {Bank} from '../../messages/BankMessages';
 
 import FixedWidthCenterAlignedLayout from '../layouts/FixedWidthCenterAlignedLayout';
 import AddBankModal from './AddBankModal';
 
-// TODO: Move to components, and other files
 type BankDetails = {
   bankName: string;
   bankDescription: string;
@@ -37,27 +37,6 @@ function BankCard({
         <p>{bankDescription}</p>
       </Card.Body>
     </Card>
-  );
-}
-// TODO: move to components and other files
-type EmptyStateProps = {
-  onCreate: () => void;
-};
-
-function EmptyState({onCreate}: EmptyStateProps): JSX.Element {
-  return (
-    <Col xs={{offset: 2, span: 8}} className="py-4">
-      <div className="h-100" style={{textAlign: 'center', paddingTop: '40%)'}}>
-        <p className="lead">
-          You have not created banks yet. Create your first bank!
-        </p>
-        <p className="text-center">
-          <Button variant="success" size="lg" onClick={onCreate}>
-            Create Bank
-          </Button>
-        </p>
-      </div>
-    </Col>
   );
 }
 
@@ -113,7 +92,14 @@ export default function ViewAllBanks(): JSX.Element {
         ) : null}
 
         {neverFetched === false && banks.length === 0 ? (
-          <EmptyState onCreate={() => setShowCreateModal(true)} />
+          <EmptyState>
+            <EmptyState.Lead>
+              You have not created banks yet. Create your first bank!
+            </EmptyState.Lead>
+            <EmptyState.CTA onClick={() => setShowCreateModal(true)}>
+              Create Bank
+            </EmptyState.CTA>
+          </EmptyState>
         ) : null}
         {neverFetched === false && banks.length !== 0 ? (
           <Col xs={{offset: 2, span: 8}}>

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBankMember.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  */
 
-import React, {useState, useEffect} from 'react';
+import React, {useState, useContext, useEffect} from 'react';
 import {
   Row,
   Col,
@@ -17,9 +17,8 @@ import {
 import {useParams, Link} from 'react-router-dom';
 
 import {useFormik} from 'formik';
-import {triangleSharp} from 'ionicons/icons';
-import {notStrictEqual} from 'assert';
 import FixedWidthCenterAlignedLayout from '../layouts/FixedWidthCenterAlignedLayout';
+import {ConfirmationsContext} from '../../AppWithConfirmations';
 import {BankMemberWithSignals} from '../../messages/BankMessages';
 import Loader from '../../components/Loader';
 import {fetchBankMember, removeBankMember, updateBankMember} from '../../Api';
@@ -153,7 +152,6 @@ function BankMemberEditableAttributesForm({
 
 export default function ViewBankMember(): JSX.Element {
   const {bankMemberId} = useParams<{bankMemberId: string}>();
-  const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
 
   const [member, setMember] = useState<BankMemberWithSignals>();
   const [pollBuster, setPollBuster] = useState<number>(1);
@@ -170,7 +168,6 @@ export default function ViewBankMember(): JSX.Element {
 
   const removeMember = () => {
     removeBankMember(bankMemberId).then(() => {
-      setShowConfirmModal(false);
       setPollBuster(pollBuster + 1);
     });
   };
@@ -178,6 +175,18 @@ export default function ViewBankMember(): JSX.Element {
   const handleEditableAttributesSubmit = (notes: string, tags: string[]) => {
     updateBankMember(bankMemberId, notes, tags).then(() => {
       setPollBuster(pollBuster + 1);
+    });
+  };
+
+  const confirmations = useContext(ConfirmationsContext);
+  const confirmDeleteBankMember = () => {
+    confirmations.confirm({
+      message:
+        'Are you sure you want to remove this bank member? Once the index rebuilds, HMA will stop matching against this member.',
+      ctaVariant: 'danger',
+      ctaText: 'Yes. Remove this Member.',
+      onCancel: () => undefined,
+      onConfirm: removeMember,
     });
   };
 
@@ -203,7 +212,7 @@ export default function ViewBankMember(): JSX.Element {
             <Button
               size="sm"
               variant="danger"
-              onClick={() => setShowConfirmModal(true)}>
+              onClick={confirmDeleteBankMember}>
               Delete Member
             </Button>
           ) : null}
@@ -296,27 +305,6 @@ export default function ViewBankMember(): JSX.Element {
           </Col>
         </Row>
       )}
-      <Modal show={showConfirmModal} onHide={() => setShowConfirmModal(false)}>
-        <Modal.Header closeButton>
-          <Modal.Title>Remove the BankMember </Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <p>
-            Are you sure you want to remove this bank member? Once the index
-            rebuilds, HMA will stop matching against this member.
-          </p>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button
-            variant="secondary"
-            onClick={() => setShowConfirmModal(false)}>
-            Cancel
-          </Button>
-          <Button variant="primary" onClick={removeMember}>
-            Yes, Remove this Member
-          </Button>
-        </Modal.Footer>
-      </Modal>
     </FixedWidthCenterAlignedLayout>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.tsx
@@ -12,6 +12,7 @@ import {
   Card,
   Col,
 } from 'react-bootstrap';
+import classNames from 'classnames';
 import ThreatExchangePrivacyGroupCard from '../../components/settings/ThreatExchangePrivacyGroupCard';
 import {
   HolidaysDatasetInformationBlock,
@@ -27,27 +28,7 @@ import {
 import {NotificationsContext} from '../../AppWithNotifications';
 import SettingsTabPane from './SettingsTabPane';
 import ThreatExchangeTokenEditor from './ThreatExchangeTokenEditor';
-
-/**
- * Empty state when no datasets are found in the backend.
- */
-function EmptyState(): JSX.Element {
-  return (
-    <Col xs={{offset: 2, span: 8}} className="py-4">
-      <div className="h-100" style={{textAlign: 'center'}}>
-        <p className="lead">No ThreatExchange Datasets found.</p>
-        <p>
-          Datasets map to{' '}
-          <a href="https://developers.facebook.com/docs/threat-exchange/reference/apis/threat-privacy-group/v12.0">
-            Threat Privacy Groups
-          </a>{' '}
-          on ThreatExchange. Use the sync button to fetch all privacy groups you
-          have access to.
-        </p>
-      </div>
-    </Col>
-  );
-}
+import EmptyState from '../../components/EmptyState';
 
 type Dataset = {
   privacy_group_id: string;
@@ -148,7 +129,14 @@ export default function ThreatExchangeSettingsTab(): JSX.Element {
         <Col xs={{span: 8}}>
           <h3>ThreatExchange Datasets </h3>
         </Col>
-        <Col xs={{span: 4}} className="text-right">
+        <Col
+          xs={{span: 4}}
+          className={classNames({
+            'text-right': true,
+            // Only show the sync button if not we have datasets, otherwise
+            // there will be two CTAs (in the empty state and this one)
+            invisible: !loading && (!datasets || datasets.length === 0),
+          })}>
           <OverlayTrigger
             key="syncButton"
             placement="left"
@@ -191,7 +179,19 @@ export default function ThreatExchangeSettingsTab(): JSX.Element {
         ) : null}
 
         {!loading && (!datasets || datasets.length === 0) ? (
-          <EmptyState />
+          <EmptyState>
+            <EmptyState.Lead>No ThreatExchange Datasets found</EmptyState.Lead>
+
+            <p>
+              Datasets map to{' '}
+              <a href="https://developers.facebook.com/docs/threat-exchange/reference/apis/threat-privacy-group/v12.0">
+                Threat Privacy Groups
+              </a>{' '}
+              on ThreatExchange. Use the sync button to fetch all privacy groups
+              you have access to.
+            </p>
+            <EmptyState.CTA onClick={onSync}>Sync</EmptyState.CTA>
+          </EmptyState>
         ) : (
           datasets.map(dataset => (
             <ThreatExchangePrivacyGroupCard


### PR DESCRIPTION
Summary
---------
### [`cf266444`](https://github.com/facebook/ThreatExchange/pull/926/commits/cf26644485287d6e8a0156a6f9a6b6c7149bf3e3) Consolidate empty state into its own component
I found myself using empty states again in ActionRuleSettings and a TODO in ViewAllBanks asking me to consolidate them.  Also, with the new <EmptyState> ThreatExchangeSettingsTab would have two CTA's so added a conditional that hides 'Sync' when empty state is shown.  
### [`d58d5846`](https://github.com/facebook/ThreatExchange/pull/926/commit
s/d58d5846ab21145d1d24d6b882ec3d58613cbf62) Consolidate confirmations into a single component
Confirming some action on the UI is  a pretty common workflow. I have noticed many Modals scattered through the codebase all trying the same thing.  This, much like toasts introduced in #897 adds common infrastructure to do confirmations.  It also ports over almost all instances of confirmations. Except ActionRules because that is turning out to be harder to extract because of other changes I am making.  

Test Plan
---------
# For Empty States

<img width="1132" alt="Screen Shot 2022-02-02 at 12 14 28" src="https://user-images.githubusercontent.com/217056/152712398-49821171-688d-40e5-bdc5-1014b6b466e7.png">
<img width="1126" alt="Screen Shot 2022-02-02 at 12 14 40" src="https://user-images.githubusercontent.com/217056/152712401-ca944847-cc73-48e0-93f2-5bc920019ec2.png">
<img width="1141" alt="Screen Shot 2022-02-02 at 12 15 15" src="https://user-images.githubusercontent.com/217056/152712402-08410936-061b-4915-8694-2839e6a33e94.png">

# For confirmations

<img width="860" alt="Screen Shot 2022-02-06 at 20 47 37" src="https://user-images.githubusercontent.com/217056/152712595-c3e50d8a-b858-4211-abb1-017203099f34.png">
<img width="760" alt="Screen Shot 2022-02-06 at 20 47 59" src="https://user-images.githubusercontent.com/217056/152712596-428ec72a-1461-4faf-b178-44e6a2869a65.png">
<img width="897" alt="Screen Shot 2022-02-06 at 20 48 18" src="https://user-images.githubusercontent.com/217056/152712598-5c6c31ff-5b9b-4d9e-b9d7-85b407ca1e4e.png">

