### PR TITLE
[VPDQ] Add standalone function for vpdq-python import

### DIFF
--- a/pdq/cpp/common/pdqhashtypes.cpp
+++ b/pdq/cpp/common/pdqhashtypes.cpp
@@ -198,7 +198,9 @@ Hash256 Hash256::fuzz(int numErrorBits) {
 int hammingDistance(const Hash256& hash1, const Hash256& hash2) {
   return hash1.hammingDistance(hash2);
 }
-
+std::string hashToString(const Hash256& hash) {
+  return hash.format();
+}
 } // namespace hashing
 } // namespace pdq
 } // namespace facebook

--- a/pdq/cpp/common/pdqhashtypes.h
+++ b/pdq/cpp/common/pdqhashtypes.h
@@ -172,6 +172,7 @@ struct Hash256 {
 };
 
 int hammingDistance(const Hash256& hash1, const Hash256& hash2);
+std::string hashToString(const Hash256& hash);
 
 } // namespace hashing
 } // namespace pdq


### PR DESCRIPTION
Summary
---------

Add a standalone function for hashToHex in PDQ CPP implementation. So, VPDQ python binding can use this function instead of NumPy vector translation. 

Test Plan
---------
Won't affect pdq CPP. Test correctness it in python-binding PR.
