### PR TITLE
[VPDQ]  Add VPDQ python bidning  and FAISS Flat Index

### DIFF
--- a/vpdq/python/test_vpdq_faiss.py
+++ b/vpdq/python/test_vpdq_faiss.py
@@ -2,7 +2,6 @@
 
 import unittest
 import typing as t
-import functools
 import vpdq_matcher
 import vpdq_util
 import os

--- a/vpdq/python/test_vpdq_faiss.py
+++ b/vpdq/python/test_vpdq_faiss.py
@@ -1,0 +1,75 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+import typing as t
+import functools
+import vpdq_matcher
+import vpdq_util
+import os
+
+SAMPLE = "/sample-hashes"
+
+
+class TestVPDQFaiss(unittest.TestCase):
+    def setUp(self):
+        d = os.path.dirname(os.getcwd())
+        sample_folder = d + SAMPLE
+        self.index = vpdq_matcher.VPDQFlatHashIndex()
+        self.test_videos = []
+        id = 0
+        for file in os.listdir(sample_folder):
+            if file.endswith(".txt"):
+                sample_file = f"{sample_folder}/{file}"
+                cur = vpdq_util.read_file_to_hash(sample_file)
+                self.index.add_single_video(cur, video_id=id)
+                self.test_videos.append(cur)
+                id += 1
+        self.target_hash = self.test_videos[0]
+
+    def assertEqualVPDQPercentMatchResults(self, result, expected):
+        self.assertEqual(
+            result[0],
+            expected[0],
+            "search results not of expected target match percentage",
+        )
+        self.assertEqual(
+            result[1],
+            expected[1],
+            "search results not of expected target query percentage",
+        )
+
+    def test_VPDQ_Faiss_match_result(self):
+        faiss_result = vpdq_matcher.match_VPDQ_FAISS(
+            self.target_hash, self.index, 50, 31
+        )
+        brute_result = []
+        for v in self.test_videos:
+            brute_result.append(
+                vpdq_matcher.match_VPDQ_hash_brute(self.target_hash, v, 50, 31)
+            )
+        for f in faiss_result:
+            faiss_percent = f[1:3]
+            video_id = f[0]
+            self.assertEqualVPDQPercentMatchResults(
+                faiss_percent, brute_result[video_id]
+            )
+
+    def test_VPDQ_Faiss_quality_filter(self):
+        faiss_result = vpdq_matcher.match_VPDQ_FAISS(
+            self.target_hash, self.index, 100, 31
+        )
+        brute_result = []
+        for v in self.test_videos:
+            brute_result.append(
+                vpdq_matcher.match_VPDQ_hash_brute(self.target_hash, v, 100, 31)
+            )
+        for f in faiss_result:
+            faiss_percent = f[1:3]
+            video_id = f[0]
+            self.assertEqualVPDQPercentMatchResults(
+                faiss_percent, brute_result[video_id]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vpdq/python/vpdq.pyx
+++ b/vpdq/python/vpdq.pyx
@@ -1,0 +1,109 @@
+# distutils: language = c++
+# cython: language_level=3
+import numpy as np
+cimport numpy as np
+import cv2
+
+from dataclasses import dataclass
+from libcpp cimport bool
+from libcpp.vector cimport vector
+from libcpp.string cimport string
+from vpdq_util import hash_to_hex
+
+
+cdef extern from "pdq/cpp/common/pdqhashtypes.h" namespace "facebook::pdq::hashing":
+    cdef struct Hash256:
+        unsigned short w[16];
+    int hammingDistance(
+        Hash256 hash1,
+        Hash256 hash2
+    )
+cdef extern from "pdq/cpp/common/pdqhashtypes.h" namespace "facebook::pdq::hashing::Hash256":
+    Hash256 fromStringOrDie(
+        char* hex_str
+    )
+
+cdef extern from "vpdq/cpp/hashing/vpdqHashType.h" namespace "facebook::vpdq::hashing":
+    cdef struct vpdqFeature:
+        Hash256 pdqHash;
+        int frameNumber;
+        int quality;
+
+cdef extern from "vpdq/cpp/hashing/filehasher.h" namespace "facebook::vpdq::hashing":
+    bool hashVideoFile(
+        string inputVideoFileName,
+        vector[vpdqFeature]& pdqHashes,
+        string ffmpegPath,
+        bool verbose,
+        int secondsPerHash,
+        int width,
+        int height,
+        const char* argv0
+    )
+
+@dataclass
+class vpdq_feature:
+    quality: int
+    frame_number: int
+    hash: Hash256
+    hex: str
+    def __init__(self, quality, frame_number, hash):
+        self.quality = quality
+        self.frame_number = frame_number
+        self.hash = hash
+        self.hex = hash_to_hex(hash)
+    def hamming_distance(self, that):
+        return hammingDistance(self.hash, that.hash)
+
+def fromString(str_hash):
+    return fromStringOrDie(str(str_hash).encode('utf-8'))
+
+def hamming_distance(hash1, hash2):
+    """Return the hamming distance between two pdq hashes
+
+    Args:
+        hash1 (Hash256)
+        hash2 (Hash256)
+
+    Returns:
+        int: The hamming distance
+    """
+    return hammingDistance(hash1, hash2)
+
+def computeHash(inputVideoFileName, ffmpegPath, verbose, secondsPerHash, width, height):
+    """Compute vpdq hash
+
+    Args:
+        inputVideoFileName (str): Input video file path
+        ffmpegPath (str): ffmpeg path
+        verbose (bool): If verbose, will print detailed information
+        secondsPerHash (int): The frequence(per second) a hash is generated from the video
+        width (int): Width to downsample the video to before hashing frames.. If it is 0, will use the original width of the video to hash
+        height (int): Height to downsample the video to before hashing frames.. If it is 0, will use the original height of the video to hash
+    Returns:
+        list of vpdq_feature: VPDQ hash from the video
+    """
+    cdef vector[vpdqFeature] vpdqHash;
+    if width == 0:
+        vid = cv2.VideoCapture(inputVideoFileName)
+        width = vid.get(cv2.CAP_PROP_FRAME_WIDTH)
+
+    if height == 0:
+        vid = cv2.VideoCapture(inputVideoFileName)
+        height = vid.get(cv2.CAP_PROP_FRAME_HEIGHT)
+
+    rt = hashVideoFile(
+        inputVideoFileName.encode('utf-8'),
+        vpdqHash,
+        ffmpegPath.encode('utf-8'),
+        verbose,
+        secondsPerHash,
+        width,
+        height,
+        "vpdqPY"
+        )
+
+    hashs= [vpdq_feature(hash.quality,
+                         hash.frameNumber,
+                         hash.pdqHash)  for hash in vpdqHash]
+    return hashs

--- a/vpdq/python/vpdq.pyx
+++ b/vpdq/python/vpdq.pyx
@@ -31,11 +31,11 @@ cdef extern from "vpdq/cpp/hashing/vpdqHashType.h" namespace "facebook::vpdq::ha
 
 cdef extern from "vpdq/cpp/hashing/filehasher.h" namespace "facebook::vpdq::hashing":
     bool hashVideoFile(
-        string inputVideoFileName,
+        string input_video_filename,
         vector[vpdqFeature]& pdqHashes,
-        string ffmpegPath,
+        string ffmpeg_path,
         bool verbose,
-        int secondsPerHash,
+        int seconds_per_hash,
         int width,
         int height,
         const char* argv0
@@ -70,34 +70,34 @@ def hamming_distance(hash1, hash2):
     """
     return hammingDistance(hash1, hash2)
 
-def computeHash(inputVideoFileName, ffmpegPath, verbose, secondsPerHash, width, height):
+def computeHash(input_video_filename, ffmpeg_path, verbose, seconds_per_hash, width, height):
     """Compute vpdq hash
 
     Args:
-        inputVideoFileName (str): Input video file path
-        ffmpegPath (str): ffmpeg path
+        input_video_filename (str): Input video file path
+        ffmpeg_path (str): ffmpeg path
         verbose (bool): If verbose, will print detailed information
-        secondsPerHash (int): The frequence(per second) a hash is generated from the video
+        seconds_per_hash (int): The frequence(per second) a hash is generated from the video
         width (int): Width to downsample the video to before hashing frames.. If it is 0, will use the original width of the video to hash
         height (int): Height to downsample the video to before hashing frames.. If it is 0, will use the original height of the video to hash
     Returns:
         list of vpdq_feature: VPDQ hash from the video
     """
-    cdef vector[vpdqFeature] vpdqHash;
+    cdef vector[vpdqFeature] vpdq_hash;
     if width == 0:
-        vid = cv2.VideoCapture(inputVideoFileName)
+        vid = cv2.VideoCapture(input_video_filename)
         width = vid.get(cv2.CAP_PROP_FRAME_WIDTH)
 
     if height == 0:
-        vid = cv2.VideoCapture(inputVideoFileName)
+        vid = cv2.VideoCapture(input_video_filename)
         height = vid.get(cv2.CAP_PROP_FRAME_HEIGHT)
 
     rt = hashVideoFile(
-        inputVideoFileName.encode('utf-8'),
-        vpdqHash,
-        ffmpegPath.encode('utf-8'),
+        input_video_filename.encode('utf-8'),
+        vpdq_hash,
+        ffmpeg_path.encode('utf-8'),
         verbose,
-        secondsPerHash,
+        seconds_per_hash,
         width,
         height,
         "vpdqPY"
@@ -105,5 +105,5 @@ def computeHash(inputVideoFileName, ffmpegPath, verbose, secondsPerHash, width, 
 
     hashs= [vpdq_feature(hash.quality,
                          hash.frameNumber,
-                         hash.pdqHash)  for hash in vpdqHash]
+                         hash.pdqHash)  for hash in vpdq_hash]
     return hashs

--- a/vpdq/python/vpdq_matcher.py
+++ b/vpdq/python/vpdq_matcher.py
@@ -92,7 +92,6 @@ def match_VPDQ_hash_brute(
     )
 
 
-# TODO: Add quality Filter
 def match_VPDQ_FAISS(target_hash, VPDQ_index, quality_tolerance, distance_tolerance):
     """Searches this VPDQ index for target hashes within the index that are no more than the threshold away from the query hashes by
         hamming distance.

--- a/vpdq/python/vpdq_matcher.py
+++ b/vpdq/python/vpdq_matcher.py
@@ -1,0 +1,267 @@
+import vpdq
+import typing as t
+import faiss  # type: ignore
+import binascii
+import numpy  # type: ignore
+
+BITS_IN_VPDQ = 256
+
+
+def dedupe(hashes):
+    """Filter out the VPDQ feature with exact same hash in a list of VPDQ features
+
+    Args:
+        hashes (list of VPDQ feature)
+
+    Returns:
+        list of VPDQ feature: List of VPDQeatures with unique hashes
+    """
+    unique_hashes = set()
+    ret = []
+    for h in hashes:
+        if h.hex not in unique_hashes:
+            ret.append(h)
+            unique_hashes.add(h.hex)
+    return ret
+
+
+def quality_filter(hashes, quality_tolerance):
+    """Filter VPDQ feature that has a quality lower than quality_tolerance
+
+    Args:
+        hashes (list of VPDQ feature)
+        distance_tolerance (int): If frames is this quality level then it will be ignored
+
+    Returns:
+        list of VPDQ feature: List of VPDQeatures with quality higher than distance_tolerance
+    """
+    return list(filter(lambda hash: hash.quality >= quality_tolerance, hashes))
+
+
+def match_VPDQ_in_another(hash1, hash2, distance_tolerance):
+    """Count matches of hash1 in hash2
+
+    Args:
+        hash1 (list of VPDQ feature)
+        hash2 (list of VPDQ feature)
+        distance_tolerance (int):The hamming distance tolerance of between two frames.
+        If the hamming distance is bigger than the tolerance, it will be considered as unmatched
+
+    Returns:
+        int: The count of matches of hash1 in hash2
+    """
+    cnt = 0
+    for h1 in hash1:
+        for h2 in hash2:
+            if h1.hamming_distance(h2) < distance_tolerance:
+                cnt += 1
+                break
+    return cnt
+
+
+def match_VPDQ_hash_brute(
+    target_hash, query_hash, quality_tolerance, distance_tolerance
+):
+    """Match two VPDQ hashes. Return the query-match percentage and target-match percentage
+
+    Args:
+        target_hash (list of VPDQ feature): Target VPDQ hash
+        query_hash (list of VPDQ feature): Query VPDQ hash
+        quality_tolerance (int): The quality tolerance of matching two frames.
+        If either frames is below this quality level then they will not be compared
+        distance_tolerance (int): The hamming distance tolerance of between two frames.
+        If the hamming distance is bigger than the tolerance, it will be considered as unmatched
+
+    Returns:
+        float: Percentage matched in total target hash
+        flaot: Percentage matched in total query hash
+
+    """
+    target_match_cnt = 0
+    query_match_cnt = 0
+    filtered_target = quality_filter(dedupe(target_hash), quality_tolerance)
+    filtered_query = quality_filter(dedupe(query_hash), quality_tolerance)
+    target_match_cnt = match_VPDQ_in_another(
+        filtered_target, filtered_query, distance_tolerance
+    )
+    query_match_cnt = match_VPDQ_in_another(
+        filtered_query, filtered_target, distance_tolerance
+    )
+    return target_match_cnt * 100 / len(filtered_target), query_match_cnt * 100 / len(
+        filtered_query
+    )
+
+
+# TODO: Add quality Filter
+def match_VPDQ_FAISS(target_hash, VPDQ_index, quality_tolerance, distance_tolerance):
+    """Searches this VPDQ index for target hashes within the index that are no more than the threshold away from the query hashes by
+        hamming distance.
+
+    Args:
+        target_hash (list of VPDQfeature): Target VPDQ hash
+        VPDQ_index (VPDQFlatHashIndex): Query VPDQ hash
+        quality_tolerance (int): The quality tolerance of matching two frames.
+        If either frames is below this quality level then they will not be compared
+        distance_tolerance (int): The hamming distance tolerance of between two frames.
+        If the hamming distance is bigger than the tolerance, it will be considered as unmatched
+
+    Returns:
+        float: Percentage matched in total target hash
+        flaot: Percentage matched in total query hash
+    """
+    target_hash = quality_filter(dedupe(target_hash), quality_tolerance)
+    ret = VPDQ_index.search_with_detail_in_result(target_hash, 31)
+    target_matched = {}
+    index_matched = {}
+    for r in ret:
+        for matched_frame in ret[r]:
+            # query_str =>  (id, video_id, frame_number, hex_str of hash, quality, distance)
+            _, video_id, frame_number, _, quality, _ = matched_frame
+            if quality < quality_tolerance:
+                continue
+
+            if video_id not in target_matched:
+                target_matched[video_id] = set()
+            target_matched[video_id].add(r)
+
+            if video_id not in index_matched:
+                index_matched[video_id] = set()
+            index_matched[video_id].add(frame_number)
+
+    return [
+        (
+            video_id,
+            len(target_matched[video_id]) * 100 / len(target_hash),
+            len(index_matched[video_id])
+            * 100
+            / VPDQ_index.get_video_frame_counts(video_id, quality_tolerance),
+        )
+        for video_id in sorted(target_matched)
+    ]
+
+
+class VPDQFlatHashIndex:
+    """Wrapper around an faiss binary index for use with searching for similar VPDQ features
+
+    The "flat" variant uses an exhaustive search approach that may use less memory than other approaches and may be more
+    performant when using larger thresholds for VPDQ similarity.
+    """
+
+    def __init__(self) -> None:
+        faiss_index = faiss.IndexBinaryFlat(BITS_IN_VPDQ)
+        self.faiss_index = faiss_index
+        self._idx_to_vpdq = []
+        self._video_id_to_vpdq = {}
+        super().__init__()
+
+    def get_video_frame_counts(self, video_id: int, quality_tolerance: int):
+        """
+        Args:
+            video_id (int)
+            quality_tolerance (int)
+        Returns:
+            Size of VPDQ features in the video that has a quality larger or equal to quality_tolerance
+        """
+        return len(quality_filter(self._video_id_to_vpdq[video_id], quality_tolerance))
+
+    def add_multiple_videos(
+        self,
+        hashes: t.Iterable[vpdq.vpdq_feature],
+        video_id: t.Iterable[int],
+    ):
+        """
+        Args:
+            hashes (sequence of VPDQ feature): Multiple videos' VPDQ features to create the index with
+            video_id (sequence of int): Video id for the hashes
+        """
+        for h, id in zip(hashes, video_id):
+            self.add_single_video(h, id)
+
+    def add_single_video(
+        self,
+        hashes: t.Iterable[vpdq.vpdq_feature],
+        video_id: int,
+    ):
+        """
+        Args:
+            hashes (sequence of VPDQ feature): One video's VPDQ features of to create the index with
+            video_id (int): Video id corresponeds to the hashes in a single video
+        """
+        hashes = dedupe(hashes)
+        self._idx_to_vpdq.extend([(video_id, h) for h in hashes])
+        self._video_id_to_vpdq[video_id] = hashes
+        hex_hashes = [h.hex for h in hashes]
+        hash_bytes = [binascii.unhexlify(h) for h in hex_hashes]
+        vectors = list(
+            map(lambda h: numpy.frombuffer(h, dtype=numpy.uint8), hash_bytes)
+        )
+        self.faiss_index.add(numpy.array(vectors))
+
+    def search_with_detail_in_result(
+        self,
+        queries: t.Sequence[vpdq.vpdq_feature],
+        threshhold: int,
+    ):
+        """
+        Searches this index for PDQ hashes within the index that are no more than the threshold away from the query hashes by
+        hamming distance.
+
+        Args:
+            queries (sequence of VPDQ feature): The VPDQ features to against the index
+            threshold (int): Threshold value to use for this search. The hamming distance between the result hashes and the related query will
+            be no more than the threshold value. i.e., hamming_dist(q_i,r_i_j) <= threshold.
+
+        Returns:
+        sequence of matches per query
+            For each query provided in queries, the returned sequence will contain a sequence of matches within the index
+            that were within threshold hamming distance of that query. These matches will be (id, video_id, frame_number,
+            hex_str of hash, quality, distance). The inner sequences may be empty in the case of no hashes within the index.
+            The same VPDQ feature may also appear in more than one inner sequence if it matches multiple query hashes.
+            For example the hash "000000000000000000000000000000000000000000000000000000000000FFFF" would match both
+            "00000000000000000000000000000000000000000000000000000000FFFFFFFF" and
+            "0000000000000000000000000000000000000000000000000000000000000000" for a threshold of 16. Thus it would appear in
+            the entry for both the hashes if they were both in the queries list.
+
+            eg.
+            query_str =>  (id, video_id, frame_number, hex_str of hash, quality, distance)
+            result = {
+                "000000000000000000000000000000000000000000000000000000000000FFFF": [
+                    (12345678901, 5, 38, "00000000000000000000000000000000000000000000000000000000FFFFFFFF",97, 16.0)
+                ]
+            }
+        """
+
+        queries = dedupe(queries)
+        query_vectors = [
+            numpy.frombuffer(binascii.unhexlify(q.hex), dtype=numpy.uint8)
+            for q in queries
+        ]
+        qs = numpy.array(query_vectors)
+        limits, similarities, I = self.faiss_index.range_search(qs, threshhold + 1)
+
+        result = {}
+        for i, query in enumerate(queries):
+            match_tuples = []
+            matches = [idx.item() for idx in I[limits[i] : limits[i + 1]]]
+            distances = [idx for idx in similarities[limits[i] : limits[i + 1]]]
+            for match, distance in zip(matches, distances):
+                video_id, vpdq_match = self._idx_to_vpdq[match]
+                match_tuples.append(
+                    (
+                        match,
+                        video_id,
+                        vpdq_match.frame_number,
+                        vpdq_match.hex,
+                        vpdq_match.quality,
+                        distance,
+                    )
+                )
+            result[query.hex] = match_tuples
+        return result
+
+    def __getstate__(self):
+        data = faiss.serialize_index_binary(self.faiss_index)
+        return data
+
+    def __setstate__(self, data):
+        self.faiss_index = faiss.deserialize_index_binary(data)

--- a/vpdq/python/vpdq_util.py
+++ b/vpdq/python/vpdq_util.py
@@ -1,0 +1,88 @@
+import vpdq
+import numpy as np
+
+
+def vector_to_hex(hash_vector):
+    """Convect from hash vector to hex string
+
+    Args:
+        hash_vector (numpy array): Numpy array vector of a pdq hash
+
+    Returns:
+        str : Hex string of the hash
+    """
+    bin_str = "".join([str(x) for x in hash_vector])
+    # binary to hex using format string
+    # '%0*' is for padding up to ceil(num_bits/4),
+    # '%X' create a hex representation from the binary string's integer value
+    hex_str = "%0*X" % ((len(bin_str) + 3) // 4, int(bin_str, 2))
+    hex_str = hex_str.lower()
+    return hex_str
+
+
+def hash_to_vector(hash_value):
+    """Convect from pdq hash to numpy array
+
+    Args:
+        hash_value (Hash256):
+
+    Returns:
+        numpy array:
+    """
+    hash_value = hash_value["w"]
+    return np.array([(hash_value[(k & 255) >> 4] >> (k & 15)) & 1 for k in range(256)])[
+        ::-1
+    ]
+
+
+def hash_to_hex(hash_value):
+    """Convect from pdq hash to hex str
+
+    Args:
+        hash_value (Hash256):
+
+    Returns:
+        str: hex str of hash
+    """
+    return vector_to_hex(hash_to_vector(hash_value))
+
+
+def output_hash_to_file(outputHashFileName, hashes):
+    """Output vpdq hash to txt file
+
+    Args:
+        outputHashFileName (str): Output hash file path
+        hash (list of vpdq_feature): Vpdq Hash
+    """
+    with open(outputHashFileName, "w") as file:
+        for cur in hashes:
+            file.write(
+                str(cur.frame_number)
+                + ","
+                + str(cur.quality)
+                + ","
+                + hash_to_hex(cur.hash["w"])
+            )
+            file.write("\n")
+
+
+def read_file_to_hash(inputHashFileName):
+    """Read hash file and return vpdq hash
+
+    Args:
+        inputHashFileName (str): Input hash file path
+
+    Returns:
+        list of vpdq_feature: vpdq hash from the hash file
+    """
+    hash = []
+    with open(inputHashFileName, "r") as file:
+        lines = file.readlines()
+        for line in lines:
+            line = line.strip()
+            content = line.split(",")
+            pdq_hash = vpdq.fromString(content[2])
+            feature = vpdq.vpdq_feature(int(content[1]), int(content[0]), pdq_hash)
+            hash.append(feature)
+
+    return hash

--- a/vpdq/requirements.txt
+++ b/vpdq/requirements.txt
@@ -1,0 +1,4 @@
+setuptools >= 40.6.0
+wheel
+numpy
+cython

--- a/vpdq/setup.py
+++ b/vpdq/setup.py
@@ -1,0 +1,40 @@
+from setuptools import setup
+from setuptools.extension import Extension
+from setuptools.command.build_py import build_py
+import sys
+import subprocess
+import os
+import numpy
+
+
+class Build(build_py):
+    """Customized setuptools build command - builds protos on build."""
+    def run(self):
+        os.chdir("cpp")
+        command = ["mkdir","build"]
+        subprocess.call(command)
+        os.chdir("build")
+        command = ["cmake",".."]
+        if subprocess.call(command) != 0:
+            sys.exit(-1)
+        command = ["make"]
+        if subprocess.call(command) != 0:
+            sys.exit(-1)
+        # os.chdir("../../../")
+        os.chdir("../../")
+        build_py.run(self)
+
+EXTENSIONS = [
+    Extension(
+        'python.vpdq',
+        ['python/vpdq.pyx'],
+        extra_objects=["cpp/build/libvpdqlib.a"],
+        include_dirs=['../', numpy.get_include()],
+        language='c++',
+        extra_compile_args=['--std=c++11'])
+]
+
+setup(
+    cmdclass={'build_py': Build},
+    ext_modules=EXTENSIONS
+    )

--- a/vpdq/setup.py
+++ b/vpdq/setup.py
@@ -20,7 +20,6 @@ class Build(build_py):
         command = ["make"]
         if subprocess.call(command) != 0:
             sys.exit(-1)
-        # os.chdir("../../../")
         os.chdir("../../")
         build_py.run(self)
 


### PR DESCRIPTION
Summary
---------

Implement python binding for VPDQ. Now, CPP functionalities can be used in python. 
Add Faiss FlatIndex matching for VPDQ as well as the quality filter.
Faiss FlatIndex also returns matching percentages

Test Plan
---------
Build python binding:
python3 setup.py build_py build_ext --inplace

Test Faiss Matching by unit test:
python3 -m unittest test_vpdq_faiss.py -v
