### PR TITLE
[pytx][cli] Dash for stdin for `hash`, `match` and friends

### DIFF
--- a/python-threatexchange/threatexchange/cli/helpers.py
+++ b/python-threatexchange/threatexchange/cli/helpers.py
@@ -6,6 +6,7 @@ import pathlib
 import sys
 import tempfile
 import shutil
+import typing as t
 
 from threatexchange.cli.exceptions import CommandError
 
@@ -36,18 +37,18 @@ class FlexFilesInputAction(argparse.Action):
     """
 
     def __call__(self, _parser, namespace, values, _option_string=None):
-        args = list(values)
-        if not args:  # If inputs, assume stdin
-            with tempfile.NamedTemporaryFile("wb", delete=False) as tmp:
-                logging.debug("Writing stdin to %s", tmp.name)
-                shutil.copyfileobj(sys.stdin.buffer, tmp)
-            args.append(tmp.name)
+        args: t.List[str] = list(values)
         # We have special behavior for -- but argparse sometimes eats it during parsing...
         if "--" in sys.argv and sys.argv[-len(args) - 1] == "--":
             args.insert(0, "--")
         ret = []
         for i, filename in enumerate(args):
-            if filename.strip() == "--":
+            if filename.strip() == "-":
+                with tempfile.NamedTemporaryFile("wb", delete=False) as tmp:
+                    logging.debug("Writing stdin to %s", tmp.name)
+                    shutil.copyfileobj(sys.stdin.buffer, tmp)
+                filename = tmp.name
+            elif filename.strip() == "--":
                 # We could also just open this as a series of streams and seek() them
                 with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
                     logging.debug("Writing -- to %s", tmp.name)

--- a/python-threatexchange/threatexchange/cli/helpers.py
+++ b/python-threatexchange/threatexchange/cli/helpers.py
@@ -38,6 +38,8 @@ class FlexFilesInputAction(argparse.Action):
 
     def __call__(self, _parser, namespace, values, _option_string=None):
         args: t.List[str] = list(values)
+        if not args:
+            raise argparse.ArgumentError(self, "this argument is required")
         # We have special behavior for -- but argparse sometimes eats it during parsing...
         if "--" in sys.argv and sys.argv[-len(args) - 1] == "--":
             args.insert(0, "--")
@@ -57,6 +59,6 @@ class FlexFilesInputAction(argparse.Action):
                 break
             path = pathlib.Path(filename)
             if not path.is_file():
-                raise CommandError(f"No such file {path}", 2)
+                raise argparse.ArgumentError(self, f"no such file {path}")
             ret.append(path)
         setattr(namespace, self.dest, ret)

--- a/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
+++ b/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
@@ -17,6 +17,7 @@ from threatexchange.cli.exceptions import CommandError
 
 class E2ETestSystemExit(Exception):
     def __init__(self, code: int) -> None:
+        super().__init__()
         self.returncode = code
 
 

--- a/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
@@ -27,7 +27,7 @@ def test_file(hash_cli: ThreatExchangeCLIE2eHelper, tmp_file: pathlib.Path):
         "url_md5 6d3af727a4e7b025fd59a5469b3a9c57",
     )
 
-    hash_cli.assert_cli_usage_error(("url", "blah.txt"), "No such file blah.txt")
+    hash_cli.assert_cli_usage_error(("url", "blah.txt"))
 
 
 def test_dashdash(hash_cli: ThreatExchangeCLIE2eHelper):
@@ -46,7 +46,7 @@ def test_stdin(
 
     monkeypatch.setattr("sys.stdin", tmp_file.open())
     hash_cli.assert_cli_output(
-        ("url",),
+        ("url", "-"),
         "url_md5 6d3af727a4e7b025fd59a5469b3a9c57",
     )
 
@@ -65,3 +65,8 @@ def test_mixed(hash_cli: ThreatExchangeCLIE2eHelper, tmp_path: pathlib.Path):
             "url_md5 fb8191ebebc85f9eb6fd21e198f20979",
         ],
     )
+
+
+def test_missing(hash_cli: ThreatExchangeCLIE2eHelper):
+    hash_cli.assert_cli_usage_error(())
+    hash_cli.assert_cli_usage_error(("photo",))


### PR DESCRIPTION
Summary
---------

Folks found the empty argument behavior confusing, and on reflection, I find it confusing too, Instead use `-`. Also force it to be considered required. 

Test Plan
---------

Test on cli, also add regression test.
