### PR TITLE
[pytx] Allow passing in URLs to hash/match and friends

### DIFF
--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -7,7 +7,6 @@ Hash command to convert content into signatures.
 
 import argparse
 import pathlib
-import sys
 import typing as t
 from threatexchange.cli.cli_config import CLISettings
 
@@ -61,7 +60,7 @@ class HashCommand(command_base.Command):
             "files",
             nargs=argparse.REMAINDER,
             action=FlexFilesInputAction,
-            help="list of files or -- to interpret remainder as a string",
+            help="list of files, URLs, - for stdin, or -- to interpret remainder as a string",
         )
 
         ap.add_argument(
@@ -102,7 +101,6 @@ class HashCommand(command_base.Command):
             for s in settings.get_signal_types_for_content(content_type)
             if self.signal_type in (None, s.get_name())
         ]
-
         byte_hashers = [s for s in all_signal_types if issubclass(s, BytesHasher)]
         str_hashers = [s for s in all_signal_types if issubclass(s, TextHasher)]
 

--- a/python-threatexchange/threatexchange/cli/helpers.py
+++ b/python-threatexchange/threatexchange/cli/helpers.py
@@ -47,7 +47,6 @@ class FlexFilesInputAction(argparse.Action):
             args.insert(0, "--")
         ret = []
         for i, filename in enumerate(args):
-            path = pathlib.Path(filename)
             if filename.strip() == "-":
                 with tempfile.NamedTemporaryFile("wb", delete=False) as tmp:
                     logging.debug("Writing stdin to %s", tmp.name)
@@ -58,6 +57,7 @@ class FlexFilesInputAction(argparse.Action):
                 with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
                     logging.debug("Writing -- to %s", tmp.name)
                     tmp.write(" ".join(args[i + 1 :]))
+                filename = tmp.name
                 ret.append(pathlib.Path(tmp.name))
                 break
             elif filename.startswith(("http://", "https://")):
@@ -66,9 +66,9 @@ class FlexFilesInputAction(argparse.Action):
                 with tempfile.NamedTemporaryFile("wb", delete=False) as tmp:
                     logging.debug("Writing -- to %s", tmp.name)
                     tmp.write(resp.content)
-                ret.append(pathlib.Path(tmp.name))
-                break
-            elif not path.is_file():
+                filename = pathlib.Path(tmp.name)
+            path = pathlib.Path(filename)
+            if not path.is_file():
                 raise argparse.ArgumentError(self, f"no such file {path}")
             ret.append(path)
         setattr(namespace, self.dest, ret)


### PR DESCRIPTION
Summary
---------

I always find myself wishing I had this capability, and it looks like it's easier to add than I thought.

Test Plan
---------

```
$ threatexchange hash photo ../pdq/data/misc-images/b.jpg 
pdq f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22

$ threatexchange hash photo https://github.com/facebook/ThreatExchange/blob/main/pdq/data/misc-images/b.jpg?raw=true
pdq f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22
```
