### PR TITLE
[pytx][cli] fetch help refresh

### DIFF
--- a/python-threatexchange/threatexchange/cli/fetch_cmd.py
+++ b/python-threatexchange/threatexchange/cli/fetch_cmd.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import collections
@@ -23,6 +22,14 @@ from threatexchange.cli import command_base
 class FetchCommand(command_base.Command):
     """
     Download content from signal exchange APIs to disk.
+
+    Fetches data for collaborations that you've configured with
+      $ threatexchange config collab edit
+
+    Fetching is checkpointed, and you can safely interrupt by using CTRL+C.
+
+    Some APIs require that you regularly re-fetch them within some number
+    of days or else the stored data becomes invalid.
     """
 
     PROGRESS_PRINT_INTERVAL_SEC = 30


### PR DESCRIPTION
Summary
---------

Continuing help refreshes, here's fetch

Test Plan
---------

```
$ threatexchange fetch --help
usage: threatexchange fetch [-h] [--clear] [--skip-index-rebuild] [--limit LIMIT] [--time-limit-sec SEC] [--only-api {sample,local_file,stop_ncii,ncmec,fb_threat_exchange}] [--only-collab NAME]

    Download content from signal exchange APIs to disk.

    Fetches data for collaborations that you've configured with
      $ threatexchange config collab edit

    Fetching is checkpointed, and you can safely interrupt by using CTRL+C.

    Some APIs require that you regularly re-fetch them within some number
    of days or else the stored data becomes invalid.
    

optional arguments:
  -h, --help            show this help message and exit
  --clear               delete fetched state and checkpoints (you almost never need to do this)
  --skip-index-rebuild  don't rebuild indices after fetch
  --limit LIMIT         stop after fetching this many items
  --time-limit-sec SEC  stop fetching after this many seconds
  --only-api {sample,local_file,stop_ncii,ncmec,fb_threat_exchange}
                        only fetch from this API
  --only-collab NAME    only fetch for this collaboration
```
