### PR TITLE
Connecting Timebucketizer instance to LCC Indexer class

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/tests/test_timebucket.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_timebucket.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass
 import datetime
 import tempfile
+import typing as t
 import unittest
 
 from freezegun import freeze_time
@@ -21,7 +22,8 @@ class SampleCSViableClass(CSViable):
     def to_csv(self):
         return [self.a, self.b]
 
-    def from_csv(self, value):
+    @classmethod
+    def from_csv(cls, value: t.List[str]):
         return SampleCSViableClass()
 
 

--- a/hasher-matcher-actioner/hmalib/common/timebucketizer.py
+++ b/hasher-matcher-actioner/hmalib/common/timebucketizer.py
@@ -174,8 +174,6 @@ class TimeBucketizer(t.Generic[T]):
 
         for file in file_list:
             with open(file, "r") as my_file:
-                content_list.extend(
-                    list(map(type_class.from_csv, csv.reader(my_file)))
-                )
+                content_list.extend(list(map(type_class.from_csv, csv.reader(my_file))))
 
         return content_list

--- a/hasher-matcher-actioner/hmalib/common/timebucketizer.py
+++ b/hasher-matcher-actioner/hmalib/common/timebucketizer.py
@@ -175,7 +175,7 @@ class TimeBucketizer(t.Generic[T]):
         for file in file_list:
             with open(file, "r") as my_file:
                 content_list.extend(
-                    list(map(type_class().from_csv, csv.reader(my_file)))
+                    list(map(type_class.from_csv, csv.reader(my_file)))
                 )
 
         return content_list

--- a/hasher-matcher-actioner/hmalib/indexers/lcc.py
+++ b/hasher-matcher-actioner/hmalib/indexers/lcc.py
@@ -2,6 +2,7 @@
 
 import glob
 import os.path
+import pathlib
 import pickle
 import time
 import typing as t
@@ -21,15 +22,16 @@ logger = get_logger(__name__)
 
 class LCCIndexer:
     @classmethod
-    def get_recent_index(cls, storage_path, signal_type, bucket_width) -> PDQIndex:
+    def get_recent_index(cls, storage_path, signal_type) -> PDQIndex:
         """Get the most recent index."""
+        directory = os.path.join(storage_path, signal_type)
+        latest_directory = max(pathlib.Path(directory).glob("*/"), key=os.path.getmtime)
 
-        file_type = r"\*csv"
-        files = glob.glob(f"{storage_path}''{signal_type}")
-        latest_index_file = max(files, key=os.path.getctime)
+        print(latest_directory)
+        # latest_index_file = max(latest_directory, key=os.path.getctime)
 
-        with open(f"{latest_index_file}", "rb") as f:
-            pickle.load(f)
+        with open(latest_directory, "rb") as f:
+            return pickle.load(f)
 
     # find some way to access most recent index in file structure
     # indexObjPath = path of index with latest creation time (should already be sorted by time in file structure)
@@ -70,16 +72,7 @@ class LCCIndexer:
         get most recent index of type PDQ
         write most recent index of specific index type
         """
-        # use path lib for file directory
-        with open(
-            f"{storage_path}''{signal_type}''{datetime.now()-bucket_width}", "wb"
-        ) as f:
+        creation_time = str(datetime.now().strftime("%Y-%m-%d_%H:%M"))
+        directory = os.path.join(storage_path, signal_type, creation_time)
+        with open(directory, "wb") as f:
             pickle.dump(index, f)
-
-        # # variable name with creation time, index type, time delta value
-        # indexObj = {testIndex, datetime.now(), PDQIndex, d}
-        # # write_path = open(indexpath,"w")
-        # pickle.dump(indexObj, write_path)
-        # # example file structure
-        # # "/var/data/threatexchange/LCCIndexes/<hash_type>/2022-02-08-20-45-<pickle-name>.pickle"
-        # # os.listdirs, check if this returns sorted list of files

--- a/hasher-matcher-actioner/hmalib/indexers/lcc.py
+++ b/hasher-matcher-actioner/hmalib/indexers/lcc.py
@@ -1,11 +1,14 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import glob
+import os.path
 import pickle
 import time
 import typing as t
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
+from threatexchange.signal_type.index import SignalTypeIndex
 from threatexchange.signal_type.pdq_index import PDQIndex
 
 from hmalib.common.logging import get_logger
@@ -28,8 +31,13 @@ logger = get_logger(__name__)
 
 class LCCIndexer:
     @classmethod
-    def get_recent_index(cls) -> PDQIndex:
+    def get_recent_index(cls, storage_path) -> PDQIndex:
         """Get the most recent index."""
+        os.listdir(storage_path)[0]
+        file_type = r"\*csv"
+        files = glob.glob(storage_path + file_type)
+        latest_index = max(files, key=os.path.getctime)
+        return latest_index
 
     # find some way to access most recent index in file structure
     # indexObjPath = path of index with latest creation time (should already be sorted by time in file structure)
@@ -39,26 +47,37 @@ class LCCIndexer:
     # return latest_index
 
     @classmethod
-    def build_index_from_last_24h(cls, tbi) -> None:
+    def build_index_from_last_24h(cls, signal_type, storage_path, bucket_width) -> None:
         """Create an index"""
         d = timedelta(days=1)
 
         past_day_content = TimeBucketizer.get_records(
             (datetime.now() - d),
             datetime.now(),
-            tbi.type,
-            tbi.storage_path,
-            tbi.bucket_width,
+            signal_type,
+            storage_path,
+            bucket_width,
             HashRecord,
         )
-        # now = datetime.now()
-        print(past_day_content)
+
         record_list = []
         for record in past_day_content:
             record_list.append((record.content_hash, record.content_id))
         testIndex = PDQIndex.build(record_list)
-
         return testIndex
+
+    @classmethod
+    def override_recent_index(
+        cls, index: SignalTypeIndex, signal_type, storage_path, bucket_width, write_path
+    ) -> None:
+        """
+        get most recent index of type PDQ
+        write most recent index of specific index type
+        """
+        d = timedelta(days=1)
+        pickle.dump(
+            index, f"{write_path}''{signal_type}''{datetime.now()-bucket_width}"
+        )
         # # variable name with creation time, index type, time delta value
         # indexObj = {testIndex, datetime.now(), PDQIndex, d}
         # # write_path = open(indexpath,"w")

--- a/hasher-matcher-actioner/hmalib/indexers/lcc.py
+++ b/hasher-matcher-actioner/hmalib/indexers/lcc.py
@@ -27,18 +27,8 @@ class LCCIndexer:
         directory = os.path.join(storage_path, signal_type)
         latest_directory = max(pathlib.Path(directory).glob("*/"), key=os.path.getmtime)
 
-        print(latest_directory)
-        # latest_index_file = max(latest_directory, key=os.path.getctime)
-
         with open(latest_directory, "rb") as f:
             return pickle.load(f)
-
-    # find some way to access most recent index in file structure
-    # indexObjPath = path of index with latest creation time (should already be sorted by time in file structure)
-    # file = open(indexObjPath,"r")
-    # latest_index = pickle.load(file)
-    # file.close()
-    # return latest_index
 
     @classmethod
     def build_index_from_last_24h(cls, signal_type, storage_path, bucket_width) -> None:

--- a/hasher-matcher-actioner/hmalib/indexers/lcc.py
+++ b/hasher-matcher-actioner/hmalib/indexers/lcc.py
@@ -18,26 +18,18 @@ from hmalib.common.timebucketizer import TimeBucketizer
 starttime = time.time()
 logger = get_logger(__name__)
 
-# parameters of get_records
-# def get_records(
-#         since: datetime.datetime,
-# until: datetime.datetime,
-# type: str,
-# storage_path: str,
-# bucket_width: datetime.timedelta,
-# type_class: t.Type[CSViable],
-# ):
-
 
 class LCCIndexer:
     @classmethod
-    def get_recent_index(cls, storage_path) -> PDQIndex:
+    def get_recent_index(cls, storage_path, signal_type, bucket_width) -> PDQIndex:
         """Get the most recent index."""
-        os.listdir(storage_path)[0]
+
         file_type = r"\*csv"
-        files = glob.glob(storage_path + file_type)
-        latest_index = max(files, key=os.path.getctime)
-        return latest_index
+        files = glob.glob(f"{storage_path}''{signal_type}")
+        latest_index_file = max(files, key=os.path.getctime)
+
+        with open(f"{latest_index_file}", "rb") as f:
+            pickle.load(f)
 
     # find some way to access most recent index in file structure
     # indexObjPath = path of index with latest creation time (should already be sorted by time in file structure)
@@ -68,16 +60,22 @@ class LCCIndexer:
 
     @classmethod
     def override_recent_index(
-        cls, index: SignalTypeIndex, signal_type, storage_path, bucket_width, write_path
+        cls,
+        index: SignalTypeIndex,
+        signal_type,
+        storage_path,
+        bucket_width,
     ) -> None:
         """
         get most recent index of type PDQ
         write most recent index of specific index type
         """
-        d = timedelta(days=1)
-        pickle.dump(
-            index, f"{write_path}''{signal_type}''{datetime.now()-bucket_width}"
-        )
+        # use path lib for file directory
+        with open(
+            f"{storage_path}''{signal_type}''{datetime.now()-bucket_width}", "wb"
+        ) as f:
+            pickle.dump(index, f)
+
         # # variable name with creation time, index type, time delta value
         # indexObj = {testIndex, datetime.now(), PDQIndex, d}
         # # write_path = open(indexpath,"w")

--- a/hasher-matcher-actioner/hmalib/indexers/lcc.py
+++ b/hasher-matcher-actioner/hmalib/indexers/lcc.py
@@ -1,0 +1,68 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import pickle
+import time
+import typing as t
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from threatexchange.signal_type.pdq_index import PDQIndex
+
+from hmalib.common.logging import get_logger
+from hmalib.common.models.pipeline import HashRecord
+from hmalib.common.timebucketizer import TimeBucketizer
+
+starttime = time.time()
+logger = get_logger(__name__)
+
+# parameters of get_records
+# def get_records(
+#         since: datetime.datetime,
+# until: datetime.datetime,
+# type: str,
+# storage_path: str,
+# bucket_width: datetime.timedelta,
+# type_class: t.Type[CSViable],
+# ):
+
+
+class LCCIndexer:
+    @classmethod
+    def get_recent_index(cls) -> PDQIndex:
+        """Get the most recent index."""
+
+    # find some way to access most recent index in file structure
+    # indexObjPath = path of index with latest creation time (should already be sorted by time in file structure)
+    # file = open(indexObjPath,"r")
+    # latest_index = pickle.load(file)
+    # file.close()
+    # return latest_index
+
+    @classmethod
+    def build_index_from_last_24h(cls, tbi) -> None:
+        """Create an index"""
+        d = timedelta(days=1)
+
+        past_day_content = TimeBucketizer.get_records(
+            (datetime.now() - d),
+            datetime.now(),
+            tbi.type,
+            tbi.storage_path,
+            tbi.bucket_width,
+            HashRecord,
+        )
+        # now = datetime.now()
+        print(past_day_content)
+        record_list = []
+        for record in past_day_content:
+            record_list.append((record.content_hash, record.content_id))
+        testIndex = PDQIndex.build(record_list)
+
+        return testIndex
+        # # variable name with creation time, index type, time delta value
+        # indexObj = {testIndex, datetime.now(), PDQIndex, d}
+        # # write_path = open(indexpath,"w")
+        # pickle.dump(indexObj, write_path)
+        # # example file structure
+        # # "/var/data/threatexchange/LCCIndexes/<hash_type>/2022-02-08-20-45-<pickle-name>.pickle"
+        # # os.listdirs, check if this returns sorted list of files

--- a/hasher-matcher-actioner/hmalib/indexers/tests/test_lcc_indexer.py
+++ b/hasher-matcher-actioner/hmalib/indexers/tests/test_lcc_indexer.py
@@ -30,11 +30,5 @@ class TestLCCIndexer(unittest.TestCase):
             test_index = test_class.build_index_from_last_24h(
                 tbi.type, tbi.storage_path, tbi.bucket_width
             )
-            # test_class.override_recent_index(test_index,tbi.type,tbi.storage_path,tbi.bucket_width,write_path)
-            # print(
-            #     test_index.query(
-            #         "19055fc67a4e8d667d9668700c1920ff19005fc67a4e8d667d9668700c1920ff"
-            #     )
-            # )
-            # should return a list with non-zero length
-            # self.assertEqual(3, 4)
+            test_class.override_recent_index(test_index, tbi.type, td, tbi.bucket_width)
+            print(test_class.get_recent_index(td, tbi.type))

--- a/hasher-matcher-actioner/hmalib/indexers/tests/test_lcc_indexer.py
+++ b/hasher-matcher-actioner/hmalib/indexers/tests/test_lcc_indexer.py
@@ -7,26 +7,8 @@ from hmalib.common.models.pipeline import HashRecord
 from hmalib.common.timebucketizer import CSViable, TimeBucketizer
 from hmalib.indexers.lcc import LCCIndexer
 
+
 # python -m py.test hmalib/indexers/tests/test_lcc_indexer.py::TestLCCIndexer::test
-
-
-@dataclass(eq=True)
-class SampleCSViableClass(CSViable):
-    """
-    Example class used for testing purposes.
-    """
-
-    def __init__(self):
-        self.a = "a"
-        self.b = "b"
-
-    def to_csv(self):
-        return [self.a, self.b]
-
-    def from_csv(self, value):
-        return SampleCSViableClass()
-
-
 class TestLCCIndexer(unittest.TestCase):
     def test(self):
         with tempfile.TemporaryDirectory() as td:
@@ -45,12 +27,14 @@ class TestLCCIndexer(unittest.TestCase):
             )
             tbi.force_flush()
             test_class = LCCIndexer()
-            test_index = test_class.build_index_from_last_24h(tbi)
-            print(
-                test_index.query(
-                    "19055fc67a4e8d667d9668700c1920ff19005fc67a4e8d667d9668700c1920ff"
-                )
+            test_index = test_class.build_index_from_last_24h(
+                tbi.type, tbi.storage_path, tbi.bucket_width
             )
+            # test_class.override_recent_index(test_index,tbi.type,tbi.storage_path,tbi.bucket_width,write_path)
+            # print(
+            #     test_index.query(
+            #         "19055fc67a4e8d667d9668700c1920ff19005fc67a4e8d667d9668700c1920ff"
+            #     )
+            # )
             # should return a list with non-zero length
-            self.assertEqual(3, 4)
-        # print("Hello", testClass)
+            # self.assertEqual(3, 4)

--- a/hasher-matcher-actioner/hmalib/indexers/tests/test_lcc_indexer.py
+++ b/hasher-matcher-actioner/hmalib/indexers/tests/test_lcc_indexer.py
@@ -7,8 +7,6 @@ from hmalib.common.models.pipeline import HashRecord
 from hmalib.common.timebucketizer import CSViable, TimeBucketizer
 from hmalib.indexers.lcc import LCCIndexer
 
-
-# python -m py.test hmalib/indexers/tests/test_lcc_indexer.py::TestLCCIndexer::test
 class TestLCCIndexer(unittest.TestCase):
     def test(self):
         with tempfile.TemporaryDirectory() as td:

--- a/hasher-matcher-actioner/hmalib/indexers/tests/test_lcc_indexer.py
+++ b/hasher-matcher-actioner/hmalib/indexers/tests/test_lcc_indexer.py
@@ -7,6 +7,7 @@ from hmalib.common.models.pipeline import HashRecord
 from hmalib.common.timebucketizer import CSViable, TimeBucketizer
 from hmalib.indexers.lcc import LCCIndexer
 
+
 class TestLCCIndexer(unittest.TestCase):
     def test(self):
         with tempfile.TemporaryDirectory() as td:

--- a/hasher-matcher-actioner/hmalib/indexers/tests/test_lcc_indexer.py
+++ b/hasher-matcher-actioner/hmalib/indexers/tests/test_lcc_indexer.py
@@ -1,0 +1,56 @@
+import datetime
+import tempfile
+import unittest
+from dataclasses import dataclass
+
+from hmalib.common.models.pipeline import HashRecord
+from hmalib.common.timebucketizer import CSViable, TimeBucketizer
+from hmalib.indexers.lcc import LCCIndexer
+
+# python -m py.test hmalib/indexers/tests/test_lcc_indexer.py::TestLCCIndexer::test
+
+
+@dataclass(eq=True)
+class SampleCSViableClass(CSViable):
+    """
+    Example class used for testing purposes.
+    """
+
+    def __init__(self):
+        self.a = "a"
+        self.b = "b"
+
+    def to_csv(self):
+        return [self.a, self.b]
+
+    def from_csv(self, value):
+        return SampleCSViableClass()
+
+
+class TestLCCIndexer(unittest.TestCase):
+    def test(self):
+        with tempfile.TemporaryDirectory() as td:
+            tbi = TimeBucketizer(datetime.timedelta(minutes=1), td, "hasher", "2")
+            tbi.add_record(
+                HashRecord(
+                    "55fc67a4e8d667d9668700c1920ff19055fc67a4e8d667d9668700c1920ff190",
+                    "teststring",
+                )
+            )
+            tbi.add_record(
+                HashRecord(
+                    "5c4474f0e17bb56d0d73cca24c77e0d75c4474f0e17bb56d0d73cca24c77e0d7",
+                    "teststring",
+                )
+            )
+            tbi.force_flush()
+            test_class = LCCIndexer()
+            test_index = test_class.build_index_from_last_24h(tbi)
+            print(
+                test_index.query(
+                    "19055fc67a4e8d667d9668700c1920ff19005fc67a4e8d667d9668700c1920ff"
+                )
+            )
+            # should return a list with non-zero length
+            self.assertEqual(3, 4)
+        # print("Hello", testClass)


### PR DESCRIPTION
Summary
---------
I made and connected a Timebucketizer instance to my LCCIndexer class and its build_index_from_last_24h method. I added Hash Records to the TB instance and built those records into an index. I also queried a hash record from the test index to check that the index is populated.
<!--Replace with a summary of your change-->

Test Plan
---------
To run and test the LCC indexer, run the command below.
`python -m py.test hmalib/indexers/tests/test_lcc_indexer.py::TestLCCIndexer::test`

<!--Replace with a description of how you tested this change, did you add test, run something locally...-->
