### PR TITLE
During index building, measure time to fetch data from banks.

### DIFF
--- a/hasher-matcher-actioner/hmalib/banks/bank_operations.py
+++ b/hasher-matcher-actioner/hmalib/banks/bank_operations.py
@@ -135,7 +135,7 @@ def add_detached_bank_member_signal_batch(
     signals: t.Iterable[Signal],
 ) -> t.Iterable[BankMemberSignal]:
     """
-    Dump a large number of detached signals into a bank. Check
+    Dump multiple detached signals into a bank. Check
     add_detached_bank_member_signal for more details.
 
     TODO: At this point, is dumb. Does not actually batch the requests, instead

--- a/hasher-matcher-actioner/hmalib/lambdas/unified_indexer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/unified_indexer.py
@@ -137,7 +137,8 @@ def lambda_handler(event, context):
             config=s3_config, metrics_logger=metrics.names.indexer
         ).load_data()
 
-        bank_data = get_all_bank_hash_rows(signal_type, banks_table)
+        with metrics.timer(metrics.names.indexer.get_bank_data):
+            bank_data = get_all_bank_hash_rows(signal_type, banks_table)
 
         with metrics.timer(metrics.names.indexer.merge_datafiles):
             logger.info(f"Merging {signal_type} Hash files")

--- a/hasher-matcher-actioner/hmalib/metrics/__init__.py
+++ b/hasher-matcher-actioner/hmalib/metrics/__init__.py
@@ -103,6 +103,7 @@ class names:
         merge_datafiles = f"{_prefix}.merge_datafiles"
         search_index = f"{_prefix}.search_index"
         download_index = f"{_prefix}.download_index"
+        get_bank_data = f"{_prefix}.get_bank_data"
 
 
 _METRICS_NAMESPACE_ENVVAR = "METRICS_NAMESPACE"


### PR DESCRIPTION
Summary
---
The indexing process has multiple stages. One of the newer ones is getting member signals from banks.

So far, it was not getting measured. Now that we are building 1M+ banks, this becomes a significant part of the indexing duration.

Add a metric name and measure it during index building.

Test Plan
---
Deployed to my personal hma instance.

Attached screenshot of cloudwatch metrics. Notice `get_bank_data` in the graph.
<img width="1753" alt="Screen Shot 2022-03-28 at 15 32 29" src="https://user-images.githubusercontent.com/217056/160472859-3d38a9d3-373a-4d8a-aebe-1fb89852e522.png">

During the course of 1 day, as I added more members to the bank, the index building time increased specifically because the `get_bank_data` time increased.
