### PR TITLE
hot-fix: docusaurus hrefs

### DIFF
--- a/hasher-matcher-actioner/docs/docusaurus.config.js
+++ b/hasher-matcher-actioner/docs/docusaurus.config.js
@@ -77,19 +77,19 @@ const config = {
             title: 'Guides',
             items: [
               {
-                href: 'installation/index',
+                href: 'docs/installation',
                 label: 'Install',
               },
               {
-                href: 'guides/index',
+                href: 'docs/guides',
                 label: 'Usage',
               },
               {
-                href: 'customizing/index',
+                href: 'docs/customizing',
                 label: 'Customize',
               },
               {
-                href: 'contributing/index',
+                href: 'docs/contributing',
                 label: 'Contribute',
               }
             ],


### PR DESCRIPTION
Summary
---------
A [recently added workflow](https://github.com/facebook/ThreatExchange/runs/5514990131?check_suite_focus=true) failed because the hrefs were wrongly setup.

Test Plan
---------
```
dipanjanm@<devcontainer>:/workspaces/ThreatExchange/hasher-matcher-actioner/docs$ npm run build 

> docs@0.0.0 build
> docusaurus build

[INFO] [en] Creating an optimized production build...
..... stuff
[SUCCESS] Generated static files in build.
[INFO] Use `npm run serve` command to test your build locally.
```

This [SUCCESS] did not happen earlier. We got the same error as in the logs of the workflow.