### PR TITLE
Make hasher work with pytx refactored

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -75,12 +75,11 @@ def _get_matcher(index_bucket_name: str, banks_table: BanksTable) -> Matcher:
 _hasher = None
 
 
-def _get_hasher() -> UnifiedHasher:
+def _get_hasher(signal_type_mapping: HMASignalTypeMapping) -> UnifiedHasher:
     global _hasher
     if _hasher is None:
         _hasher = UnifiedHasher(
-            supported_content_types=[PhotoContent, VideoContent],
-            supported_signal_types=[PdqSignal, VideoMD5Signal],
+            signal_type_mapping=signal_type_mapping,
             output_queue_url="",
         )
 
@@ -570,7 +569,9 @@ def get_matches_api(
             return MediaFetchError()
 
         signal_to_matches = {}
-        for signal in _get_hasher().get_hashes(request.content_type, bytes_):
+        for signal in _get_hasher(signal_type_mapping=signal_type_mapping).get_hashes(
+            request.content_type, bytes_
+        ):
             signal_to_matches[signal.signal_type.get_name()] = {
                 signal.signal_value: _matches_for_hash(
                     signal_type=signal.signal_type, signal_value=signal.signal_value

--- a/hasher-matcher-actioner/terraform/hasher/main.tf
+++ b/hasher-matcher-actioner/terraform/hasher/main.tf
@@ -24,6 +24,7 @@ resource "aws_lambda_function" "hashing_lambda" {
       MEASURE_PERFORMANCE = var.measure_performance ? "True" : "False"
       HASHES_QUEUE_URL    = var.hashes_queue.url
       IMAGE_PREFIX        = var.image_data_storage.image_prefix
+      HMA_CONFIG_TABLE    = var.config_table.name
     }
   }
 
@@ -98,6 +99,11 @@ data "aws_iam_policy_document" "hashing_lambda" {
     effect    = "Allow"
     actions   = ["dynamodb:PutItem", "dynamodb:UpdateItem"]
     resources = [var.datastore.arn, var.banks_datastore.arn]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan"]
+    resources = [var.config_table.arn]
   }
   statement {
     effect    = "Allow"


### PR DESCRIPTION
Summary
---------
Use signal-type-mapping (rely on dynamic config drivent mappings).

Open hma-config access to hashing lambda.

Test Plan
---------
Ran locally. Running remote is harder because submissions don't work with refactor yet.
```sh
$ python -m hmalib.scripts.cli.main run-lambda --lambda-name hasher
Loading faiss with AVX2 support.
Could not load library with AVX2 support due to:
ModuleNotFoundError("No module named 'faiss.swigfaiss_avx2'")
Loading faiss.
Successfully loaded faiss.
Performance measurement requested. Supplying appmetrics instrumentation.
Unable to load THREAT_EXCHANGE_API_TOKEN_SECRET_NAME from env
/home/dipanjanm/.local/lib/python3.8/site-packages/pdqhash/__init__.py:3: UserWarning: Hash vector order changed between version 0.1.8 and 0.2.0. See https://github.com/faustomorales/pdqhash-python/issues/1 for more details.
  warnings.warn(
```

No errors, verified that the hash_record got created in dynamodb. Visited [hma content page](http://fb-dipanjanm-hma-webapp.s3-website-us-east-1.amazonaws.com/matches/006b9c44-0071-4653-abc8-3a1ed53a4f29). Screenshot attached.
<img width="724" alt="Screen Shot 2022-04-27 at 15 39 00" src="https://user-images.githubusercontent.com/217056/165610761-1d107a2f-b6b6-4ae1-8e0e-c0740d89c26d.png">


