### PR TITLE
[py-tx][cli] hash --help rewrite

### DIFF
--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -20,15 +20,26 @@ from threatexchange.cli import command_base
 from threatexchange.cli.helpers import FlexFilesInputAction
 
 
-# TODO consider refactor to handle overlap with match
 class HashCommand(command_base.Command):
     """
-    Hash content into signatures (aka hashes).
+    Take content and convert it into signatures (aka hashes)
 
-    Reads inputs as filenames by default, though it will attempt to read
-    inline with --inline. Most useful with with content type `text`.
+    # Input
+    You can pass in data to the command in a few different ways:
+    (Note - you may not be able to hash text without an extension)
+    ```
+    # As an input file that contains one signal
+    $ threatexchange hash photo my_photo.jpg
 
-    You can also pass in via stdin not passing in any files
+    # As stdin
+    $ echo This is my cool text | threatexchange hash text -
+
+    # Inline
+    $ threatexchange hash text -- This is my cool text
+    ```
+
+    # Output
+    <SignalType> <hash string>
     """
 
     @classmethod


### PR DESCRIPTION
Summary
---------

Continuing onward, now to `hash`

Test Plan
---------

```
$ threatexchange hash --help
usage: threatexchange hash [-h] [--signal-type {pdq,video_md5,url_md5}] {photo,video,url} ...

    Take content and convert it into signatures (aka hashes)

    # Input
    You can pass in data to the command in a few different ways:
    (Note - you may not be able to hash text without an extension)
    ```
    # As an input file that contains one signal
    $ threatexchange hash photo my_photo.jpg

    # As stdin
    $ echo This is my cool text | threatexchange hash text -

    # Inline
    $ threatexchange hash text -- This is my cool text
    ```

    # Output
    <SignalType> <hash string>
    

positional arguments:
  {photo,video,url}     what kind of content to hash
  files                 list of files or -- to interpret remainder as a string

optional arguments:
  -h, --help            show this help message and exit
  --signal-type {pdq,video_md5,url_md5}, -S {pdq,video_md5,url_md5}
                        only generate these signal types
```
