### PR TITLE
Memory pressure test of indexes

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/eat_memory.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/eat_memory.py
@@ -1,0 +1,28 @@
+from hmalib.common.logging import get_logger
+from threatexchange.signal_type.pdq_index import PDQIndex,PDQFlatIndex
+from threatexchange.signal_type.signal_base import TrivialSignalTypeIndex
+import secrets
+
+
+# Make upload_docker
+# terraform -chdir=terraform apply
+
+logger = get_logger(__name__)
+
+items = []
+indexDict = {'PDQIndex':PDQIndex,'PDQFlatIndex':PDQFlatIndex,'TrivialSignalTypeIndex':TrivialSignalTypeIndex}
+def index_increaser(indexType):
+    logger.info(len(items))
+    indexType.build(items)
+    logger.info(f'{indexType} Built')
+
+
+def lambda_handler(event, context):
+    events = list(event.values())
+    i= 1
+    while i < (int(events[1])+1):
+        items.append((secrets.token_hex(32),{"content_id": "8a642764-efab-4d53-a601-523abdcebee3"}))
+        i +=1
+    index_increaser(indexDict[events[0]])
+    items.clear()
+

--- a/hasher-matcher-actioner/terraform/eat_memory/main.tf
+++ b/hasher-matcher-actioner/terraform/eat_memory/main.tf
@@ -1,0 +1,84 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+### Lambda for eat_memory ###
+
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_lambda_function" "eat_memory" {
+  function_name = "${var.prefix}_eat_memory"
+  package_type  = "Image"
+  role          = aws_iam_role.eat_memory.arn
+  image_uri     = var.lambda_docker_info.uri
+  image_config {
+    command = ["hmalib.lambdas.eat_memory.lambda_handler"]
+  }
+
+  # Timeout is kept less than the fetch frequency. Right now, fetch frequency is
+  # 15 minutes, so we timeout at 12. The more this value, the more time every
+  # single fetch has to complete.
+  # TODO: make this computed from var.fetch_frequency.
+  timeout = 60 * 12
+
+  memory_size = 128
+environment {
+    variables = {  FRANKLIN="franklin"
+}
+}
+}
+
+
+resource "aws_cloudwatch_log_group" "eat_memory" {
+  name              = "/aws/lambda/${aws_lambda_function.eat_memory.function_name}"
+  tags = merge(
+    var.additional_tags,
+    {
+      Name = "FetcherLambdaLogGroup"
+    }
+  )
+}
+
+resource "aws_iam_role" "eat_memory" {
+  name_prefix        = "${var.prefix}_eat_memory"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags = merge(
+    var.additional_tags,
+    {
+      Name = "EatMemoryLambdaRole"
+    }
+  )
+}
+
+data "aws_iam_policy_document" "eat_memory" {
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams"
+    ]
+    resources = ["${aws_cloudwatch_log_group.eat_memory.arn}:*"]
+  }
+
+}
+
+resource "aws_iam_policy" "eat_memory" {
+  name_prefix = "${var.prefix}_eat_memory_role_policy"
+  description = "Permissions for Fetcher Lambda"
+  policy      = data.aws_iam_policy_document.eat_memory.json
+}
+
+resource "aws_iam_role_policy_attachment" "eat_memory" {
+  role       = aws_iam_role.eat_memory.name
+  policy_arn = aws_iam_policy.eat_memory.arn
+}
+

--- a/hasher-matcher-actioner/terraform/eat_memory/variables.tf
+++ b/hasher-matcher-actioner/terraform/eat_memory/variables.tf
@@ -1,0 +1,20 @@
+variable "prefix" {
+  description = "Prefix to use for resource names"
+  type        = string
+}
+
+variable "lambda_docker_info" {
+  description = "Docker container information for lambda functions"
+  type = object({
+    uri = string
+    commands = object({
+      eat_memory = string
+    })
+  })
+}
+
+
+variable "additional_tags" {
+  description = "Additional resource tags"
+  type        = map(string)
+}

--- a/lambda-terminal.py
+++ b/lambda-terminal.py
@@ -1,0 +1,21 @@
+import subprocess
+import json
+
+for x in range(100):
+    itemCount = 87672000+(x*1000)
+    payload ={
+        "index": "PDQFlatIndex",
+        "itemCount": f"{itemCount}"
+        }
+    payload_obj = json.dumps(payload)   
+    invoke_command = f"""aws lambda invoke --function-name franklin_eat_memory --cli-binary-format raw-in-base64-out --payload '{payload_obj}' response.json """
+    print("Item Count: ",itemCount)
+
+    status = subprocess.Popen(invoke_command,shell=True,stdout=subprocess.PIPE)
+
+    status_string = (str(status.stdout.read()))
+    if "FunctionError" not in status_string:
+        print(status_string)
+    else:
+        print(status_string)
+        break


### PR DESCRIPTION
Content
---------
To use the existing FAISS based indexes for Live Content Clustering, we wanted to identify how many content ids could be accommodated in a FAISS index in a lambda index. If users wanted to exceed the limits, they would have to go for a larger lambda instance.

We tested PDQIndex, PDQFlatIndex and TrivialSignalType indexes at increasing lambda memory size values and measured how many hash + content_id entries it could take before AWS killed the lambda for taking up more memory than allocated.

Methodology
---------
A new lambda `eat_memory` was written and terraformed. It takes in the number of entries to generate in the event payload. It then tries to create an index of that size.

Because AWS will kill a lambda that takes more memory than is allocated, we were able to use the killed lambda logs as a signal and identify at what point the lambda memory is exhausted. We tested each index max breakpoint at least 3 times and occasionally the index would still build because of slightly different index build sizes. Each datapoint is subject to a margin of error of 1-2 thousand above what was recorded because of that but that shouldn't affect the slope of each index greatly since millions of Content IDs are required to determine an overall trend.  

Automation
---------

The tests for the `eat_memory` lambda were automated with the lambda-terminal script. The index being tested and how many starting content IDS added to the index can be adjusted in the payload of the script. By adjusting the for loop range amount, you can determine how many content IDs the tests increment by. To change how much memory is being allocated to the lambda, in the AWS Management Console, navigate to the Lambda page, select the eat_memory function, and go to the configuration section and under memory you can allot up to 10240 MBs. After configuring the index type, starting content ID amount, testing range, and allotted lambda memory, you can run the script to obtain test results with
```
python lambda-terminal.py 
```
The readout for if the lambda calls was successful should print out in the terminal. You can read the logs for the `eat_memory` lambda in the Cloud Watch page of the AWS Management Console.

Summary
---------
Below I have provided test results of how many content IDs a certain index can build at specific AWS Lambda memory allocations. The three indexes I tested were the PDQ Index, PDQ Flat Index, and Trivial Signal Type Index. The lambda for these tests is written in eat_memory.py and I automated the tests with my lambda-terminal script. 

Out Of Memory Content ID Count Breakpoints (In Thousands)
| # MB | PDQ | PDQF | TST |
| --- | --- | ---| --- | 
| 128 | 50  | 109  | 174  |
| 256  | 138  | 248 | 369  |
| 512 | 347  | 524 | 783  |
| 1024  | 720  | 1077  | 1657 |
| 2048  | 1550  | 2180 | 3462 |
| 4096 | 3251  | 4388  | 7100  |

![PDQ Index Breakpoints](https://user-images.githubusercontent.com/54521266/158892604-6598835d-8ee4-4dcc-a9a9-ffa05d7012c2.png)
![PDQ Flat Index Breakpoints](https://user-images.githubusercontent.com/54521266/158892752-66d768f9-fa83-4a4f-8a94-738587cda3f3.png)
![Trivial Signal Type Index Breakpoints](https://user-images.githubusercontent.com/54521266/158892653-4a97ed1a-40e5-4705-96c9-2113bea1f890.png)
![Index Breakpoint Comparison](https://user-images.githubusercontent.com/54521266/158892665-f2402b12-9ba9-4b0d-bb9e-8c63fc61c4b0.png)

