### PR TITLE
Add text support for hashing for python threatexchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ HMA is a ready-to-deploy content moderation project for AWS, containing many sub
 
 ## python-threatexchange
 
-A python Library/CLI tool available on pypi under `threatexchange` which provides implementations for content scanning and signal exchange. It provides reference implementations in python for downloading hashes from Meta's ThreatExchange API, scanning images with PDQ, and others. It can also be easily extended to work with other hash exchanges and other tecnhniques, not all of which are written by the maintainers of this repository.
+A python Library/CLI tool available on pypi under `threatexchange` which provides implementations for content scanning and signal exchange. It provides reference implementations in python for downloading hashes from Meta's ThreatExchange API, scanning images with PDQ, and others. It can also be easily extended to work with other hash exchanges and other techniques, not all of which are written by the maintainers of this repository.
 
 
 ## Meta's ThreatExchange API Reference Examples

--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -12,6 +12,7 @@ from threatexchange.cli.cli_config import CLISettings
 
 from threatexchange.signal_type.signal_base import BytesHasher, FileHasher, TextHasher
 from threatexchange.cli import command_base
+from threatexchange.signal_type.text_md5 import TextMD5Signal
 
 
 # TODO consider refactor to handle overlap with match

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -41,6 +41,7 @@ from threatexchange.signal_type import (
     url as url_signal,
     url_md5,
     trend_query,
+    text_md5,
 )
 from threatexchange.cli.cli_config import CLiConfig, CliState
 from threatexchange.cli.cli_config import CLISettings
@@ -172,6 +173,7 @@ def _get_settings(config: CLiConfig, dir: pathlib.Path) -> CLISettings:
             url_signal.URLSignal,
             url_md5.UrlMD5Signal,
             trend_query.TrendQuerySignal,
+            text_md5.TextMD5Signal,
         ]
         + extensions.signal_types,
     )

--- a/python-threatexchange/threatexchange/cli/tests/sample_data_e2e_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/sample_data_e2e_test.py
@@ -14,7 +14,12 @@ class SampleDataE2ETest(ThreatExchangeCLIE2eTest):
         """The classic first use of the CLI"""
         self.assert_cli_output(
             ("match", "text", "-I", self.MATCHES_ONE),
-            "raw_text - (Sample Signals) WORTH_INVESTIGATING",
+            "\n".join(
+                (
+                    "raw_text - (Sample Signals) WORTH_INVESTIGATING",
+                    "text_md5 - (Sample Signals) WORTH_INVESTIGATING",
+                )
+            ),
         )
 
     def test_sequential_to_match(self):
@@ -23,7 +28,12 @@ class SampleDataE2ETest(ThreatExchangeCLIE2eTest):
         self.cli_call("dataset", "-r")
         self.assert_cli_output(
             ("match", "text", "-I", self.MATCHES_ONE),
-            "raw_text - (Sample Signals) WORTH_INVESTIGATING",
+            "\n".join(
+                (
+                    "raw_text - (Sample Signals) WORTH_INVESTIGATING",
+                    "text_md5 - (Sample Signals) WORTH_INVESTIGATING",
+                )
+            ),
         )
 
     def test_multiple_match(self):
@@ -34,6 +44,7 @@ class SampleDataE2ETest(ThreatExchangeCLIE2eTest):
                 (
                     "raw_text - (Sample Signals) WORTH_INVESTIGATING",
                     "trend_query - (Sample Signals) WORTH_INVESTIGATING",
+                    "text_md5 - (Sample Signals) WORTH_INVESTIGATING",
                 ),
             ),
         )

--- a/python-threatexchange/threatexchange/signal_type/text_md5.py
+++ b/python-threatexchange/threatexchange/signal_type/text_md5.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Wrapper around the Text MD5 signal types.
+"""
+
+import typing as t
+import hashlib
+import pathlib
+from threatexchange.content_type.content_base import ContentType
+from threatexchange.content_type.text import TextContent
+
+from threatexchange.signal_type import signal_base
+from threatexchange import common
+from threatexchange.signal_type.raw_text import RawTextSignal
+from threatexchange.fetcher.apis.fb_threatexchange_signal import (
+    HasFbThreatExchangeIndicatorType,
+)
+
+
+class TextMD5Signal(
+    signal_base.SimpleSignalType,
+    signal_base.TextHasher,
+    signal_base.FileHasher,
+    HasFbThreatExchangeIndicatorType,
+):
+    """
+    Simple signal type for Text MD5s.
+    """
+
+    INDICATOR_TYPE = "TEXT_URL_MD5"
+
+    @classmethod
+    def get_content_types(self) -> t.List[t.Type[ContentType]]:
+        return [TextContent]
+
+    @classmethod
+    def hash_from_str(cls, text: str) -> str:
+        encoded_text = common.normalize_string(text).encode("utf-8")
+        text_hash = hashlib.md5(encoded_text)
+        return text_hash.hexdigest()
+
+    @classmethod
+    def hash_from_file(cls, path: pathlib.Path) -> str:
+        file_hash = hashlib.md5()
+        blocksize = 8192
+        with open(path, "rb") as f:
+            chunk = f.read(blocksize)
+            while chunk:
+                file_hash.update(chunk)
+                chunk = f.read(blocksize)
+        return file_hash.hexdigest()
+
+    @staticmethod
+    def get_examples() -> t.List[str]:
+        return [TextMD5Signal.hash_from_str(s) for s in RawTextSignal.get_examples()]


### PR DESCRIPTION
Summary
---------
Previously `text` was an invalid choice for the hash command, both for inline and for file hashing.

#### Before
```
$ threatexchange hash text -I "sdfsdhkfhsdj"
usage: threatexchange hash [-h] [--signal-type {pdq,video_md5,url_md5}] [--inline] {
     photo,video,url} content [content ...]
threatexchange hash: error: argument content_type: invalid choice: 'text' (choose from 'photo', 'video', 'url')
```

```
threatexchange hash text file.txt                                 
usage: threatexchange hash [-h] [--signal-type {pdq,video_md5,url_md5}] [--inline]
                           {photo,video,url} content [content ...]
threatexchange hash: error: argument content_type: invalid choice: 'text' (choose from 'photo', 'video', 'url')
```

#### After

There is a new SignalType `text_md5`. I am not sure why it didn't exist before. Was it deleted?
Anyway, adding it here in this PR. The only thing is I just copied the hashing for the file from what we do on md5 😢 .
 Not the hashing expert so if anyone has other thoughts, feel free to comment.

```
threatexchange hash text -I "helllooooooooo" 
text_md5 eb6238a4a35130945111fd77bd3bf988
```

```
threatexchange hash text file.txt  
text_md5 6074299e0bea6a7842a2148e23d914f4
```

##### Note:

Not having an existing file will now throw a FileNotFoundError

```
threatexchange hash text blahblah.txt        speters/fix_cmd_validation  ✱
Traceback (most recent call last):
  File "/Users/sahanapeters/Code/ThreatExchange/python-threatexchange/env/bin/threatexchange", line 11, in <module>
    load_entry_point('threatexchange', 'console_scripts', 'threatexchange')()
  File "/Users/sahanapeters/Code/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 218, in main
    execute_command(settings, namespace)
  File "/Users/sahanapeters/Code/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 101, in execute_command
    command.execute(settings)
  File "/Users/sahanapeters/Code/ThreatExchange/python-threatexchange/threatexchange/cli/hash_cmd.py", line 112, in execute
    hash_str = hash_fn(signal_type, inp)
  File "/Users/sahanapeters/Code/ThreatExchange/python-threatexchange/threatexchange/cli/hash_cmd.py", line 105, in <lambda>
    hash_fn = lambda s, t: s.hash_from_file(t)
  File "/Users/sahanapeters/Code/ThreatExchange/python-threatexchange/threatexchange/signal_type/text_md5.py", line 48, in hash_from_file
    with open(path, "rb") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'blahblah.txt'
```

<!--Replace with a summary of your change-->

Test Plan
---------

<!--Replace with a description of how you tested this change, did you add test, run something locally...-->
Ran `make test`
