### PR TITLE
Add get_index() and  connect lcc_hasher() to LCCIndexer

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -48,7 +48,7 @@ IMAGE_BUCKET_NAME = os.environ["IMAGE_BUCKET_NAME"]
 IMAGE_PREFIX = os.environ["IMAGE_PREFIX"]
 SUBMISSIONS_QUEUE_URL = os.environ["SUBMISSIONS_QUEUE_URL"]
 HASHES_QUEUE_URL = os.environ["HASHES_QUEUE_URL"]
-
+LCC_DURABLE_FS_PATH = os.environ["LCC_DURABLE_FS_PATH"]
 INDEXES_BUCKET_NAME = os.environ["INDEXES_BUCKET_NAME"]
 INDEXER_FUNCTION_NAME = os.environ["INDEXER_FUNCTION_NAME"]
 WRITEBACK_QUEUE_URL = os.environ["WRITEBACKS_QUEUE_URL"]
@@ -166,7 +166,10 @@ def bottle_init_once() -> t.Tuple[
 
     app.mount(
         "/lcc/",
-        get_lcc_api(),
+        get_lcc_api(
+            storage_path=LCC_DURABLE_FS_PATH,
+            signal_type_mapping=functionality_mapping.signal_and_content,
+        ),
     )
 
     apig_wsgi_handler = make_lambda_handler(app)

--- a/hasher-matcher-actioner/hmalib/lambdas/api/lcc.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/lcc.py
@@ -1,3 +1,4 @@
+import functools
 import typing as t
 from dataclasses import asdict, dataclass
 
@@ -7,8 +8,7 @@ from mypy_boto3_dynamodb.service_resource import Table
 from hmalib.common.config import HMAConfig
 from hmalib.common.models.bank import BankMember, BanksTable
 from hmalib.indexers.lcc import LCCIndexer
-from hmalib.lambdas.api.middleware import (DictParseable, JSONifiable, SubApp,
-                                           jsoninator)
+from hmalib.lambdas.api.middleware import DictParseable, JSONifiable, SubApp, jsoninator
 
 
 @dataclass

--- a/hasher-matcher-actioner/hmalib/lambdas/api/lcc.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/lcc.py
@@ -2,11 +2,13 @@ import typing as t
 from dataclasses import asdict, dataclass
 
 import bottle
+from mypy_boto3_dynamodb.service_resource import Table
+
 from hmalib.common.config import HMAConfig
 from hmalib.common.models.bank import BankMember, BanksTable
 from hmalib.indexers.lcc import LCCIndexer
-from hmalib.lambdas.api.middleware import DictParseable, JSONifiable, SubApp, jsoninator
-from mypy_boto3_dynamodb.service_resource import Table
+from hmalib.lambdas.api.middleware import (DictParseable, JSONifiable, SubApp,
+                                           jsoninator)
 
 
 @dataclass
@@ -22,10 +24,13 @@ class LCCResponse(JSONifiable):
             "preview_url": self.preview_url,
         }
 
+
 @functools.lru_cache(maxsize=None)
 def get_index(storage_path, signal_type):
     index = LCCIndexer.get_recent_index(storage_path, signal_type)
     return index
+
+
 def get_lcc_api(storage_path) -> bottle.Bottle:
 
     lcc_api = SubApp()

--- a/hasher-matcher-actioner/hmalib/lambdas/api/lcc.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/lcc.py
@@ -1,18 +1,20 @@
 import functools
 import typing as t
 from dataclasses import asdict, dataclass
-
 import bottle
+
 from mypy_boto3_dynamodb.service_resource import Table
 
-from hmalib.common.config import HMAConfig
-from hmalib.common.models.bank import BankMember, BanksTable
+from threatexchange.signal_type.index import SignalTypeIndex
+from threatexchange.signal_type.signal_base import SignalType
+
+from hmalib.common.mappings import HMASignalTypeMapping
 from hmalib.indexers.lcc import LCCIndexer
 from hmalib.lambdas.api.middleware import DictParseable, JSONifiable, SubApp, jsoninator
 
 
 @dataclass
-class LCCResponse(JSONifiable):
+class RecentlySeenLCCResponse(JSONifiable):
     found_match: bool
     content_id: t.Optional[str]
     preview_url: t.Optional[str]
@@ -26,23 +28,47 @@ class LCCResponse(JSONifiable):
 
 
 @functools.lru_cache(maxsize=None)
-def get_index(storage_path, signal_type):
-    index = LCCIndexer.get_recent_index(storage_path, signal_type)
+def get_index(storage_path: str, signal_type_name: str):
+    index = LCCIndexer.get_recent_index(storage_path, signal_type_name)
     return index
 
 
-def get_lcc_api(storage_path) -> bottle.Bottle:
+def get_lcc_api(
+    signal_type_mapping: HMASignalTypeMapping, storage_path: str
+) -> bottle.Bottle:
+    """
+    Some APIs to provide live content clustering cabilities. This will index all
+    recently seen content and provide a way to query for content_ids matching a
+    given hash.
+    """
 
     lcc_api = SubApp()
 
-    @lcc_api.get("/", apply=[jsoninator])
-    def lcc_hasher() -> LCCResponse:
-        index = get_index(storage_path, bottle.request.query.hash.signal_type)
+    @lcc_api.get("/recently-seen/", apply=[jsoninator])
+    def recently_seen_in_lcc() -> RecentlySeenLCCResponse:
+        """
+        Given a signal_type and a hash, have we seen something like this
+        recently? Uses default precision knobs.
+
+        TODO: Make thresholds configurable.
+        """
+        signal_type = signal_type_mapping.get_signal_type_enforce(
+            bottle.request.query.signal_type
+        )
         hash_value = bottle.request.query.hash
+
+        index = get_index(storage_path, signal_type.get_name())
+
         match_array = index.query(hash_value)
-        match_value = False
-        if len(match_array) != 0:
-            match_value = True
-        return LCCResponse(match_value, hash_value, match_value[0].metadata)
+        found_match = bool(len(match_array))
+
+        if not found_match:
+            return RecentlySeenLCCResponse(False, None, None)
+
+        # Use the first result as the content_id, TODO: convert content_Id to
+        # preview_url, also add content_type
+        content_id = match_array[0].metadata
+        preview_url = content_id
+        return RecentlySeenLCCResponse(found_match, content_id, preview_url)
 
     return lcc_api

--- a/hasher-matcher-actioner/hmalib/lambdas/api/lcc.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/lcc.py
@@ -4,6 +4,7 @@ from dataclasses import asdict, dataclass
 import bottle
 from hmalib.common.config import HMAConfig
 from hmalib.common.models.bank import BankMember, BanksTable
+from hmalib.indexers.lcc import LCCIndexer
 from hmalib.lambdas.api.middleware import DictParseable, JSONifiable, SubApp, jsoninator
 from mypy_boto3_dynamodb.service_resource import Table
 
@@ -21,14 +22,22 @@ class LCCResponse(JSONifiable):
             "preview_url": self.preview_url,
         }
 
-
-def get_lcc_api() -> bottle.Bottle:
+@functools.lru_cache(maxsize=None)
+def get_index(storage_path, signal_type):
+    index = LCCIndexer.get_recent_index(storage_path, signal_type)
+    return index
+def get_lcc_api(storage_path) -> bottle.Bottle:
 
     lcc_api = SubApp()
 
     @lcc_api.get("/", apply=[jsoninator])
     def lcc_hasher() -> LCCResponse:
-        print("Hash: ", bottle.request.query.hash)
-        return LCCResponse(False, "", "")
+        index = get_index(storage_path, bottle.request.query.hash.signal_type)
+        hash_value = bottle.request.query.hash
+        match_array = index.query(hash_value)
+        match_value = False
+        if len(match_array) != 0:
+            match_value = True
+        return LCCResponse(match_value, hash_value, match_value[0].metadata)
 
     return lcc_api

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -49,6 +49,7 @@ resource "aws_lambda_function" "api_root" {
       HASHES_QUEUE_URL                      = var.hashes_queue.url
       BANKS_MEDIA_BUCKET_NAME               = var.banks_media_storage.bucket_name
       INDEXER_FUNCTION_NAME                 = var.indexer_function_name
+      LCC_DURABLE_FS_PATH                   = "TODO: GET actual path. Verify API works with EFS security groups."
     }
   }
   tags = merge(


### PR DESCRIPTION
Summary
---------

I added a get_index method that gets the latest index to the LCC API. I also called it inside the lcc_hasher method so that the index can query a hash_value from a bottle request.

