### PR TITLE
[pytx] Fetcher Implementation for NCMEC, Many Supporting Changes

### DIFF
--- a/python-threatexchange/threatexchange/cli/cli_config.py
+++ b/python-threatexchange/threatexchange/cli/cli_config.py
@@ -51,7 +51,7 @@ class CLiConfig:
     """A place to store misc configuration for the CLI"""
 
     fb_threatexchange_api_token: t.Optional[str] = None
-    ncmec_access: t.Optional[t.Tuple[str, str]] = None
+    ncmec_credentials: t.Optional[t.Tuple[str, str]] = None
     stop_ncii_keys: t.Optional[StopNCIIKeys] = None
     extensions: t.Set[str] = field(default_factory=set)
     # Every item needs a default for backwards compatibility

--- a/python-threatexchange/threatexchange/cli/cli_config.py
+++ b/python-threatexchange/threatexchange/cli/cli_config.py
@@ -17,6 +17,7 @@ import logging
 
 from dacite import WrongTypeError
 
+from threatexchange.stopncii import api as stopncii_api
 from threatexchange.fetcher import collab_config
 from threatexchange.fetcher.fetch_api import SignalExchangeAPI
 from threatexchange.content_type import content_base
@@ -32,11 +33,28 @@ CONFIG_FILENAME = "config.json"
 
 
 @dataclass
+class StopNCIIKeys:
+    subscription_key: str
+    fetch_function_key: str
+    # Someday, additional keys
+
+    @property
+    def keys_are_valid(self):
+        return all(
+            stopncii_api.is_valid_key(k)
+            for k in (self.subscription_key, self.fetch_function_key)
+        )
+
+
+@dataclass
 class CLiConfig:
     """A place to store misc configuration for the CLI"""
 
     fb_threatexchange_api_token: t.Optional[str] = None
+    ncmec_access: t.Optional[t.Tuple[str, str]] = None
+    stop_ncii_keys: t.Optional[StopNCIIKeys] = None
     extensions: t.Set[str] = field(default_factory=set)
+    # Every item needs a default for backwards compatibility
 
 
 class CliState(collab_config.CollaborationConfigStoreBase):

--- a/python-threatexchange/threatexchange/cli/dataclass_json.py
+++ b/python-threatexchange/threatexchange/cli/dataclass_json.py
@@ -26,12 +26,12 @@ def _as_dict(obj: t.Any) -> t.Dict[str, t.Any]:
 
 def dataclass_dump(fp: t.IO[str], obj) -> None:
     json_dict = _as_dict(obj)
-    return json.dump(json_dict, fp, indent=2, default=_json_set_default)
+    return json.dump(json_dict, fp, indent=2, default=_json_cast_default)
 
 
 def dataclass_dumps(fp: t.IO[str], obj) -> str:
     json_dict = _as_dict(obj)
-    return json.dumps(json_dict, indent=2, default=_json_set_default)
+    return json.dumps(json_dict, indent=2, default=_json_cast_default)
 
 
 def dataclass_load_file(
@@ -59,11 +59,13 @@ def dataclass_load_dict(json_dict: t.Dict[str, t.Any], cls: t.Type[T]) -> T:
     return dacite.from_dict(
         data_class=cls,
         data=json_dict,
-        config=dacite.Config(cast=[Enum, set]),
+        config=dacite.Config(cast=[Enum, set, tuple]),
     )
 
 
-def _json_set_default(obj):
+def _json_cast_default(obj):
     if isinstance(obj, set):
         return list(obj)
+    if isinstance(obj, Enum):
+        return obj.value
     raise TypeError

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -71,12 +71,6 @@ def get_argparse(settings: CLISettings) -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    ap.add_argument(
-        "--app-token",
-        "-a",
-        metavar="TOKEN",
-        help="the App token for ThreatExchange",
-    )
     # is_config = Safe mode to try and let you fix bad settings from CLI
     ap.set_defaults(is_config=False)
     subparsers = ap.add_subparsers(title="verbs", help="which action to do")
@@ -186,7 +180,7 @@ def _get_stopncii_tokens(
 
 def _get_ncmec_credentials(config: CLiConfig) -> t.Tuple[str, str]:
     """Get user+pass from NCMEC from the config"""
-    environment_var = "TX_STOPNCII_KEYS"
+    environment_var = "TX_NCMEC_CREDENTIALS"
     not_found = "", ""
 
     def get_from_environ() -> t.Optional[t.Tuple[str, str]]:

--- a/python-threatexchange/threatexchange/fetcher/apis/ncmec_api.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/ncmec_api.py
@@ -186,7 +186,7 @@ class NCMECSignalExchangeAPI(
             start_time = checkpoint.max_timestamp
         for result in self.client.get_entries_iter(start_timestamp=start_time):
             yield state.FetchDelta(
-                {entry.id: entry for entry in result.updates},
+                {f"{entry.member_id}-{entry.id}": entry for entry in result.updates},
                 NCMECCheckpoint.from_ncmec_fetch(result),
             )
 

--- a/python-threatexchange/threatexchange/fetcher/apis/ncmec_api.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/ncmec_api.py
@@ -98,12 +98,11 @@ NCMECUpdate = t.Dict[str, api.NCMECEntryUpdate]
 
 
 class NCMECSignalExchangeAPI(
-    fetch_api.SignalExchangeAPIWithKeyedUpdates[
+    fetch_api.SignalExchangeAPI[
         NCMECCollabConfig,
         NCMECCheckpoint,
         NCMECSignalMetadata,
-        str,
-        api.NCMECEntryUpdate,
+        NCMECUpdate,
     ]
 ):
     """
@@ -167,6 +166,14 @@ class NCMECSignalExchangeAPI(
                 {f"{entry.member_id}-{entry.id}": entry for entry in result.updates},
                 NCMECCheckpoint.from_ncmec_fetch(result),
             )
+
+    @classmethod
+    def naive_fetch_merge(
+        cls, old: t.Optional[NCMECUpdate], new: NCMECUpdate
+    ) -> NCMECUpdate:
+        ret = old or {}
+        ret.update(new)
+        return ret
 
     @classmethod
     def naive_convert_to_signal_type(

--- a/python-threatexchange/threatexchange/fetcher/apis/ncmec_api.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/ncmec_api.py
@@ -1,0 +1,166 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+SignalExchangeAPI impl for the NCMEC hash exchange
+
+"""
+
+
+import time
+import typing as t
+from dataclasses import dataclass
+from threatexchange.fetcher.simple.state import (
+    SimpleFetchDelta,
+)
+
+from threatexchange.ncmec import hash_api as api
+
+from threatexchange.fetcher import fetch_state as state
+from threatexchange.fetcher import fetch_api
+from threatexchange.fetcher.collab_config import (
+    CollaborationConfigBase,
+    CollaborationConfigWithDefaults,
+)
+from threatexchange.signal_type.signal_base import SignalType
+from threatexchange.signal_type.md5 import VideoMD5Signal
+
+
+@dataclass
+class NCMECCheckpoint(
+    state.FetchCheckpointBase,
+):
+    """
+    NCMEC primarily revolves around polling the timestamp.
+
+    NCMEC IDs seem to stay around forever, so no need for is_stale()
+    """
+
+    max_timestamp: int
+
+    def get_progress_timestamp(self) -> t.Optional[int]:
+        return self.max_timestamp
+
+    @classmethod
+    def from_ncmec_fetch(cls, response: api.GetEntriesResponse) -> "NCMECCheckpoint":
+        return cls(response.max_timestamp, int(time.time()))
+
+
+class NCMECCollaboration(CollaborationConfigWithDefaults, CollaborationConfigBase):
+    environment: api.NCMECEnvironment
+
+
+# @dataclass
+# class NCMECCspOpinion(state.SignalOpinion):
+#     ids: t.Set[str]
+#     category: state.SignalOpinionCategory = field(
+#         default=state.SignalOpinionCategory.TRUE_POSITIVE, init=False
+#     )
+
+
+# @dataclass
+# class NCMECHashMetadata(state.FetchedSignalMetadata):
+
+#     opinions: t.List[NCMECCspOpinion]
+
+#     def get_as_opinions(self) -> t.List[state.SignalOpinion]:
+#         return self.opinions
+
+
+@dataclass
+class _NCMECEntryMetadata(state.FetchedSignalMetadata):
+    """
+    Placeholder to store entries from the API
+
+    TODO: It turns out I was not smart enough and build the API interface
+          poorly, which NCMEC has exposed.
+          The chain of Delta => Dict[(type, hash): ?Metadata] => Store => Index
+          breaks because NCME doesn't map easily to a unique (type, hash) pairing.
+          Instead, it has its own unique keys (esp_id, entry_id).
+
+          The fix is to seperate out the concerns needed for UpdateDelta to work
+          (any unique key, a combining function) from the concerns needed for Index
+          to work (group by signal type => Metadata).
+    """
+
+    entry: api.NCMECEntryUpdate
+
+    def get_as_opinions(self) -> t.List[state.SignalOpinion]:
+        raise NotImplementedError(
+            "Placeholder while I figure out the correct model for NCMEC"
+        )
+
+
+@dataclass
+class NCMECSignalMetadata(state.FetchedSignalMetadata):
+    """
+    NCMEC metadata includes who uploaded it, as well as what they tagged.
+
+    The NCMEC API has no concept of false positives - every entry is reported.
+    """
+
+    member_entries: t.Dict[int, t.Set[str]]
+
+    def get_as_opinions(self) -> t.List[state.SignalOpinion]:
+        return [
+            state.SignalOpinion(
+                member_id, state.SignalOpinionCategory.TRUE_POSITIVE, tags
+            )
+            for member_id, tags in self.member_entries.items()
+        ]
+
+
+class NCMECSignalExchangeAPI(fetch_api.SignalExchangeAPIWithIterFetch[NCMECCheckpoint]):
+    """
+    Conversion for the NCMEC hash API
+
+    Key implementation details:
+        1. API is a stream of content: opinion, hashes,
+           which need to be remapped to hash => opinion
+        2. Owners have ids
+        3. As of 5/2022 there are no false positive or seen statuses
+    """
+
+    def __init__(
+        self,
+        username: str = "",
+        password: str = "",
+    ) -> None:
+        super().__init__()
+        self._api = None
+        if username and password:
+            self._api = api.NCMECHashAPI(
+                username,
+                password,
+            )
+
+    @property
+    def api(self) -> api.NCMECHashAPI:
+        if self._api is None:
+            raise Exception("NCMEC username and password not configured.")
+        return self._api
+
+    def fetch_iter(
+        self,
+        _supported_signal_types: t.List[t.Type[SignalType]],
+        _collab: CollaborationConfigBase,
+        checkpoint: t.Optional[NCMECCheckpoint],
+    ) -> t.Iterator[SimpleFetchDelta[NCMECCheckpoint, NCMECSignalMetadata]]:
+        start_time = 0
+        if checkpoint is not None:
+            start_time = checkpoint.max_timestamp
+        for result in self.api.get_entries_iter(start_timestamp=start_time):
+            translated = (_get_update_mapping(u) for u in result.updates)
+            yield SimpleFetchDelta(
+                dict(t for t in translated if t[0][0]),
+                NCMECCheckpoint.from_ncmec_fetch(result),
+                done=not result.next,
+            )
+
+
+def _get_update_mapping(
+    entry: api.NCMECEntryUpdate,
+) -> t.Tuple[t.Tuple[str, str], t.Optional[_NCMECEntryMetadata]]:
+    metadata = None
+    if not entry.deleted:
+        metadata = _NCMECEntryMetadata(entry)
+    return ((str(entry.member_id), entry.id), metadata)

--- a/python-threatexchange/threatexchange/fetcher/apis/tests/test_ncmec.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/tests/test_ncmec.py
@@ -1,0 +1,71 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import pytest
+import typing as t
+
+from threatexchange.fetcher.fetch_state import AggregateSignalOpinionCategory
+
+from threatexchange.ncmec.tests.test_hash_api import api
+from threatexchange.fetcher.apis.ncmec_api import (
+    NCMECCollabConfig,
+    NCMECSignalExchangeAPI,
+    NCMECSignalMetadata,
+    NCMECUpdate,
+)
+
+from threatexchange.ncmec.hash_api import NCMECEnvironment, NCMECHashAPI
+
+from threatexchange.signal_type.md5 import VideoMD5Signal
+
+
+@pytest.fixture
+def fetcher(api: NCMECHashAPI):
+    signal_exchange = NCMECSignalExchangeAPI("user", "pass")
+    signal_exchange._api = api
+    return signal_exchange
+
+
+def test_fetch(fetcher: NCMECSignalExchangeAPI, monkeypatch: pytest.MonkeyPatch):
+    collab = NCMECCollabConfig(NCMECEnvironment.Industry, "Test")
+    it = fetcher.fetch_iter([], collab, None)
+    delta = next(it)
+
+    assert len(delta.updates) == 4
+
+    assert delta.checkpoint.get_progress_timestamp() == 1508858400
+    assert delta.checkpoint.is_stale() is False
+    assert delta.checkpoint.max_timestamp == 1508858400
+
+    assert set(delta.updates) == {"43-image4", "42-image1", "42-video1", "42-video4"}
+    updates = delta.updates
+
+    assert_expected_updates(updates)
+
+    delta = next(it)
+    assert len(delta.updates) == 1
+
+    assert {t for t in delta.updates} == {"42-image10"}
+    updates = fetcher.naive_fetch_merge(updates, delta.updates)
+    assert_expected_updates(updates)
+
+
+def assert_expected_updates(updates: NCMECUpdate):
+    """We can do this because the return of the API return is hardcoded"""
+    as_signal_types = NCMECSignalExchangeAPI.naive_convert_to_signal_type(
+        [VideoMD5Signal], updates
+    )
+
+    assert len(as_signal_types) == 1
+    vmd5s = as_signal_types[VideoMD5Signal]
+    assert len(vmd5s) == 1
+    signal_metadata: NCMECSignalMetadata
+    vmd5, signal_metadata = next(iter(vmd5s.items()))
+    assert vmd5 == "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
+
+    opinions = signal_metadata.get_as_opinions()
+    assert len(opinions) == 1
+    opinion = opinions[0]
+    assert opinion.owner == 42
+    agg = signal_metadata.get_as_aggregate_opinion()
+    assert agg.category == AggregateSignalOpinionCategory.TRUE_POSITIVE
+    assert agg.tags == set()

--- a/python-threatexchange/threatexchange/fetcher/fetch_state.py
+++ b/python-threatexchange/threatexchange/fetcher/fetch_state.py
@@ -198,6 +198,7 @@ TFetchedSignalMetadata = t.TypeVar(
     "TFetchedSignalMetadata", bound=FetchedSignalMetadata
 )
 
+
 # TODO t.Generic[TFetchDeltaBase, TFetchedSignalDataBase, FetchCheckpointBase]
 #      to help keep track of the expected subclasses for an impl
 class FetchedStateStoreBase(ABC):

--- a/python-threatexchange/threatexchange/ncmec/hash_api.py
+++ b/python-threatexchange/threatexchange/ncmec/hash_api.py
@@ -210,6 +210,7 @@ class NCMECHashAPI:
         password: str,
         environment: NCMECEnvironment = NCMECEnvironment.test_Industry,
     ) -> None:
+        assert is_valid_user_pass(username, password)
         self.username = username
         self.password = password
         self._base_url = environment.value
@@ -326,3 +327,7 @@ class NCMECHashAPI:
 def _date_format(timestamp: int) -> str:
     """ISO 8601 format yyyy-MM-dd'T'HH:mm:ss.SSSZ"""
     return datetime.fromtimestamp(timestamp).strftime(_DATE_FORMAT_STR)
+
+
+def is_valid_user_pass(user: str, password: str) -> bool:
+    return user and password  # Is there anything more we can do here?

--- a/python-threatexchange/threatexchange/ncmec/hash_api.py
+++ b/python-threatexchange/threatexchange/ncmec/hash_api.py
@@ -330,4 +330,4 @@ def _date_format(timestamp: int) -> str:
 
 
 def is_valid_user_pass(user: str, password: str) -> bool:
-    return user and password  # Is there anything more we can do here?
+    return bool(user and password)  # Is there anything more we can do here?

--- a/python-threatexchange/threatexchange/ncmec/tests/__init__.py
+++ b/python-threatexchange/threatexchange/ncmec/tests/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/python-threatexchange/threatexchange/ncmec/tests/test_hash_api.py
+++ b/python-threatexchange/threatexchange/ncmec/tests/test_hash_api.py
@@ -24,6 +24,15 @@ NEXT_UNESCAPED = (
     "&to=2017-10-30T00%3A00%3A00.000Z&start=2001&size=1000&max=3000"
 )
 
+NEXT_UNESCAPED2 = (
+    "/v2/entries?from=2017-10-20T00%3A00%3A00.000Z"
+    "&to=2017-10-30T00%3A00%3A00.000Z&start=3001&size=1000&max=4000"
+)
+NEXT_UNESCAPED3 = (
+    "/v2/entries?from=2017-10-20T00%3A00%3A00.000Z"
+    "&to=2017-10-30T00%3A00%3A00.000Z&start=4001&size=1000&max=5000"
+)
+
 ENTRIES_XML = """
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
@@ -84,6 +93,61 @@ ENTRIES_XML2 = """
             </fingerprints>
         </image>
     </images>
+    <paging>
+        <next>/v2/entries?from=2017-10-20T00%3A00%3A00.000Z&amp;to=2017-10-30T00%3A00%3A00.000Z&amp;start=3001&amp;size=1000&amp;max=4000</next>
+    </paging>
+</queryResult>
+""".strip()
+
+# This example isn't in the documentation, but shows how updates work
+ENTRIES_XML3 = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+    <videos count="2" maxTimestamp="2019-11-25T15:10:00Z">
+        <video>
+            <member id="101">TX Example</member>
+            <timestamp>2019-11-25T15:10:00Z</timestamp>
+            <id>willupdate</id>
+            <classification>A1</classification>
+            <fingerprints>
+                <md5>facefacefacefacefacefacefaceface</md5>
+            </fingerprints>
+        </video>
+        <video>
+            <member id="101">TX Example</member>
+            <timestamp>2019-11-24T15:10:00Z</timestamp>
+            <id>willdelete</id>
+            <classification>A1</classification>
+            <fingerprints>
+                <md5>bacebacebacebacebacebacebacebace</md5>
+            </fingerprints>
+        </video>
+    </videos>
+    <paging>
+        <next>/v2/entries?from=2017-10-20T00%3A00%3A00.000Z&amp;to=2017-10-30T00%3A00%3A00.000Z&amp;start=4001&amp;size=1000&amp;max=5000</next>
+    </paging>
+</queryResult>
+""".strip()
+
+ENTRIES_XML4 = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+    <videos count="2" maxTimestamp="2019-11-24T15:10:00Z">
+        <video>
+            <member id="101">TX Example</member>
+            <timestamp>2019-11-24T15:10:00Z</timestamp>
+            <id>willupdate</id>
+            <classification>A2</classification>
+            <fingerprints>
+                <md5>facefacefacefacefacefacefaceface</md5>
+            </fingerprints>
+        </video>
+        <deletedVideo>
+            <member id="101">TX Example</member>
+            <timestamp>2019-11-25T15:10:00Z</timestamp>
+            <id>willdelete</id>
+        </deletedVideo>
+    </videos>
 </queryResult>
 """.strip()
 
@@ -92,6 +156,10 @@ def mock_get_impl(url: str, **params):
     content = ENTRIES_XML
     if url.endswith(NEXT_UNESCAPED):
         content = ENTRIES_XML2
+    if url.endswith(NEXT_UNESCAPED2):
+        content = ENTRIES_XML3
+    if url.endswith(NEXT_UNESCAPED3):
+        content = ENTRIES_XML4
     # Void your warantee by messing with requests state
     resp = requests.Response()
     resp._content = content.encode()
@@ -181,6 +249,17 @@ def test_mocked_get_hashes(api: NCMECHashAPI):
 
     assert len(second_result.updates) == 1
     assert second_result.max_timestamp == 1571929800
-    assert second_result.next == ""
+    assert second_result.next != ""
     five = second_result.updates[0]
     assert_fifth_entry(five)
+
+    # These later results don't need to be tested for this test, matters
+    # for the SignalExchange API
+    third_result = api.get_entries(next_=second_result.next)
+    assert third_result.next != ""
+    assert third_result not in (result, second_result)
+    forth_result = api.get_entries(next_=third_result.next)
+    assert forth_result not in (result, second_result, third_result)
+    assert forth_result.next == ""
+
+    # The other updates don't need to be tested here

--- a/python-threatexchange/threatexchange/ncmec/tests/test_hash_api.py
+++ b/python-threatexchange/threatexchange/ncmec/tests/test_hash_api.py
@@ -102,7 +102,7 @@ def mock_get_impl(url: str, **params):
 
 @pytest.fixture
 def api(monkeypatch: pytest.MonkeyPatch):
-    api = NCMECHashAPI("", "")
+    api = NCMECHashAPI("fake_user", "fake_pass")
     session = None
     session = Mock(
         strict_spec=["get", "__enter__", "__exit__"],

--- a/python-threatexchange/threatexchange/stopncii/api.py
+++ b/python-threatexchange/threatexchange/stopncii/api.py
@@ -322,7 +322,7 @@ class StopNCIIAPI:
         self._post(StopNCIIEndpoint.SubmitFeedback, json=payload)
 
 
-def is_valid_key(key: str) -> str:
+def is_valid_key(key: str) -> bool:
     """
     Returns true if the string looks like a valid access token
     """

--- a/python-threatexchange/threatexchange/stopncii/api.py
+++ b/python-threatexchange/threatexchange/stopncii/api.py
@@ -320,3 +320,10 @@ class StopNCIIAPI:
             feedback_dicts.append(fb_dict)
         payload = {"count": len(feedbacks), "hashFeedbacks": feedback_dicts}
         self._post(StopNCIIEndpoint.SubmitFeedback, json=payload)
+
+
+def is_valid_key(key: str) -> str:
+    """
+    Returns true if the string looks like a valid access token
+    """
+    return bool(key)  # TODO


### PR DESCRIPTION
Summary
---------

This one got away from me a little bit:
1. SignalExchangeAPI implementation for NCMEC
2. CLI configuration updates to store credentials
3. Random bug fixes where I found them

Test Plan
---------

### New Halps
#### Collab Edit
```
$ threatexchange config collab edit ncmec --help
usage: threatexchange config collab edit ncmec [-h] [--create] [--enable [{0,1}] | --disable] [--only-signal-types [NAME [NAME ...]]] [--not-signal-types [NAME [NAME ...]]] [--only-owners [ID [ID ...]]] [--not-owners [ID [ID ...]]] [--only-tags [TAG [TAG ...]]] [--not-tags [TAG [TAG ...]]] [--json] [--environment [Industry,NGO,Exploitative]] collab_name

positional arguments:
  collab_name           the name of the collab

optional arguments:
  -h, --help            show this help message and exit
  --create, -C          indicate you intend to create a config
  --enable [{0,1}]      enable the config (default on create)
  --disable             disable the config
  --only-signal-types [NAME [NAME ...]], -s [NAME [NAME ...]]
                        limit to these signal types
  --not-signal-types [NAME [NAME ...]], -S [NAME [NAME ...]]
                        dont use these signal types
  --only-owners [ID [ID ...]], -o [ID [ID ...]]
                        only use signals from these owner ids
  --not-owners [ID [ID ...]], -O [ID [ID ...]]
                        dont use signals from these owner ids
  --only-tags [TAG [TAG ...]], -t [TAG [TAG ...]]
                        use only signals with one of these tags
  --not-tags [TAG [TAG ...]], -T [TAG [TAG ...]]
                        don't use signals with one of these tags
  --json, -J            instead, interpret the argument as JSON and use that to edit the config
  --environment [Industry,NGO,Exploitative]
                        [auto generated from config class]
```

#### Configure NCMEC
```
$ threatexchange config api ncmec --help
usage: threatexchange config api ncmec [-h] [--credentials STR STR]

Configure NCMEC hash api integration

optional arguments:
  -h, --help            show this help message and exit
  --credentials STR STR
                        set the username and password to access the NCMEC API
```

### E2E Test
```
$ threatexchange extensions add pytx_photodna  # Non-public extension
$ threatexchange config api ncmec --credentials <secret>
$ threatexchange config collab edit ncmec -C 'Test NCMEC' --environment NGO
$ threatexchange fetch --limit 5000
$ threatexchange match -HS photodna photo -- 0.0.0... # The zero hash
$ threatexchange match -HS photodna photo -- <secret>  # A hash from the database
photodna - (Test NCMEC) TRUE_POSITIVE B2
```
