### PR TITLE
[pytx] Incremental progress fixing up fb_threat_exchange

### DIFF
--- a/python-threatexchange/threatexchange/cli/dataset_cmd.py
+++ b/python-threatexchange/threatexchange/cli/dataset_cmd.py
@@ -164,7 +164,6 @@ class DatasetCommand(command_base.Command):
         collabs = [
             c for c in settings.get_all_collabs(default_to_sample=True) if c.enabled
         ]
-
         if self.only_collabs:
             collabs = [c for c in collabs if c.name in self.only_collabs]
         return collabs

--- a/python-threatexchange/threatexchange/cli/fetch_cmd.py
+++ b/python-threatexchange/threatexchange/cli/fetch_cmd.py
@@ -226,7 +226,7 @@ class FetchCommand(command_base.Command):
 
         from_time = ""
         if self.last_update_time is not None:
-            if not from_time:
+            if self.last_update_time <= 0:
                 from_time = "ages long past"
             elif self.last_update_time >= time.time() - 1:
                 from_time = "moments ago"

--- a/python-threatexchange/threatexchange/extensions/text_tlsh/tests/test_tlsh_hash_and_match.py
+++ b/python-threatexchange/threatexchange/extensions/text_tlsh/tests/test_tlsh_hash_and_match.py
@@ -4,11 +4,12 @@ import unittest
 
 try:
     import tlsh
-    from threatexchange.extensions.text_tlsh.text_tlsh import TextTLSHSignal
 
     _DISABLED = False
 except ImportError:
     _DISABLED = True
+else:
+    from threatexchange.extensions.text_tlsh.text_tlsh import TextTLSHSignal
 
 
 @unittest.skipIf(_DISABLED, "tlsh not installed")

--- a/python-threatexchange/threatexchange/extensions/text_tlsh/tests/test_tlsh_hash_and_match.py
+++ b/python-threatexchange/threatexchange/extensions/text_tlsh/tests/test_tlsh_hash_and_match.py
@@ -1,10 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import unittest
 
-from threatexchange.extensions.text_tlsh.text_tlsh import TextTLSHSignal
 
 try:
     import tlsh
+    from threatexchange.extensions.text_tlsh.text_tlsh import TextTLSHSignal
 
     _DISABLED = False
 except ImportError:

--- a/python-threatexchange/threatexchange/fetcher/apis/fb_threatexchange_signal.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/fb_threatexchange_signal.py
@@ -1,0 +1,33 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Helper to allow you to hint at the ThreatExchange type string on SignalTypes
+"""
+
+import typing as t
+
+
+class HasFbThreatExchangeIndicatorType:
+    """
+    A mixin to hint to fb_threatexchange_api how to handle this SignalType
+
+    For example, PDQSignalType, aka "pdq" in ThreatExchange is "HASH_PDQ"
+
+    We could hardcode all of these into the fetch() method, but that doesn't
+    play nicely with expansions. Our solution:
+
+    ```
+    class PDQSignalType(SignalType, HasFbThreatExchangeIndicatorType):
+        INDICATOR_TYPE = "HASH_PDQ"
+        ...
+    ```
+    """
+
+    INDICATOR_TYPE: t.ClassVar[t.Union[str, t.Tuple[str, ...]]] = ()
+
+    @classmethod
+    def facebook_threatexchange_indicator_applies(cls, indicator_type: str) -> bool:
+        types = cls.INDICATOR_TYPE
+        if isinstance(cls.INDICATOR_TYPE, str):
+            types = (cls.INDICATOR_TYPE,)
+        return indicator_type in types

--- a/python-threatexchange/threatexchange/fetcher/simple/state.py
+++ b/python-threatexchange/threatexchange/fetcher/simple/state.py
@@ -136,10 +136,9 @@ class SimpleFetchedStateStore(fetch_state.FetchedStateStoreBase):
 
     def _get_state(self, collab_name: str) -> _StateTracker:
         if collab_name not in self._state:
+            logging.debug("Loading state for %s", collab_name)
             read_state = self._read_state(collab_name) or ({}, None)
-            ret = _StateTracker(*read_state)
-            self._state[collab_name] = ret
-            return ret
+            self._state[collab_name] = _StateTracker(*read_state)
         return self._state[collab_name]
 
     def merge(  # type: ignore[override]  # fix with generics on base

--- a/python-threatexchange/threatexchange/signal_type/md5.py
+++ b/python-threatexchange/threatexchange/signal_type/md5.py
@@ -10,13 +10,18 @@ import pathlib
 import typing as t
 
 from threatexchange.content_type.content_base import ContentType
-from threatexchange.content_type.photo import PhotoContent
 from threatexchange.content_type.video import VideoContent
+from threatexchange.fetcher.apis.fb_threatexchange_signal import (
+    HasFbThreatExchangeIndicatorType,
+)
+from threatexchange.signal_type import signal_base
 
-from . import signal_base
 
-
-class VideoMD5Signal(signal_base.SimpleSignalType, signal_base.BytesHasher):
+class VideoMD5Signal(
+    signal_base.SimpleSignalType,
+    signal_base.BytesHasher,
+    HasFbThreatExchangeIndicatorType,
+):
     """
     Simple signal type for Video MD5s.
 
@@ -54,20 +59,3 @@ class VideoMD5Signal(signal_base.SimpleSignalType, signal_base.BytesHasher):
     @staticmethod
     def get_examples() -> t.List[str]:
         return ["cab08b36195edb1a1231d2d09fa450e0", "d41d8cd98f00b204e9800998ecf8427e"]
-
-
-class PhotoMD5Signal(VideoMD5Signal):
-    """
-    Simple signal type for Photo MD5s.
-
-    Unlike Videos, transcoding of photos is quite common. This should be
-    a format of last resort, as the open source PDQ algorithm will usually
-    have much higher recall without too much loss in precision.
-    """
-
-    INDICATOR_TYPE = "HASH_MD5"
-    TYPE_TAG = "media_type_photo"
-
-    @classmethod
-    def get_content_types(self) -> t.List[t.Type[ContentType]]:
-        return [PhotoContent]

--- a/python-threatexchange/threatexchange/signal_type/pdq.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq.py
@@ -12,6 +12,9 @@ from threatexchange.content_type.content_base import ContentType
 from threatexchange.content_type.photo import PhotoContent
 from threatexchange.signal_type import signal_base
 from threatexchange.hashing.pdq_utils import simple_distance
+from threatexchange.fetcher.apis.fb_threatexchange_signal import (
+    HasFbThreatExchangeIndicatorType,
+)
 
 
 # TODO force this as a required library?
@@ -22,7 +25,11 @@ def _raise_pillow_warning():
     )
 
 
-class PdqSignal(signal_base.SimpleSignalType, signal_base.BytesHasher):
+class PdqSignal(
+    signal_base.SimpleSignalType,
+    signal_base.BytesHasher,
+    HasFbThreatExchangeIndicatorType,
+):
     """
     PDQ is an open source photo similarity algorithm.
 
@@ -38,7 +45,6 @@ class PdqSignal(signal_base.SimpleSignalType, signal_base.BytesHasher):
     """
 
     INDICATOR_TYPE = "HASH_PDQ"
-    TYPE_TAG = "media_type_photo"
 
     # This may need to be updated (TODO make more configurable)
     # Hashes of distance less than or equal to this threshold are considered a 'match'

--- a/python-threatexchange/threatexchange/signal_type/pdq_ocr.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_ocr.py
@@ -16,13 +16,19 @@ from threatexchange.content_type.content_base import ContentType
 from threatexchange.content_type.photo import PhotoContent
 
 from threatexchange.hashing.pdq_utils import pdq_match, simple_distance
-from threatexchange import common
 from threatexchange.signal_type.pdq import PdqSignal
 from threatexchange.signal_type.raw_text import RawTextSignal
-from . import signal_base
+from threatexchange.signal_type import signal_base
+from threatexchange.fetcher.apis.fb_threatexchange_signal import (
+    HasFbThreatExchangeIndicatorType,
+)
 
 
-class PdqOcrSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
+class PdqOcrSignal(
+    signal_base.SimpleSignalType,
+    signal_base.FileHasher,
+    HasFbThreatExchangeIndicatorType,
+):
     """
     PDQ is an open source photo similarity algorithm. See 'pdq.py'
     This signal type combines pdq hashes with a text string found using

--- a/python-threatexchange/threatexchange/signal_type/raw_text.py
+++ b/python-threatexchange/threatexchange/signal_type/raw_text.py
@@ -15,9 +15,16 @@ from threatexchange.content_type.content_base import ContentType
 from threatexchange.content_type.text import TextContent
 from threatexchange.signal_type import signal_base
 from threatexchange.signal_type import index
+from threatexchange.fetcher.apis.fb_threatexchange_signal import (
+    HasFbThreatExchangeIndicatorType,
+)
 
 
-class RawTextSignal(signal_base.SimpleSignalType, signal_base.MatchesStr):
+class RawTextSignal(
+    signal_base.SimpleSignalType,
+    signal_base.MatchesStr,
+    HasFbThreatExchangeIndicatorType,
+):
     """
     Raw text signal is the same as raw text content: the exact text content.
 

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -160,27 +160,6 @@ class SimpleSignalType(SignalType):
     Assumes that the signal type can easily merge on a string.
     """
 
-    INDICATOR_TYPE: t.Union[str, t.Tuple[str, ...]] = ()
-    TYPE_TAG: t.Optional[str] = None
-
-    @classmethod
-    def facebook_threatexchange_indicator_applies(
-        cls, indicator_type: str, tags: t.List[str]
-    ) -> bool:
-        """
-        A helper for Facebook ThreatExchange indicator conversion.
-
-        TODO: Consider moving to its own helper class.
-        """
-        types = cls.INDICATOR_TYPE
-        if isinstance(cls.INDICATOR_TYPE, str):
-            types = (cls.INDICATOR_TYPE,)
-        if indicator_type not in types:
-            return False
-        if cls.TYPE_TAG is not None:
-            return cls.TYPE_TAG in tags
-        return True
-
     @classmethod
     def compare_hash(
         cls, hash1: str, hash2: str, distance_threshold: t.Optional[int] = None

--- a/python-threatexchange/threatexchange/signal_type/tests/test_hash_from_x.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/test_hash_from_x.py
@@ -21,7 +21,6 @@ class SignalTypeHashTest(unittest.TestCase):
 
     # TODO - maybe make a metaclass for this to automatically detect?
     SIGNAL_TYPES_TO_TEST = [
-        md5.PhotoMD5Signal,
         md5.VideoMD5Signal,
         pdq_ocr.PdqOcrSignal,
         pdq.PdqSignal,

--- a/python-threatexchange/threatexchange/signal_type/trend_query.py
+++ b/python-threatexchange/threatexchange/signal_type/trend_query.py
@@ -13,6 +13,9 @@ from threatexchange.content_type.text import TextContent
 
 from threatexchange.signal_type import signal_base
 from threatexchange.signal_type import index
+from threatexchange.fetcher.apis.fb_threatexchange_signal import (
+    HasFbThreatExchangeIndicatorType,
+)
 
 
 class TrendQuery:
@@ -46,7 +49,9 @@ class TrendQuery:
         return False
 
 
-class TrendQuerySignal(signal_base.SignalType, signal_base.MatchesStr):
+class TrendQuerySignal(
+    signal_base.SignalType, signal_base.MatchesStr, HasFbThreatExchangeIndicatorType
+):
     """
     Trend Queries are a combination of and/or/not regexes.
 
@@ -56,6 +61,8 @@ class TrendQuerySignal(signal_base.SignalType, signal_base.MatchesStr):
 
     They have high "recall" but potentially low "precision".
     """
+
+    INDICATOR_TYPE = "TREND_QUERY"
 
     @classmethod
     def get_content_types(self) -> t.List[t.Type[ContentType]]:

--- a/python-threatexchange/threatexchange/signal_type/url.py
+++ b/python-threatexchange/threatexchange/signal_type/url.py
@@ -10,9 +10,12 @@ import typing as t
 from threatexchange.content_type.content_base import ContentType
 from threatexchange.content_type.url import URLContent
 from threatexchange.signal_type import signal_base
+from threatexchange.fetcher.apis.fb_threatexchange_signal import (
+    HasFbThreatExchangeIndicatorType,
+)
 
 
-class URLSignal(signal_base.SimpleSignalType):
+class URLSignal(signal_base.SimpleSignalType, HasFbThreatExchangeIndicatorType):
     """
     Wrapper around URL links, such as https://github.com/
     """

--- a/python-threatexchange/threatexchange/signal_type/url_md5.py
+++ b/python-threatexchange/threatexchange/signal_type/url_md5.py
@@ -13,9 +13,16 @@ from threatexchange.content_type.url import URLContent
 from threatexchange.signal_type import signal_base
 from threatexchange import common
 from threatexchange.signal_type.url import URLSignal
+from threatexchange.fetcher.apis.fb_threatexchange_signal import (
+    HasFbThreatExchangeIndicatorType,
+)
 
 
-class UrlMD5Signal(signal_base.SimpleSignalType, signal_base.TextHasher):
+class UrlMD5Signal(
+    signal_base.SimpleSignalType,
+    signal_base.TextHasher,
+    HasFbThreatExchangeIndicatorType,
+):
     """
     Simple signal type for URL MD5s.
     """


### PR DESCRIPTION
Summary
---------

This is the result of a few hours of work trying to fix up fb_threatexchange.

Features:
1. HasFbThreatExchangeIndicatorType allows signal types to record their fb type
2. (Maybe dangerous/should be removed) Will fall back to trying the signal name otherwise

Misc fixes:
1. Fix cli storage not using all correct translations by switching to the helper
4. Fix errors during serialization leaving partial files by writing to a tmpfile first
5. Fix display from fetch always showing "since the beginning of time"

Test Plan
---------

```
$ threatexchange config api fb_threat_exchange -I 303636684709969

$ threatexchange fetch
[fb_threat_exchange] HMA Test Collaboration (Superset) - Up to date, at 2021-12-19T04:09:52
Rebuilding match indices...
Building index for raw_text with 1 signals...
Index for raw_text ready
Building index for pdq with 138 signals...
Index for pdq ready
Building index for url with 3 signals...
Index for url ready
```

Sadly, the data doesn't actually match, but that's a future diff.