### PR TITLE
[hma][config] allow config set attributes to be empty

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/tests/config_test.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/config_test.py
@@ -272,3 +272,22 @@ class ConfigTest(unittest.TestCase):
             " but it's not in get_subtype_classes",
         ):
             config.create_config(SubtypeAbstractParentClass("Foo", False))
+
+    def test_empty_set(self):
+        """
+        Unfortunately moto does not follow the API to a T.
+
+        https://github.com/spulec/moto/issues/5116
+
+        So we simply verify that writing an empty set and retrieving it works.
+        Behind the scenes, we are not writing empty sets, but a sentinel value
+        instead.
+        """
+
+        @dataclass
+        class HasSetConfig(config.HMAConfig):
+            a_set: t.Set[str] = field(default_factory=set)
+
+        conf = HasSetConfig(name="maybe-this-matters?")
+
+        self.assertEqualsAfterDynamodb(conf)


### PR DESCRIPTION
Summary
---
DynamoDB [does not support](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes) empty sets. However, some config attributes (like `only_tags`, `except_tags` for APIs) might be empty sets. This change adds a sentinel value to an empty set and removes that on retrieval for integer and string set types.

Test Plan
---
A unit test was added.

While it is possible to verify this behavior (empty set not allowed) on boto, moto does not raise the exception.  [Filed an issue](https://github.com/spulec/moto/issues/5116) for them and might fix it in a PR later.