### PR TITLE
[VPDQ] Make ffmpeg path optional

### DIFF
--- a/.github/workflows/vpdq-ci-cpp.yml
+++ b/.github/workflows/vpdq-ci-cpp.yml
@@ -35,6 +35,5 @@ jobs:
           python-version: '3.x'
           architecture: 'x64'
       - run: |
-          cd ..
           mkdir -p output-hashes
-          python regtest.py -d ${GITHUB_WORKSPACE}/vpdq/output-hashes -i ${GITHUB_WORKSPACE}/tmk/sample-videos
+          python regtest.py -d ${GITHUB_WORKSPACE}/vpdq/cpp/output-hashes -i ${GITHUB_WORKSPACE}/tmk/sample-videos

--- a/.github/workflows/vpdq-ci-cpp.yml
+++ b/.github/workflows/vpdq-ci-cpp.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           python-version: '3.x'
           architecture: 'x64'
+      - name: regression test
       - run: |
           mkdir -p output-hashes
           python regtest.py -d ${GITHUB_WORKSPACE}/vpdq/cpp/output-hashes -i ${GITHUB_WORKSPACE}/tmk/sample-videos

--- a/.github/workflows/vpdq-ci-cpp.yml
+++ b/.github/workflows/vpdq-ci-cpp.yml
@@ -2,7 +2,7 @@ name: vpdq CI - cpp
 on:
   push:
     branches:
-      - main
+      - VPDQ-FFMPEG_PATH
     paths:
       - "vpdq/cpp/**"
       - ".github/workflows/vpdq-ci-cpp.yml"
@@ -30,3 +30,10 @@ jobs:
           cd build
           cmake ..
           make
+      - uses: actions/setup-python@v4
+        with:
+        python-version: '3.x'
+        architecture: 'x64'
+        run: |
+          mkdir -p output-hashes
+          python regtest.py -d /ThreatExchange/vpdq/output-hashes -i ThreatExchange/tmk/sample-videos

--- a/.github/workflows/vpdq-ci-cpp.yml
+++ b/.github/workflows/vpdq-ci-cpp.yml
@@ -36,4 +36,4 @@ jobs:
           architecture: 'x64'
       - run: |
           mkdir -p output-hashes
-          python regtest.py -d /ThreatExchange/vpdq/output-hashes -i /ThreatExchange/tmk/sample-videos
+          python regtest.py -d ${GITHUB_WORKSPACE}/vpdq/output-hashes -i ${GITHUB_WORKSPACE}/tmk/sample-videos

--- a/.github/workflows/vpdq-ci-cpp.yml
+++ b/.github/workflows/vpdq-ci-cpp.yml
@@ -34,7 +34,8 @@ jobs:
         with:
           python-version: '3.x'
           architecture: 'x64'
+      - uses: actions/checkout@v2
       - name: regression test
-      - run: |
+        run: |
           mkdir -p output-hashes
           python regtest.py -d ${GITHUB_WORKSPACE}/vpdq/cpp/output-hashes -i ${GITHUB_WORKSPACE}/tmk/sample-videos

--- a/.github/workflows/vpdq-ci-cpp.yml
+++ b/.github/workflows/vpdq-ci-cpp.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
       - name: make
         run: |
           sudo apt-get update
@@ -30,12 +33,7 @@ jobs:
           cd build
           cmake ..
           make
-      - uses: actions/checkout@v2
-      - name: Regression test
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-          architecture: 'x64'
-      - run: |
+      - name: regression test
+        run: |
           mkdir -p output-hashes
           python regtest.py -d ${GITHUB_WORKSPACE}/vpdq/cpp/output-hashes -i ${GITHUB_WORKSPACE}/tmk/sample-videos

--- a/.github/workflows/vpdq-ci-cpp.yml
+++ b/.github/workflows/vpdq-ci-cpp.yml
@@ -32,8 +32,8 @@ jobs:
           make
       - uses: actions/setup-python@v4
         with:
-        python-version: '3.x'
-        architecture: 'x64'
-        run: |
+          python-version: '3.x'
+          architecture: 'x64'
+      - run: |
           mkdir -p output-hashes
-          python regtest.py -d /ThreatExchange/vpdq/output-hashes -i ThreatExchange/tmk/sample-videos
+          python regtest.py -d /ThreatExchange/vpdq/output-hashes -i /ThreatExchange/tmk/sample-videos

--- a/.github/workflows/vpdq-ci-cpp.yml
+++ b/.github/workflows/vpdq-ci-cpp.yml
@@ -2,7 +2,7 @@ name: vpdq CI - cpp
 on:
   push:
     branches:
-      - VPDQ-FFMPEG_PATH
+      - main
     paths:
       - "vpdq/cpp/**"
       - ".github/workflows/vpdq-ci-cpp.yml"

--- a/.github/workflows/vpdq-ci-cpp.yml
+++ b/.github/workflows/vpdq-ci-cpp.yml
@@ -35,5 +35,6 @@ jobs:
           python-version: '3.x'
           architecture: 'x64'
       - run: |
+          cd ..
           mkdir -p output-hashes
           python regtest.py -d ${GITHUB_WORKSPACE}/vpdq/output-hashes -i ${GITHUB_WORKSPACE}/tmk/sample-videos

--- a/.github/workflows/vpdq-ci-cpp.yml
+++ b/.github/workflows/vpdq-ci-cpp.yml
@@ -30,12 +30,12 @@ jobs:
           cd build
           cmake ..
           make
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v2
+      - name: Regression test
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
           architecture: 'x64'
-      - uses: actions/checkout@v2
-      - name: regression test
-        run: |
+      - run: |
           mkdir -p output-hashes
           python regtest.py -d ${GITHUB_WORKSPACE}/vpdq/cpp/output-hashes -i ${GITHUB_WORKSPACE}/tmk/sample-videos

--- a/vpdq/README.md
+++ b/vpdq/README.md
@@ -120,13 +120,27 @@ $ make
 ```
 Then you will have executable "vpdq-hash-video", "match-hashes-byline" and "match-hashes-brute". And two python scripts "vpdq_match.py" and "regtest.py" to run the executables. Please run executable with "-h" for more detailed reference information and usages.
 
+#### Installing FFmpeg
+
+Before using VPDQ to create hashes, FFmpeg must be installed. (Easier to use if Accessible via the `$PATH` environment variable)
+
+There are a variety of ways to install FFmpeg, such as the [official download links](https://ffmpeg.org/download.html), or using your package manager of choice (e.g. `sudo apt install ffmpeg` on Debian/Ubuntu, `brew install ffmpeg` on OS X, etc.).
+
+Regardless of how FFmpeg is installed, you can check if your environment path is set correctly by running the `ffmpeg` command from the terminal, as in the following example (truncated for brevity):
+
+```
+$ ffmpeg
+ffmpeg version 4.4.2 Copyright (c) 2000-2021 the FFmpeg developers
+```
+
+> **Note**: The actual version information displayed here may vary from one system to another; but if a message such as `ffmpeg: command not found` appears instead of the version information, FFmpeg is not properly installed.
 
 #### Compute hashes of sample videos and compare to previous outputs
 Hash the provided sample videos and compare the output hashes with sample hashes line by line.
 
 ```
 cd cpp
-python3 regtest.py -i ../ThreatExchange/tmk/sample-videos -d ../ThreatExchange/vpdq/output-hashes -f /usr/bin/ffmpeg
+python3 regtest.py -i ../ThreatExchange/tmk/sample-videos -d ../ThreatExchange/vpdq/output-hashes
 Matching File pattern-sd-with-small-logo-bar.txt
 100.000000 Percentage  matches
 

--- a/vpdq/README.md
+++ b/vpdq/README.md
@@ -120,7 +120,7 @@ $ make
 ```
 Then you will have executable "vpdq-hash-video", "match-hashes-byline" and "match-hashes-brute". And two python scripts "vpdq_match.py" and "regtest.py" to run the executables. Please run executable with "-h" for more detailed reference information and usages.
 
-#### Installing FFmpeg
+#### Install FFmpeg
 
 Before using VPDQ to create hashes, FFmpeg must be installed. (Easier to use if Accessible via the `$PATH` environment variable)
 

--- a/vpdq/cpp/bin/vpdq-hash-video.cpp
+++ b/vpdq/cpp/bin/vpdq-hash-video.cpp
@@ -9,11 +9,11 @@ static void usage(char* argv0, int rc) {
   FILE* fp = (rc == 0) ? stdout : stderr;
   fprintf(fp, "Usage: %s [options]\n", argv0);
   fprintf(fp, "Required:\n");
-  fprintf(fp, "-f|--ffmpeg-path ...\n");
   fprintf(fp, "-i|--input-video-file-name ...\n");
   fprintf(fp, "-o|--output-hash-file-name ...\n");
   fprintf(fp, "-r|--seconds-per-hash ...:Must be a positive integer\n");
   fprintf(fp, "Options:\n");
+  fprintf(fp, "-f|--ffmpeg-path: Specific ffmpeg's address you want to use\n");
   fprintf(fp, "-v|--verbose: Show all hash matching information\n");
   fprintf(
       fp,
@@ -71,7 +71,7 @@ string stripExtension(const string& path, const string& delimiter) {
 int main(int argc, char** argv) {
   int argi = 1;
   bool verbose = false;
-  string ffmpegPath = "";
+  string ffmpegPath = "ffmpeg";
   string inputVideoFileName = "";
   string outputHashFileName = "";
   string outputDirectory = "";
@@ -126,11 +126,6 @@ int main(int argc, char** argv) {
       downsampleFrameDimension = atoi(argv[argi++]);
       continue;
     }
-    usage(argv[0], 1);
-  }
-
-  if (ffmpegPath.empty()) {
-    fprintf(stderr, "%s: --ffmpeg-path missing\n", argv[0]);
     usage(argv[0], 1);
   }
 

--- a/vpdq/cpp/bin/vpdq-hash-video.cpp
+++ b/vpdq/cpp/bin/vpdq-hash-video.cpp
@@ -13,7 +13,7 @@ static void usage(char* argv0, int rc) {
   fprintf(fp, "-o|--output-hash-file-name ...\n");
   fprintf(fp, "-r|--seconds-per-hash ...:Must be a positive integer\n");
   fprintf(fp, "Options:\n");
-  fprintf(fp, "-f|--ffmpeg-path: Specific ffmpeg's address you want to use\n");
+  fprintf(fp, "-f|--ffmpeg-path: Specific path to ffmpeg you want to use\n");
   fprintf(fp, "-v|--verbose: Show all hash matching information\n");
   fprintf(
       fp,

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -8,7 +8,13 @@ def get_argparse() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    ap.add_argument("-f", "--ffmpegPath", metavar="FFMPEG_PATH", help="ffmpeg path")
+    ap.add_argument(
+        "-f",
+        "--ffmpegPath",
+        metavar="FFMPEG_PATH",
+        help="Specific ffmpeg's address you want to use",
+        default="ffmpeg",
+    )
     ap.add_argument(
         "-r",
         "--secondsPerHash",
@@ -82,7 +88,6 @@ def main():
     secondsPerHash = str(args.secondsPerHash)
     downsampleFrameDimension = str(args.downsampleFrameDimension)
     verbose = args.verbose
-    # TODO: Add more general options for other video encodings.
     for file in os.listdir(inputVideoFolder):
         if file.endswith(".mp4"):
             if verbose:

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -6,7 +6,7 @@ import argparse
 
 def get_argparse() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+        description=__doc__
     )
     ap.add_argument(
         "-f",

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -29,7 +29,7 @@ def get_argparse() -> argparse.ArgumentParser:
         metavar="OUTPUT_HASH_Folder_PATH",
         help="Output Hash Folder's Name",
         default="/ThreatExchange/vpdq/output-hashes",
-        # type=dir_path,
+        type=dir_path,
     )
     ap.add_argument(
         "-i",
@@ -37,7 +37,7 @@ def get_argparse() -> argparse.ArgumentParser:
         metavar="INPUTPUT_VIDEO_FOLDER_PATH",
         help="Input Video Folder",
         default="/ThreatExchange/tmk/sample-videos",
-        # type=dir_path,
+        type=dir_path,
     )
     ap.add_argument(
         "-s",

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -29,7 +29,7 @@ def get_argparse() -> argparse.ArgumentParser:
         metavar="OUTPUT_HASH_Folder_PATH",
         help="Output Hash Folder's Name",
         default="/ThreatExchange/vpdq/output-hashes",
-        type=dir_path,
+        # type=dir_path,
     )
     ap.add_argument(
         "-i",
@@ -37,7 +37,7 @@ def get_argparse() -> argparse.ArgumentParser:
         metavar="INPUTPUT_VIDEO_FOLDER_PATH",
         help="Input Video Folder",
         default="/ThreatExchange/tmk/sample-videos",
-        type=dir_path,
+        # type=dir_path,
     )
     ap.add_argument(
         "-s",

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -88,6 +88,7 @@ def main():
     secondsPerHash = str(args.secondsPerHash)
     downsampleFrameDimension = str(args.downsampleFrameDimension)
     verbose = args.verbose
+    # TODO: Add more general options for other video encodings.
     for file in os.listdir(inputVideoFolder):
         if file.endswith(".mp4"):
             if verbose:

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -12,7 +12,7 @@ def get_argparse() -> argparse.ArgumentParser:
         "-f",
         "--ffmpegPath",
         metavar="FFMPEG_PATH",
-        help="Specific ffmpeg's address you want to use",
+        help="Specific path to ffmpeg you want to use",
         default="ffmpeg",
     )
     ap.add_argument(


### PR DESCRIPTION
Summary
---------

Invofe ffmpeg by using $PATH 'ffmpeg' in CPP implementation instead of binary's address. So, the ffmpeg's path is optional if it is installed properly.

Test Plan
---------

Run through the regression test without ffmpeg path argument.
python3 regtest.py -d ../ThreatExchange/vpdq/output-hashes -i ../ThreatExchange/tmk/sample-videos

