### PR TITLE
hotfix: use appropriate baseUrl. github repo names are case-sensitive

### DIFF
--- a/hasher-matcher-actioner/docs/docusaurus.config.js
+++ b/hasher-matcher-actioner/docs/docusaurus.config.js
@@ -9,7 +9,7 @@ const config = {
   title: 'HMA',
   tagline: 'Hasher Matcher Actioner',
   url: 'https://facebook.github.io/',
-  baseUrl: '/threatexchange/',
+  baseUrl: '/ThreatExchange/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
Test Plan
---------
<img width="731" alt="Screen Shot 2022-03-11 at 15 20 25" src="https://user-images.githubusercontent.com/217056/157955254-185ec556-527d-4f50-811c-ed080af39505.png">
 this change, did you add test, run something locally...-->
