### PR TITLE
Parallel processing - improved

### DIFF
--- a/tmk/README.md
+++ b/tmk/README.md
@@ -77,12 +77,30 @@ Notes:
 ## Windows users
 
 Some basic modifications have been made to enable support for Windows. To compile, you will also need to install `make`, e.g., via [choco](https://community.chocolatey.org/packages/make) and [MinGW](https://osdn.net/projects/mingw/).
-  - MinGW needs to be added to the system path in order to compile and use the executables
+
+- MinGW needs to be added to the system path in order to compile and use the executables
 
 Known issues:
-  - The tests will not run after `make` without more changes, but they can be run manually
-  - Avoid BOM or CRLF line endings (e.g., if `haystack.txt` files are supplied)
-  - Use of absolute file paths may need more work in some cases. Try relative paths, or copying executables (like `ffmpeg.exe`) to your local directory.
+
+- The tests will not run after `make` without more changes, but they can be run manually
+- Avoid BOM or CRLF line endings (e.g., if `haystack.txt` files are supplied)
+- Use of absolute file paths may need more work in some cases. Try relative paths, or copying executables (like `ffmpeg.exe`) to your local directory.
+
+## Performance and parallelization
+
+Parallelized variants of some of the binaries can be compiled using `make parallel`.
+
+OpenMP's runtime library and [FAISS](https://github.com/facebookresearch/faiss) are required dependencies. On a Mac, these can be installed with brew (i.e., `brew install libomp faiss`).
+
+Drop-in replacements:
+
+- `tmk-clusterize-parallel` instead of `tmk-clusterize`
+- `tmk-two-level-score-parallel` instead of `tmk-two-level-score`
+- `tmk-query-parallel` or `tmk-query-with-faiss` instead of `tmk-query`
+
+Known issues:
+
+- The current faiss implementation is almost certainly wrong and will produce different results than `tmk-query`
 
 ## Compute hashes of sample videos and compare to previous outputs
 

--- a/tmk/cpp/bin/tmk-query-with-faiss.cpp
+++ b/tmk/cpp/bin/tmk-query-with-faiss.cpp
@@ -207,7 +207,7 @@ int main(int argc, char** argv) {
       printf("MINIMUM POINTS NOT MET FOR FAISS: %d FOUND vs %d EXPECTED\n", (int)num_database_vectors, min_points);
     }
     if (!force) {
-      printf(stderr, "Number of points is below minimum size for faiss. Run with --force flag to ignore this error.\n");
+      fprintf(stderr, "Number of points is below minimum size for faiss. Run with --force flag to ignore this error.\n");
       exit(2);
     }
   }


### PR DESCRIPTION
Summary
---------

This is an improvement to https://github.com/facebook/ThreatExchange/pull/959.

#### Bug fix for faiss

- Minor bug fix: 0bed18fd86869b349689bb30aa6b1c375ff95822

#### Simplified/optimized use of omp parallel

- Eliminates the OOM faults from the existing version, and is generally a lot simpler. It seems to be very slightly faster as well.

#### Unordered maps

- Switch to unordered maps. Since we are running this in parallel, we can achieve faster lookups, and there is no advantage to use ordered maps since we are sorting the final output anyway.

#### Optimized for loops

- Rather than iterating through the entire loop twice, and checking whether or not it's a degenerate pair within the inner loop, this optimization allows for just a single run through to produce all of the unique pairs.

```cpp

    for (unsigned int i = 0; i < filenames.size() - 1; i++) {
      for (unsigned int j = i + 1; j < filenames.size(); j++) {
        // comparison here
      }
    }
```

- The iteration through the TMK arrays was modified to accommodate a more facile parallelization. Essentially, we build a list of filenames like this first. This also allows us to prefill the adjacencyMatrix diagonal and avoid an unneeded extra computation.

```cpp
  std::vector<std::string> filenames;
  filenames.reserve(metadataToFeatures.size());

  for (const auto &s : metadataToFeatures) {
    // prefill adjacencyMatrix diagonal
    adjacencyMatrix[s.first].insert(s.first);
    filenames.push_back(s.first);
  }
  ```

#### Documentation

- Updated README to add notes about how to build the parallel versions

Test Plan
---------

<!--Replace with a description of how you tested this change, did you add test, run something locally...-->
