### PR TITLE
[pytx] Hide mypy errors that only happen to me apparently

### DIFF
--- a/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
+++ b/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
@@ -62,7 +62,7 @@ class ThreatExchangeCLIE2eHelper:
     def assert_cli_usage_error(
         self, args: t.Iterable[str], msg_regex: str = None
     ) -> None:
-        with pytest.raises((CommandError, E2ETestSystemExit), match=msg_regex) as ex:
+        with pytest.raises((CommandError, E2ETestSystemExit), match=msg_regex) as ex:  # type: ignore
             self.cli_call(*args)
         exception = t.cast(t.Union[CommandError, E2ETestSystemExit], ex.value)
         assert exception.returncode == 2

--- a/python-threatexchange/threatexchange/fetcher/apis/file_api.py
+++ b/python-threatexchange/threatexchange/fetcher/apis/file_api.py
@@ -93,10 +93,10 @@ class LocalFileSignalExchangeAPI(
         if opinion.tags:
             raise NotImplementedError
         path = Path(collab.filename)
-        with path.open("rb") as f:
-            f.seek(-1, os.SEEK_END)
-            has_newline = f.read1(1) == b"\n"
+        with path.open("rb") as rf:
+            rf.seek(-1, os.SEEK_END)
+            has_newline = rf.read1(1) == b"\n"  # type: ignore  # mypy bug? read1 noexist
         # Appending will overwrite previous ones, and compaction is for scrubs
-        with path.open("wa") as f:
+        with path.open("wta") as wf:
             nl = "" if has_newline else "\n"
-            f.write(f"{nl}{s_type.get_name()} {signal}\n")
+            wf.write(f"{nl}{s_type.get_name()} {signal}\n")


### PR DESCRIPTION
Summary
---------

I get these in my local checkout:
```
threatexchange/fetcher/apis/file_api.py:98: error: "BinaryIO" has no attribute "read1"
threatexchange/fetcher/apis/file_api.py:100: error: Incompatible types in assignment (expression has type "TextIO", variable has type "BinaryIO")
threatexchange/fetcher/apis/file_api.py:102: error: Argument 1 to "write" of "IO" has incompatible type "str"; expected "bytes"
threatexchange/cli/tests/e2e_test_helper.py:65: error: Need type annotation for "ex"
threatexchange/cli/tests/e2e_test_helper.py:65: error: Argument 1 to "raises" has incompatible type "Tuple[Type[CommandError], Type[E2ETestSystemExit]]"; expected "Union[Type[<nothing>], Tuple[Type[<nothing>], ...]]"
Found 5 errors in 2 files (checked 90 source files)
```

However, on server they are fine. This only happened on my new devcontainer checkout, and after spending about 15 minutes comparing the workflow to what I'm doing locally, decided it's not worth the effort and just ignored it

Test Plan
---------

`python -m mypy threatexchange` and it's clean
