### PR TITLE
[hashing][minor][fix] update cpp Makefiles and README on details of running on M1

### DIFF
--- a/pdq/cpp/Makefile
+++ b/pdq/cpp/Makefile
@@ -1,5 +1,6 @@
 # ================================================================
-CC=g++ -g -std=c++11
+CXX=g++ # please customize according to your system --- Note: Apple clang on M1 is not currently supported 
+CC=$(CXX) -g -std=c++11
 IFLAGS=-I../.. -I.
 # -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation is because of CImg.h
 WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation -Wno-unknown-warning-option -Werror

--- a/pdq/cpp/README.md
+++ b/pdq/cpp/README.md
@@ -8,6 +8,11 @@ Please see [../README.md](https://github.com/facebook/ThreatExchange/blob/main/p
 * `CImg.h` is included for reference, though note it is not under the same license as the rest of the repository. It is expected that your company will already have image-processing logic. Dependencies of this code on `CImg.h` are confined solely to `io/pdqio.h` and `io/pdqio.cpp` which you can customize for your site.
 * ImageMagick or other JPEG/PNG libraries: for example, `brew install imagemagick` on MacOSX
 
+## MacOS on Apple M1
+
+* Currently the builtin Apple clang g++ does not work for building this implementation.
+  * Installing gcc and updating the `Makefile`s CXX to use that version of g++ instead is recommend.
+
 # Contact
 
 threatexchange@fb.com

--- a/tmk/cpp/Makefile
+++ b/tmk/cpp/Makefile
@@ -1,12 +1,13 @@
 # ----------------------------------------------------------------
-CC=g++ -O2 -std=c++14 -I../..
-FFMPEG=/usr/local/bin/ffmpeg # please customize according to your installation
+CXX=g++ # please customize according to your system --- Note: Apple clang is not supported 
+CC=$(CXX) -O2 -std=c++14 -I../.. #
+FFMPEG=/Users/barrett/homebrew/bin/ffmpeg # please customize according to your installation
 
 ifeq ($(OS),Windows_NT)
-  CC_IF_WIN=g++ -O2 -std=gnu++14 -I../..
+  CC_IF_WIN=$(CXX) -O2 -std=gnu++14 -I../..
   OMP_LIB=-lgomp
 else
-  CC_IF_WIN=g++ -O2 -std=c++14 -I../..
+  CC_IF_WIN=$(CXX) -O2 -std=c++14 -I../.. 
   OMP_LIB=-lomp
 endif
 

--- a/tmk/cpp/README.md
+++ b/tmk/cpp/README.md
@@ -2,4 +2,9 @@
 
 * C++ 14 or higher
 * `ffmpeg` command-line executable somewhere on your system
-* FAISS (https://github.com/facebookresearch/faiss) is optional. Its integration into this repository is a work in progress (you can build without it).
+* FAISS (<https://github.com/facebookresearch/faiss>) is optional. Its integration into this repository is a work in progress (you can build without it).
+
+## MacOS on Apple M1
+
+* Currently the builtin Apple clang g++ does not work for building this implementation.
+  * Installing gcc and updating the `Makefile`s CXX to use that version of g++ instead is recommend.


### PR DESCRIPTION
Summary
---------

M1's Apple clang  i.e. the builtin g++ doesn't work out of the box for the pdq or tmk c++ implementations. However gcc (g++-11 if installed via homebrew) still works fine.

- the Apple clang issues for tmk just seem to be linking errors however for pdq the resulting executables actually have incorrect behavior.  `Hash256::hammingNorm` and `Hash256::hammingDistance` do not return the correct results when the compiler is given a -02 flag or higher
 
I think it likely that Apple clang has a bug that will eventually be fixed but for how gcc should be used. 

Test Plan
---------

# on M1 system
1. install gcc 
2. update CXX in Makefile(s) to point to gcc's g++ instead of builtin Apple clang
3. Run `make` in `tmk/cpp` and `pdq/cpp` and make sure both regression tests pass. 
