### PR TITLE
Cli e2e testing

### DIFF
--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -57,7 +57,7 @@ setup(
     ],
     keywords="facebook threatexchange",
     url="https://www.github.com/facebook/ThreatExchange",
-    packages=find_packages(exclude=["tests*"]),
+    packages=find_packages(exclude=["tests*"]),  # TODO also exclude subdir tests
     install_requires=[
         "python-Levenshtein",
         "requests>=2.26.0",

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -57,7 +57,7 @@ setup(
     ],
     keywords="facebook threatexchange",
     url="https://www.github.com/facebook/ThreatExchange",
-    packages=find_packages(exclude=["tests*"]),  # TODO also exclude subdir tests
+    packages=find_packages(exclude=["tests*"]),
     install_requires=[
         "python-Levenshtein",
         "requests>=2.26.0",

--- a/python-threatexchange/threatexchange/cli/dataset_cmd.py
+++ b/python-threatexchange/threatexchange/cli/dataset_cmd.py
@@ -108,20 +108,22 @@ class DatasetCommand(command_base.Command):
         )
 
     def __init__(
+        # These all have defaults to make it easier to call
+        # only for rebuld
         self,
         # Mode
-        clear_indices: bool,
-        rebuild_indices: bool,
-        signal_summary: bool,
-        print_records: bool,
+        clear_indices: bool = False,
+        rebuild_indices: bool = False,
+        signal_summary: bool = False,
+        print_records: bool = False,
         # Signal selectors
-        only_collabs: t.List[str],
-        only_signals: t.List[t.Type[SignalType]],
-        only_content: t.List[t.Type[ContentType]],
-        only_tags: t.List[str],
+        only_collabs: t.Sequence[str] = (),
+        only_signals: t.Sequence[t.Type[SignalType]] = (),
+        only_content: t.Sequence[t.Type[ContentType]] = (),
+        only_tags: t.Sequence[str] = (),
         # Print stuff
-        signals_only: bool,
-        limit: t.Optional[int],
+        signals_only: bool = False,
+        limit: t.Optional[int] = None,
     ) -> None:
         self.clear_indices = clear_indices
         self.rebuild_indices = rebuild_indices

--- a/python-threatexchange/threatexchange/cli/fetch_cmd.py
+++ b/python-threatexchange/threatexchange/cli/fetch_cmd.py
@@ -9,6 +9,7 @@ import time
 import typing as t
 
 from threatexchange.cli.cli_config import CLISettings
+from threatexchange.cli.dataset_cmd import DatasetCommand
 from threatexchange.fetcher.collab_config import CollaborationConfigBase
 from threatexchange.fetcher.fetch_api import SignalExchangeAPI
 from threatexchange.fetcher.fetch_state import (
@@ -58,12 +59,13 @@ class FetchCommand(command_base.Command):
 
     def __init__(
         self,
-        clear: bool,
-        time_limit_sec: t.Optional[int],
-        limit: t.Optional[int],
-        skip_index_rebuild: bool,
-        only_api: t.Optional[str],
-        only_collab: t.Optional[str],
+        # Defaults to make it easier to call from match
+        clear: bool = False,
+        time_limit_sec: t.Optional[int] = None,
+        limit: t.Optional[int] = None,
+        skip_index_rebuild: bool = False,
+        only_api: t.Optional[str] = None,
+        only_collab: t.Optional[str] = None,
     ) -> None:
         self.clear = clear
         self.time_limit_sec = time_limit_sec
@@ -129,6 +131,7 @@ class FetchCommand(command_base.Command):
 
         if any_succeded and not self.skip_index_rebuild:
             self.stderr("Rebuilding match indices...")
+            DatasetCommand().execute_generate_indices(settings)
 
         if not all_succeeded:
             raise command_base.CommandError("Some collabs had errors!", 3)

--- a/python-threatexchange/threatexchange/cli/label_cmd.py
+++ b/python-threatexchange/threatexchange/cli/label_cmd.py
@@ -87,7 +87,7 @@ class LabelCommand(command_base.Command):
 
         ap.add_argument(
             "collab",
-            type=lambda n: settings.get_collab(n),
+            type=lambda n: _collab_type(n, settings),
             help="The name of the collaboration",
         )
 
@@ -128,6 +128,9 @@ class LabelCommand(command_base.Command):
             if len(self.only_signals) != 1:
                 raise ArgumentTypeError("[-H] use only one argument for -S")
 
+        if self.collab is None:
+            raise ArgumentTypeError("No such collaboration!")
+
         self.action = self.execute_upload
         if true_positive:
             self.action = self.execute_true_positive
@@ -167,3 +170,10 @@ class LabelCommand(command_base.Command):
 
     def execute_false_positive(self, settings: CLISettings) -> None:
         raise NotImplementedError
+
+
+def _collab_type(name: str, settings: CLISettings) -> CollaborationConfigBase:
+    ret = settings.get_collab(name)
+    if ret is None:
+        raise ArgumentTypeError(f"No such collab '{name}'!")
+    return ret

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -155,7 +155,7 @@ def _get_extended_functionality(config: CLiConfig) -> _ExtendedTypes:
     return ret
 
 
-def _get_settings(config: CLiConfig) -> CLISettings:
+def _get_settings(config: CLiConfig, dir: pathlib.Path) -> CLISettings:
     """
     Configure the behavior and functionality.
     """
@@ -184,7 +184,7 @@ def _get_settings(config: CLiConfig) -> CLISettings:
         ]
         + extensions.api_instances
     )
-    state = CliState(list(fetchers.fetchers_by_name.values()))
+    state = CliState(list(fetchers.fetchers_by_name.values()), dir=dir)
 
     return CLISettings(meta.FunctionalityMapping(signals, fetchers, state), state)
 
@@ -202,12 +202,15 @@ def _setup_logging():
 
 
 def main(
-    args: t.Optional[t.Sequence[t.Text]] = None, state_dir: pathlib.Path = None
+    args: t.Optional[t.Sequence[t.Text]] = None,
+    state_dir: pathlib.Path = pathlib.Path("~/.threatexchange"),
 ) -> None:
     _setup_logging()
 
-    config = CliState([]).get_persistent_config()  # TODO fix the circular dependency
-    settings = _get_settings(config)
+    config = CliState(
+        [], state_dir
+    ).get_persistent_config()  # TODO fix the circular dependency
+    settings = _get_settings(config, state_dir)
     ap = get_argparse(settings)
     namespace = ap.parse_args(args)
     execute_command(settings, namespace)

--- a/python-threatexchange/threatexchange/cli/match_cmd.py
+++ b/python-threatexchange/threatexchange/cli/match_cmd.py
@@ -13,6 +13,7 @@ import typing as t
 
 
 from threatexchange import common
+from threatexchange.cli.fetch_cmd import FetchCommand
 from threatexchange.fetcher.fetch_state import FetchedSignalMetadata
 
 from threatexchange.signal_type.index import IndexMatch
@@ -169,6 +170,11 @@ class MatchCommand(command_base.Command):
                 yield parsed
 
     def execute(self, settings: CLISettings) -> None:
+        if not settings.index_store.get_available():
+            if not settings.in_demo_mode:
+                raise CommandError("No indices available. Do you need to fetch?")
+            self.stderr("You haven't built any indices, so we'll call `fetch` for you!")
+            FetchCommand().execute(settings)
 
         signal_types = settings.get_signal_types_for_content(self.content_type)
 

--- a/python-threatexchange/threatexchange/cli/tests/cli_smoke_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/cli_smoke_test.py
@@ -1,27 +1,16 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-import sys
-import pytest
-
 from threatexchange.cli import main
+from threatexchange.cli.tests.e2e_test_helper import ThreatExchangeCLIE2eTest
 
 
-def test_all_helps():
-    """
-    Just executes all the commands to make sure they don't throw on help.
+class CLISmokeTest(ThreatExchangeCLIE2eTest):
+    def test_all_helps(self):
+        """
+        Just executes all the commands to make sure they don't throw on help.
 
-    View the pretty output with py.test -s
-    """
-
-    def help(command=None):
-        args = [command.get_name()] if command else []
-        args.append("--help")
-
-        with pytest.raises(SystemExit) as exc:
-            print("\n$ threatexchange", " ".join(args), file=sys.stderr)
-            main.main(args)
-        assert exc.value.code == 0
-
-    help()  # root help
-    for command in main.get_subcommands():
-        help(command)
+        View the pretty output with py.test -s
+        """
+        self.cli_call("--help")  # root help
+        for command in main.get_subcommands():
+            self.cli_call(command.get_name(), "--help")

--- a/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
+++ b/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
@@ -1,12 +1,17 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 
+from io import StringIO
+import math
 import pathlib
 import shutil
+import sys
 import tempfile
+import typing as t
+from unittest.mock import patch
 import unittest
 
-from threatexchange.cli import main
+from threatexchange.cli.main import main
 from threatexchange.cli.exceptions import CommandError
 
 
@@ -17,29 +22,49 @@ class E2ETestSystemExit(Exception):
 
 class ThreatExchangeCLIE2eTest(unittest.TestCase):
 
+    COMMON_CALL_ARGS: t.ClassVar[t.Sequence[str]] = ()
+
     _state_dir: pathlib.Path
 
     def setUp(self) -> None:
         super().setUp()
 
-        self._state_dir = pathlib.Path(tempfile.mkdtemp())
+        state_dir = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(str(state_dir)))
+        self._state_dir = state_dir
 
-    def tearDown(self) -> None:
-        super().tearDown()
-
-        if self._state_dir.is_dir():
-            shutil.rmtree(str(self._state_dir))
-
-    def cli_call(self, *args: str) -> None:
+    def cli_call(self, *given_args: str) -> str:
+        args = list(self.COMMON_CALL_ARGS)
+        args.extend(given_args)
+        print("Calling: $ threatexchange", " ".join(args), file=sys.stderr)
         try:
-            main(args, state_dir = self._state_dir)
+            with patch("sys.stdout", new=StringIO()) as fake_out:
+                main(args, state_dir=self._state_dir)
+            return fake_out.getvalue()
         except SystemExit as se:
+            if se.code == 0:  # ERROR: Everything is fine
+                return fake_out.getvalue()
             raise E2ETestSystemExit(se.code)
 
-    def cli_call_assert_usage_error(self, *args: str, msg_regex: str = None) -> None:
+    def assert_cli_output(
+        self, args: t.Iterable[str], expected_output: str, line: t.Optional[int] = None
+    ) -> None:
+        output = self.cli_call(*args)
+        if line is not None:
+            lines = output.strip().split("\n")
+            if line < 0:
+                self.assertGreaterEqual(line, -len(lines))
+            else:
+                self.assertLess(line, len(lines))
+            output = lines[line]
+        self.assertEqual(expected_output.strip(), output.strip())
+
+    def assert_cli_usage_error(
+        self, args: t.Iterable[str], msg_regex: str = None
+    ) -> None:
         with self.assertRaises((CommandError, E2ETestSystemExit)) as ex:
-            self.cli_call(args)
-        self.assertEqual(ex.exception.returncode, 2)
+            self.cli_call(*args)
+        exception = t.cast(t.Union[CommandError, E2ETestSystemExit], ex.exception)
+        self.assertEqual(exception.returncode, 2)
         if msg_regex is not None:
-            self.assertIsInstance(ex.exception, CommandError)
-            self.assertRegex(ex.exception.args[0], msg_regex)
+            self.assertRegex(str(exception), msg_regex)

--- a/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
+++ b/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
@@ -1,0 +1,45 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+
+import pathlib
+import shutil
+import tempfile
+import unittest
+
+from threatexchange.cli import main
+from threatexchange.cli.exceptions import CommandError
+
+
+class E2ETestSystemExit(Exception):
+    def __init__(self, code: int) -> None:
+        self.returncode = code
+
+
+class ThreatExchangeCLIE2eTest(unittest.TestCase):
+
+    _state_dir: pathlib.Path
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self._state_dir = pathlib.Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        super().tearDown()
+
+        if self._state_dir.is_dir():
+            shutil.rmtree(str(self._state_dir))
+
+    def cli_call(self, *args: str) -> None:
+        try:
+            main(args, state_dir = self._state_dir)
+        except SystemExit as se:
+            raise E2ETestSystemExit(se.code)
+
+    def cli_call_assert_usage_error(self, *args: str, msg_regex: str = None) -> None:
+        with self.assertRaises((CommandError, E2ETestSystemExit)) as ex:
+            self.cli_call(args)
+        self.assertEqual(ex.exception.returncode, 2)
+        if msg_regex is not None:
+            self.assertIsInstance(ex.exception, CommandError)
+            self.assertRegex(ex.exception.args[0], msg_regex)

--- a/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
@@ -1,0 +1,19 @@
+import tempfile
+from threatexchange.cli.tests.e2e_test_helper import ThreatExchangeCLIE2eTest
+
+
+class HashCommandTest(ThreatExchangeCLIE2eTest):
+
+    COMMON_CALL_ARGS = ("hash",)
+
+    def test(self):
+        self.assert_cli_output(
+            ("url", "--inline", "http://evil.com"),
+            "url_md5 6d3af727a4e7b025fd59a5469b3a9c57",
+        )
+
+        with tempfile.NamedTemporaryFile() as fp:
+            # Empty file
+            self.assert_cli_output(
+                ("video", fp.name), "video_md5 d41d8cd98f00b204e9800998ecf8427e"
+            )

--- a/python-threatexchange/threatexchange/cli/tests/sample_data_e2e_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/sample_data_e2e_test.py
@@ -1,0 +1,25 @@
+from threatexchange.cli.tests.e2e_test_helper import ThreatExchangeCLIE2eTest
+
+
+class SampleDataE2ETest(ThreatExchangeCLIE2eTest):
+    """
+    The CLI should demonstrate functionality with only sample data.
+    """
+
+    def test_sequential_to_match(self):
+        self.cli_call("fetch")
+        self.cli_call("dataset", "-r")
+        self.assert_cli_output(
+            ("match", "text", "-I", "bball now?"),
+            "raw_text - (Sample Signals) WORTH_INVESTIGATING",
+        )
+
+    def test_direct_to_match(self):
+        self.assert_cli_output(
+            ("match", "text", "-I", "bball now?"),
+            "raw_text - (Sample Signals) WORTH_INVESTIGATING",
+            -1,
+        )
+
+    def test_no_labeling(self):
+        self.assert_cli_usage_error(("label", "Sample Signals", "text", "foo"))

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -110,14 +110,6 @@ class TextHasher:
         return cls.hash_from_str(file.read_text())
 
 
-class TrivialTextHasher(TextHasher):
-    """The text == the hash"""
-
-    @classmethod
-    def hash_from_str(cls, content: str) -> str:
-        return content
-
-
 class MatchesStr:
     @classmethod
     def matches_str(

--- a/python-threatexchange/threatexchange/signal_type/url.py
+++ b/python-threatexchange/threatexchange/signal_type/url.py
@@ -12,7 +12,7 @@ from threatexchange.content_type.url import URLContent
 from threatexchange.signal_type import signal_base
 
 
-class URLSignal(signal_base.SimpleSignalType, signal_base.TrivialTextHasher):
+class URLSignal(signal_base.SimpleSignalType):
     """
     Wrapper around URL links, such as https://github.com/
     """


### PR DESCRIPTION
Summary
---------

This diff adds a backstop for testing, which is simple e2e tests that pretend to be executing the CLI. Each test:
1. Is treated like a fresh install of threatexchange. You can change this by just overriding the setUp() method and move it to a setUpBeforeClass type deal.
2. Has helpers for triggering CLI runs, or looking for specific output.

Test Plan
---------

New unittests!
