### PR TITLE
[hma][api] add prototype hash + match synchronous API 

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -76,7 +76,7 @@ def _get_matcher(index_bucket_name: str, banks_table: BanksTable) -> Matcher:
 _hasher = None
 
 
-def _get_haher() -> UnifiedHasher:
+def _get_hasher() -> UnifiedHasher:
     global _hasher
     if _hasher is None:
         _hasher = UnifiedHasher(
@@ -549,7 +549,7 @@ def get_matches_api(
             return MediaFetchError()
 
         signal_to_matches = {}
-        for signal in _get_haher().get_hashes(request.content_type, bytes_):
+        for signal in _get_hasher().get_hashes(request.content_type, bytes_):
             signal_to_matches[signal.signal_type.get_name()] = {
                 signal.signal_value: _matches_for_hash(
                     signal_type=signal.signal_type, signal_value=signal.signal_value

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -9,13 +9,20 @@ from dataclasses import dataclass, asdict
 from mypy_boto3_dynamodb.service_resource import Table
 import typing as t
 from enum import Enum
+from urllib.error import HTTPError
 from mypy_boto3_sqs.client import SQSClient
 
 from threatexchange.descriptor import ThreatDescriptor
 from threatexchange.signal_type.signal_base import SignalType
 from threatexchange.signal_type.md5 import VideoMD5Signal
 from threatexchange.signal_type.pdq import PdqSignal
-from threatexchange.content_type.meta import get_signal_types_by_name
+from threatexchange.content_type.content_base import ContentType
+from threatexchange.content_type.photo import PhotoContent
+from threatexchange.content_type.video import VideoContent
+from threatexchange.content_type.meta import (
+    get_signal_types_by_name,
+    get_content_types_by_name,
+)
 
 from hmalib.common.models.pipeline import MatchRecord
 from hmalib.common.models.signal import (
@@ -25,7 +32,10 @@ from hmalib.common.models.signal import (
 from hmalib.common.logging import get_logger
 from hmalib.common.messages.match import BankedSignal
 from hmalib.common.messages.writeback import WritebackMessage
-from hmalib.indexers.metadata import BANKS_SOURCE_SHORT_CODE
+from hmalib.indexers.metadata import (
+    BANKS_SOURCE_SHORT_CODE,
+    BankedSignalIndexMetadata,
+)
 from hmalib.lambdas.api.middleware import (
     jsoninator,
     JSONifiable,
@@ -35,6 +45,9 @@ from hmalib.lambdas.api.middleware import (
 from hmalib.common.config import HMAConfig
 from hmalib.common.models.bank import BankMember, BanksTable
 from hmalib.matchers.matchers_base import Matcher
+
+from hmalib.hashing.unified_hasher import UnifiedHasher
+from hmalib.common.content_sources import URLContentSource
 
 
 logger = get_logger(__name__)
@@ -58,6 +71,21 @@ def _get_matcher(index_bucket_name: str, banks_table: BanksTable) -> Matcher:
         )
 
     return _matcher
+
+
+_hasher = None
+
+
+def _get_haher() -> UnifiedHasher:
+    global _hasher
+    if _hasher is None:
+        _hasher = UnifiedHasher(
+            supported_content_types=[PhotoContent, VideoContent],
+            supported_signal_types=[PdqSignal, VideoMD5Signal],
+            output_queue_url="",
+        )
+
+    return _hasher
 
 
 @dataclass
@@ -252,8 +280,20 @@ class MatchesForHashRequest(DictParseable):
 
     @classmethod
     def from_dict(cls, d):
-        base = cls(**{f.name: d.get(f.name, None) for f in dataclasses.fields(cls)})
-        base.signal_type = get_signal_types_by_name()[base.signal_type]
+        base = cls(**{f.name: d.get(f.name, None) for f in dataclasses.fields(cls)})  # type: ignore # tiny hack to get convert string fields
+        base.signal_type = get_signal_types_by_name()[base.signal_type]  # type: ignore # tiny hack to get SignalType from string in request
+        return base
+
+
+@dataclass
+class MatchesForMediaRequest(DictParseable):
+    content_url: str
+    content_type: t.Type[ContentType]
+
+    @classmethod
+    def from_dict(cls, d):
+        base = cls(**{f.name: d.get(f.name, None) for f in dataclasses.fields(cls)})  # type: ignore # tiny hack to get convert string fields
+        base.content_type = get_content_types_by_name()[base.content_type]  # type: ignore # tiny hack to get ContentType from string in request
         return base
 
 
@@ -296,10 +336,32 @@ class MatchesForHash(JSONifiable):
 @dataclass
 class MatchesForHashResponse(JSONifiable):
     matches: t.List[MatchesForHash]
-    signal_value: str
 
     def to_json(self) -> t.Dict:
         return {"matches": [match.to_json() for match in self.matches]}
+
+
+@dataclass
+class MatchesForMediaResponse(JSONifiable):
+    signal_to_matches: t.Dict[str, t.Dict[str, t.List[MatchesForHash]]]
+    # example: { "pdq" : { "<hash>" : [<matches?>] } }
+
+    def to_json(self) -> t.Dict:
+        return {
+            "signal_to_matches": {
+                signal_type: {signal_val: [match.to_json() for match in matches]}
+                for (signal_val, matches) in hash_to_match.items()
+            }
+            for (signal_type, hash_to_match) in self.signal_to_matches.items()
+        }
+
+
+@dataclass
+class MediaFetchError(JSONifiable):
+    def to_json(self) -> t.Dict:
+        return {
+            "message": "Failed to fetch media from provided url",
+        }
 
 
 def get_matches_api(
@@ -327,9 +389,9 @@ def get_matches_api(
         """
         Return all, or a filtered list of matches based on query params.
         """
-        signal_q = bottle.request.query.signal_q or None
-        signal_source = bottle.request.query.signal_source or None
-        content_q = bottle.request.query.content_q or None
+        signal_q = bottle.request.query.signal_q or None  # type: ignore # ToDo refactor to use `jsoninator(<requestObj>, from_query=True)``
+        signal_source = bottle.request.query.signal_source or None  # type: ignore # ToDo refactor to use `jsoninator(<requestObj>, from_query=True)``
+        content_q = bottle.request.query.content_q or None  # type: ignore # ToDo refactor to use `jsoninator(<requestObj>, from_query=True)``
 
         if content_q:
             records = MatchRecord.get_from_content_id(datastore_table, content_q)
@@ -359,7 +421,7 @@ def get_matches_api(
         Return the match details for a given content id.
         """
         results = []
-        if content_id := bottle.request.query.content_id or None:
+        if content_id := bottle.request.query.content_id or None:  # type: ignore # ToDo refactor to use `jsoninator(<requestObj>, from_query=True)``
             results = get_match_details(
                 datastore_table=datastore_table,
                 banks_table=banks_table,
@@ -372,10 +434,10 @@ def get_matches_api(
         """
         Request a change to the opinion for a signal in a given privacy_group.
         """
-        signal_id = bottle.request.query.signal_id or None
-        signal_source = bottle.request.query.signal_source or None
-        privacy_group_id = bottle.request.query.privacy_group_id or None
-        opinion_change = bottle.request.query.opinion_change or None
+        signal_id = bottle.request.query.signal_id or None  # type: ignore # ToDo refactor to use `jsoninator(<requestObj>, from_query=True)``
+        signal_source = bottle.request.query.signal_source or None  # type: ignore # ToDo refactor to use `jsoninator(<requestObj>, from_query=True)``
+        privacy_group_id = bottle.request.query.privacy_group_id or None  # type: ignore # ToDo refactor to use `jsoninator(<requestObj>, from_query=True)``
+        opinion_change = bottle.request.query.opinion_change or None  # type: ignore # ToDo refactor to use `jsoninator(<requestObj>, from_query=True)``
 
         if (
             not signal_id
@@ -415,19 +477,11 @@ def get_matches_api(
 
         return ChangeSignalOpinionResponse(success)
 
-    @matches_api.get(
-        "/for-hash/", apply=[jsoninator(MatchesForHashRequest, from_query=True)]
-    )
-    def for_hash(request: MatchesForHashRequest) -> MatchesForHashResponse:
-        """
-        For a given hash/signal check the index(es) for matches and return the details.
-
-        This does not change system state, metadata returned will not be written any tables
-        unlike when matches are found for submissions.
-        """
-
+    def _matches_for_hash(
+        signal_type: t.Type[SignalType], signal_value: str
+    ) -> t.List[MatchesForHash]:
         matches = _get_matcher(indexes_bucket_name, banks_table=banks_table).match(
-            request.signal_type, request.signal_value
+            signal_type, signal_value
         )
 
         match_objects: t.List[MatchesForHash] = []
@@ -441,7 +495,7 @@ def get_matches_api(
                         matched_signal=signal_metadata,
                     )
                     for signal_metadata in Matcher.get_te_metadata_objects_from_match(
-                        request.signal_type, match
+                        signal_type, match
                     )
                 ]
             )
@@ -451,6 +505,7 @@ def get_matches_api(
             for metadata_obj in filter(
                 lambda m: m.get_source() == BANKS_SOURCE_SHORT_CODE, match.metadata
             ):
+                metadata_obj = t.cast(BankedSignalIndexMetadata, metadata_obj)
                 match_objects.append(
                     MatchesForHash(
                         match_distance=int(match.distance),
@@ -460,6 +515,47 @@ def get_matches_api(
                     )
                 )
 
-        return MatchesForHashResponse(match_objects, request.signal_value)
+        return match_objects
+
+    @matches_api.get(
+        "/for-hash/", apply=[jsoninator(MatchesForHashRequest, from_query=True)]
+    )
+    def for_hash(request: MatchesForHashRequest) -> MatchesForHashResponse:
+        """
+        For a given hash/signal check the index(es) for matches and return the details.
+
+        This does not change system state, metadata returned will not be written any tables
+        unlike when matches are found for submissions.
+        """
+
+        return MatchesForHashResponse(
+            matches=_matches_for_hash(request.signal_type, request.signal_value)
+        )
+
+    @matches_api.post("/for-media/", apply=[jsoninator(MatchesForMediaRequest)])
+    def for_media(
+        request: MatchesForMediaRequest,
+    ) -> t.Union[MatchesForMediaResponse, MediaFetchError]:
+        """
+        For a given piece of media hash it, check the index(es) for matches, and return the details.
+
+        This does not change system state, metadata returned will not be written any tables
+        unlike when matches are found for submissions.
+        """
+        try:
+            bytes_: bytes = URLContentSource().get_bytes(request.content_url)
+        except Exception as e:
+            bottle.response.status = 400
+            return MediaFetchError()
+
+        signal_to_matches = {}
+        for signal in _get_haher().get_hashes(request.content_type, bytes_):
+            signal_to_matches[signal.signal_type.get_name()] = {
+                signal.signal_value: _matches_for_hash(
+                    signal_type=signal.signal_type, signal_value=signal.signal_value
+                )
+            }
+
+        return MatchesForMediaResponse(signal_to_matches=signal_to_matches)
 
     return matches_api

--- a/hasher-matcher-actioner/terraform/.terraform.lock.hcl
+++ b/hasher-matcher-actioner/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.74.3"
   constraints = "~> 3.0, >= 3.63.0"
   hashes = [
+    "h1:SpYaB/QoM6MBiAV8k25LRVvdSEHoCoUVanXwECLEWok=",
     "h1:h4TYqgRKTuuWfZtxJnEGcs/NxGCaxZ4jr0IwTfgZDRM=",
     "zh:25401cd4667d0496caf7e92e74ecef7c98cf74465570705cda2207770c27ff6c",
     "zh:2d154527a9b2585f72fc5eceac635257e3f50f68de8a519e71c795d5166a0a22",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/hashicorp/local" {
     "h1:/OpJKWupvFd8WJX1mTt8vi01pP7dkA6e//4l4C3TExE=",
     "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
     "h1:KfieWtVyGWwplSoLIB5usKAUnrIkDQBkWaR5TI+4WYg=",
+    "h1:PaQTpxHMbZB9XV+c1od1eaUvndQle3ZZHx79hrI6C3k=",
     "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
     "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
     "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
@@ -44,6 +46,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version = "3.1.0"
   hashes = [
     "h1:SFT7X3zY18CLWjoH2GfQyapxsRv6GDKsy9cF1aRwncc=",
+    "h1:grYDj8/Lvp1OwME+g1AsECPN1czO5ssSf+8fCluCHQY=",
     "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
     "h1:xhbHC6in3nQryvTQBWKxebi3inG5OCgHgc4fRxL0ymc=",
     "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",


### PR DESCRIPTION
Summary
---------

Similar the GET `matches/for-hash/` endpoint this PR adds a:
POST `matches/for-media` endpoint.

Aside: also adds some typing fixes that shouldn't change behavior.
Note: for this PR reviewing commit by commit is the same as file by file (though the commit message might still add some limited context).

The endpoint expects a json request body:
```
{
    "content_url": "<pre-signed url of media's bytes>",
    "content_type": "[photo|video]"
}
```
and responds in the form:
```
{
    "signal_to_matches": {
        "<signal_type>": {
            "<signal_value/hash>": [
               <match with details if any are found>
            ]
        }
    }
}
``` 

Example (bytes behind url match a banked hash/image):
POST https://{{api_id}}.execute-api.us-east-1.amazonaws.com/api/matches/for-media/
```
{
    "content_url": "https://hma-fake-signedrul&Auth=123abc",
    "content_type": "photo"
}
```

```
{
    "signal_to_matches": {
        "pdq": {
            "abc91924995ba646a32635ae79aef6b4ecb9da5d64f5d4d45b462a46262b00000": [
                {
                    "match_distance": 0,
                    "matched_signal": {
                        "bank_id": "3227bac9-5f0b-4e1c-8d51-bcb2bdd391e5",
                        "bank_member_id": "453829e0-002a-4fb7-8f03-a90cf1ecceee",
                        "content_type": "photo",
                        "storage_bucket": "barrett-banks-media-<redacted>",
                        "storage_key": "bank-media/image/jpeg/2022-01-28/5313edb9-77f8-4cc6-8fb7-64a8bf852d6f.jpg",
                        "raw_content": null,
                        "notes": "puppy-tea",
                        "created_at": "2022-01-28T16:35:43.032422",
                        "is_removed": false,
                        "is_media_unavailable": false,
                        "bank_member_tags": []
                    }
                }
            ]
        }
    }
}
```

Test Plan
---------

Ran examples like the one above in postman as well as some stress tests with `scripts/benchmark_for_match_api.py`

e.g. 
bad content url: response code 400 
```
{
    "message": "Failed to fetch media from provided url"
}
```
match video in sample set:
```
{
    "signal_to_matches": {
        "video_md5": {
            "e255a0f7186963764b984c8c00c1f98b": [
                {
                    "match_distance": 0,
                    "matched_signal": {
                        "signal_id": "<id>",
                        "privacy_group_id": "<id>",
                        "signal_type": "video_md5",
                        "signal_hash": "e255a0f7186963764b984c8c00c1f98b",
                        "tags": [
                            "true_positive",
                            "uploaded_by_hma"
                        ]
                    }
                }
            ]
        }
    }
}
```
same video url but with matching on sample set disabled:
```
{
    "signal_to_matches": {
        "video_md5": {
            "e255a0f7186963764b984c8c00c1f98b": []
        }
    }
}
```
