### PR TITLE
added HashRecord class to pipeline.py on separate branch

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/models/pipeline.py
+++ b/hasher-matcher-actioner/hmalib/common/models/pipeline.py
@@ -10,6 +10,7 @@ from boto3.dynamodb.conditions import Key
 
 from threatexchange.content_type.meta import get_signal_types_by_name
 from threatexchange.signal_type.signal_base import SignalType
+from threatexchange.signal_type.timebucketizer import CSViable
 
 from hmalib.common.models.models_base import (
     DynamoDBItem,
@@ -405,3 +406,20 @@ class MatchRecord(PipelineRecordDefaultsBase, _MatchRecord):
             )
             for item in items
         ]
+
+
+@dataclass(eq=True)
+class HashRecord(CSViable):
+    """
+    Example class used for testing purposes.
+    """
+
+    content_hash: str
+    content_id: str
+
+    def to_csv(self) -> t.List[t.Union[str, int]]:
+        return [self.content_hash, self.content_id]
+
+    @classmethod
+    def from_csv(cls: t.Type["HashRecord"], value: t.List[str]) -> "HashRecord":
+        return HashRecord(value[0], value[1])

--- a/hasher-matcher-actioner/hmalib/common/models/pipeline.py
+++ b/hasher-matcher-actioner/hmalib/common/models/pipeline.py
@@ -10,7 +10,7 @@ from boto3.dynamodb.conditions import Key
 
 from threatexchange.content_type.meta import get_signal_types_by_name
 from threatexchange.signal_type.signal_base import SignalType
-from threatexchange.signal_type.timebucketizer import CSViable
+from threatexchange.hmalib.common import CSViable
 
 from hmalib.common.models.models_base import (
     DynamoDBItem,
@@ -411,7 +411,7 @@ class MatchRecord(PipelineRecordDefaultsBase, _MatchRecord):
 @dataclass(eq=True)
 class HashRecord(CSViable):
     """
-    Example class used for testing purposes.
+    We are getting these records, with content_hashes and content_ids from the hashing process with intent to build an PDQIndex 
     """
 
     content_hash: str

--- a/hasher-matcher-actioner/hmalib/common/models/pipeline.py
+++ b/hasher-matcher-actioner/hmalib/common/models/pipeline.py
@@ -10,7 +10,7 @@ from boto3.dynamodb.conditions import Key
 
 from threatexchange.content_type.meta import get_signal_types_by_name
 from threatexchange.signal_type.signal_base import SignalType
-from threatexchange.hmalib.common import CSViable
+from hmalib.common.timebucketizer import CSViable
 
 from hmalib.common.models.models_base import (
     DynamoDBItem,
@@ -411,7 +411,7 @@ class MatchRecord(PipelineRecordDefaultsBase, _MatchRecord):
 @dataclass(eq=True)
 class HashRecord(CSViable):
     """
-    We are getting these records, with content_hashes and content_ids from the hashing process with intent to build an PDQIndex 
+    We are getting these records, with content_hashes and content_ids from the hashing process with intent to build an PDQIndex
     """
 
     content_hash: str


### PR DESCRIPTION
Summary
---------
I added a HashRecord class that contains data for content_hash and content_id to the pipeline.py file.

Test Plan
---------
```
hasher-matcher-actioner $ python -m py.test hmalib/common/models/pipeline.py
hasher-matcher-actioner $ python -m mypy hmalib/common/models/pipeline.py
hasher-matcher-actioner $ python -m black hmalib/common/models/pipeline.py
```