### PR TITLE
[pytx] threatexchange hash to give error on invalid file

### DIFF
--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -9,6 +9,7 @@ import pathlib
 import sys
 import typing as t
 from threatexchange.cli.cli_config import CLISettings
+from threatexchange.cli.exceptions import CommandError
 
 from threatexchange.signal_type.signal_base import BytesHasher, FileHasher, TextHasher
 from threatexchange.cli import command_base
@@ -112,6 +113,6 @@ class HashCommand(command_base.Command):
                     if hash_str:
                         print(signal_type.get_name(), hash_str)
                 except FileNotFoundError:
-                    self.stderr(
-                        f"The file {inp} doesn't exist or the file path is incorrect"
+                    raise CommandError(
+                        f"The file {inp} doesn't exist or the file path is incorrect", 2
                     )

--- a/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
@@ -18,7 +18,7 @@ class HashCommandTest(ThreatExchangeCLIE2eTest):
                 ("video", fp.name), "video_md5 d41d8cd98f00b204e9800998ecf8427e"
             )
 
-        self.assert_cli_error_output(
+        self.assert_cli_usage_error(
             ("url", "blah.txt"),
             "The file blah.txt doesn't exist or the file path is incorrect",
         )


### PR DESCRIPTION
Summary
---------
I wasn't looking close enough and missed this in the original PR, apologies!

Return codes can inform you if a program executed as expected. Return code 0 = success, 2 = user error (invalid arguments, etc)
```
# Before
$ threatexchange hash noexist
$ echo $?  # Display return code
0

# After
$ threatexchange hash noexist
$ echo $?  # Display return code
2
```

Test Plan
---------

Updated test