### PR TITLE
Fix validation on threatexchange hash inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ HMA is a ready-to-deploy content moderation project for AWS, containing many sub
 
 ## python-threatexchange
 
-A python Library/CLI tool available on pypi under `threatexchange` which provides implementations for content scanning and signal exchange. It provides reference implementations in python for downloading hashes from Meta's ThreatExchange API, scanning images with PDQ, and others. It can also be easily extended to work with other hash exchanges and other tecnhniques, not all of which are written by the maintainers of this repository.
+A python Library/CLI tool available on pypi under `threatexchange` which provides implementations for content scanning and signal exchange. It provides reference implementations in python for downloading hashes from Meta's ThreatExchange API, scanning images with PDQ, and others. It can also be easily extended to work with other hash exchanges and other techniques, not all of which are written by the maintainers of this repository.
 
 
 ## Meta's ThreatExchange API Reference Examples

--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -106,8 +106,12 @@ class HashCommand(command_base.Command):
             if isinstance(inp, str):
                 hash_fn = lambda s, t: s.hash_from_str(t)
                 signal_types = str_hashers
-
             for signal_type in signal_types:
-                hash_str = hash_fn(signal_type, inp)
-                if hash_str:
-                    print(signal_type.get_name(), hash_str)
+                try:
+                    hash_str = hash_fn(signal_type, inp)
+                    if hash_str:
+                        print(signal_type.get_name(), hash_str)
+                except FileNotFoundError:
+                    self.stderr(
+                        f"The file {inp} doesn't exist or the file path is incorrect"
+                    )

--- a/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
+++ b/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
@@ -33,18 +33,21 @@ class ThreatExchangeCLIE2eTest(unittest.TestCase):
         self.addCleanup(lambda: shutil.rmtree(str(state_dir)))
         self._state_dir = state_dir
 
-    def cli_call(self, *given_args: str) -> str:
+    def cli_call_helper(self, std_op: str, *given_args: str) -> str:
         args = list(self.COMMON_CALL_ARGS)
         args.extend(given_args)
         print("Calling: $ threatexchange", " ".join(args), file=sys.stderr)
         try:
-            with patch("sys.stdout", new=StringIO()) as fake_out:
+            with patch(std_op, new=StringIO()) as fake_out:
                 main(args, state_dir=self._state_dir)
             return fake_out.getvalue()
         except SystemExit as se:
             if se.code == 0:  # ERROR: Everything is fine
                 return fake_out.getvalue()
             raise E2ETestSystemExit(se.code)
+
+    def cli_call(self, *given_args: str) -> str:
+        return self.cli_call_helper("sys.stdout", *given_args)
 
     def assert_cli_output(
         self, args: t.Iterable[str], expected_output: t.Union[str, t.Dict[int, str]]
@@ -70,3 +73,9 @@ class ThreatExchangeCLIE2eTest(unittest.TestCase):
         self.assertEqual(exception.returncode, 2)
         if msg_regex is not None:
             self.assertRegex(str(exception), msg_regex)
+
+    def assert_cli_error_output(
+        self, given_args: t.Iterable[str], expected_err: t.Union[str, t.Dict[int, str]]
+    ) -> None:
+        output = self.cli_call_helper("sys.stderr", *given_args)
+        self.assertEqual(expected_err, output.strip())

--- a/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
@@ -17,3 +17,8 @@ class HashCommandTest(ThreatExchangeCLIE2eTest):
             self.assert_cli_output(
                 ("video", fp.name), "video_md5 d41d8cd98f00b204e9800998ecf8427e"
             )
+
+        self.assert_cli_error_output(
+            ("url", "blah.txt"),
+            "The file blah.txt doesn't exist or the file path is incorrect",
+        )

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -95,7 +95,18 @@ class SignalType:
         return []
 
 
-class TextHasher:
+class FileHasher:
+    """
+    This class can hash files.
+    """
+
+    @classmethod
+    def hash_from_file(cls, file: pathlib.Path) -> str:
+        """Get a string representation of the hash from a file"""
+        raise NotImplementedError
+
+
+class TextHasher(FileHasher):
     """
     This class can turn text into intermediary representations (hashes)
     """
@@ -121,20 +132,6 @@ class MatchesStr:
         Note that this can just be a reference/helper, and the efficient
         version of the algorithm can live in the index class.
         """
-        raise NotImplementedError
-
-
-class FileHasher:
-    """
-    This class can hash files.
-
-    If also inheiriting from StrHasher, put this second in the inheiretence
-    to prefer file hashing to reading the file in as a Str.
-    """
-
-    @classmethod
-    def hash_from_file(cls, file: pathlib.Path) -> str:
-        """Get a string representation of the hash from a file"""
         raise NotImplementedError
 
 


### PR DESCRIPTION
Summary
---------

Opening this PR in favor of closing https://github.com/facebook/ThreatExchange/pull/984 for cleanliness.

What this PR does

1. Adds an error handling for file not found exception for `hash_cmd.py`
2. Makes TextHasher extend FileHasher. 
 Since `threatexchange hash text file.txt` or `threatexchange hash url file.txt` would not return hashes.
3. ~~Raise a ValueError for text_tlsh when the input text is too short.~~

##### For future reference

How to add `tlsh` extension for Threatexchange

```
$ threatexchange config extensions add threatexchange.extensions.text_tlsh
```


Test Plan
---------
`make test`
<!--Replace with a description of how you tested this change, did you add test, run something locally...-->
