### PR TITLE
WIP: Compilation changes for Windows

### DIFF
--- a/pdq/cpp/hashing/pdqhashing.cpp
+++ b/pdq/cpp/hashing/pdqhashing.cpp
@@ -13,7 +13,6 @@
 
 #if defined(_WIN32)
   #define _USE_MATH_DEFINES
-  #include <iostream>
 #endif
 
 #include <cassert>

--- a/pdq/cpp/hashing/pdqhashing.cpp
+++ b/pdq/cpp/hashing/pdqhashing.cpp
@@ -11,6 +11,11 @@
 // https://github.com/facebookexternal/ThreatExchange-PDQ/blob/main/pdqhash-2017-10-09.pdf
 // ================================================================
 
+#if defined(_WIN32)
+  #define _USE_MATH_DEFINES
+  #include <iostream>
+#endif
+
 #include <cassert>
 #include <chrono>
 #include <cmath>

--- a/tmk/.gitignore
+++ b/tmk/.gitignore
@@ -18,3 +18,4 @@ cpp/tmk-show-pair-offsets
 cpp/tmk-two-level-score
 cpp/tmkdump
 cpp/vstr2feat
+cpp/*.exe

--- a/tmk/README.md
+++ b/tmk/README.md
@@ -28,7 +28,7 @@ produced in conjunction with Facebook AI Research ('FAIR').
 - Make sure you can hash the exact same sample videos (in this repo -- see below) and get the same hashes (within roundoff error)
 - Let us know about file-format issues: at FB the upload-checker runs after videos in various formats have been transcoded to MP4, so we have no data on TMK with AVI, MOV, etc. Also note that the floating-point numbers within the `.tmk` files are all stored **little-endian**.
 - See if you can find matching content on your site, using initial match-threshold numbers.
-- Please feel free to contact us with feedback on the code, this documentation, or any other suggestions for additional rollout of this algorithm. And/or simply put up a pul request if you prefer.
+- Please feel free to contact us with feedback on the code, this documentation, or any other suggestions for additional rollout of this algorithm. And/or simply put up a pull request if you prefer.
 - In particular, we already know that several companies preferred a Java port of PDQ; we suspect the same will hold true for TMK.
 
 # TMK scoring
@@ -73,6 +73,9 @@ Notes:
 - We have a simple `Makefile` in order to reduce the number of dependencies, so people can get up and running quicker.
 - FB-internally we use `buck`; please let us know if you want Buck `TARGETS` files.
 - This simple Makefile build does not execute any `*test*.cpp` files, which `buck test` would. Hence the importance of computing hashes for sample videos (see next step).
+- To compile on Windows, you will also need to install `make`, e.g., via [choco](https://community.chocolatey.org/packages/make) and [MinGW](https://osdn.net/projects/mingw/).
+  - MinGW needs to be added to the system path in order to compile and use the executables
+  - The tests will not run after `make` without more changes, but they can be run manually
 
 ## Compute hashes of sample videos and compare to previous outputs
 

--- a/tmk/README.md
+++ b/tmk/README.md
@@ -73,9 +73,16 @@ Notes:
 - We have a simple `Makefile` in order to reduce the number of dependencies, so people can get up and running quicker.
 - FB-internally we use `buck`; please let us know if you want Buck `TARGETS` files.
 - This simple Makefile build does not execute any `*test*.cpp` files, which `buck test` would. Hence the importance of computing hashes for sample videos (see next step).
-- To compile on Windows, you will also need to install `make`, e.g., via [choco](https://community.chocolatey.org/packages/make) and [MinGW](https://osdn.net/projects/mingw/).
+
+## Windows users
+
+Some basic modifications have been made to enable support for Windows. To compile, you will also need to install `make`, e.g., via [choco](https://community.chocolatey.org/packages/make) and [MinGW](https://osdn.net/projects/mingw/).
   - MinGW needs to be added to the system path in order to compile and use the executables
+
+Known issues:
   - The tests will not run after `make` without more changes, but they can be run manually
+  - Avoid BOM or CRLF line endings (e.g., if `haystack.txt` files are supplied)
+  - Use of absolute file paths may need more work in some cases. Try relative paths, or copying executables (like `ffmpeg.exe`) to your local directory.
 
 ## Compute hashes of sample videos and compare to previous outputs
 

--- a/tmk/README.md
+++ b/tmk/README.md
@@ -1,55 +1,57 @@
 # Summary
 
-TMK (for *Temporal Match Kernel*) is a video-similarity-detection algorithm
+TMK (for _Temporal Match Kernel_) is a video-similarity-detection algorithm
 produced in conjunction with Facebook AI Research ('FAIR').
 
-* Full details are located in the [hashing.pdf](https://github.com/facebook/ThreatExchange/blob/main/hashing/hashing.pdf) document.
+- Full details are located in the [hashing.pdf](https://github.com/facebook/ThreatExchange/blob/main/hashing/hashing.pdf) document.
 
-* See https://newsroom.fb.com/news/2019/08/open-source-photo-video-matching for context.
+- See https://newsroom.fb.com/news/2019/08/open-source-photo-video-matching for context.
 
-* Researchers in video copy-detection algorithms may also be interested in
+- Researchers in video copy-detection algorithms may also be interested in
   https://github.com/facebookresearch/videoalignment for a research version of
   TMK, with different parameter-weighting than presented here.
 
 # Status
 
-* For cross-company sharing, for exports, one needs to compute hashes for a
-relatively small list of banked videos, then publish those data (over
-ThreatExchange, for example) -- this is a small-scale endeavor. For imports,
-one needs to hash *all* to-be-checked videos and compare them against a
-hash-list -- this is a large-scale endeavor.  At present (2019-01-18) this code
-is single-machine-only: nothing is connected up to databases or RPC yet.
+- For cross-company sharing, for exports, one needs to compute hashes for a
+  relatively small list of banked videos, then publish those data (over
+  ThreatExchange, for example) -- this is a small-scale endeavor. For imports,
+  one needs to hash _all_ to-be-checked videos and compare them against a
+  hash-list -- this is a large-scale endeavor. At present (2019-01-18) this code
+  is single-machine-only: nothing is connected up to databases or RPC yet.
 
-* Integration with [FAISS](https://github.com/facebookresearch/faiss) has been
-successfully prototyped -- we will post information about this soon.
+- Integration with [FAISS](https://github.com/facebookresearch/faiss) has been
+  successfully prototyped -- we will post information about this soon.
 
 # Goals
 
-* Make sure you can hash the exact same sample videos (in this repo -- see below) and get the same hashes (within roundoff error)
-* Let us know about file-format issues: at FB the upload-checker runs after videos in various formats have been transcoded to MP4, so we have no data on TMK with AVI, MOV, etc. Also note that the floating-point numbers within the `.tmk` files are all stored **little-endian**.
-* See if you can find matching content on your site, using initial match-threshold numbers.
-* Please feel free to contact us with feedback on the code, this documentation, or any other suggestions for additional rollout of this algorithm. And/or simply put up a pul request if you prefer.
-* In particular, we already know that several companies preferred a Java port of PDQ; we suspect the same will hold true for TMK.
+- Make sure you can hash the exact same sample videos (in this repo -- see below) and get the same hashes (within roundoff error)
+- Let us know about file-format issues: at FB the upload-checker runs after videos in various formats have been transcoded to MP4, so we have no data on TMK with AVI, MOV, etc. Also note that the floating-point numbers within the `.tmk` files are all stored **little-endian**.
+- See if you can find matching content on your site, using initial match-threshold numbers.
+- Please feel free to contact us with feedback on the code, this documentation, or any other suggestions for additional rollout of this algorithm. And/or simply put up a pul request if you prefer.
+- In particular, we already know that several companies preferred a Java port of PDQ; we suspect the same will hold true for TMK.
 
 # TMK scoring
 
-* For each video file, the hasher channels the output of `ffmpeg` (which you need to separately install) to produce a `.tmk` file.
-* You can think of the feature-vectors file as opaque binary files if you like. However please do see `./tmk/tools/tmkdump.py` which shows how to display the binary `.tmk` files in human-readable format.
-* The **.tmk** files contain:
-  * **Metadata** about how the hash was computed (so we can avoid mixing hashes produced by different, incompatible software).
-  * A **pure-average feature**. Think of a 'frame feature' as a floating-point hash of a single video frame. Then the pure-average feature is the slotwise average over all the frames of the video.
-  * **Cosine and sine features**. These are nothing more than **weighted** average of frame features, with various periods and various fourier-coefficient weights
-* We can compute a **level-1 score** for a pair of videos using cosine similarity of their pure-average features. This is quick to compute.
-* If the level-1 score is less than a threshold, the videos don't match. If it's above, then we compute a **level-2 score** using all the cosine/sine features. (Details are in `tmkfv.cpp`.) If this level-2 score is over a second threshold, then the videos do match. (If you want to compute the full TMK level-2 pair-score between an arbitrary pair of videos, then set the level-1 threshold to -1.)
-* Possible values for level-1 score range from -1 to 1 (1 being perfect match); possible values for level-2 score range from 0 to 1 (1 being perfect match).
-* Values of those thresholds are suggested at 0.7 for each.
+- For each video file, the hasher channels the output of `ffmpeg` (which you need to separately install) to produce a `.tmk` file.
+- You can think of the feature-vectors file as opaque binary files if you like. However please do see `./tmk/tools/tmkdump.py` which shows how to display the binary `.tmk` files in human-readable format.
+- The **.tmk** files contain:
+  - **Metadata** about how the hash was computed (so we can avoid mixing hashes produced by different, incompatible software).
+  - A **pure-average feature**. Think of a 'frame feature' as a floating-point hash of a single video frame. Then the pure-average feature is the slotwise average over all the frames of the video.
+  - **Cosine and sine features**. These are nothing more than **weighted** average of frame features, with various periods and various fourier-coefficient weights
+- We can compute a **level-1 score** for a pair of videos using cosine similarity of their pure-average features. This is quick to compute.
+- If the level-1 score is less than a threshold, the videos don't match. If it's above, then we compute a **level-2 score** using all the cosine/sine features. (Details are in `tmkfv.cpp`.) If this level-2 score is over a second threshold, then the videos do match. (If you want to compute the full TMK level-2 pair-score between an arbitrary pair of videos, then set the level-1 threshold to -1.)
+- Possible values for level-1 score range from -1 to 1 (1 being perfect match); possible values for level-2 score range from 0 to 1 (1 being perfect match).
+- Values of those thresholds are suggested at 0.7 for each.
 
 # Prerequisites
-We need to have ffmpeg (https://www.ffmpeg.org/) downloaded and working. 
+
+We need to have ffmpeg (https://www.ffmpeg.org/) downloaded and working.
 
 The sample hashes were generated with ffmpeg version 4.1 so if you have any issues with `make regtest` check your ffmpeg version.
 
 # Getting started
+
 First let's compile the code and compute hashes of some sample videos, and make
 sure we're all getting compatible results. Namely, I've got some sample videos
 in this repository which I've hashed on my platform. If you hash those exact
@@ -68,9 +70,9 @@ $ make
 
 Notes:
 
-* We have a simple `Makefile` in order to reduce the number of dependencies, so people can get up and running quicker.
-* FB-internally we use `buck`; please let us know if you want Buck `TARGETS` files.
-* This simple Makefile build does not execute any `*test*.cpp` files, which `buck test` would. Hence the importance of computing hashes for sample videos (see next step).
+- We have a simple `Makefile` in order to reduce the number of dependencies, so people can get up and running quicker.
+- FB-internally we use `buck`; please let us know if you want Buck `TARGETS` files.
+- This simple Makefile build does not execute any `*test*.cpp` files, which `buck test` would. Hence the importance of computing hashes for sample videos (see next step).
 
 ## Compute hashes of sample videos and compare to previous outputs
 
@@ -281,7 +283,7 @@ $ find /path/to/your/hashes -name '*.tmk' | tmk-clusterize -s --min 2 -i
 $ find /path/to/shared/hashes -name '*.tmk' | tmk-clusterize --min 2 -i
 ```
 
-This concludes the walkthrough.  Please see
+This concludes the walkthrough. Please see
 [README-more.md](https://github.com/facebook/ThreatExchange/blob/main/hashing/tmk/README-more.md)
 for more detailed reference information.
 
@@ -290,7 +292,7 @@ for more detailed reference information.
 Out of `n` videos there are `n*(n-1)/2` pairs. For all 2,679 video hashes
 within a particular dataset used for this section, that's over 3 million
 pair-scores to compute. So we took a random sample of about 400, resulting in
-about 85,000 possible distinct pairs.  Here we're plotting histograms of the
+about 85,000 possible distinct pairs. Here we're plotting histograms of the
 level-1 scores, the level-2 scores, and the joint density.
 
 Remember from above we use the level-2 score to decide if two videos match or

--- a/tmk/cpp/Makefile
+++ b/tmk/cpp/Makefile
@@ -2,6 +2,14 @@
 CC=g++ -O2 -std=c++14 -I../..
 FFMPEG=/usr/local/bin/ffmpeg # please customize according to your installation
 
+ifeq ($(OS),Windows_NT)
+  CC_IF_WIN=g++ -O2 -std=gnu++14 -I../..
+  OMP_LIB=-lgomp
+else
+  CC_IF_WIN=g++ -O2 -std=c++14 -I../..
+  OMP_LIB=-lomp
+endif
+
 # ----------------------------------------------------------------
 LIBHDR= \
 ../../pdq/cpp/common/pdqbasetypes.h \
@@ -119,7 +127,7 @@ libtmk.a: $(LIBOBJ)
 	$(CC) -c ./hashing/bufferhashers.cpp -o ./hashing/bufferhashers.o
 
 ./hashing/filehasher.o: ./hashing/filehasher.cpp $(LIBHDR)
-	$(CC) -c ./hashing/filehasher.cpp -o ./hashing/filehasher.o
+	$(CC_IF_WIN) -c ./hashing/filehasher.cpp -o ./hashing/filehasher.o
 
 ./io/tmkio.o: ./io/tmkio.cpp $(LIBHDR)
 	$(CC) -c ./io/tmkio.cpp -o ./io/tmkio.o
@@ -142,7 +150,7 @@ feat2tmk: ./bin/feat2tmk.cpp $(LIBHDR) libtmk.a
 featdump: ./bin/featdump.cpp $(LIBHDR) libtmk.a
 	$(CC) bin/featdump.cpp -o featdump -L. -ltmk
 tmkdump: ./bin/tmkdump.cpp $(LIBHDR) libtmk.a
-	$(CC) bin/tmkdump.cpp -o tmkdump -L. -ltmk
+	$(CC_IF_WIN) bin/tmkdump.cpp -o tmkdump -L. -ltmk
 
 # ----------------------------------------------------------------
 tmk-compare-two-tmks: ./bin/tmk-compare-two-tmks.cpp $(LIBHDR) libtmk.a
@@ -152,13 +160,21 @@ tmk-show-pair-offsets: ./bin/tmk-show-pair-offsets.cpp $(LIBHDR) libtmk.a
 
 # ----------------------------------------------------------------
 tmk-clusterize: ./bin/tmk-clusterize.cpp $(LIBHDR) libtmk.a
-	$(CC) bin/tmk-clusterize.cpp -o tmk-clusterize -L. -ltmk
+	$(CC_IF_WIN) bin/tmk-clusterize.cpp -o tmk-clusterize -L. -ltmk
 tmk-query: ./bin/tmk-query.cpp $(LIBHDR) libtmk.a
-	$(CC) bin/tmk-query.cpp -o tmk-query -L. -ltmk
-tmk-query-with-faiss: ./bin/tmk-query-with-faiss.cpp $(LIBHDR) libtmk.a
-	$(CC) -I/usr/local/include/faiss bin/tmk-query-with-faiss.cpp -o tmk-query-with-faiss -L. -L/usr/local/lib -ltmk -lfaiss -Wl,-rpath=/usr/local/lib
+	$(CC_IF_WIN) bin/tmk-query.cpp -o tmk-query -L. -ltmk
 tmk-two-level-score: ./bin/tmk-two-level-score.cpp $(LIBHDR) libtmk.a
-	$(CC) bin/tmk-two-level-score.cpp -o tmk-two-level-score -L. -ltmk
+	$(CC_IF_WIN) bin/tmk-two-level-score.cpp -o tmk-two-level-score -L. -ltmk
+
+# ----------------------------------------------------------------
+tmk-clusterize-parallel: ./bin/tmk-clusterize.cpp $(LIBHDR) libtmk.a
+	$(CC_IF_WIN) -Xpreprocessor -fopenmp bin/tmk-clusterize.cpp -o tmk-clusterize-parallel -L. -ltmk $(OMP_LIB)
+tmk-query-with-faiss: ./bin/tmk-query-with-faiss.cpp $(LIBHDR) libtmk.a
+	$(CC_IF_WIN) -Xpreprocessor -fopenmp -I/usr/local/include/faiss -DTMK_PREFER_FAISS bin/tmk-query.cpp bin/tmk-query-with-faiss.cpp -o tmk-query-with-faiss -L. -L/usr/local/lib -ltmk -lfaiss $(OMP_LIB) -Wl,-rpath,/usr/local/lib
+tmk-query-parallel: ./bin/tmk-query.cpp $(LIBHDR) libtmk.a
+	$(CC_IF_WIN) -Xpreprocessor -fopenmp bin/tmk-query.cpp -o tmk-query-parallel -L. -ltmk $(OMP_LIB)
+tmk-two-level-score-parallel: ./bin/tmk-two-level-score.cpp $(LIBHDR) libtmk.a
+	$(CC_IF_WIN) -Xpreprocessor -fopenmp bin/tmk-two-level-score.cpp -o tmk-two-level-score-parallel -L. -ltmk $(OMP_LIB)
 
 # ================================================================
 tags:

--- a/tmk/cpp/algo/tmkfv.cpp
+++ b/tmk/cpp/algo/tmkfv.cpp
@@ -13,7 +13,6 @@
 
 #if defined(_WIN32)
   #define _USE_MATH_DEFINES
-  #include <iostream>
 #endif
 
 #include <cmath>

--- a/tmk/cpp/algo/tmkfv.cpp
+++ b/tmk/cpp/algo/tmkfv.cpp
@@ -11,6 +11,11 @@
 #include <tmk/cpp/algo/tmkfv.h>
 #include <tmk/cpp/lib/vec.h>
 
+#if defined(_WIN32)
+  #define _USE_MATH_DEFINES
+  #include <iostream>
+#endif
+
 #include <cmath>
 #include <stdexcept>
 

--- a/tmk/cpp/bin/tmk-hash-video.cpp
+++ b/tmk/cpp/bin/tmk-hash-video.cpp
@@ -19,6 +19,13 @@
 
 using namespace std;
 
+const std::string PATH_SEPARATOR =
+#if defined(_WIN32)
+                                    "\\";
+#else
+                                    "/";
+#endif
+
 // ----------------------------------------------------------------
 void usage(char* argv0, int exit_rc) {
   FILE* fp = (exit_rc == 0) ? stdout : stderr;
@@ -163,11 +170,11 @@ int main(int argc, char* argv[]) {
   //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   if (outputDirectory != "") {
     // Strip containing directory:
-    std::string b = basename(inputVideoFileName, "/");
+    std::string b = basename(inputVideoFileName, PATH_SEPARATOR);
     // Strip file extension:
     b = stripExtension(b, ".");
     // E.g. -i /path/to/foo.mp4 -d /tmp -> /tmp/foo.tmk
-    outputFeatureVectorsFileName = outputDirectory + "/" + b + ".tmk";
+    outputFeatureVectorsFileName = outputDirectory + PATH_SEPARATOR + b + ".tmk";
   }
 
   FILE* outputFp = facebook::tmk::io::openFileOrDie(

--- a/tmk/cpp/hashing/filehasher.cpp
+++ b/tmk/cpp/hashing/filehasher.cpp
@@ -9,7 +9,6 @@
 #include <stdio.h>
 #include <memory>
 
-#include <iostream>
 #include <iomanip>
 #include <sstream>
 

--- a/tmk/cpp/hashing/filehasher.cpp
+++ b/tmk/cpp/hashing/filehasher.cpp
@@ -9,6 +9,17 @@
 #include <stdio.h>
 #include <memory>
 
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+
+const char* POPEN_MODE =
+#if defined(_WIN32)
+                          "rb";
+#else
+                          "r";
+#endif
+
 using namespace std;
 
 namespace facebook {
@@ -27,7 +38,7 @@ bool hashVideo(
     fprintf(stderr, "%s\n", ffmpegGeneratorCommand.c_str());
   }
 
-  FILE* inputFp = popen(ffmpegGeneratorCommand.c_str(), "r");
+  FILE* inputFp = popen(ffmpegGeneratorCommand.c_str(), POPEN_MODE);
   if (inputFp == nullptr) {
     fprintf(stderr, "%s: ffmpeg to generate video stream failed\n", argv0);
     return false;
@@ -180,17 +191,14 @@ bool hashVideoFile(
 
   // add single quotes around the file name and then escape any single quotes inside it
   // example: my file's.mp4 -> 'my file'\''s.mp4'
-  std::string escapedInputVideoFileName = "'";
-  for (char c : inputVideoFileName) {
-    if (c == '\'') {
-      escapedInputVideoFileName += "'\\''";
-    } else {
-      escapedInputVideoFileName += c;
-    }
-  }
-  escapedInputVideoFileName += "'";
+  std::stringstream ss;
 
-  std::string command = ffmpegPath + " -nostdin -i " + escapedInputVideoFileName + " -s " +
+  ss << quoted(inputVideoFileName);
+  std::string escapedInputVideoFileName = ss.str();
+  std::string ffmpegLogLevel = verbose ? "" : "-loglevel warning -hide_banner -stats";
+
+  std::string command = ffmpegPath + " " + ffmpegLogLevel + " -nostdin -i " +
+      escapedInputVideoFileName + " -s " +
       std::to_string(downsampleFrameDimension) + ":" +
       std::to_string(downsampleFrameDimension) +
       " -an -f rawvideo -c:v rawvideo -pix_fmt rgb24 -r " +


### PR DESCRIPTION
Summary
---------

Had similar issues as described in https://github.com/facebook/ThreatExchange/issues/189 so made several edits which allow compilation to succeed on Windows.

I also added some flags to reduce `ffmpeg`'s noisy output (if verbose was not enabled).

There are still changes needed to the Makefile, but I haven't attempted merging those yet. In brief:

Instead of:
`CC=g++ -O2 -std=c++14 -I../..`

Use:
`CC_WIN=g++ -O2 -std=gnu++14 -I../..`

for:
- ./hashing/filehasher.o
- tmkdump
- tmk-clusterize
- tmk-query
- tmk-two-level-score

You will also need to install `make`, e.g., via [choco](https://community.chocolatey.org/packages/make) and [MinGW](https://osdn.net/projects/mingw/). Note that, MinGW needs to be added to the system path in order to compile and use the executables.

The tests will not run after `make` without more changes, but they can be run manually. Haven't extensively tested, but output appears identical.

Still need:
- [ ] README
- [ ] Makefile changes (including testing)

Test Plan
---------

<!--Replace with a description of how you tested this change, did you add test, run something locally...-->
