### PR TITLE
Add CI action for tmk/cpp make regtest

### DIFF
--- a/.github/workflows/tmk-ci-cpp.yml
+++ b/.github/workflows/tmk-ci-cpp.yml
@@ -4,18 +4,18 @@ on:
     branches:
       - main
     paths:
-      - "ThreatExchange/tmk/cpp/**"
+      - "tmk/cpp/**"
       - ".github/workflows/tmk-ci-cpp.yml"
   pull_request:
     branches:
       - main
     paths:
-      - "ThreatExchange/tmk/cpp/**"
+      - "tmk/cpp/**"
       - ".github/workflows/tmk-ci-cpp.yml"
 
 defaults:
   run:
-    working-directory: ThreatExchange/tmk/cpp
+    working-directory: tmk/cpp
 
 jobs:
   build-and-test:

--- a/.github/workflows/tmk-ci-cpp.yml
+++ b/.github/workflows/tmk-ci-cpp.yml
@@ -1,0 +1,29 @@
+name: tmk CI - cpp
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "ThreatExchange/tmk/cpp/**"
+      - ".github/workflows/tmk-ci-cpp.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "ThreatExchange/tmk/cpp/**"
+      - ".github/workflows/tmk-ci-cpp.yml"
+
+defaults:
+  run:
+    working-directory: ThreatExchange/tmk/cpp
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: make
+        run: |
+          sudo apt-get update
+          sudo apt-get install ffmpeg
+          make

--- a/tmk/cpp/Makefile
+++ b/tmk/cpp/Makefile
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------
 CXX=g++ # please customize according to your system --- Note: Apple clang is not supported 
 CC=$(CXX) -O2 -std=c++14 -I../.. #
-FFMPEG=/Users/barrett/homebrew/bin/ffmpeg # please customize according to your installation
+FFMPEG=/usr/bin/ffmpeg # please customize according to your installation (but do not commit)
 
 ifeq ($(OS),Windows_NT)
   CC_IF_WIN=$(CXX) -O2 -std=gnu++14 -I../..


### PR DESCRIPTION
Summary
---------

pdq/cpp has a gh action but tmk/cpp was missing one. This adds it.

There is a side benefit that it now you mistakenly commit your local FFMPEG path the CI will fail (something that I missed and committed a few PRs ago by mistake which is also fixed here)

Test Plan
---------

Created this PR made sure both the new and existing gh action pass.
