### PR TITLE
[hma][hotfix] comment out vpc setting for hasher lambda 

### DIFF
--- a/hasher-matcher-actioner/terraform/hasher/main.tf
+++ b/hasher-matcher-actioner/terraform/hasher/main.tf
@@ -27,15 +27,15 @@ resource "aws_lambda_function" "hashing_lambda" {
     }
   }
 
-  vpc_config {
-    security_group_ids = var.durable_fs_security_group_ids
-    subnet_ids         = var.durable_fs_subnet_ids
-  }
+  # vpc_config {
+  #   security_group_ids = var.durable_fs_security_group_ids
+  #   subnet_ids         = var.durable_fs_subnet_ids
+  # }
 
-  file_system_config {
-    local_mount_path = var.durable_fs_local_mount_path
-    arn              = var.durable_fs_arn
-  }
+  # file_system_config {
+  #   local_mount_path = var.durable_fs_local_mount_path
+  #   arn              = var.durable_fs_arn
+  # }
 
   tags = merge(
     var.additional_tags,


### PR DESCRIPTION
Summary
---------

Adding a VPC to the hasher lambda seem to prevent it from adding to an SQS queue (for matching) or writing to ddb (for HashRecord)
Because VPC is only needed for efs which is not part of the HMA pipeline yet. I think the best hotfix is just to comment out these setting to unblock the hashing lambda and follow up with the needed changes / network setting to support the filesystem that won't break things. 

Test Plan
---------
```
make upload_docker
...
make dev_apply_with_newest_docker_image 
...
make dev_test_instance
...
```