### PR TITLE
Support `t.Optional[]` types in HMAConfig

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/aws_dataclass.py
+++ b/hasher-matcher-actioner/hmalib/common/aws_dataclass.py
@@ -61,7 +61,11 @@ def py_to_aws(py_field: t.Any, in_type: t.Optional[t.Type[T]] = None) -> T:
         )
 
     if origin == t.Union:
-        # For union types, call py_to_aws and OR their results.
+        if len(args) != 2 or type(None) not in args:
+            raise AWSSerializationFailure("Serialization error: Only t.Optional is supported as a Union Type.")
+
+        # For union types, call py_to_aws and return the first successful
+        # serialization result.
         for unioned_type in args:
             try:
                 result = py_to_aws(py_field, unioned_type)  # type: ignore
@@ -152,7 +156,11 @@ def aws_to_py(in_type: t.Type[T], aws_field: t.Any) -> T:
         check_type = str
 
     if origin == t.Union:
-        # For union types, call py_to_aws and OR their results.
+        if len(args) != 2 or type(None) not in args:
+            raise AWSSerializationFailure("Deserialization error: Only t.Optional is supported as a Union Type.")
+
+        # For union types, call aws_to_py and return the first successful
+        # serialization result.
         for unioned_type in args:
             try:
                 result = aws_to_py(unioned_type, aws_field)  # type: ignore

--- a/hasher-matcher-actioner/hmalib/common/aws_dataclass.py
+++ b/hasher-matcher-actioner/hmalib/common/aws_dataclass.py
@@ -32,7 +32,6 @@ from enum import Enum
 
 import json
 import typing as t
-import types
 
 T = t.TypeVar("T")
 

--- a/hasher-matcher-actioner/hmalib/common/aws_dataclass.py
+++ b/hasher-matcher-actioner/hmalib/common/aws_dataclass.py
@@ -62,7 +62,9 @@ def py_to_aws(py_field: t.Any, in_type: t.Optional[t.Type[T]] = None) -> T:
 
     if origin == t.Union:
         if len(args) != 2 or type(None) not in args:
-            raise AWSSerializationFailure("Serialization error: Only t.Optional is supported as a Union Type.")
+            raise AWSSerializationFailure(
+                "Serialization error: Only t.Optional is supported as a Union Type."
+            )
 
         # For union types, call py_to_aws and return the first successful
         # serialization result.
@@ -157,7 +159,9 @@ def aws_to_py(in_type: t.Type[T], aws_field: t.Any) -> T:
 
     if origin == t.Union:
         if len(args) != 2 or type(None) not in args:
-            raise AWSSerializationFailure("Deserialization error: Only t.Optional is supported as a Union Type.")
+            raise AWSSerializationFailure(
+                "Deserialization error: Only t.Optional is supported as a Union Type."
+            )
 
         # For union types, call aws_to_py and return the first successful
         # serialization result.

--- a/hasher-matcher-actioner/hmalib/common/tests/aws_dataclass_test.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/aws_dataclass_test.py
@@ -28,6 +28,11 @@ class Complicated:
 
 
 @dataclass
+class SimpleOptional(aws_dataclass.HasAWSSerialization):
+    a: t.Optional[int] = field(default=None)
+
+
+@dataclass
 class SimpleInt:
     a: int = 2
 
@@ -143,3 +148,17 @@ class AWSDataclassTest(unittest.TestCase):
         n.n = n
         # No recursion guard currently
         self.assertSerializesCorrectly(head)
+
+    def test_optional_attribute(self):
+        o_left_none = SimpleOptional()
+        self.assertSerializesCorrectly(o_left_none)
+
+        o_filled = SimpleOptional(12)
+        self.assertSerializesCorrectly(o_filled)
+
+        o_fail = SimpleOptional("should_fail")
+        self.assertRaises(
+            aws_dataclass.AWSSerializationFailure,
+            self.assertSerializesCorrectly,
+            o_fail,
+        )

--- a/hasher-matcher-actioner/hmalib/common/tests/test_aws_dataclass.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_aws_dataclass.py
@@ -162,3 +162,23 @@ class AWSDataclassTest(unittest.TestCase):
             self.assertSerializesCorrectly,
             o_fail,
         )
+
+    def test_only_optional_unions_allowed(self):
+        # We want to discourage typing unions where multiple types are used.
+        # Only optional is supported out of the box.
+        @dataclass
+        class _NastyOptional_WithTwoTypes(aws_dataclass.HasAWSSerialization):
+            fieldd: t.Union[int, float] = 12.0
+
+        @dataclass
+        class _NastyOptional_WithThreeTypes(aws_dataclass.HasAWSSerialization):
+            fieldd: t.Union[int, float, str] = "really"
+
+        nasties = [_NastyOptional_WithTwoTypes(), _NastyOptional_WithThreeTypes()]
+
+        for o_nasty in nasties:
+            self.assertRaises(
+                aws_dataclass.AWSSerializationFailure,
+                self.assertSerializesCorrectly,
+                o_nasty,
+            )


### PR DESCRIPTION
Summary
---
Some attributes in HMAConfigs can be optional.

HMAConfig objects at present do not support optional because it is a unioned type. I think they should.

This change enables those unioned types which are optional. A unit test has been added for
optional attributes. A second test has been added to ensure unions like t.Union[int, float], or t.Union[...2+ types] do not work.

Test Plan
---

New tests for aws_dataclass