### PR TITLE
[pytx] CLI can fix extension failures itself

### DIFF
--- a/python-threatexchange/threatexchange/cli/config_cmd.py
+++ b/python-threatexchange/threatexchange/cli/config_cmd.py
@@ -372,6 +372,7 @@ class ConfigExtensionsCommand(command_base.Command):
             nargs="?",
             help="the module path to the extension. foo.bar.baz",
         )
+        ap.set_defaults(is_config=True)
 
     def __init__(self, action: str, module: t.Optional[str]) -> None:
         self.action = {

--- a/python-threatexchange/threatexchange/cli/exceptions.py
+++ b/python-threatexchange/threatexchange/cli/exceptions.py
@@ -4,10 +4,36 @@
 CLI exceptions. Alone to prevent circular imports.
 """
 
+from enum import IntEnum
+
+
+class ReturnCode(IntEnum):
+    """Check out http://tldp.org/LDP/abs/html/exitcodes.html"""
+
+    SUCCESS = 0
+    GENERAL_ERROR = 1
+    USER_ERROR = 2
+    EXTERNAL_DEPENDENCY_ERROR = 3
+
+    INTERRUPT = 130
+    MAX = 255
+
 
 class CommandError(Exception):
     """Wrapper for exceptions which cause return codes"""
 
-    def __init__(self, message: str, returncode: int = 1) -> None:
+    def __init__(
+        self, message: str, returncode: int = ReturnCode.GENERAL_ERROR.value
+    ) -> None:
         super().__init__(message)
         self.returncode = returncode
+
+    @classmethod
+    def user(cls, message: str) -> "CommandError":
+        """When PEBKAC"""
+        return cls(message, 2)
+
+    @classmethod
+    def external_dependency(cls, message: str) -> "CommandError":
+        """When you don't have internet access or the APIs are down"""
+        return cls(message, ReturnCode.EXTERNAL_DEPENDENCY_ERROR.value)

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -18,6 +18,7 @@ import logging
 import inspect
 import os
 import sys
+from textwrap import dedent
 import typing as t
 import pathlib
 
@@ -158,8 +159,10 @@ class _ExtendedTypes(t.NamedTuple):
             return
         err_list = "\n  ".join(self.load_failures)
         raise base.CommandError.user(
-            "Some extensions are no longer loadable! "
-            f"Fix them with the `config extensions` command:\n  {err_list}"
+            "Some extensions are no longer loadable! You might need to "
+            "re-install, or else remove them with the "
+            "`threatexchange config extension remove` command:\n  "
+            f"{err_list}"
         )
 
 

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -161,7 +161,7 @@ class _ExtendedTypes(t.NamedTuple):
         raise base.CommandError.user(
             "Some extensions are no longer loadable! You might need to "
             "re-install, or else remove them with the "
-            "`threatexchange config extension remove` command:\n  "
+            "`threatexchange config extensions remove` command:\n  "
             f"{err_list}"
         )
 

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -77,6 +77,8 @@ def get_argparse(settings: CLISettings) -> argparse.ArgumentParser:
         metavar="TOKEN",
         help="the App token for ThreatExchange",
     )
+    # is_config = Safe mode to try and let you fix bad settings from CLI
+    ap.set_defaults(is_config=False)
     subparsers = ap.add_subparsers(title="verbs", help="which action to do")
     for command in get_subcommands():
         command.add_command_to_subparser(settings, subparsers)
@@ -149,20 +151,36 @@ class _ExtendedTypes(t.NamedTuple):
     content_types: t.List[t.Type[ContentType]]
     signal_types: t.List[t.Type[SignalType]]
     api_instances: t.List[SignalExchangeAPI]
+    load_failures: t.List[str]
+
+    def assert_no_errors(self) -> None:
+        if not self.load_failures:
+            return
+        err_list = "\n  ".join(self.load_failures)
+        raise base.CommandError.user(
+            "Some extensions are no longer loadable! "
+            f"Fix them with the `config extensions` command:\n  {err_list}"
+        )
 
 
 def _get_extended_functionality(config: CLiConfig) -> _ExtendedTypes:
-    ret = _ExtendedTypes([], [], [])
+    ret = _ExtendedTypes([], [], [], [])
     for extension in config.extensions:
         logging.debug("Loading extension %s", extension)
-        manifest = ThreatExchangeExtensionManifest.load_from_module_name(extension)
-        ret.signal_types.extend(manifest.signal_types)
-        ret.content_types.extend(manifest.content_types)
-        ret.api_instances.extend(api() for api in manifest.apis)
+        try:
+            manifest = ThreatExchangeExtensionManifest.load_from_module_name(extension)
+        except (ValueError, ImportError):
+            ret.load_failures.append(extension)
+        else:
+            ret.signal_types.extend(manifest.signal_types)
+            ret.content_types.extend(manifest.content_types)
+            ret.api_instances.extend(api() for api in manifest.apis)
     return ret
 
 
-def _get_settings(config: CLiConfig, dir: pathlib.Path) -> CLISettings:
+def _get_settings(
+    config: CLiConfig, dir: pathlib.Path
+) -> t.Tuple[CLISettings, _ExtendedTypes]:
     """
     Configure the behavior and functionality.
     """
@@ -193,7 +211,10 @@ def _get_settings(config: CLiConfig, dir: pathlib.Path) -> CLISettings:
     )
     state = CliState(list(fetchers.fetchers_by_name.values()), dir=dir)
 
-    return CLISettings(meta.FunctionalityMapping(signals, fetchers, state), state)
+    return (
+        CLISettings(meta.FunctionalityMapping(signals, fetchers, state), state),
+        extensions,
+    )
 
 
 def _setup_logging():
@@ -216,9 +237,11 @@ def inner_main(
     config = CliState(
         [], state_dir
     ).get_persistent_config()  # TODO fix the circular dependency
-    settings = _get_settings(config, state_dir)
+    settings, extensions = _get_settings(config, state_dir)
     ap = get_argparse(settings)
     namespace = ap.parse_args(args)
+    if not namespace.is_config:
+        extensions.assert_no_errors()
     execute_command(settings, namespace)
 
 


### PR DESCRIPTION
Summary
---------



Test Plan
---------

```
$ pip install <extension>

$ threatexchange config extension add <extension>

$ threatexchange dataset
# OK

$ pip uninstall <extension>

$ threatexchange dataset
Some extensions are no longer loadable! Fix them with the `config extension` command:
  <extension>

$ threatexchange config extension remove <extension>
```