### PR TITLE
Missing toplevel command

### DIFF
--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -73,7 +73,9 @@ def get_argparse(settings: CLISettings) -> argparse.ArgumentParser:
     )
     # is_config = Safe mode to try and let you fix bad settings from CLI
     ap.set_defaults(is_config=False)
-    subparsers = ap.add_subparsers(title="verbs", help="which action to do")
+    subparsers = ap.add_subparsers(
+        dest="toplevel_command_name", title="verbs", help="which action to do"
+    )
     for command in get_subcommands():
         command.add_command_to_subparser(settings, subparsers)
 
@@ -311,6 +313,9 @@ def inner_main(
     namespace = ap.parse_args(args)
     if not namespace.is_config:
         extensions.assert_no_errors()
+    if not namespace.toplevel_command_name:
+        ap.print_help()
+        return
     execute_command(settings, namespace)
 
 

--- a/python-threatexchange/threatexchange/cli/tests/cli_smoke_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/cli_smoke_test.py
@@ -11,6 +11,7 @@ class CLISmokeTest(ThreatExchangeCLIE2eTest):
 
         View the pretty output with py.test -s
         """
+        self.cli_call()  # root help
         self.cli_call("--help")  # root help
         for command in main.get_subcommands():
             self.cli_call(command.get_name(), "--help")

--- a/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
+++ b/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
@@ -36,15 +36,15 @@ class ThreatExchangeCLIE2eTest(unittest.TestCase):
         args = list(self.COMMON_CALL_ARGS)
         args.extend(given_args)
         print("Calling: $ threatexchange", " ".join(args), file=sys.stderr)
-        try:
-            with patch("sys.stdout", new=StringIO()) as fake_out, patch(
-                "sys.argv", new=args
-            ):
+        with patch("sys.stdout", new=StringIO()) as fake_out, patch(
+            "sys.argv", new=["threatexchange"] + args
+        ):
+            try:
                 inner_main(args, state_dir=self._state_dir)
-        except SystemExit as se:
-            if se.code != 0:
-                raise E2ETestSystemExit(se.code)
-        return fake_out.getvalue()
+            except SystemExit as se:
+                if se.code != 0:
+                    raise E2ETestSystemExit(se.code)
+            return fake_out.getvalue()
 
     def assert_cli_output(
         self, args: t.Iterable[str], expected_output: t.Union[str, t.Dict[int, str]]


### PR DESCRIPTION
Summary
---------

Calling with so subcommands is not an error, but generates an assertion failure shortly afterwards. Fix that I guess

Test Plan
---------

Unittest

```
$ threatexchange
<see help>
```
