### PR TITLE
[pdq][cpp] add -Wno-unknown-warning-option to Makefile flags avoid error for unrecognized flags

### DIFF
--- a/pdq/cpp/Makefile
+++ b/pdq/cpp/Makefile
@@ -3,7 +3,7 @@ CC=g++ -g -std=c++11
 IFLAGS=-I../.. -I.
 # -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation is because of CImg.h
 WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation -Wno-unknown-warning-option -Werror
-LFLAGS=-lm
+LFLAGS=-lm -lpthread
 
 CCOPT=$(CC) $(CFLAGS) $(IFLAGS) $(WFLAGS) -O3
 CCDBG=$(CC) -g $(CFLAGS) $(IFLAGS) $(WFLAGS)

--- a/pdq/cpp/Makefile
+++ b/pdq/cpp/Makefile
@@ -2,7 +2,7 @@
 CC=g++ -g -std=c++11
 IFLAGS=-I../.. -I.
 # -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation is because of CImg.h
-WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation -Werror
+WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation -Wno-unknown-warning-option -Werror
 LFLAGS=-lm
 
 CCOPT=$(CC) $(CFLAGS) $(IFLAGS) $(WFLAGS) -O3


### PR DESCRIPTION
Summary
---------

Some of the ignore warning flags added a long time ago are not longer supported by all version of clang/gcc. Adding `-Wno-unknown-warning-option` should allow those version to still successfully build the pdq cpp executables.

Test Plan
---------
ran `make` and confirmed successful compilation both on macOS and linux machines:
- Apple clang version 13.0.0 (clang-1300.0.29.30) arm64-apple-darwin21.3.0
- g++ (GCC) 8.5.0 20210514 (Red Hat 8.5.0-3)