### PR TITLE
[pytx] Cleaner behavior for `threatexchange hash`

### DIFF
--- a/python-threatexchange/threatexchange/cli/match_cmd.py
+++ b/python-threatexchange/threatexchange/cli/match_cmd.py
@@ -57,7 +57,7 @@ class MatchCommand(command_base.Command):
     USE_STDIN = "-"
 
     @classmethod
-    def init_argparse(cls, settings: CLISettings, ap) -> None:
+    def init_argparse(cls, settings: CLISettings, ap: argparse.ArgumentParser) -> None:
 
         ap.add_argument(
             "content_type",


### PR DESCRIPTION
Summary
---------

This one is just a fix for something that was bother me, as I continue to procrastinate implementing StopNCII.org's API. It's inspired by grep (and will likely add similar file notations as grep at some point).

```
    # Stdin
    $ echo "Some text" | threatexchange hash text     

    # File
    $ threatexchange hash text a_file.txt b_file.txt

    # --
    $ threatexchange hash text -- Some text
```

Test Plan
---------

Added unittests
