### PR TITLE
[devcontainer] update Dockerfile base image to specify AMD64 

### DIFF
--- a/hasher-matcher-actioner/.devcontainer/Dockerfile
+++ b/hasher-matcher-actioner/.devcontainer/Dockerfile
@@ -2,7 +2,9 @@
 
 # [Install python]
 # TODO: pin version later. Otherwise starting up will be too slow.
-FROM python:3.8-buster
+# Note: We specify AMD64 architecture as it is currently the only one supported for this devcontainer
+# relevant for ARM architecture machines as using `python:3.8-buster` will have it try to use that instead
+FROM amd64/python:3.8-buster
 
 # [Unixname wrestling]
 # Some of our script (docker-related) are dependent on the unixname. Would 


### PR DESCRIPTION
Summary
---------

Fixes a bug where if an ARM architecture machine attempts to use the base image in the dev Dockerfile, it will use the ARM version and fail. amd64 is now specified to address this. 

This shouldn't change anything for other users of the dev container but they will still need to rebuild. 

Test Plan
---------

Built devcontainer with change on both an M1 Pro Mac and an Intel Core i9 machine without errors. 
