### PR TITLE
[pytx][cli] Handle demo dataset empty, settings helpers

### DIFF
--- a/python-threatexchange/threatexchange/cli/cli_state.py
+++ b/python-threatexchange/threatexchange/cli/cli_state.py
@@ -108,6 +108,15 @@ class CliSimpleState(simple_state.SimpleFetchedStateStore):
         """The file location for collaboration state"""
         return self.dir / f"{collab_name}.state.pickle"
 
+    def exists(self, collab: CollaborationConfigBase) -> bool:
+        """
+        Returns true if the state file is available
+
+        This usually means that state is available, but the file could also be
+        corrupt or unparsable.
+        """
+        return self.collab_file(collab.name).is_file()
+
     def clear(self, collab: CollaborationConfigBase) -> None:
         """Delete a collaboration and its state directory"""
         file = self.collab_file(collab.name)

--- a/python-threatexchange/threatexchange/cli/label_cmd.py
+++ b/python-threatexchange/threatexchange/cli/label_cmd.py
@@ -157,7 +157,7 @@ class LabelCommand(command_base.Command):
         self.action(settings)
 
     def execute_upload(self, settings: CLISettings) -> None:
-        api = settings.get_api_for_collab(self.collab)
+        api = settings.apis.get_for_collab(self.collab)
         # signal_types = self.only_signals or settings.get_signal_types_for_content(
         #     self.content_type
         # )

--- a/python-threatexchange/threatexchange/cli/tests/dataset_cmd_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/dataset_cmd_test.py
@@ -13,11 +13,9 @@ class DatasetCommandTest(ThreatExchangeCLIE2eTest):
         of development, which will unexpectedly break this test, so apologies
         future developers.
         """
-        self.assert_cli_output(("dataset",), "")  # No datas yet
         signal_count = sum(len(st.get_examples()) for st in _DEFAULT_SIGNAL_TYPES)
 
-        self.cli_call("fetch")
-
+        # Since we didn't set a collab config, this will fetch on first call
         self.assert_cli_output(
             ("dataset",),
             [


### PR DESCRIPTION
Summary
---------

If you call dataset as your first command, instead of doing nothing, fetch first.

Test Plan
---------

```
$ rm -r ~/.threatexchange
$ tx fetch --clear
Looks like you haven't set up a collaboration config, so using the sample one against sample data
Clearing fetched state
dcallies@eecd010a7c71:/workspaces/devcontainer-ThreatExchange/python-threatexchange$ tx dataset
You haven't fetched any state, so we'll call `fetch` for you!
Looks like you haven't set up a collaboration config, so using the sample one against sample data
[sample] Sample Signals - Up to date
Rebuilding match indices...
Building index for trend_query with 1 signals...
Index for trend_query ready
Building index for video_md5 with 2 signals...
Index for video_md5 ready
Building index for raw_text with 3 signals...
Index for raw_text ready
Building index for pdq with 138 signals...
Index for pdq ready
Building index for url_md5 with 1 signals...
Index for url_md5 ready
Building index for url with 1 signals...
Index for url ready
pdq: 138
raw_text: 3
video_md5: 2
trend_query: 1
url: 1
url_md5: 1

$ threatexchange dataset
Looks like you haven't set up a collaboration config, so using the sample one against sample data
pdq: 138
raw_text: 3
video_md5: 2
trend_query: 1
url: 1
url_md5: 1
```
