### PR TITLE
[pytx][lib] All Fetches are now keyed

### DIFF
--- a/python-threatexchange/threatexchange/exchanges/fetch_state.py
+++ b/python-threatexchange/threatexchange/exchanges/fetch_state.py
@@ -18,8 +18,10 @@ from threatexchange.signal_type.signal_base import SignalType
 
 Self = t.TypeVar("Self")
 
-
-TUpdateRecord = t.TypeVar("TUpdateRecord", bound=t.Sized)
+# Note - key is artificially restricted, but it's simple to add more or even
+#        remove the restriction entirely if eventually needed
+TUpdateRecordKey = t.TypeVar("TUpdateRecordKey", str, int, t.Tuple[str, str])
+TUpdateRecordValue = t.TypeVar("TUpdateRecordValue")
 
 
 @dataclass
@@ -45,24 +47,24 @@ TFetchCheckpoint = t.TypeVar("TFetchCheckpoint", bound=FetchCheckpointBase)
 
 
 @dataclass
-class FetchDelta(t.Generic[TUpdateRecord, TFetchCheckpoint]):
+class FetchDelta(t.Generic[TUpdateRecordKey, TUpdateRecordValue, TFetchCheckpoint]):
     """
     Represents an incremental chunk of state fetched from an API.
 
     The exact storage format may vary by API, and a naive implementation
     for combining updates to an in-memory state lives in the API, but it
-    often makes sense for a dedicate storage implementation to have a
+    often makes sense for a dedicated storage implementation to have a
     more efficient implementation.
 
     @see FetchStore
     """
 
-    updates: TUpdateRecord
+    updates: t.Dict[TUpdateRecordKey, t.Optional[TUpdateRecordValue]]
     checkpoint: TFetchCheckpoint
 
 
 FetchDeltaTyped = FetchDelta[
-    t.Any, FetchCheckpointBase
+    t.Any, t.Any, FetchCheckpointBase
 ]  # to anchor checkpoint for typing
 
 

--- a/python-threatexchange/threatexchange/exchanges/helpers.py
+++ b/python-threatexchange/threatexchange/exchanges/helpers.py
@@ -56,11 +56,12 @@ class _StateTracker:
     @delta.setter
     def delta(self, value: fetch_state.FetchDeltaTyped) -> None:
         if self._delta is None:
-            old = None
+            old = {}
             self._delta = value
         else:
             old = self._delta.updates
-        self._delta.updates = self.api_cls.naive_fetch_merge(old, value.updates)
+        self.api_cls.naive_fetch_merge(old, value.updates)
+        self._delta.updates = old
         self._delta.checkpoint = value.checkpoint
         self.dirty = True
 

--- a/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
@@ -177,7 +177,8 @@ class FBThreatExchangeIndicatorRecord(state.FetchedSignalMetadata):
 
 
 ThreatExchangeDelta = state.FetchDelta[
-    t.Dict[t.Tuple[str, str], t.Optional[FBThreatExchangeIndicatorRecord]],
+    t.Tuple[str, str],
+    FBThreatExchangeIndicatorRecord,
     FBThreatExchangeCheckpoint,
 ]
 

--- a/python-threatexchange/threatexchange/exchanges/impl/file_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/file_api.py
@@ -21,7 +21,8 @@ from threatexchange.exchanges.collab_config import CollaborationConfigWithDefaul
 from threatexchange.signal_type.signal_base import SignalType
 
 _TypedDelta = state.FetchDelta[
-    t.Dict[t.Tuple[str, str], t.Optional[state.FetchedSignalMetadata]],
+    t.Tuple[str, str],
+    state.FetchedSignalMetadata,
     state.FetchCheckpointBase,
 ]
 

--- a/python-threatexchange/threatexchange/exchanges/impl/static_sample.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/static_sample.py
@@ -21,7 +21,8 @@ from threatexchange.exchanges.signal_exchange_api import (
 )
 
 _TypedDelta = state.FetchDelta[
-    t.Dict[t.Tuple[str, str], t.Optional[state.FetchedSignalMetadata]],
+    t.Tuple[str, str],
+    state.FetchedSignalMetadata,
     state.FetchCheckpointBase,
 ]
 

--- a/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
@@ -109,7 +109,8 @@ class StopNCIISignalExchangeAPI(
         checkpoint: t.Optional[StopNCIICheckpoint],
     ) -> t.Iterator[
         state.FetchDelta[
-            t.Dict[t.Tuple[str, str], t.Optional[StopNCIISignalMetadata]],
+            t.Tuple[str, str],
+            StopNCIISignalMetadata,
             StopNCIICheckpoint,
         ]
     ]:

--- a/python-threatexchange/threatexchange/exchanges/impl/tests/test_ncmec.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/tests/test_ncmec.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import typing as t
 import pytest
 
 from threatexchange.exchanges.clients.ncmec.tests.test_hash_api import api
@@ -10,6 +11,7 @@ from threatexchange.exchanges.impl.ncmec_api import (
 )
 
 from threatexchange.exchanges.clients.ncmec.hash_api import (
+    NCMECEntryUpdate,
     NCMECEnvironment,
     NCMECHashAPI,
 )
@@ -47,7 +49,8 @@ def test_fetch(fetcher: NCMECSignalExchangeAPI, monkeypatch: pytest.MonkeyPatch)
     # Fetch 1
     delta = next(it)
     assert len(delta.updates) == 4
-    total_updates = fetcher.naive_fetch_merge(None, delta.updates)
+    total_updates: t.Dict[str, NCMECEntryUpdate] = {}
+    fetcher.naive_fetch_merge(total_updates, delta.updates)
 
     assert delta.checkpoint.get_progress_timestamp() == 1508858400
     assert delta.checkpoint.is_stale() is False
@@ -64,7 +67,7 @@ def test_fetch(fetcher: NCMECSignalExchangeAPI, monkeypatch: pytest.MonkeyPatch)
     assert len(delta.updates) == 1
 
     assert {t for t in delta.updates} == {"42-image10"}
-    total_updates = fetcher.naive_fetch_merge(total_updates, delta.updates)
+    fetcher.naive_fetch_merge(total_updates, delta.updates)
     as_signals = NCMECSignalExchangeAPI.naive_convert_to_signal_type(
         [VideoMD5Signal], total_updates
     )[VideoMD5Signal]
@@ -74,7 +77,7 @@ def test_fetch(fetcher: NCMECSignalExchangeAPI, monkeypatch: pytest.MonkeyPatch)
     delta = next(it)
     assert len(delta.updates) == 2
     assert {t for t in delta.updates} == {"101-willdelete", "101-willupdate"}
-    total_updates = fetcher.naive_fetch_merge(total_updates, delta.updates)
+    fetcher.naive_fetch_merge(total_updates, delta.updates)
 
     as_signals = NCMECSignalExchangeAPI.naive_convert_to_signal_type(
         [VideoMD5Signal], total_updates
@@ -85,7 +88,7 @@ def test_fetch(fetcher: NCMECSignalExchangeAPI, monkeypatch: pytest.MonkeyPatch)
     delta = next(it)
     assert len(delta.updates) == 2
     assert {t for t in delta.updates} == {"101-willdelete", "101-willupdate"}
-    total_updates = fetcher.naive_fetch_merge(total_updates, delta.updates)
+    fetcher.naive_fetch_merge(total_updates, delta.updates)
 
     as_signals = NCMECSignalExchangeAPI.naive_convert_to_signal_type(
         [VideoMD5Signal], total_updates


### PR DESCRIPTION
Summary
---------

As discussed offline with @schatten, we now enforce that all updates can be partitioned by key, which allows for naive solutions that don't need to merge the dataset in memory, since you can always partition by key

Test Plan
---------

py.test

Also did one small ThreatExchange config

```
$ tx config api fb_threat_exchange -L
$ tx config api fb_threat_exchange -I 1144372816354585
$ tx fetch
$ tx dataset -P
tx match url -- https://www.instagram.com/dcallies
url - (<omitted>) WORTH_INVESTIGATING media_priority_test
```

