### PR TITLE
[pytx] Delete fetch_once(), long live fetch_iter()

### DIFF
--- a/python-threatexchange/threatexchange/cli/config_cmd.py
+++ b/python-threatexchange/threatexchange/cli/config_cmd.py
@@ -66,7 +66,7 @@ class _UpdateCollabCommand(command_base.Command):
     documented.
     """
 
-    _API_CLS: t.ClassVar[t.Type[SignalExchangeAPI]] = SignalExchangeAPI
+    _API_CLS: t.ClassVar[t.Type[SignalExchangeAPI]]
 
     _IGNORE_FIELDS = {
         "name",

--- a/python-threatexchange/threatexchange/fetcher/apis/static_sample.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/static_sample.py
@@ -19,7 +19,7 @@ from threatexchange.fetcher.simple.state import (
     SimpleFetchDelta,
 )
 
-TDelta = SimpleFetchDelta[state.FetchCheckpointBase, state.FetchedSignalMetadata]
+TypedDelta = SimpleFetchDelta[state.FetchCheckpointBase, state.FetchedSignalMetadata]
 
 
 class StaticSampleSignalExchangeAPI(
@@ -27,7 +27,7 @@ class StaticSampleSignalExchangeAPI(
         CollaborationConfigBase,
         state.FetchCheckpointBase,
         state.FetchedSignalMetadata,
-        TDelta,
+        TypedDelta,
     ]
 ):
     """
@@ -38,13 +38,14 @@ class StaticSampleSignalExchangeAPI(
     def get_name(cls) -> str:
         return "sample"
 
-    def fetch_once(
+    def fetch_iter(
         self,
-        supported_signal_types: t.List[t.Type[SignalType]],
+        supported_signal_types: t.Sequence[t.Type[SignalType]],
         collab: CollaborationConfigBase,
-        _checkpoint: t.Optional[state.FetchCheckpointBase],
-    ) -> TDelta:
-
+        # None if fetching for the first time,
+        # otherwise the previous FetchDelta returned
+        checkpoint: t.Optional[state.TFetchCheckpoint],
+    ) -> t.Iterator[TypedDelta]:
         sample_signals: t.List[
             t.Tuple[t.Tuple[str, str], state.FetchedSignalMetadata]
         ] = []
@@ -55,10 +56,9 @@ class StaticSampleSignalExchangeAPI(
             t.Tuple[str, str], t.Optional[state.FetchedSignalMetadata]
         ] = dict(sample_signals)
 
-        return TDelta(
+        yield TypedDelta(
             updates,
             state.FetchCheckpointBase(),
-            done=True,
         )
 
 

--- a/python-threatexchange/threatexchange/fetcher/apis/stop_ncii_api.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/stop_ncii_api.py
@@ -12,7 +12,6 @@ import typing as t
 from dataclasses import dataclass
 from threatexchange.fetcher.simple.state import (
     SimpleFetchDelta,
-    SimpleFetchedSignalMetadata,
 )
 
 from threatexchange.stopncii import api
@@ -69,7 +68,7 @@ class StopNCIISignalMetadata(state.FetchedSignalMetadata):
 
 
 class StopNCIISignalExchangeAPI(
-    fetch_api.SignalExchangeAPIWithIterFetch[
+    fetch_api.SignalExchangeAPI[
         CollaborationConfigBase,
         StopNCIICheckpoint,
         StopNCIISignalMetadata,
@@ -109,7 +108,7 @@ class StopNCIISignalExchangeAPI(
 
     def fetch_iter(
         self,
-        _supported_signal_types: t.List[t.Type[SignalType]],
+        _supported_signal_types: t.Sequence[t.Type[SignalType]],
         _collab: CollaborationConfigBase,
         checkpoint: t.Optional[StopNCIICheckpoint],
     ) -> t.Iterator[SimpleFetchDelta[StopNCIICheckpoint, StopNCIISignalMetadata]]:
@@ -121,7 +120,6 @@ class StopNCIISignalExchangeAPI(
             yield SimpleFetchDelta[StopNCIICheckpoint, StopNCIISignalMetadata](
                 dict(t for t in translated if t[0][0]),
                 StopNCIICheckpoint.from_stopncii_fetch(result),
-                done=not result.hasMoreRecords,
             )
 
 

--- a/python-threatexchange/threatexchange/fetcher/fetch_api.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_api.py
@@ -229,23 +229,3 @@ TSignalExchangeAPI = SignalExchangeAPI[
 ]
 
 TSignalExchangeAPICls = t.Type[TSignalExchangeAPI]
-
-
-# def fetch_once(
-#     self,
-#     supported_signal_types: t.List[t.Type[SignalType]],
-#     collab: TCollabConfig,
-#     # None if fetching for the first time,
-#     # otherwise the previous FetchDelta returned
-#     checkpoint: t.Optional[state.TFetchCheckpoint],
-# ) -> TFetchDelta:
-#     it = self._fetch_iters.get(collab.name)
-#     if it is None:
-#         it = self.fetch_iter(supported_signal_types, collab, checkpoint)
-#         self._fetch_iters[collab.name] = it
-#     delta = next(it, None)
-#     # This can happen if the last yielded element did not set done
-#     # which will cause next() to be called again after the iterator
-#     # is exhaused
-#     assert delta is not None, "fetch_iter stopping yielding too early"
-#     return delta

--- a/python-threatexchange/threatexchange/fetcher/fetch_api.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_api.py
@@ -6,7 +6,7 @@ The fetcher is the component that talks to external APIs to get and put signals
 @see SignalExchangeAPI
 """
 
-
+from abc import ABC, abstractmethod
 import typing as t
 
 from threatexchange import common
@@ -21,7 +21,8 @@ TFetchDelta = t.TypeVar("TFetchDelta", bound=state.FetchDelta)
 class SignalExchangeAPI(
     t.Generic[
         TCollabConfig, state.TFetchCheckpoint, state.TFetchedSignalMetadata, TFetchDelta
-    ]
+    ],
+    ABC,
 ):
     """
     APIs to get and maybe put signals.
@@ -87,7 +88,7 @@ class SignalExchangeAPI(
         # Default - just knowing the type is enough
         return CollaborationConfigBase  # type: ignore
 
-    # TODO - this doens't work for StopNCII which sends the owner as a string
+    # TODO - this doesn't work for StopNCII which sends the owner as a string
     #        maybe this should take the full metadata?
     def resolve_owner(self, id: int) -> str:
         """
@@ -111,22 +112,28 @@ class SignalExchangeAPI(
         """
         return -1
 
-    def fetch_once(
+    @abstractmethod
+    def fetch_iter(
         self,
-        supported_signal_types: t.List[t.Type[SignalType]],
+        supported_signal_types: t.Sequence[t.Type[SignalType]],
         collab: TCollabConfig,
         # None if fetching for the first time,
         # otherwise the previous FetchDelta returned
         checkpoint: t.Optional[state.TFetchCheckpoint],
-    ) -> TFetchDelta:
+    ) -> t.Iterator[TFetchDelta]:
         """
-        Call out to external resources, pulling down one "batch" of content.
+        Call out to external resources, fetching a batch of updates per yield.
 
         Many APIs are a sequence of events: (creates/updates, deletions)
         In that case, it's important the these events are strictly ordered.
         I.e. if the sequence is create => delete, if the sequence is reversed
         to delete => create, the end result is a stored record, when the
         expected is a deleted one.
+
+        The iterator may be abandoned before it is completely exhausted.
+
+        If the iterator returns, it should be because there is no more data
+        (i.e. the fetch is up to date).
         """
         raise NotImplementedError
 
@@ -224,53 +231,21 @@ TSignalExchangeAPI = SignalExchangeAPI[
 TSignalExchangeAPICls = t.Type[TSignalExchangeAPI]
 
 
-class SignalExchangeAPIWithIterFetch(
-    SignalExchangeAPI[
-        TCollabConfig, state.TFetchCheckpoint, state.TFetchedSignalMetadata, TFetchDelta
-    ],
-):
-    """
-    Provides an alternative fetch_once implementation to simplify state
-
-    @see fetch_iter
-    """
-
-    def __init__(self) -> None:
-        self._fetch_iters: t.Dict[str, t.Iterator[TFetchDelta]] = {}
-
-    def fetch_once(
-        self,
-        supported_signal_types: t.List[t.Type[SignalType]],
-        collab: TCollabConfig,
-        # None if fetching for the first time,
-        # otherwise the previous FetchDelta returned
-        checkpoint: t.Optional[state.TFetchCheckpoint],
-    ) -> TFetchDelta:
-        it = self._fetch_iters.get(collab.name)
-        if it is None:
-            it = self.fetch_iter(supported_signal_types, collab, checkpoint)
-            self._fetch_iters[collab.name] = it
-        delta = next(it, None)
-        # This can happen if the last yielded element did not set done
-        # which will cause next() to be called again after the iterator
-        # is exhaused
-        assert delta is not None, "fetch_iter stopping yielding too early"
-        return delta
-
-    def fetch_iter(
-        self,
-        supported_signal_types: t.List[t.Type[SignalType]],
-        collab: TCollabConfig,
-        # None if fetching for the first time,
-        # otherwise the previous FetchDelta returned
-        checkpoint: t.Optional[state.TFetchCheckpoint],
-    ) -> t.Iterator[TFetchDelta]:
-        """
-        An alternative to fetch_once implementation to simplify state.
-
-        Since we expect fetch_once to be called sequentially, we can safely
-        store things like next_page takens in the implementation.
-
-        TODO: This seems straight up better than fetch_once, refactor out
-        """
-        raise NotImplementedError
+# def fetch_once(
+#     self,
+#     supported_signal_types: t.List[t.Type[SignalType]],
+#     collab: TCollabConfig,
+#     # None if fetching for the first time,
+#     # otherwise the previous FetchDelta returned
+#     checkpoint: t.Optional[state.TFetchCheckpoint],
+# ) -> TFetchDelta:
+#     it = self._fetch_iters.get(collab.name)
+#     if it is None:
+#         it = self.fetch_iter(supported_signal_types, collab, checkpoint)
+#         self._fetch_iters[collab.name] = it
+#     delta = next(it, None)
+#     # This can happen if the last yielded element did not set done
+#     # which will cause next() to be called again after the iterator
+#     # is exhaused
+#     assert delta is not None, "fetch_iter stopping yielding too early"
+#     return delta

--- a/python-threatexchange/threatexchange/fetcher/fetch_state.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_state.py
@@ -10,7 +10,7 @@ needed to power API features.
 
 from dataclasses import dataclass
 from enum import IntEnum
-from functools import reduce
+from abc import ABC, abstractmethod
 import typing as t
 
 from threatexchange.fetcher.collab_config import CollaborationConfigBase
@@ -201,12 +201,6 @@ class FetchDelta(t.Generic[TFetchCheckpoint, TFetchedSignalMetadata]):
         """A serializable checkpoint for fetch."""
         raise NotImplementedError
 
-    def has_more(self) -> bool:
-        """
-        Returns false if the API has no more data at this time.
-        """
-        raise NotImplementedError
-
     def merge(self: Self, newer: Self) -> None:
         """
         Merge the content of a subsequent fetch() call into this one.
@@ -239,7 +233,7 @@ class FetchDelta(t.Generic[TFetchCheckpoint, TFetchedSignalMetadata]):
 
 # TODO t.Generic[TFetchDeltaBase, TFetchedSignalDataBase, FetchCheckpointBase]
 #      to help keep track of the expected subclasses for an impl
-class FetchedStateStoreBase:
+class FetchedStateStoreBase(ABC):
     """
     An interface to previously fetched or persisted state.
 
@@ -255,6 +249,7 @@ class FetchedStateStoreBase:
     since they need to be consistent between instanciation
     """
 
+    @abstractmethod
     def get_checkpoint(
         self, collab: CollaborationConfigBase
     ) -> t.Optional[FetchCheckpointBase]:
@@ -263,6 +258,7 @@ class FetchedStateStoreBase:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def merge(self, collab: CollaborationConfigBase, delta: FetchDelta) -> None:
         """
         Merge a FetchDelta into the state.
@@ -272,6 +268,7 @@ class FetchedStateStoreBase:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def flush(self) -> None:
         """
         Finish writing the results of previous merges to persistant state.
@@ -280,12 +277,14 @@ class FetchedStateStoreBase:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def clear(self, collab: CollaborationConfigBase) -> None:
         """
         Delete all the stored state for this collaboration.
         """
         raise NotImplementedError
 
+    @abstractmethod
     def get_for_signal_type(
         self, collabs: t.List[CollaborationConfigBase], signal_type: t.Type[SignalType]
     ) -> t.Dict[str, t.Dict[str, FetchedSignalMetadata]]:

--- a/python-threatexchange/threatexchange/fetcher/simple/state.py
+++ b/python-threatexchange/threatexchange/fetcher/simple/state.py
@@ -62,7 +62,6 @@ class FetchDeltaWithUpdateStream(
 
     update_record: t.Dict[K, t.Optional[V]]
     checkpoint: fetch_state.TFetchCheckpoint
-    done: bool
 
     @classmethod
     def _merge_update(cls, old_v: V, new_v: V) -> t.Optional[V]:
@@ -91,16 +90,12 @@ class FetchDeltaWithUpdateStream(
             else:
                 self.update_record[k] = result_v
         self.checkpoint = newer.checkpoint
-        self.done = newer.done
 
     def record_count(self) -> int:
         return len(self.update_record)
 
     def next_checkpoint(self) -> fetch_state.TFetchCheckpoint:
         return self.checkpoint
-
-    def has_more(self) -> bool:
-        return not self.done
 
 
 class SimpleFetchDelta(


### PR DESCRIPTION
Summary
---------

This PR:
1. Deletes fetch_once() to standardize on the nicer fetch_iter
2. Removes delta.has_more, since it's now implied by the interface
3. Adds ABC to a few fetch classes to make it easier to verify they are implemented as expected.

Test Plan
---------

unittests, but also ran fetch for sample, (clear, threatexchange match -- bball now?)