### PR TITLE
Add an EFS durable file system for hashing lambda

### DIFF
--- a/hasher-matcher-actioner/terraform/.terraform.lock.hcl
+++ b/hasher-matcher-actioner/terraform/.terraform.lock.hcl
@@ -2,23 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.32.0"
-  constraints = "~> 3.0"
+  version     = "3.74.3"
+  constraints = "~> 3.0, >= 3.63.0"
   hashes = [
-    "h1:aY98OcgyLZJVEoqWB8tro023Fx3khJUWQOxwAfd94pQ=",
-    "h1:l8jJYQ4bPEbNwZUoHYmeR1woajPzJSX5hPCLWuRVFwc=",
-    "h1:tY5R3hRBB1v8v3MT+ofoCJ/Vz/b/4PXo3xtBKtw7T4A=",
-    "zh:04e4f700c21b1f58e7603638160bd5ad3b85519c35dc75bada3e52b164d06d3e",
-    "zh:09f2338404d4b2d4dcb29781ac59a6955d935745e896d4ee661d83cac8d7c677",
-    "zh:16bdf96d8139268766921d5b891b865f67936190dc302283ba50b94e42510ec5",
-    "zh:1f0eb671390ee41ddf22faf22d00da636e57164214a37c77f7d3fb1f19ea9cce",
-    "zh:3703b0ba118887cb558085f4b7e732e4e374f455221fcf724bada6f71bd25d55",
-    "zh:a344b8b1d0c541abcfc3a5bd22aa28d1a07aff416db753d53219158a86e956cc",
-    "zh:a4798f3bf4ecbdfcd2ea72061e54053423a47f48812749b2cc7dc8dcf8a11eb4",
-    "zh:aeb5c18afe26388748289f2a3819c7c9210cb669efe01b3e28bf542c51c83bd7",
-    "zh:b0a3f5940f76dbd3ea9699f98f9cabc443c210c06f30caeb792e5843b7550cc1",
-    "zh:baa2854e3fbf3df9653a5e6a0f1093a018dad39312346426f4bcefc2ebfd74cc",
-    "zh:e305b3d227f2013ddd7cf22f2cfa4603a55187c8eddd07f980350a828b67ce49",
+    "h1:h4TYqgRKTuuWfZtxJnEGcs/NxGCaxZ4jr0IwTfgZDRM=",
+    "zh:25401cd4667d0496caf7e92e74ecef7c98cf74465570705cda2207770c27ff6c",
+    "zh:2d154527a9b2585f72fc5eceac635257e3f50f68de8a519e71c795d5166a0a22",
+    "zh:499fa5201804a5a33a90d683147fb2f81da91bfcd8ed20293f88f6f39cedbf97",
+    "zh:730284250fd949a59afb6935b3a68a33709d5a78b686fa98f351ad32c919cfc3",
+    "zh:7461ebd6fb35900d620cfa3f42126d988ea1e604ee3828d1c64d5727f908bd26",
+    "zh:7c85743b31c7459f8e74aaa98471ba82c54517eb908603411808a12982d89b1c",
+    "zh:8ed977b7fb97de624f5414b08cab36fd973a624072e0e9082c0c822e0864c7b9",
+    "zh:94ae7313bb0b425d4007a0b70601a337972c4f0f7a323487acf69215e74b4425",
+    "zh:b5a1589672d709da725a72c46d28bf5b2dea71325f6e0b44a0049f644cd09eba",
+    "zh:c7e8e7ce59e4578416557fc2f138137af3c8365ac3e34f0ff5166323c7d641a1",
+    "zh:ccf2e286b207e749fff76bb4075deddb9e7e237936d8654f34828c54e7035455",
   ]
 }
 

--- a/hasher-matcher-actioner/terraform/durable-fs/main.tf
+++ b/hasher-matcher-actioner/terraform/durable-fs/main.tf
@@ -1,0 +1,59 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+data "aws_region" "current" {}
+
+/*
+ * # Durable file system
+ * Hashing labmda uses an elastic file-system to write hashes at a
+ * high-througput. The files so-generated are used in other lambdas to create
+ * clusters from recently seen content.
+ *
+ * EFS can only be mounted onto lambdas that are connected to a VPC. So, this
+ * module ends up creating a dedicated VPC.
+ */
+resource "aws_efs_file_system" "lcc_durable_fs" {
+  creation_token = "${var.prefix}-lcc-durable-filesystem"
+
+  tags = merge(
+    var.additional_tags,
+    {
+      Name = "LCC_DurableFS"
+    }
+  )
+}
+
+# Create a VPC for EFS mounts
+module "lcc_efs_vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name          = "${var.prefix}-lcc-efs-vpc"
+  cidr          = "10.10.0.0/16"
+  azs           = ["${data.aws_region.current.name}a", "${data.aws_region.current.name}b", "${data.aws_region.current.name}c"]
+  intra_subnets = ["10.10.101.0/24"]
+}
+
+# Mount target connects the file system to the subnet
+resource "aws_efs_mount_target" "lcc_durable_fs" {
+  file_system_id  = aws_efs_file_system.lcc_durable_fs.id
+  subnet_id       = module.lcc_efs_vpc.intra_subnets[0]
+  security_groups = [module.lcc_efs_vpc.default_security_group_id]
+}
+
+# EFS access point used by lambda file system
+resource "aws_efs_access_point" "access_point_for_lambda" {
+  file_system_id = aws_efs_file_system.lcc_durable_fs.id
+
+  root_directory {
+    path = "/lambda"
+    creation_info {
+      owner_gid   = 1000
+      owner_uid   = 1000
+      permissions = "777"
+    }
+  }
+
+  posix_user {
+    gid = 1000
+    uid = 1000
+  }
+}

--- a/hasher-matcher-actioner/terraform/durable-fs/outputs.tf
+++ b/hasher-matcher-actioner/terraform/durable-fs/outputs.tf
@@ -1,0 +1,12 @@
+
+output "durable_fs_security_group_ids" {
+  value = [module.lcc_efs_vpc.default_security_group_id]
+}
+
+output "durable_fs_subnet_ids" {
+  value = module.lcc_efs_vpc.intra_subnets
+}
+
+output "durable_fs_arn" {
+  value = aws_efs_access_point.access_point_for_lambda.arn
+}

--- a/hasher-matcher-actioner/terraform/durable-fs/variables.tf
+++ b/hasher-matcher-actioner/terraform/durable-fs/variables.tf
@@ -1,0 +1,11 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+variable "prefix" {
+  description = "Prefix to use for resource names"
+  type        = string
+}
+
+variable "additional_tags" {
+  description = "Additional resource tags"
+  type        = map(string)
+}

--- a/hasher-matcher-actioner/terraform/hasher/main.tf
+++ b/hasher-matcher-actioner/terraform/hasher/main.tf
@@ -27,6 +27,16 @@ resource "aws_lambda_function" "hashing_lambda" {
     }
   }
 
+  vpc_config {
+    security_group_ids = var.durable_fs_security_group_ids
+    subnet_ids         = var.durable_fs_subnet_ids
+  }
+
+  file_system_config {
+    local_mount_path = var.durable_fs_local_mount_path
+    arn              = var.durable_fs_arn
+  }
+
   tags = merge(
     var.additional_tags,
     {
@@ -113,6 +123,11 @@ data "aws_iam_policy_document" "hashing_lambda" {
 resource "aws_iam_role_policy_attachment" "hashing_lambda_permissions" {
   role       = aws_iam_role.hashing_lambda_role.name
   policy_arn = aws_iam_policy.hashing_lambda_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "AWSLambdaVPCAccessExecutionRole" {
+  role       = aws_iam_role.hashing_lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_lambda_event_source_mapping" "submissions_to_hasher" {

--- a/hasher-matcher-actioner/terraform/hasher/variables.tf
+++ b/hasher-matcher-actioner/terraform/hasher/variables.tf
@@ -81,3 +81,23 @@ variable "image_data_storage" {
     all_bucket_arns = list(string)
   })
 }
+
+variable "durable_fs_security_group_ids" {
+  description = "SG Ids for the durable file-system we are mounting on the hashing lambda."
+  type        = list(string)
+}
+
+variable "durable_fs_subnet_ids" {
+  description = "subnet Ids for the durable file-system we are mounting on the hashing lambda."
+  type        = list(string)
+}
+
+variable "durable_fs_local_mount_path" {
+  description = "Local mount path durable file-system we are mounting on the hashing lambda."
+  type        = string
+}
+
+variable "durable_fs_arn" {
+  description = "ARN for the durable file-system we are mounting on the hashing lambda."
+  type        = string
+}


### PR DESCRIPTION
Summary
---
This file system will be used to write content hashes by the hashing lambda so that we can build indexes to use for retroaction.

Test Plan
---
```
$ terraform init
$ terraform apply
```

Added the following snippet to the hashing lambda and deployed.

```python
    with open(f"/mnt/durable-storage/{context.aws_request_id}.file", "w") as f:
        f.write("Hello, World!")

    from os import listdir

    logger.info(listdir("/mnt/durable-storage/"))
```

Hit test on the AWS console a few times, deployed a new version of the lambda and then checked the logs..

Saw the following

```
[INFO]	2022-02-24T03:21:05.008Z	9e057c0d-2027-468a-b797-f261d3964178	['944d7e76-0fb5-4a7b-9104-de86fd90dfc0.file', 'a36b2c1b-1ef4-47d0-aa5c-7f69498c12fd.file', '57e95dc9-efaa-4707-abac-ab1017c7c7ed.file', 'abff2ab6-fd19-47dd-85d8-3bcf2f63c5b7.file', '51191f91-75fc-4f6d-a770-44c46725c054.file', '9e057c0d-2027-468a-b797-f261d3964178.file']
```

See how files accumulate in the file system.
