### PR TITLE
[pytx] allow to run as module

### DIFF
--- a/python-threatexchange/threatexchange/__main__.py
+++ b/python-threatexchange/threatexchange/__main__.py
@@ -1,0 +1,4 @@
+if __name__ == "__main__":
+    from threatexchange.cli.main import main
+
+    main()


### PR DESCRIPTION
Summary
---------

Learned about this today!

Test Plan
---------

Before:
```
$ python3 -m threatexchange --help
/usr/local/bin/python3: No module named threatexchange.__main__; 'threatexchange' is a package and cannot be directly executed
```
After:
```
$ python3 -m threatexchange --help
usage: __main__.py [-h] {config,fetch,match,label,dataset,hash} ...

Wrapper for the `threatexchange` library, can serve as a simple e2e solution.
...
```
