### PR TITLE
[py-tx][cli] Many Improvements to `collab edit` --help

### DIFF
--- a/python-threatexchange/threatexchange/cli/cli_config.py
+++ b/python-threatexchange/threatexchange/cli/cli_config.py
@@ -264,15 +264,7 @@ class CLISettings:
             )
             self._sample_message_printed = True
         return collab_config.CollaborationConfigBase(
-            "Sample Signals",
-            StaticSampleSignalExchangeAPI.get_name(),
-            enabled=True,
-            only_signal_types={s.get_name() for s in self.get_all_signal_types()},
-            not_signal_types=set(),
-            only_owners=set(),
-            not_owners=set(),
-            only_tags=set(),
-            not_tags=set(),
+            "Sample Signals", StaticSampleSignalExchangeAPI.get_name(), enabled=True
         )
 
     def get_collabs_for_fetcher(

--- a/python-threatexchange/threatexchange/cli/config_cmd.py
+++ b/python-threatexchange/threatexchange/cli/config_cmd.py
@@ -145,7 +145,7 @@ class _UpdateCollabCommand(command_base.Command):
         return True
 
     @classmethod
-    def _add_argument(cls, ap: argparse.ArgumentParser, field: Field) -> None:
+    def _add_argument(cls, ap: argparse._ArgumentGroup, field: Field) -> None:
         assert cls._is_argument_field(field)
         assert not isinstance(
             field.type, ForwardRef

--- a/python-threatexchange/threatexchange/cli/config_cmd.py
+++ b/python-threatexchange/threatexchange/cli/config_cmd.py
@@ -93,13 +93,16 @@ class _UpdateCollabCommand(command_base.Command):
 
         ap.add_argument("collab_name", help="the name of the collab")
         ap.set_defaults(api_name=cls._API_CLS.get_name())
-        on_off = ap.add_mutually_exclusive_group()
         ap.add_argument(
             "--create",
             "-C",
             action="store_true",
             help="indicate you intend to create a config",
         )
+
+        cfg_common_ap = ap.add_argument_group(description="common to all collabs")
+        on_off = cfg_common_ap.add_mutually_exclusive_group()
+
         # This goofy syntax allows --enable, --enable=1, and enable=0 to disable
         on_off.add_argument(
             "--enable",
@@ -124,58 +127,6 @@ class _UpdateCollabCommand(command_base.Command):
         for field in fields(cfg_cls):
             cls._add_argument(config_ap, field)
 
-        # ap.add_argument(
-        #     "--only-signal-types",
-        #     "-s",
-        #     nargs="*",
-        #     type=common.argparse_choices_pre_type(
-        #         [s.get_name() for s in settings.get_all_signal_types()],
-        #         settings.get_signal_type,
-        #     ),
-        #     metavar="NAME",
-        #     help="limit to these signal types",
-        # )
-        # ap.add_argument(
-        #     "--not-signal-types",
-        #     "-S",
-        #     nargs="*",
-        #     type=common.argparse_choices_pre_type(
-        #         [s.get_name() for s in settings.get_all_signal_types()],
-        #         settings.get_signal_type,
-        #     ),
-        #     metavar="NAME",
-        #     help="dont use these signal types",
-        # )
-        # ap.add_argument(
-        #     "--only-owners",
-        #     "-o",
-        #     nargs="*",
-        #     type=int,
-        #     metavar="ID",
-        #     help="only use signals from these owner ids",
-        # )
-        # ap.add_argument(
-        #     "--not-owners",
-        #     "-O",
-        #     nargs="*",
-        #     type=int,
-        #     metavar="ID",
-        #     help="dont use signals from these owner ids",
-        # )
-        # ap.add_argument(
-        #     "--only-tags",
-        #     "-t",
-        #     nargs="*",
-        #     metavar="TAG",
-        #     help="use only signals with one of these tags",
-        # )
-        # ap.add_argument(
-        #     "--not-tags",
-        #     "-T",
-        #     nargs="*",
-        #     metavar="TAG",
-        #     help="don't use signals with one of these tags",
-        # )
         ap.add_argument(
             "--json",
             "-J",
@@ -226,12 +177,6 @@ class _UpdateCollabCommand(command_base.Command):
         create: bool,
         collab_name: str,
         enable: t.Optional[int],
-        only_signal_types: t.Optional[t.List[SignalType]],
-        not_signal_types: t.Optional[t.List[SignalType]],
-        only_owners: t.Optional[t.List[int]],
-        not_owners: t.Optional[t.List[str]],
-        only_tags: t.Optional[t.List[str]],
-        not_tags: t.Optional[t.List[str]],
         is_json: bool,
     ) -> None:
         self.namespace = full_argparse_namespace
@@ -250,23 +195,6 @@ class _UpdateCollabCommand(command_base.Command):
 
         if enable is not None:
             self.edit_kwargs["enabled"] = bool(enable)
-
-        if only_signal_types is not None or create:
-            self.edit_kwargs["only_signal_types"] = {
-                s.get_name() for s in only_signal_types or ()
-            }
-        if not_signal_types is not None or create:
-            self.edit_kwargs["not_signal_types"] = {
-                s.get_name() for s in not_signal_types or ()
-            }
-        if only_owners is not None or create:
-            self.edit_kwargs["only_owners"] = set(only_owners or ())
-        if not_owners is not None or create:
-            self.edit_kwargs["not_owners"] = set(not_owners or ())
-        if only_tags is not None or create:
-            self.edit_kwargs["only_tags"] = set(only_tags or ())
-        if not_tags is not None or create:
-            self.edit_kwargs["not_tags"] = set(not_tags or ())
 
         for field in fields(self._API_CLS.get_config_class()):
             if not field.init:

--- a/python-threatexchange/threatexchange/cli/tests/cli_smoke_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/cli_smoke_test.py
@@ -1,17 +1,43 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import pytest
+import sys
+import typing as t
+
+from _pytest.config import Config
+
 from threatexchange.cli import main
-from threatexchange.cli.tests.e2e_test_helper import ThreatExchangeCLIE2eTest
+from threatexchange.cli.command_base import Command, CommandWithSubcommands
+from threatexchange.cli.tests.e2e_test_helper import ThreatExchangeCLIE2eHelper, te_cli
+
+_PRINT_TO_STDERR: bool = False
 
 
-class CLISmokeTest(ThreatExchangeCLIE2eTest):
-    def test_all_helps(self):
-        """
-        Just executes all the commands to make sure they don't throw on help.
+def test_all_helps(te_cli: ThreatExchangeCLIE2eHelper, pytestconfig: Config):
+    """
+    Just executes all the commands to make sure they don't throw on help.
 
-        View the pretty output with py.test -s
-        """
-        self.cli_call()  # root help
-        self.cli_call("--help")  # root help
-        for command in main.get_subcommands():
-            self.cli_call(command.get_name(), "--help")
+    View the pretty output with py.test -sv
+    """
+    global _PRINT_TO_STDERR
+    _PRINT_TO_STDERR = pytestconfig.getoption("verbose") > 0
+    te_cli.cli_call()  # root help
+    _run_help(te_cli)  # root help
+    for command in main.get_subcommands():
+        _recurse(te_cli, command)
+
+
+def _run_help(te_cli: ThreatExchangeCLIE2eHelper, *args: str) -> None:
+    out = te_cli.cli_call(*args, "--help")
+    if _PRINT_TO_STDERR:
+        print(out, file=sys.stderr)
+
+
+def _recurse(
+    te_cli: ThreatExchangeCLIE2eHelper, command: t.Type[Command], *parents: str
+) -> None:
+    name = command.get_name()
+    _run_help(te_cli, *parents, name)
+    if issubclass(command, CommandWithSubcommands):
+        for subcommand in command._SUBCOMMANDS:
+            _recurse(te_cli, subcommand, *parents, name)

--- a/python-threatexchange/threatexchange/cli/tests/config_cmd_collabs_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/config_cmd_collabs_test.py
@@ -1,0 +1,24 @@
+import pytest
+from threatexchange.cli.tests.e2e_test_helper import (
+    ThreatExchangeCLIE2eHelper,
+    te_cli,
+)
+from threatexchange.ncmec.hash_api import NCMECEnvironment
+
+
+@pytest.fixture
+def cli(
+    te_cli: ThreatExchangeCLIE2eHelper,
+) -> ThreatExchangeCLIE2eHelper:
+    te_cli.COMMON_CALL_ARGS = ("config", "collab")
+    return te_cli
+
+
+def test_required_argument(cli: ThreatExchangeCLIE2eHelper) -> None:
+    name = "A config name"
+    cli.assert_cli_usage_error(("edit", "ncmec", "-C", name))
+    cli.cli_call(
+        "edit", "ncmec", "-C", name, f"--environment={NCMECEnvironment.test_NGO.name}"
+    )
+    cli.assert_cli_output((), expected_output=f"ncmec {name}")  # Defaults to list
+    cli.assert_cli_output(("list",), expected_output=f"ncmec {name}")

--- a/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
@@ -9,7 +9,9 @@ from threatexchange.cli.tests.e2e_test_helper import (
 
 
 @pytest.fixture
-def hash_cli(te_cli: ThreatExchangeCLIE2eHelper) -> ThreatExchangeCLIE2eHelper:
+def hash_cli(
+    te_cli: ThreatExchangeCLIE2eHelper,
+) -> ThreatExchangeCLIE2eHelper:
     te_cli.COMMON_CALL_ARGS = ("hash",)
     return te_cli
 

--- a/python-threatexchange/threatexchange/fetcher/apis/fb_threatexchange_api.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/fb_threatexchange_api.py
@@ -30,7 +30,12 @@ _API_NAME = "fb_threat_exchange"
 
 @dataclass
 class _FBThreatExchangeCollabConfigRequiredFields:
-    privacy_group: int
+    privacy_group: int = field(
+        metadata={
+            "help": "ThreatPrivacyGroup ID for this collaboration",
+            "metavar": "id",
+        }
+    )
 
 
 @dataclass
@@ -39,7 +44,13 @@ class FBThreatExchangeCollabConfig(
     _FBThreatExchangeCollabConfigRequiredFields,
 ):
     api: str = field(init=False, default=_API_NAME)
-    app_token_override: t.Optional[str] = None
+    app_token_override: t.Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "if you need to use a specific app for this collaboration",
+            "metavar": "APP_TOKEN",
+        },
+    )
 
 
 @dataclass

--- a/python-threatexchange/threatexchange/fetcher/apis/file_api.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/file_api.py
@@ -10,7 +10,7 @@ hashes from somewhere.
 
 import os
 import typing as t
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from threatexchange.fetcher import fetch_state as state
@@ -28,14 +28,22 @@ _TypedDelta = state.FetchDelta[
 
 @dataclass
 class _FileCollaborationConfigRequiredFields:
-    filename: str
+    filename: str = field(
+        metadata={"help": "the absolute file path to the signal file"}
+    )
 
 
 @dataclass
 class FileCollaborationConfig(
     CollaborationConfigWithDefaults, _FileCollaborationConfigRequiredFields
 ):
-    signal_type: t.Optional[str] = None
+    signal_type: t.Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "if the file row doesn't list the signal type, interpret as this type (SignalType.get_name())",
+            "metavar": "SIGNAL_TYPE",
+        },
+    )
 
 
 class LocalFileSignalExchangeAPI(

--- a/python-threatexchange/threatexchange/fetcher/apis/ncmec_api.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/ncmec_api.py
@@ -49,7 +49,9 @@ class NCMECCheckpoint(
 
 @dataclass
 class _NCMECCollabConfigRequiredFields:
-    environment: api.NCMECEnvironment
+    environment: api.NCMECEnvironment = field(
+        metadata={"help": "which database to connect to"}
+    )
 
 
 @dataclass

--- a/python-threatexchange/threatexchange/fetcher/collab_config.py
+++ b/python-threatexchange/threatexchange/fetcher/collab_config.py
@@ -26,16 +26,18 @@ class CollaborationConfigBase:
     # Whether to fetch/sync. Some implementations (like the CLI) may gate matching
     # to avoid waiting for an index rebuild to stop processing matches
     enabled: bool
-    # Only fetch and index these types
-    only_signal_types: t.Set[str]
-    # Don't fetch and index these types
-    not_signal_types: t.Set[str]
-    # Only use signals from these owners
-    only_owners: t.Set[int]
-    not_owners: t.Set[int]
-    # Only use signals with these tags
-    only_tags: t.Set[str]
-    not_tags: t.Set[str]
+    # TODO - eventually re-merge these back into collab config, or allow them as
+    #        mixins
+    # # Only fetch and index these types
+    # only_signal_types: t.Set[str]
+    # # Don't fetch and index these types
+    # not_signal_types: t.Set[str]
+    # # Only use signals from these owners
+    # only_owners: t.Set[int]
+    # not_owners: t.Set[int]
+    # # Only use signals with these tags
+    # only_tags: t.Set[str]
+    # not_tags: t.Set[str]
 
 
 @dataclass
@@ -46,12 +48,12 @@ class CollaborationConfigWithDefaults(CollaborationConfigBase):
 
     api: str = ""
     enabled: bool = True
-    only_signal_types: t.Set[str] = field(default_factory=set)
-    not_signal_types: t.Set[str] = field(default_factory=set)
-    only_owners: t.Set[int] = field(default_factory=set)
-    not_owners: t.Set[int] = field(default_factory=set)
-    only_tags: t.Set[str] = field(default_factory=set)
-    not_tags: t.Set[str] = field(default_factory=set)
+    # only_signal_types: t.Set[str] = field(default_factory=set)
+    # not_signal_types: t.Set[str] = field(default_factory=set)
+    # only_owners: t.Set[int] = field(default_factory=set)
+    # not_owners: t.Set[int] = field(default_factory=set)
+    # only_tags: t.Set[str] = field(default_factory=set)
+    # not_tags: t.Set[str] = field(default_factory=set)
 
 
 class CollaborationConfigStoreBase:


### PR DESCRIPTION
Summary
---------

This one got away from me a little:
1. Fixes #1033
2. Allows annotating collab configs to add descriptions
3. Removes many unused properties in the base collab config
4. slightly change the output of `threatexchange config collab list` to play nicer with `cut`
5. Smoke test can now print all the helps with -v

Test Plan
---------

Regression test added for 1 above

See this gist for the new helps: https://gist.github.com/9a401821d7bec85575e9af9ac9b98eec
(Generated by pt.test -v smoke_test.py)