### PR TITLE
[pytx][cli] Factory reset command

### DIFF
--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -31,6 +31,7 @@ import os
 import sys
 import typing as t
 import pathlib
+import shutil
 
 from threatexchange import meta
 from threatexchange.content_type.content_base import ContentType
@@ -95,6 +96,11 @@ def get_argparse(settings: CLISettings) -> argparse.ArgumentParser:
     )
     # is_config = Safe mode to try and let you fix bad settings from CLI
     ap.set_defaults(is_config=False)
+    ap.add_argument(
+        "--factory-reset",
+        action="store_true",
+        help="Remove all state, bringing you back to a fresh install",
+    )
     subparsers = ap.add_subparsers(
         dest="toplevel_command_name", title="verbs", help="which action to do"
     )
@@ -325,6 +331,10 @@ def inner_main(
     settings, extensions = _get_settings(config, state_dir)
     ap = get_argparse(settings)
     namespace = ap.parse_args(args)
+    if namespace.factory_reset:
+        print("Resetting to factory defaults.", file=sys.stderr)
+        shutil.rmtree(str(state_dir.expanduser().absolute()))
+        return
     if not namespace.is_config:
         extensions.assert_no_errors()
     if not namespace.toplevel_command_name:


### PR DESCRIPTION
Summary
---------

A simple command that is a shortcut to `rm -r ~/.threatexchange`, but doesn't require you to know where the state directory is.

Test Plan
---------

```
$ tx config collab list
fb_threatexchange Example Hash Sharing
$ ls ~/.threatexchange 
collab_configs  config.json  fetched  index
$ tx --factory-reset
Resetting to factory defaults.
$ ls ~/.threatexchange/
ls: cannot access '/home/dcallies/.threatexchange/': No such file or directory
```

--help
```
$ tx --help
usage: threatexchange [-h] [--factory-reset] {config,fetch,match,label,dataset,hash} ...

Wrapper for the `threatexchange` library, can serve as a simple e2e solution.

The flow the CLI is generally:
  1. Configure collaborations and APIs with (or skip to use fake sample data)
     $ threatexchange config collab edit
     $ threatexchange config api  # to set up credentials if needed
  2. Fetch data and build match indices
     $ threatexchange fetch
  3. Match data
     $ threatexchange match photo my_photo.jpg
  4. Contribute labels to external APIs
     $ threatexchange label photo my_photo.jpg dog 
     $ threatexchange label photo my_photo.jpg --false-positive

Additionally, there are a number of utility commands:
  * threatexchange dataset
  * threatexchange hash

See the --help of subcommands for more information.

State is persisted between runs, entirely in the ~/.threatexchange directory

optional arguments:
  -h, --help            show this help message and exit
  --factory-reset       Remove all state, bringing you back to a fresh install

verbs:
  {config,fetch,match,label,dataset,hash}
                        which action to do
    config              configure the CLI
    fetch               download content from signal exchange APIs to disk
    match               match content to fetched signals
    label               [WIP] Label signals and content for sharing
    dataset             introspect fetched data
    hash                take content and convert it into signatures (aka hashes)
```
