### PR TITLE
[hma][hmalib] bump mypy version and update hmacli install command

### DIFF
--- a/hasher-matcher-actioner/Makefile
+++ b/hasher-matcher-actioner/Makefile
@@ -52,4 +52,4 @@ dev_apply_with_newest_docker_image:
 	terraform -chdir=terraform apply -var "hma_lambda_docker_uri=${DOCKER_URI}@$${DIGEST}"
 
 dev_install_hmacli:
-	python3 -m pip install -r requirements-dev.txt
+	python3 -m pip install -e '.[all]'

--- a/hasher-matcher-actioner/mypy.ini
+++ b/hasher-matcher-actioner/mypy.ini
@@ -3,6 +3,9 @@
 [mypy-urllib3.*]
 ignore_missing_imports = True
 
+[mypy-requests.packages.urllib3.*]
+ignore_missing_imports = True
+
 [mypy-pandas.*]
 ignore_missing_imports = True
 

--- a/hasher-matcher-actioner/requirements-dev.txt
+++ b/hasher-matcher-actioner/requirements-dev.txt
@@ -1,6 +1,6 @@
 .[all]
 pytest==6.2.1
-mypy==0.812
+mypy==0.910
 black==21.12b0
 moto==2.3.2
 pandas==1.3.5

--- a/hasher-matcher-actioner/setup.py
+++ b/hasher-matcher-actioner/setup.py
@@ -15,6 +15,7 @@ all_extras = set(sum(extras_require.values(), []))
 extras_require["test"] = sorted({"pytest==6.2.1"} | all_extras)
 extras_require["package"] = ["wheel"]
 extras_require["lint"] = ["black==21.12b0"]
+extras_require["type"] = ["types-requests==2.27.1"]
 extras_require["all"] = sorted(set(sum(extras_require.values(), [])))
 
 setup(


### PR DESCRIPTION
Summary
---------

`mypy=0.812` has a dependency that was breaking for the install commands for python3.8+ macOS on arm64. This should hopefully address that. I also updated the make install for hmalib to use `-e` which fixed an issue where my dev venv was not find `hmalib` when I tried running `hmacli` commands 

This should change anything for devcontainer users but I think it is important that install works outside of this as well.
(aside: My personal use case is if I am jumping between hmalib and python-theatexchange (or a third project) being able to use the hmacli to run quick checks or tests outside of the devcontainer  is helpful)

Test Plan
---------

Confirmed that `make dev_install_hmacli` run in both native macOS and linux devcontainer without error. 
