### PR TITLE
[pytx] Fix missing help for --api-token option

### DIFF
--- a/python-threatexchange/threatexchange/cli/config_cmd.py
+++ b/python-threatexchange/threatexchange/cli/config_cmd.py
@@ -519,8 +519,7 @@ class ConfigThreatExchangeAPICommand(command_base.Command):
         )
 
         # Not actually a type of import cmd, but to add exclusivity logic
-        config_cmds = import_cmds.add_argument_group()
-        config_cmds.add_argument(
+        import_cmds.add_argument(
             "--api-token",
             help="set the default api token (https://developers.facebook.com/tools/accesstoken/)",
         )


### PR DESCRIPTION
Summary
---------

Apparently an argparse bug of some kind.

Test Plan
---------

## Before
```
tx config api fb_threatexchange --help
usage: threatexchange config api fb_threatexchange [-h] [--list-available-collabs | --import-collab IMPORT_COLLAB] [--api-token API_TOKEN]

Configure Facebook ThreatExchange integration

optional arguments:
  -h, --help            show this help message and exit
  --list-available-collabs, -L
                        query the API to list available collabs
  --import-collab IMPORT_COLLAB, -I IMPORT_COLLAB
                        import a collaboration by privacy group ID
```

## After
```
tx config api fb_threatexchange --help
usage: threatexchange config api fb_threatexchange [-h] [--list-available-collabs | --import-collab IMPORT_COLLAB | --api-token API_TOKEN]

Configure Facebook ThreatExchange integration

optional arguments:
  -h, --help            show this help message and exit
  --list-available-collabs, -L
                        query the API to list available collabs
  --import-collab IMPORT_COLLAB, -I IMPORT_COLLAB
                        import a collaboration by privacy group ID
  --api-token API_TOKEN
                        set the default api token (https://developers.facebook.com/tools/accesstoken/)
```