### PR TITLE
[pytx] convert CLI test to py.test style

### DIFF
--- a/python-threatexchange/threatexchange/cli/tests/__init__.py
+++ b/python-threatexchange/threatexchange/cli/tests/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.register_assert_rewrite("threatexchange.cli.tests.e2e_test_helper")

--- a/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
+++ b/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
@@ -22,7 +22,7 @@ class E2ETestSystemExit(Exception):
 
 class ThreatExchangeCLIE2eHelper:
 
-    COMMON_CALL_ARGS: t.ClassVar[t.Sequence[str]] = ()
+    COMMON_CALL_ARGS: t.Sequence[str] = ()
 
     _state_dir: pathlib.Path
 

--- a/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
+++ b/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
@@ -9,6 +9,7 @@ import tempfile
 import typing as t
 from unittest.mock import patch
 import unittest
+import pytest
 
 from threatexchange.cli.main import inner_main
 from threatexchange.cli.exceptions import CommandError
@@ -19,18 +20,11 @@ class E2ETestSystemExit(Exception):
         self.returncode = code
 
 
-class ThreatExchangeCLIE2eTest(unittest.TestCase):
+class ThreatExchangeCLIE2eHelper:
 
     COMMON_CALL_ARGS: t.ClassVar[t.Sequence[str]] = ()
 
     _state_dir: pathlib.Path
-
-    def setUp(self) -> None:
-        super().setUp()
-
-        state_dir = pathlib.Path(tempfile.mkdtemp())
-        self.addCleanup(lambda: shutil.rmtree(str(state_dir)))
-        self._state_dir = state_dir
 
     def cli_call(self, *given_args: str) -> str:
         args = list(self.COMMON_CALL_ARGS)
@@ -53,24 +47,36 @@ class ThreatExchangeCLIE2eTest(unittest.TestCase):
     ) -> None:
         output = self.cli_call(*args)
         if isinstance(expected_output, str):
-            self.assertEqual(expected_output.strip(), output.strip())
+            assert expected_output.strip() == output.strip()
             return
         lines = output.strip().split("\n")
         if not isinstance(expected_output, dict):
             expected_output = dict(enumerate(expected_output))
         for line, expected_line_output in expected_output.items():
             if line < 0:
-                self.assertGreaterEqual(line, -len(lines), expected_line_output)
+                assert line >= -len(lines)
             else:
-                self.assertLess(line, len(lines), expected_line_output)
-            self.assertEqual(lines[line], expected_line_output)
+                assert line < len(lines)
+            assert lines[line] == expected_line_output
 
     def assert_cli_usage_error(
         self, args: t.Iterable[str], msg_regex: str = None
     ) -> None:
-        with self.assertRaises((CommandError, E2ETestSystemExit)) as ex:
+        with pytest.raises((CommandError, E2ETestSystemExit), match=msg_regex) as ex:
             self.cli_call(*args)
-        exception = t.cast(t.Union[CommandError, E2ETestSystemExit], ex.exception)
-        self.assertEqual(exception.returncode, 2)
-        if msg_regex is not None:
-            self.assertRegex(str(exception), msg_regex)
+        exception = t.cast(t.Union[CommandError, E2ETestSystemExit], ex.value)
+        assert exception.returncode == 2
+
+
+@pytest.fixture
+def te_cli(tmp_path: pathlib.Path) -> ThreatExchangeCLIE2eHelper:
+    ret = ThreatExchangeCLIE2eHelper()
+    ret._state_dir = tmp_path
+    return ret
+
+
+class ThreatExchangeCLIE2eTest(unittest.TestCase, ThreatExchangeCLIE2eHelper):
+    def setUp(self) -> None:
+        state_dir = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(str(state_dir)))
+        self._state_dir = state_dir

--- a/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
@@ -1,24 +1,28 @@
-import tempfile
-from threatexchange.cli.tests.e2e_test_helper import ThreatExchangeCLIE2eTest
+import pathlib
+import pytest
+from threatexchange.cli.tests.e2e_test_helper import ThreatExchangeCLIE2eHelper, te_cli
 
 
-class HashCommandTest(ThreatExchangeCLIE2eTest):
+@pytest.fixture
+def hash_cli(te_cli: ThreatExchangeCLIE2eHelper) -> ThreatExchangeCLIE2eHelper:
+    te_cli.COMMON_CALL_ARGS = ("hash",)
+    return te_cli
 
-    COMMON_CALL_ARGS = ("hash",)
 
-    def test(self):
-        self.assert_cli_output(
-            ("url", "--inline", "http://evil.com"),
-            "url_md5 6d3af727a4e7b025fd59a5469b3a9c57",
-        )
+def test(hash_cli: ThreatExchangeCLIE2eHelper, tmp_path: pathlib.Path):
+    hash_cli.assert_cli_output(
+        ("url", "--inline", "http://evil.com"),
+        "url_md5 6d3af727a4e7b025fd59a5469b3a9c57",
+    )
 
-        with tempfile.NamedTemporaryFile() as fp:
-            # Empty file
-            self.assert_cli_output(
-                ("video", fp.name), "video_md5 d41d8cd98f00b204e9800998ecf8427e"
-            )
+    empty_file = tmp_path / "empty.mp4"
+    empty_file.touch()
 
-        self.assert_cli_usage_error(
-            ("url", "blah.txt"),
-            "The file blah.txt doesn't exist or the file path is incorrect",
-        )
+    hash_cli.assert_cli_output(
+        ("video", str(empty_file)), "video_md5 d41d8cd98f00b204e9800998ecf8427e"
+    )
+
+    hash_cli.assert_cli_usage_error(
+        ("url", "blah.txt"),
+        "The file blah.txt doesn't exist or the file path is incorrect",
+    )


### PR DESCRIPTION
Summary
---------

py.test is super cool, and one of the things that makes it cool is fixtures, which are a great alternative to unittest classes. The big value add is that all the various .assert methods have been greatly improved upon via just assert methods. 

However, if you still use unittest objects, you actually don't get the benefits from the improved assertions, so you usually want to swap over.

This PR makes the unitest class more py.test-y, and swaps over one command to demonstrate.

Test Plan
---------

py.test
