### PR TITLE
[HMA] Add dumb API for batch detached signal additions

### DIFF
--- a/hasher-matcher-actioner/hmalib/banks/bank_operations.py
+++ b/hasher-matcher-actioner/hmalib/banks/bank_operations.py
@@ -115,3 +115,40 @@ def add_detached_bank_member_signal(
         signal_type=signal_type,
         signal_value=signal_value,
     )
+
+
+"""
+Represents a single detached signal being added to a bank. Container
+ContentType, SignalType and the signal value.
+"""
+
+
+class Signal(t.NamedTuple):
+    content_type: t.Type[ContentType]
+    signal_type: t.Type[SignalType]
+    signal_value: str
+
+
+def add_detached_bank_member_signal_batch(
+    banks_table: BanksTable,
+    bank_id: str,
+    signals: t.Iterable[Signal],
+) -> t.Iterable[BankMemberSignal]:
+    """
+    Dump a large number of detached signals into a bank. Check
+    add_detached_bank_member_signal for more details.
+
+    TODO: At this point, is dumb. Does not actually batch the requests, instead
+    loops through signals and calls single APIs.
+    """
+    return list(
+        map(
+            lambda signal: banks_table.add_detached_bank_member_signal(
+                bank_id=bank_id,
+                content_type=signal.content_type,
+                signal_type=signal.signal_type,
+                signal_value=signal.signal_value,
+            ),
+            signals,
+        )
+    )

--- a/hasher-matcher-actioner/requirements-dev.txt
+++ b/hasher-matcher-actioner/requirements-dev.txt
@@ -1,7 +1,7 @@
 .[all]
 pytest==6.2.1
 mypy==0.910
-black==21.12b0
+black==22.3.0
 moto==2.3.2
 pandas==1.3.5
 WebTest==2.0.35

--- a/hasher-matcher-actioner/setup.py
+++ b/hasher-matcher-actioner/setup.py
@@ -14,7 +14,7 @@ extras_require = {
 all_extras = set(sum(extras_require.values(), []))
 extras_require["test"] = sorted({"pytest==6.2.1", "freezegun==1.1.0"} | all_extras)
 extras_require["package"] = ["wheel"]
-extras_require["lint"] = ["black==21.12b0"]
+extras_require["lint"] = ["black==22.3.0"]
 extras_require["type"] = ["types-requests==2.27.1", "types-freezegun==1.1.7"]
 extras_require["all"] = sorted(set(sum(extras_require.values(), [])))
 


### PR DESCRIPTION
Summary
---
Add a bank_operation that supports batch signal additions to a bank. With threatexchange → banks being worked on, I have a hunch this will be useful. No optimizations yet, but get the API up.

- An NGO partner had asked me for this feature
- I felt the need to use this when creatng a bank with a large number of objects.

Because CI started failing, I added a second [commit](https://github.com/facebook/ThreatExchange/pull/961/commits/1884fec1c625249343daf848a917720dc2698a81) upgrading black and click to this PR. If reviewer wants, can be moved to its own PR. 

Test Plan
---
Used this to successfully create a bank with million + records. Usual python suspects (mypy, black, py.test)
