### PR TITLE
[pytx] fix subtle bug with match

### DIFF
--- a/python-threatexchange/threatexchange/cli/cli_config.py
+++ b/python-threatexchange/threatexchange/cli/cli_config.py
@@ -167,7 +167,7 @@ class CLISettings:
         self._state = cli_state
         self._sample_message_printed = False
         self._config: t.Optional[CLiConfig] = None
-        self.index_store = CliIndexStore(cli_state.index_dir)
+        self.index = CliIndexStore(cli_state.index_dir)
 
     def get_persistent_config(self) -> CLiConfig:
         if self._config is None:

--- a/python-threatexchange/threatexchange/cli/cli_state.py
+++ b/python-threatexchange/threatexchange/cli/cli_state.py
@@ -45,7 +45,7 @@ class CliIndexStore:
     def __init__(self, indice_dir: pathlib.Path) -> None:
         self.dir = indice_dir
 
-    def get_available(self) -> t.List[str]:
+    def list(self) -> t.List[str]:
         """Return the names (SignalType.get_name()) of stored indices"""
         return [
             str(f)[: -len(self.FILE_EXTENSION)]
@@ -71,7 +71,7 @@ class CliIndexStore:
         """The expected path for the index for a signal type"""
         return self.dir / f"{signal_type.get_name()}{self.FILE_EXTENSION}"
 
-    def store_index(
+    def store(
         self, signal_type: t.Type[signal_base.SignalType], index: SignalTypeIndex
     ) -> None:
         """Persist a SignalTypeIndex to disk"""
@@ -80,7 +80,7 @@ class CliIndexStore:
         with path.open("wb") as fout:
             index.serialize(fout)
 
-    def load_index(
+    def load(
         self, signal_type: t.Type[signal_base.SignalType]
     ) -> t.Optional[index.SignalTypeIndex]:
         """Load the SignalTypeIndex for this type from disk"""

--- a/python-threatexchange/threatexchange/cli/dataset_cmd.py
+++ b/python-threatexchange/threatexchange/cli/dataset_cmd.py
@@ -234,7 +234,7 @@ class DatasetCommand(command_base.Command):
         only_signals = None
         if self.only_signals or self.only_content:
             only_signals = self.get_signal_types(settings)
-        settings.index_store.clear(only_signals)
+        settings.index.clear(only_signals)
 
     def execute_generate_indices(self, settings: CLISettings) -> None:
         signal_types = self.get_signal_types(settings)
@@ -245,7 +245,7 @@ class DatasetCommand(command_base.Command):
             signals = signal_by_type.get(s_type, {})
             if not signals:
                 logging.info("No signals for %s", s_type.__name__)
-                settings.index_store.clear([s_type])
+                settings.index.clear([s_type])
                 continue
 
             self.stderr(
@@ -254,5 +254,5 @@ class DatasetCommand(command_base.Command):
                 f"with {len(signals)} signals...",
             )
             index = index_cls.build(signals.items())
-            settings.index_store.store_index(s_type, index)
+            settings.index.store(s_type, index)
             self.stderr(f"Index for {s_type.get_name()} ready")

--- a/python-threatexchange/threatexchange/cli/match_cmd.py
+++ b/python-threatexchange/threatexchange/cli/match_cmd.py
@@ -170,7 +170,7 @@ class MatchCommand(command_base.Command):
                 yield parsed
 
     def execute(self, settings: CLISettings) -> None:
-        if not settings.index_store.get_available():
+        if not settings.index.list():
             if not settings.in_demo_mode:
                 raise CommandError("No indices available. Do you need to fetch?")
             self.stderr("You haven't built any indices, so we'll call `fetch` for you!")
@@ -195,18 +195,18 @@ class MatchCommand(command_base.Command):
 
         matchers = []
         for s_type in signal_types:
-            index = settings.index_store.load_index(s_type)
+            index = settings.index.load(s_type)
             if index is None:
                 logging.info("No index for %s, skipping", s_type.get_name())
                 continue
             query = None
             if self.inline:
                 if issubclass(s_type, TextHasher):
-                    query = lambda t: index.query(s_type.hash_from_str(t))  # type: ignore
+                    query = lambda t, index=index: index.query(s_type.hash_from_str(t))  # type: ignore
                 elif issubclass(s_type, MatchesStr):
-                    query = lambda t: index.query(t)  # type: ignore
+                    query = lambda t, index=index: index.query(t)  # type: ignore
             else:
-                query = lambda f: index.query(s_type.hash_from_file(f))  # type: ignore
+                query = lambda f, index=index: index.query(s_type.hash_from_file(f))  # type: ignore
             if query:
                 matchers.append((s_type, query))
 

--- a/python-threatexchange/threatexchange/extensions/text_tlsh/tests/test_tlsh_hash_and_match.py
+++ b/python-threatexchange/threatexchange/extensions/text_tlsh/tests/test_tlsh_hash_and_match.py
@@ -1,7 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import unittest
 
-from threatexchange.extensions.text_tlsh.text_tlsh import TextTLSHSignal
 
 try:
     import tlsh
@@ -9,6 +8,8 @@ try:
     _DISABLED = False
 except ImportError:
     _DISABLED = True
+else:
+    from threatexchange.extensions.text_tlsh.text_tlsh import TextTLSHSignal
 
 
 @unittest.skipIf(_DISABLED, "tlsh not installed")

--- a/python-threatexchange/threatexchange/signal_type/url.py
+++ b/python-threatexchange/threatexchange/signal_type/url.py
@@ -15,7 +15,11 @@ from threatexchange.fetcher.apis.fb_threatexchange_signal import (
 )
 
 
-class URLSignal(signal_base.SimpleSignalType, signal_base.MatchesStr, HasFbThreatExchangeIndicatorType):
+class URLSignal(
+    signal_base.SimpleSignalType,
+    signal_base.MatchesStr,
+    HasFbThreatExchangeIndicatorType,
+):
     """
     Wrapper around URL links, such as https://github.com/
     """

--- a/python-threatexchange/threatexchange/signal_type/url.py
+++ b/python-threatexchange/threatexchange/signal_type/url.py
@@ -12,7 +12,7 @@ from threatexchange.content_type.url import URLContent
 from threatexchange.signal_type import signal_base
 
 
-class URLSignal(signal_base.SimpleSignalType):
+class URLSignal(signal_base.SimpleSignalType, signal_base.MatchesStr):
     """
     Wrapper around URL links, such as https://github.com/
     """
@@ -22,6 +22,13 @@ class URLSignal(signal_base.SimpleSignalType):
     @classmethod
     def get_content_types(self) -> t.List[t.Type[ContentType]]:
         return [URLContent]
+
+    @classmethod
+    def matches_str(
+        cls, signal: str, haystack: str, distance_threshold: t.Optional[int] = None
+    ) -> signal_base.HashComparisonResult:
+        # TODO - normalization
+        return signal_base.HashComparisonResult.from_bool(signal == haystack)
 
     @staticmethod
     def get_examples() -> t.List[str]:


### PR DESCRIPTION
Summary
---------

Lambdas can capture variables in unexpected ways. In this case, the "index" variable was being overridden each loop, being left with the last value. A trick you can use to force it to capture the right value is to set it as a default value to an argument, which is evaluated at declaration time (whereas captured variables are evaluated at runtime).

Also minor renames, of the index accessor, which I plan to follow up with others as well:
```
settings.index  # Indices
settings.collabs  # collab configs
settings.fetchers  # apis
...
```

Test Plan
---------

I had a collaboration that had URLs, but not URL MD5s, and the md5s were evaluated second, which would be None. This generated a None attribute error without the fix.



