### PR TITLE
[py-tx][backwards incompatible] Split Update Format and Index Format

### DIFF
--- a/python-threatexchange/threatexchange/cli/cli_state.py
+++ b/python-threatexchange/threatexchange/cli/cli_state.py
@@ -11,16 +11,13 @@ There are a few categories of state that this wraps:
 """
 
 import pickle
-import json
 import pathlib
 import typing as t
-import dataclasses
 import logging
 
 from threatexchange.signal_type.index import SignalTypeIndex
 from threatexchange.signal_type.signal_base import SignalType
 from threatexchange.cli.exceptions import CommandError
-from threatexchange.cli import dataclass_json
 from threatexchange.fetcher.collab_config import CollaborationConfigBase
 from threatexchange.fetcher.fetch_state import (
     FetchCheckpointBase,
@@ -28,7 +25,7 @@ from threatexchange.fetcher.fetch_state import (
     FetchedSignalMetadata,
 )
 from threatexchange.fetcher.simple import state as simple_state
-from threatexchange.fetcher.fetch_api import SignalExchangeAPI, TFetchDelta
+from threatexchange.fetcher.fetch_api import SignalExchangeAPI
 from threatexchange.signal_type import signal_base
 from threatexchange.signal_type import index
 
@@ -134,7 +131,7 @@ class CliSimpleState(simple_state.SimpleFetchedStateStore):
             with file.open("rb") as f:
                 delta = pickle.load(f)
 
-            assert isinstance(delta, FetchDelta), "got the wrong type of file"
+            assert isinstance(delta, FetchDelta), "Unexpected class type?"
             delta = t.cast(simple_state.T_FetchDelta, delta)
             assert (
                 delta.next_checkpoint().__class__.__name__
@@ -144,8 +141,6 @@ class CliSimpleState(simple_state.SimpleFetchedStateStore):
             logging.debug(
                 "Loaded %s with %d records", collab_name, delta.record_count()
             )
-            # Minor stab at lowering memory footprint by converting kinda
-            # inline
             return delta
         except Exception:
             logging.exception("Failed to read state for %s", collab_name)

--- a/python-threatexchange/threatexchange/cli/cli_state.py
+++ b/python-threatexchange/threatexchange/cli/cli_state.py
@@ -10,6 +10,7 @@ There are a few categories of state that this wraps:
   3. Index state - serializations of indexes for SignalType
 """
 
+import pickle
 import json
 import pathlib
 import typing as t
@@ -23,10 +24,11 @@ from threatexchange.cli import dataclass_json
 from threatexchange.fetcher.collab_config import CollaborationConfigBase
 from threatexchange.fetcher.fetch_state import (
     FetchCheckpointBase,
+    FetchDelta,
     FetchedSignalMetadata,
 )
 from threatexchange.fetcher.simple import state as simple_state
-from threatexchange.fetcher.fetch_api import SignalExchangeAPI
+from threatexchange.fetcher.fetch_api import SignalExchangeAPI, TFetchDelta
 from threatexchange.signal_type import signal_base
 from threatexchange.signal_type import index
 
@@ -124,37 +126,27 @@ class CliSimpleState(simple_state.SimpleFetchedStateStore):
     def _read_state(
         self,
         collab_name: str,
-    ) -> t.Optional[
-        t.Tuple[
-            t.Dict[str, t.Dict[str, FetchedSignalMetadata]],
-            FetchCheckpointBase,
-        ]
-    ]:
+    ) -> t.Optional[simple_state.T_FetchDelta]:
         file = self.collab_file(collab_name)
         if not file.is_file():
             return None
         try:
-            with file.open("r") as f:
-                json_dict = json.load(f)
+            with file.open("rb") as f:
+                delta = pickle.load(f)
 
-            checkpoint = dataclass_json.dataclass_load_dict(
-                json_dict=json_dict[self.JSON_CHECKPOINT_KEY],
-                cls=self.api_cls.get_checkpoint_cls(),
+            assert isinstance(delta, FetchDelta), "got the wrong type of file"
+            delta = t.cast(simple_state.T_FetchDelta, delta)
+            assert (
+                delta.next_checkpoint().__class__.__name__
+                == self.api_cls.get_checkpoint_cls().__name__
+            ), "wrong checkpoint class?"
+
+            logging.debug(
+                "Loaded %s with %d records", collab_name, delta.record_count()
             )
-            records = json_dict[self.JSON_RECORDS_KEY]
-
-            logging.debug("Loaded %s with records for: %s", collab_name, list(records))
             # Minor stab at lowering memory footprint by converting kinda
             # inline
-            for stype in list(records):
-                records[stype] = {
-                    signal: dataclass_json.dataclass_load_dict(
-                        json_dict=json_record,
-                        cls=self.api_cls.get_record_cls(),
-                    )
-                    for signal, json_record in records[stype].items()
-                }
-            return records, checkpoint
+            return delta
         except Exception:
             logging.exception("Failed to read state for %s", collab_name)
             raise CommandError(
@@ -162,22 +154,19 @@ class CliSimpleState(simple_state.SimpleFetchedStateStore):
                 "You might have to delete it with `threatexchange fetch --clear`"
             )
 
-    def _write_state(  # type: ignore[override]  # fix with generics on base
+    def _write_state(  # type: ignore[override]  # Fix in followup PR
         self,
         collab_name: str,
-        updates_by_type: t.Dict[str, t.Dict[str, FetchedSignalMetadata]],
-        checkpoint: FetchCheckpointBase,
+        delta: simple_state.SimpleFetchDelta[
+            FetchCheckpointBase, FetchedSignalMetadata
+        ],
     ) -> None:
         file = self.collab_file(collab_name)
         if not file.parent.exists():
             file.parent.mkdir(parents=True)
 
         record_sanity_check = next(
-            (
-                record
-                for records in updates_by_type.values()
-                for record in records.values()
-            ),
+            (record for record in delta.update_record.values()),
             None,
         )
 
@@ -188,26 +177,7 @@ class CliSimpleState(simple_state.SimpleFetchedStateStore):
                 f"Record cls: want {self.api_cls.get_record_cls().__name__} "
                 f"got {record_sanity_check.__class__.__name__}"
             )
-
-        json_dict = {
-            self.JSON_CHECKPOINT_KEY: dataclasses.asdict(checkpoint),
-            self.JSON_RECORDS_KEY: {
-                stype: {
-                    s: dataclasses.asdict(record)
-                    for s, record in signal_to_record.items()
-                }
-                for stype, signal_to_record in updates_by_type.items()
-            },
-        }
-
         tmpfile = file.with_name(f".{file.name}")
-
-        with tmpfile.open("w") as f:
-            json.dump(json_dict, f, indent=2, default=_json_set_default)
+        with tmpfile.open("wb") as f:
+            pickle.dump(delta, f)
         tmpfile.rename(file)
-
-
-def _json_set_default(obj):
-    if isinstance(obj, set):
-        return list(obj)
-    raise TypeError

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -12,13 +12,10 @@ between stages, and a state file to store hashes.
 """
 
 import argparse
-from dataclasses import dataclass
-from distutils import extension
 import logging
 import inspect
 import os
 import sys
-from textwrap import dedent
 import typing as t
 import pathlib
 

--- a/python-threatexchange/threatexchange/common.py
+++ b/python-threatexchange/threatexchange/common.py
@@ -87,9 +87,9 @@ def argparse_choices_pre_type(choices: t.List[str], type: t.Callable[[str], t.An
     def ret(s: str):
         if s not in choices:
             raise argparse.ArgumentTypeError(
-                "invalid choice: %s (choose from %s)",
-                s,
-                ", ".join(repr(c) for c in choices),
+                "invalid choice: {} (choose from {})".format(
+                    s, ", ".join(repr(c) for c in choices)
+                ),
             )
         return type(s)
 

--- a/python-threatexchange/threatexchange/fetcher/apis/file_api.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/file_api.py
@@ -66,7 +66,7 @@ class LocalFileSignalExchangeAPI(
         with path.open("r") as f:
             lines = f.readlines()
 
-        updates = {}
+        updates: t.Dict[t.Tuple[str, str], t.Optional[state.FetchedSignalMetadata]] = {}
         for line in lines:
             signal_type = collab.signal_type
             signal = line.strip()

--- a/python-threatexchange/threatexchange/fetcher/apis/static_sample.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/static_sample.py
@@ -51,8 +51,12 @@ class StaticSampleSignalExchangeAPI(
         for stype in supported_signal_types:
             sample_signals.extend(_signals(stype))
 
-        return SimpleFetchDelta(
-            dict(sample_signals),
+        updates: t.Dict[
+            t.Tuple[str, str], t.Optional[state.FetchedSignalMetadata]
+        ] = dict(sample_signals)
+
+        return TDelta(
+            updates,
             state.FetchCheckpointBase(),
             done=True,
         )

--- a/python-threatexchange/threatexchange/fetcher/apis/stop_ncii_api.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/stop_ncii_api.py
@@ -118,7 +118,7 @@ class StopNCIISignalExchangeAPI(
             start_time = checkpoint.update_time
         for result in self.api.fetch_hashes_iter(start_timestamp=start_time):
             translated = (_get_delta_mapping(r) for r in result.hashRecords)
-            yield SimpleFetchDelta(
+            yield SimpleFetchDelta[StopNCIICheckpoint, StopNCIISignalMetadata](
                 dict(t for t in translated if t[0][0]),
                 StopNCIICheckpoint.from_stopncii_fetch(result),
                 done=not result.hasMoreRecords,

--- a/python-threatexchange/threatexchange/fetcher/apis/tests/test_stopncii.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/tests/test_stopncii.py
@@ -1,3 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
 import pytest
 import typing as t
 

--- a/python-threatexchange/threatexchange/fetcher/apis/tests/test_stopncii.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/tests/test_stopncii.py
@@ -39,7 +39,7 @@ def test_fetch(fetcher: SignalExchangeAPI, monkeypatch: pytest.MonkeyPatch):
     assert checkpoint.update_time == 1625175071
     assert checkpoint.last_fetch_time == 10**8
 
-    updates = delta.get_as_update_dict()
+    updates = delta.update_record
     assert len(updates) == 2
     assert {t[0] for t in updates} == {"pdq"}
 
@@ -59,7 +59,7 @@ def test_fetch(fetcher: SignalExchangeAPI, monkeypatch: pytest.MonkeyPatch):
     delta = t.cast(SimpleFetchDelta, fetcher.fetch_once([], collab, None))
     assert delta.has_more() is False
     assert delta.record_count() == 1
-    updates = delta.get_as_update_dict()
+    updates = delta.update_record
     assert len(updates) == 1
     assert "pdq" == tuple(updates)[0][0]
     a = t.cast(StopNCIISignalMetadata, tuple(updates.values())[0])

--- a/python-threatexchange/threatexchange/fetcher/fetch_api.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_api.py
@@ -218,7 +218,7 @@ TSignalExchangeAPI = SignalExchangeAPI[
     CollaborationConfigBase,
     state.FetchCheckpointBase,
     state.FetchedSignalMetadata,
-    state.FetchDelta[state.FetchCheckpointBase],
+    state.FetchDelta[state.FetchCheckpointBase, state.FetchedSignalMetadata],
 ]
 
 TSignalExchangeAPICls = t.Type[TSignalExchangeAPI]

--- a/python-threatexchange/threatexchange/fetcher/fetch_api.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_api.py
@@ -221,6 +221,8 @@ TSignalExchangeAPI = SignalExchangeAPI[
     state.FetchDelta[state.FetchCheckpointBase],
 ]
 
+TSignalExchangeAPICls = t.Type[TSignalExchangeAPI]
+
 
 class SignalExchangeAPIWithIterFetch(
     SignalExchangeAPI[

--- a/python-threatexchange/threatexchange/fetcher/fetch_api.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_api.py
@@ -212,6 +212,16 @@ class SignalExchangeAPI(
         )
 
 
+# A convenience helper since mypy can't intuit that bound != t.Any
+# For methods like get_checkpoint_cls
+TSignalExchangeAPI = SignalExchangeAPI[
+    CollaborationConfigBase,
+    state.FetchCheckpointBase,
+    state.FetchedSignalMetadata,
+    state.FetchDelta[state.FetchCheckpointBase],
+]
+
+
 class SignalExchangeAPIWithIterFetch(
     SignalExchangeAPI[
         TCollabConfig, state.TFetchCheckpoint, state.TFetchedSignalMetadata, TFetchDelta

--- a/python-threatexchange/threatexchange/fetcher/fetch_state.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_state.py
@@ -185,8 +185,12 @@ class FetchDelta(t.Generic[TFetchCheckpoint]):
     """
     Contains the result of a fetch.
 
-    You'll need to extend this, but it only to be interpretable by your
-    API's version of FetchedState
+    In order to make naive storage (such as on the CLI) work, implementations
+    of this class must be pickle-able.
+
+    Note that the way that this class organizes and stores data does not
+    need to be the same way that that the index class organizes data,
+    which is hash => Record.
     """
 
     def record_count(self) -> int:
@@ -199,7 +203,36 @@ class FetchDelta(t.Generic[TFetchCheckpoint]):
 
     def has_more(self) -> bool:
         """
-        Returns true if the API has no more data at this time.
+        Returns false if the API has no more data at this time.
+        """
+        raise NotImplementedError
+
+    def merge(self: Self, newer: Self) -> None:
+        """
+        Merge the content of a subsequent fetch() call into this one.
+
+        Different APIs might have different approaches to merging.
+
+        You can assume the caller has kept track, and is only
+        merging in sequential order.
+
+        delta_1 = api.fetch_once(...)
+        delta_2 = api.fetch_once(..., delta_1.checkpoint)
+        delta_3 = api.fetch_once(..., delta_2.checkpoint)
+
+        delta_1.merge(delta_2)
+        delta_1.merge(delta_3)
+        """
+        raise NotImplementedError
+
+    def get_for_signal_type(
+        self, signal_type: t.Type[SignalType]
+    ) -> t.Dict[str, FetchedSignalMetadata]:
+        """
+        Get as a map of signal => Metadata
+
+        This powers simple storage solutions, and provides the mapping
+        from how the API provides update to how the index needs.
         """
         raise NotImplementedError
 
@@ -207,12 +240,6 @@ class FetchDelta(t.Generic[TFetchCheckpoint]):
 class FetchDeltaWithUpdateStream(
     t.Generic[TFetchCheckpoint, TFetchedSignalMetadata], FetchDelta[TFetchCheckpoint]
 ):
-    """
-    For most APIs, they can represented in a simple update stream.
-
-    This allows naive implementations for storage.
-    """
-
     def get_as_update_dict(
         self,
     ) -> t.Mapping[t.Tuple[str, str], t.Optional[TFetchedSignalMetadata]]:

--- a/python-threatexchange/threatexchange/fetcher/fetch_state.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_state.py
@@ -18,6 +18,7 @@ from threatexchange.signal_type.signal_base import SignalType
 
 Self = t.TypeVar("Self")
 
+
 @dataclass
 class FetchCheckpointBase:
     """

--- a/python-threatexchange/threatexchange/fetcher/fetch_state.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_state.py
@@ -18,7 +18,6 @@ from threatexchange.signal_type.signal_base import SignalType
 
 Self = t.TypeVar("Self")
 
-
 @dataclass
 class FetchCheckpointBase:
     """
@@ -181,7 +180,7 @@ TFetchedSignalMetadata = t.TypeVar(
 )
 
 
-class FetchDelta(t.Generic[TFetchCheckpoint]):
+class FetchDelta(t.Generic[TFetchCheckpoint, TFetchedSignalMetadata]):
     """
     Contains the result of a fetch.
 
@@ -227,27 +226,12 @@ class FetchDelta(t.Generic[TFetchCheckpoint]):
 
     def get_for_signal_type(
         self, signal_type: t.Type[SignalType]
-    ) -> t.Dict[str, FetchedSignalMetadata]:
+    ) -> t.Dict[str, TFetchedSignalMetadata]:
         """
         Get as a map of signal => Metadata
 
         This powers simple storage solutions, and provides the mapping
         from how the API provides update to how the index needs.
-        """
-        raise NotImplementedError
-
-
-class FetchDeltaWithUpdateStream(
-    t.Generic[TFetchCheckpoint, TFetchedSignalMetadata], FetchDelta[TFetchCheckpoint]
-):
-    def get_as_update_dict(
-        self,
-    ) -> t.Mapping[t.Tuple[str, str], t.Optional[TFetchedSignalMetadata]]:
-        """
-        Returns the contents of the delta as
-         (signal_type, signal_str) => record
-        If the record is set to None, this indicates the record should be
-        deleted if it exists.
         """
         raise NotImplementedError
 

--- a/python-threatexchange/threatexchange/fetcher/simple/state.py
+++ b/python-threatexchange/threatexchange/fetcher/simple/state.py
@@ -51,10 +51,10 @@ class SimpleFetchedSignalMetadata(fetch_state.FetchedSignalMetadata):
 
 @dataclass
 class FetchDeltaWithUpdateStream(
-    t.Generic[fetch_state.TFetchCheckpoint, fetch_state.TFetchedSignalMetadata, K, V],
     fetch_state.FetchDelta[
         fetch_state.TFetchCheckpoint, fetch_state.TFetchedSignalMetadata
     ],
+    t.Generic[fetch_state.TFetchCheckpoint, fetch_state.TFetchedSignalMetadata, K, V],
 ):
     """
     TODO
@@ -74,7 +74,9 @@ class FetchDeltaWithUpdateStream(
         """
         return new_v
 
-    def merge(self: fetch_state.Self, newer: fetch_state.Self) -> None:
+    def merge(
+        self: "FetchDeltaWithUpdateStream", newer: "FetchDeltaWithUpdateStream"
+    ) -> None:
         updates = newer.update_record
         if not updates:
             return
@@ -101,9 +103,7 @@ class FetchDeltaWithUpdateStream(
         return not self.done
 
 
-@dataclass
 class SimpleFetchDelta(
-    t.Generic[fetch_state.TFetchCheckpoint, fetch_state.TFetchedSignalMetadata],
     FetchDeltaWithUpdateStream[
         fetch_state.TFetchCheckpoint,
         fetch_state.TFetchedSignalMetadata,
@@ -148,7 +148,7 @@ class _StateTracker:
         return self._delta
 
     @property
-    def checkpoint(self) -> t.Optional[fetch_state.TFetchCheckpoint]:
+    def checkpoint(self) -> t.Optional[fetch_state.FetchCheckpointBase]:
         return None if self._delta is None else self._delta.next_checkpoint()
 
 

--- a/python-threatexchange/threatexchange/fetcher/simple/state.py
+++ b/python-threatexchange/threatexchange/fetcher/simple/state.py
@@ -1,15 +1,22 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 
-from collections import defaultdict
 from dataclasses import dataclass, field
 import logging
 import typing as t
-from threatexchange.fetcher.fetch_api import SignalExchangeAPI
+from threatexchange.fetcher.fetch_api import (
+    TSignalExchangeAPICls,
+)
 
 from threatexchange.signal_type.signal_base import SignalType
 from threatexchange.fetcher import fetch_state
 from threatexchange.fetcher.collab_config import CollaborationConfigBase
+
+K = t.TypeVar("K")
+V = t.TypeVar("V")
+TFetchDelta = fetch_state.FetchDelta[
+    fetch_state.FetchCheckpointBase, fetch_state.FetchedSignalMetadata
+]
 
 
 @dataclass
@@ -41,26 +48,47 @@ class SimpleFetchedSignalMetadata(fetch_state.FetchedSignalMetadata):
 
 
 @dataclass
-class SimpleFetchDelta(
-    fetch_state.FetchDeltaWithUpdateStream[
+class FetchDeltaWithUpdateStream(
+    t.Generic[fetch_state.TFetchCheckpoint, fetch_state.TFetchedSignalMetadata, K, V],
+    fetch_state.FetchDelta[
         fetch_state.TFetchCheckpoint, fetch_state.TFetchedSignalMetadata
-    ]
+    ],
 ):
-    """
-    Simple class for deltas.
+    """ """
 
-    If the record is set to None, this indicates the record should be
-    deleted if it exists.
-    """
-
-    updates: t.Mapping[
-        t.Tuple[str, str], t.Optional[fetch_state.TFetchedSignalMetadata]
-    ]
+    update_record: t.Dict[K, t.Optional[V]]
     checkpoint: fetch_state.TFetchCheckpoint
-    done: bool  # powers has_more
+    done: bool
+
+    @classmethod
+    def _merge_update(cls, old_v: V, new_v: V) -> t.Optional[V]:
+        """
+        How to merge updates.
+
+        By default, assume newer replaces older. Another strategy might be
+        merging records together.
+        """
+        return new_v
+
+    def merge(self: fetch_state.Self, newer: fetch_state.Self) -> None:
+        updates = newer.update_record
+        if not updates:
+            return
+
+        for k, new_v in updates.items():
+            old_v = self.update_record.get(k)
+            result_v: t.Optional[V] = new_v
+            if None not in (old_v, new_v):
+                result_v = self._merge_update(old_v, new_v)
+            if result_v is None:
+                self.update_record.pop(k, None)
+            else:
+                self.update_record[k] = result_v
+        self.checkpoint = newer.checkpoint
+        self.done = newer.done
 
     def record_count(self) -> int:
-        return len(self.updates)
+        return len(self.update_record)
 
     def next_checkpoint(self) -> fetch_state.TFetchCheckpoint:
         return self.checkpoint
@@ -68,50 +96,61 @@ class SimpleFetchDelta(
     def has_more(self) -> bool:
         return not self.done
 
-    def get_as_update_dict(
-        self,
-    ) -> t.Mapping[t.Tuple[str, str], t.Optional[fetch_state.TFetchedSignalMetadata]]:
-        return self.updates
+
+@dataclass
+class SimpleFetchDelta(
+    FetchDeltaWithUpdateStream[
+        fetch_state.TFetchCheckpoint,
+        fetch_state.TFetchedSignalMetadata,
+        t.Tuple[str, str],
+        fetch_state.TFetchedSignalMetadata,
+    ]
+):
+    """
+    If the update stream is already stored as signal types, no conversion is needed.
+    """
+
+    def get_for_signal_type(
+        self, signal_type: t.Type[SignalType]
+    ) -> t.Dict[str, fetch_state.TFetchedSignalMetadata]:
+        type_str = signal_type.get_name()
+        return {
+            signal_str: meta
+            for (signal_type_str, signal_str), meta in self.update_record.items()
+            if signal_type_str == type_str and meta is not None
+        }
 
 
 @dataclass
 class _StateTracker:
-    updates_by_type: t.Dict[str, t.Dict[str, fetch_state.FetchedSignalMetadata]]
-    checkpoint: t.Optional[fetch_state.FetchCheckpointBase]
+    _delta: t.Optional[TFetchDelta]
     dirty: bool = False
 
-    def merge(self, newer: fetch_state.FetchDeltaWithUpdateStream) -> None:
-        updates = newer.get_as_update_dict()
-        if not updates:
-            return
-        newer_by_type: t.DefaultDict[
-            str, t.List[t.Tuple[str, t.Optional[fetch_state.FetchedSignalMetadata]]]
-        ] = defaultdict(list)
-        for (stype, signal_str), record in updates.items():
-            newer_by_type[stype].append((signal_str, record))
-
-        for n_type, n_updates in newer_by_type.items():
-            o_updates = self.updates_by_type.setdefault(n_type, {})
-            for sig_str, new_record in n_updates:
-                if new_record is None:
-                    o_updates.pop(sig_str, None)
-                else:
-                    old_record = o_updates.get(sig_str)
-                    if old_record:
-                        new_record = new_record.merge_metadata(old_record, new_record)
-                    o_updates[sig_str] = new_record
-        self.checkpoint = newer.next_checkpoint()
+    def merge(self, new_delta: TFetchDelta) -> None:
+        if not self._delta:
+            self._delta = new_delta
+        else:
+            self._delta.merge(new_delta)
         self.dirty = True
+
+    @property
+    def delta(self) -> TFetchDelta:
+        assert self._delta is not None
+        return self._delta
+
+    @property
+    def checkpoint(self) -> t.Optional[fetch_state.TFetchCheckpoint]:
+        return None if self._delta is None else self._delta.next_checkpoint()
 
 
 class SimpleFetchedStateStore(fetch_state.FetchedStateStoreBase):
     """
-    Standardizes on merging on (type, indicator), merges in memory.
+    TODO
     """
 
     def __init__(
         self,
-        api_cls: t.Type[SignalExchangeAPI],
+        api_cls: TSignalExchangeAPICls,
     ) -> None:
         self.api_cls = api_cls
         self._state: t.Dict[str, _StateTracker] = {}
@@ -119,20 +158,10 @@ class SimpleFetchedStateStore(fetch_state.FetchedStateStoreBase):
     def _read_state(
         self,
         collab_name: str,
-    ) -> t.Optional[
-        t.Tuple[
-            t.Dict[str, t.Dict[str, fetch_state.FetchedSignalMetadata]],
-            t.Optional[fetch_state.FetchCheckpointBase],
-        ]
-    ]:
+    ) -> t.Optional[TFetchDelta]:
         raise NotImplementedError
 
-    def _write_state(
-        self,
-        collab_name: str,
-        updates_by_type: t.Dict[str, t.Dict[str, fetch_state.FetchedSignalMetadata]],
-        checkpoint: fetch_state.FetchCheckpointBase,
-    ) -> None:
+    def _write_state(self, collab_name: str, delta, TFetchDelta) -> None:
         raise NotImplementedError
 
     def get_checkpoint(
@@ -143,14 +172,14 @@ class SimpleFetchedStateStore(fetch_state.FetchedStateStoreBase):
     def _get_state(self, collab_name: str) -> _StateTracker:
         if collab_name not in self._state:
             logging.debug("Loading state for %s", collab_name)
-            read_state = self._read_state(collab_name) or ({}, None)
-            self._state[collab_name] = _StateTracker(*read_state)
+            delta = self._read_state(collab_name)
+            self._state[collab_name] = _StateTracker(delta)
         return self._state[collab_name]
 
-    def merge(  # type: ignore[override]  # fix with generics on base
+    def merge(
         self,
         collab: CollaborationConfigBase,
-        delta: fetch_state.FetchDeltaWithUpdateStream,
+        delta: TFetchDelta,
     ) -> None:
         """
         Merge a FetchDeltaBase into the state.
@@ -173,8 +202,8 @@ class SimpleFetchedStateStore(fetch_state.FetchedStateStoreBase):
     def flush(self):
         for collab_name, state in self._state.items():
             if state.dirty:
-                assert state.checkpoint
-                self._write_state(collab_name, state.updates_by_type, state.checkpoint)
+                assert state.delta is not None
+                self._write_state(collab_name, state.delta)
                 state.dirty = False
 
     def get_for_signal_type(
@@ -184,5 +213,5 @@ class SimpleFetchedStateStore(fetch_state.FetchedStateStoreBase):
         ret = {}
         for collab in collabs:
             state = self._get_state(collab.name)
-            ret[collab.name] = state.updates_by_type.get(st_name, {})
+            ret[collab.name] = state.delta.get_for_signal_type(signal_type)
         return ret

--- a/python-threatexchange/threatexchange/fetcher/simple/tests/test_state.py
+++ b/python-threatexchange/threatexchange/fetcher/simple/tests/test_state.py
@@ -4,24 +4,24 @@ from collections import defaultdict
 from dataclasses import dataclass
 import typing as t
 
-from fetcher.collab_config import CollaborationConfigWithDefaults
-from fetcher.fetch_api import TSignalExchangeAPICls
-from fetcher.fetch_state import (
+from threatexchange.fetcher.collab_config import CollaborationConfigWithDefaults
+from threatexchange.fetcher.fetch_api import TSignalExchangeAPI, TSignalExchangeAPICls
+from threatexchange.fetcher.fetch_state import (
     FetchCheckpointBase,
     SignalOpinion,
     SignalOpinionCategory,
 )
 
-from fetcher.simple.state import (
+from threatexchange.fetcher.simple.state import (
     FetchDeltaWithUpdateStream,
     SimpleFetchDelta,
     SimpleFetchedSignalMetadata,
     SimpleFetchedStateStore,
     T_FetchDelta,
 )
-from signal_type.md5 import VideoMD5Signal
-from signal_type.raw_text import RawTextSignal
-from signal_type.signal_base import SignalType
+from threatexchange.signal_type.md5 import VideoMD5Signal
+from threatexchange.signal_type.raw_text import RawTextSignal
+from threatexchange.signal_type.signal_base import SignalType
 
 
 @dataclass
@@ -51,10 +51,12 @@ class FakeFetchDelta(
 
     def get_for_signal_type(
         self, signal_type: t.Type[SignalType]
-    ) -> t.Dict[str, FakeUpdateRecord]:
-        remapped = defaultdict(lambda: defaultdict(set))
+    ) -> t.Dict[str, SimpleFetchedSignalMetadata]:
+        remapped: t.DefaultDict[str, t.DefaultDict[int, t.Set[str]]] = defaultdict(
+            lambda: defaultdict(set)
+        )
         if signal_type == VideoMD5Signal:
-            for k, update in self.update_record.items():
+            for _k, update in self.update_record.items():
                 if update is not None:
                     remapped[update.md5][update.owner].add(update.tag)
 
@@ -83,8 +85,8 @@ class FakeFetchStore(SimpleFetchedStateStore):
     def __init__(
         self,
     ) -> None:
-        super().__init__(TSignalExchangeAPICls)
-        self._fake_storage = {}
+        super().__init__(TSignalExchangeAPI)
+        self._fake_storage: t.Dict[str, T_FetchDelta] = {}
 
     def _read_state(
         self,

--- a/python-threatexchange/threatexchange/fetcher/simple/tests/test_state.py
+++ b/python-threatexchange/threatexchange/fetcher/simple/tests/test_state.py
@@ -1,0 +1,389 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from collections import defaultdict
+from dataclasses import dataclass
+import typing as t
+
+from fetcher.collab_config import CollaborationConfigWithDefaults
+from fetcher.fetch_api import TSignalExchangeAPICls
+from fetcher.fetch_state import (
+    FetchCheckpointBase,
+    SignalOpinion,
+    SignalOpinionCategory,
+)
+
+from fetcher.simple.state import (
+    FetchDeltaWithUpdateStream,
+    SimpleFetchDelta,
+    SimpleFetchedSignalMetadata,
+    SimpleFetchedStateStore,
+    T_FetchDelta,
+)
+from signal_type.md5 import VideoMD5Signal
+from signal_type.raw_text import RawTextSignal
+from signal_type.signal_base import SignalType
+
+
+@dataclass
+class FakeCheckpoint(FetchCheckpointBase):
+    update_time: int
+
+
+@dataclass
+class FakeUpdateRecord:
+    owner: int
+    tag: str
+    md5: str
+
+
+@dataclass
+class FakeFetchDelta(
+    FetchDeltaWithUpdateStream[
+        FakeCheckpoint, SimpleFetchedSignalMetadata, int, FakeUpdateRecord
+    ]
+):
+    """
+    Simulates an update types that uses per-owner opinions with an int ID.
+
+    Its easiest to store as record_id => opinion, but then we need to
+    map it to hash => merged_opinions
+    """
+
+    def get_for_signal_type(
+        self, signal_type: t.Type[SignalType]
+    ) -> t.Dict[str, FakeUpdateRecord]:
+        remapped = defaultdict(lambda: defaultdict(set))
+        if signal_type == VideoMD5Signal:
+            for k, update in self.update_record.items():
+                if update is not None:
+                    remapped[update.md5][update.owner].add(update.tag)
+
+        return {
+            h: SimpleFetchedSignalMetadata(
+                [
+                    SignalOpinion(
+                        owner=owner,
+                        category=SignalOpinionCategory.WORTH_INVESTIGATING,
+                        tags=tags,
+                    )
+                    for owner, tags in tags_per_owner.items()
+                ]
+            )
+            for h, tags_per_owner in remapped.items()
+        }
+
+
+class FakeSimpleFetchDelta(
+    SimpleFetchDelta[FakeCheckpoint, SimpleFetchedSignalMetadata]
+):
+    pass
+
+
+class FakeFetchStore(SimpleFetchedStateStore):
+    def __init__(
+        self,
+    ) -> None:
+        super().__init__(TSignalExchangeAPICls)
+        self._fake_storage = {}
+
+    def _read_state(
+        self,
+        collab_name: str,
+    ) -> t.Optional[T_FetchDelta]:
+        return self._fake_storage.get(collab_name)
+
+    def _write_state(self, collab_name: str, delta: T_FetchDelta) -> None:
+        self._fake_storage[collab_name] = delta
+
+
+def md5(n):
+    return f"{n:032x}"
+
+
+def test_test_impls():
+    """
+    Since we're faking these interfaces, lets make sure they behave as expected
+    """
+    store = FakeFetchStore()
+    config = CollaborationConfigWithDefaults("fake_collab_name")
+
+    assert store.get_checkpoint(config) == None
+    assert store.get_for_signal_type([config], VideoMD5Signal) == {}
+
+    checkpoint = FakeCheckpoint(100)
+
+    md5 = "0" * 32
+    delta = FakeFetchDelta({1: FakeUpdateRecord(1, "tag", md5)}, checkpoint, False)
+
+    record = SimpleFetchedSignalMetadata(
+        [SignalOpinion(1, SignalOpinionCategory.WORTH_INVESTIGATING, {"tag"})]
+    )
+
+    assert delta.next_checkpoint() == checkpoint
+    assert delta.record_count() == 1
+    assert delta.has_more() == True
+
+    assert delta.get_for_signal_type(VideoMD5Signal) == {md5: record}
+    assert delta.get_for_signal_type(RawTextSignal) == {}
+
+
+def test_update_stream_delta():
+    t1 = "tag"
+    t2 = "other"
+    t3 = "foo"
+
+    updates = [
+        # Hash 1
+        (0, FakeUpdateRecord(1, t1, md5(1))),
+        (1, FakeUpdateRecord(1, t2, md5(1))),  # Combine
+        (2, FakeUpdateRecord(2, t3, md5(1))),  # Combine
+        # Hash 2
+        (3, FakeUpdateRecord(3, t1, md5(2))),
+        (3, FakeUpdateRecord(3, t2, md5(2))),  # Replace
+        # Hash 1 again
+        (0, FakeUpdateRecord(1, t3, md5(1))),
+        (4, FakeUpdateRecord(3, t3, md5(1))),
+        # Deletes
+        (0, None),  # Delete a record
+        (1, None),
+        (2, None),
+        (4, None),  # Completely remove hash
+    ]
+
+    h1_full = SimpleFetchedSignalMetadata(
+        [
+            SignalOpinion(1, SignalOpinionCategory.WORTH_INVESTIGATING, {t1, t2}),
+            SignalOpinion(2, SignalOpinionCategory.WORTH_INVESTIGATING, {t3}),
+        ]
+    )
+    h2_full = SimpleFetchedSignalMetadata(
+        [
+            SignalOpinion(3, SignalOpinionCategory.WORTH_INVESTIGATING, {t2}),
+        ]
+    )
+
+    expected_states = [
+        # Hash 1
+        {
+            md5(1): SimpleFetchedSignalMetadata(
+                [SignalOpinion(1, SignalOpinionCategory.WORTH_INVESTIGATING, {t1})]
+            )
+        },
+        {
+            md5(1): SimpleFetchedSignalMetadata(
+                [SignalOpinion(1, SignalOpinionCategory.WORTH_INVESTIGATING, {t1, t2})]
+            )
+        },
+        {md5(1): h1_full},
+        # Hash 2
+        {
+            md5(1): h1_full,
+            md5(2): SimpleFetchedSignalMetadata(
+                [
+                    SignalOpinion(3, SignalOpinionCategory.WORTH_INVESTIGATING, {t1}),
+                ]
+            ),
+        },
+        {
+            md5(1): h1_full,
+            md5(2): h2_full,
+        },
+        # Hash 1 again
+        {
+            md5(1): SimpleFetchedSignalMetadata(
+                [
+                    SignalOpinion(
+                        1, SignalOpinionCategory.WORTH_INVESTIGATING, {t2, t3}
+                    ),
+                    SignalOpinion(2, SignalOpinionCategory.WORTH_INVESTIGATING, {t3}),
+                ]
+            ),
+            md5(2): h2_full,
+        },
+        {
+            md5(1): SimpleFetchedSignalMetadata(
+                [
+                    SignalOpinion(
+                        1, SignalOpinionCategory.WORTH_INVESTIGATING, {t2, t3}
+                    ),
+                    SignalOpinion(2, SignalOpinionCategory.WORTH_INVESTIGATING, {t3}),
+                    SignalOpinion(3, SignalOpinionCategory.WORTH_INVESTIGATING, {t3}),
+                ]
+            ),
+            md5(2): h2_full,
+        },
+        # Deletes
+        {
+            md5(1): SimpleFetchedSignalMetadata(
+                [
+                    SignalOpinion(1, SignalOpinionCategory.WORTH_INVESTIGATING, {t2}),
+                    SignalOpinion(2, SignalOpinionCategory.WORTH_INVESTIGATING, {t3}),
+                    SignalOpinion(3, SignalOpinionCategory.WORTH_INVESTIGATING, {t3}),
+                ]
+            ),
+            md5(2): h2_full,
+        },
+        {
+            md5(1): SimpleFetchedSignalMetadata(
+                [
+                    SignalOpinion(2, SignalOpinionCategory.WORTH_INVESTIGATING, {t3}),
+                    SignalOpinion(3, SignalOpinionCategory.WORTH_INVESTIGATING, {t3}),
+                ]
+            ),
+            md5(2): h2_full,
+        },
+        {
+            md5(1): SimpleFetchedSignalMetadata(
+                [
+                    SignalOpinion(3, SignalOpinionCategory.WORTH_INVESTIGATING, {t3}),
+                ]
+            ),
+            md5(2): h2_full,
+        },
+        {md5(2): h2_full},
+    ]
+
+    store = FakeFetchStore()
+    collab = CollaborationConfigWithDefaults("fake_collab_name")
+    checkpoint = FakeCheckpoint(100)
+
+    # If we appy updates all at once, we expect just the final state
+    # Note - dict(updates) work because our merge behavior is replace
+    delta = FakeFetchDelta(dict(updates), checkpoint, True)
+    assert delta.get_for_signal_type(VideoMD5Signal) == expected_states[-1]
+
+    store.merge(collab, delta)
+    store.flush()
+    assert store.get_for_signal_type([collab], VideoMD5Signal) == {
+        collab.name: expected_states[-1]
+    }
+
+    store = FakeFetchStore()
+    # If we appy updates 1-by-1 we expect all the end states
+    for i, update in enumerate(updates):
+        checkpoint = FakeCheckpoint(100 + i)
+        delta = FakeFetchDelta(dict([update]), checkpoint, False)
+        store.merge(collab, delta)
+        store.flush()
+        assert store.get_for_signal_type([collab], VideoMD5Signal) == {
+            collab.name: expected_states[i]
+        }, f"Update {i}"
+        assert store.get_checkpoint(collab) == checkpoint
+
+
+def test_simple_update_delta():
+    def key(n):
+        return (VideoMD5Signal.get_name(), md5(n))
+
+    t1 = "tag"
+    t2 = "other"
+    t3 = "foo"
+
+    h1_full = SimpleFetchedSignalMetadata(
+        [
+            SignalOpinion(1, SignalOpinionCategory.WORTH_INVESTIGATING, {t1, t2}),
+            SignalOpinion(2, SignalOpinionCategory.WORTH_INVESTIGATING, {t3}),
+        ]
+    )
+    h2_full = SimpleFetchedSignalMetadata(
+        [
+            SignalOpinion(3, SignalOpinionCategory.WORTH_INVESTIGATING, {t2}),
+        ]
+    )
+
+    updates = [
+        # Hash 1
+        (
+            key(1),
+            SimpleFetchedSignalMetadata(
+                [SignalOpinion(1, SignalOpinionCategory.WORTH_INVESTIGATING, {t1})]
+            ),
+        ),
+        (
+            key(1),
+            SimpleFetchedSignalMetadata(
+                [SignalOpinion(1, SignalOpinionCategory.WORTH_INVESTIGATING, {t1, t2})]
+            ),
+        ),
+        (key(1), h1_full),
+        # Hash 2
+        (
+            key(2),
+            h2_full,
+        ),
+        # Hash 1 again
+        (
+            key(1),
+            SimpleFetchedSignalMetadata(
+                [
+                    SignalOpinion(
+                        1, SignalOpinionCategory.WORTH_INVESTIGATING, {t2, t3}
+                    ),
+                    SignalOpinion(2, SignalOpinionCategory.WORTH_INVESTIGATING, {t3}),
+                ]
+            ),
+        ),
+        # Delete
+        (key(1), None),
+    ]
+
+    expected_states = [
+        # Hash 1
+        {
+            md5(1): SimpleFetchedSignalMetadata(
+                [SignalOpinion(1, SignalOpinionCategory.WORTH_INVESTIGATING, {t1})]
+            )
+        },
+        {
+            md5(1): SimpleFetchedSignalMetadata(
+                [SignalOpinion(1, SignalOpinionCategory.WORTH_INVESTIGATING, {t1, t2})]
+            )
+        },
+        {md5(1): h1_full},
+        # Hash 2
+        {
+            md5(1): h1_full,
+            md5(2): h2_full,
+        },
+        # Hash 1 again
+        {
+            md5(1): SimpleFetchedSignalMetadata(
+                [
+                    SignalOpinion(
+                        1, SignalOpinionCategory.WORTH_INVESTIGATING, {t2, t3}
+                    ),
+                    SignalOpinion(2, SignalOpinionCategory.WORTH_INVESTIGATING, {t3}),
+                ]
+            ),
+            md5(2): h2_full,
+        },
+        # Delete
+        {md5(2): h2_full},
+    ]
+
+    store = FakeFetchStore()
+    collab = CollaborationConfigWithDefaults("fake_collab_name")
+    checkpoint = FakeCheckpoint(100)
+
+    # If we appy updates all at once, we expect just the final state
+    # Note - dict(updates) work because our merge behavior is replace
+    delta = FakeSimpleFetchDelta(dict(updates), checkpoint, True)
+    assert delta.get_for_signal_type(VideoMD5Signal) == expected_states[-1]
+
+    store.merge(collab, delta)
+    store.flush()
+    assert store.get_for_signal_type([collab], VideoMD5Signal) == {
+        collab.name: expected_states[-1]
+    }
+
+    store = FakeFetchStore()
+    # If we appy updates 1-by-1 we expect all the end states
+    for i, update in enumerate(updates):
+        checkpoint = FakeCheckpoint(100 + i)
+        delta = FakeSimpleFetchDelta(dict([update]), checkpoint, False)
+        store.merge(collab, delta)
+        store.flush()
+        assert store.get_for_signal_type([collab], VideoMD5Signal) == {
+            collab.name: expected_states[i]
+        }, f"Update {i}"
+        assert store.get_checkpoint(collab) == checkpoint


### PR DESCRIPTION
Summary
---------
The flow of information through the system is:

API.fetch() => Delta => Store => Index => Metadata

NCMEC's API is like the tag-based ThreatExchange API, and it's not stored as hash => record, it's actually stored record => [hash, hash, hash] which is incompatible with many assumptions made along the way.

After lots of mulling, I think the solution is to:
1. Separate considerations about storing the record that the fetch() API produces
2. Converting the format from the fetch() update store to the signal => metadata

As a part of that, I need to mess with a lot of the interfaces above. There are more changes that I want to make, and I tried to checkpoint with this diff.

The final version I want to end up with is:
1. Storing what the update format is from fetch should move from Delta => SignalExchangeAPI
2. Delta should become a trivial object, with no need to override it

As a side effect, the storage format for the CLI changed from JSON to pickle. It's possible I can actually revert this in a few more PRs, but right now Delta is the only object that knows the correct format.


Test Plan
---------

Added a test

Also went through:
1. Fetch from threatexchange
3. Match some content
4. Run the dataset command to make sure it isn't broken (yet).
