### PR TITLE
[pytx][ncmec] Fix endpoint names

### DIFF
--- a/python-threatexchange/threatexchange/ncmec/hash_api.py
+++ b/python-threatexchange/threatexchange/ncmec/hash_api.py
@@ -180,9 +180,9 @@ class NCMECEnvironment(Enum):
     content exists on them.
     """
 
-    Industry = "https://exttest.cybertip.org/hashsharing"
-    NGO = "https://hashsharing-test.ncmec.org/npo"
-    Exploitative = "https://hashsharing-test.ncmec.org/exploitative"
+    Industry = "https://report.cybertip.org/hashsharing"
+    NGO = "https://hashsharing.ncmec.org/npo"
+    Exploitative = "https://hashsharing.ncmec.org/exploitative"
 
     test_Industry = "https://exttest.cybertip.org/hashsharing"
     test_NGO = "https://hashsharing-test.ncmec.org/npo"


### PR DESCRIPTION
Summary
---------

Copy paste error :/

Re-copied from https://report.cybertip.org/hashsharing/v2/documentation.pdf


Test Plan
---------

I can no longer e2e test this as I've lost access to the API key! (Re-requested permission).

However, the --help now properly shows the options:

```
$ tx config collab edit ncmec --help
...
 --environment [Industry,NGO,Exploitative,test_Industry,test_NGO,test_Exploitative]
                        [auto generated from config class]
```
