### PR TITLE
[pytx][hash_cmd] FileHasher instead BytesHasher in hash cli

### DIFF
--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -13,7 +13,6 @@ from threatexchange.cli.cli_config import CLISettings
 from threatexchange.signal_type.signal_base import (
     FileHasher,
     SignalType,
-    TextHasher,
 )
 from threatexchange.cli import command_base
 from threatexchange.cli.helpers import FlexFilesInputAction

--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -45,9 +45,7 @@ class HashCommand(command_base.Command):
     def init_argparse(cls, settings: CLISettings, ap: argparse.ArgumentParser) -> None:
 
         signal_types = [
-            s
-            for s in settings.get_all_signal_types()
-            if issubclass(s, (TextHasher, FileHasher))
+            s for s in settings.get_all_signal_types() if issubclass(s, FileHasher)
         ]
 
         ap.add_argument(
@@ -101,20 +99,12 @@ class HashCommand(command_base.Command):
             if self.signal_type in (None, s.get_name())
         ]
 
-        file_hashers = [
-            s
-            for s in all_signal_types
-            if issubclass(s, FileHasher) and not issubclass(s, TextHasher)
-        ]
-        str_hashers = [s for s in all_signal_types if issubclass(s, TextHasher)]
+        hashers = [s for s in all_signal_types if issubclass(s, FileHasher)]
 
         for file in self.files:
-            for s_hasher in str_hashers:
-                hash_str = s_hasher.hash_from_str(file.read_text())
-                _print_hash(s_hasher, hash_str)
-            for f_hasher in file_hashers:  # type: ignore  # mypy thinks its mixin
-                hash_str = f_hasher.hash_from_file(file)
-                _print_hash(f_hasher, hash_str)  # type: ignore  # mypy thinks its mixin
+            for hasher in hashers:
+                hash_str = hasher.hash_from_file(file)
+                _print_hash(hasher, hash_str)
 
 
 def _print_hash(s_type: t.Type[SignalType], hash_str: str) -> None:

--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -101,7 +101,11 @@ class HashCommand(command_base.Command):
             if self.signal_type in (None, s.get_name())
         ]
 
-        file_hashers = [s for s in all_signal_types if issubclass(s, FileHasher)]
+        file_hashers = [
+            s
+            for s in all_signal_types
+            if issubclass(s, FileHasher) and not issubclass(s, TextHasher)
+        ]
         str_hashers = [s for s in all_signal_types if issubclass(s, TextHasher)]
 
         for file in self.files:

--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -11,7 +11,7 @@ import typing as t
 from threatexchange.cli.cli_config import CLISettings
 
 from threatexchange.signal_type.signal_base import (
-    BytesHasher,
+    FileHasher,
     SignalType,
     TextHasher,
 )
@@ -47,7 +47,7 @@ class HashCommand(command_base.Command):
         signal_types = [
             s
             for s in settings.get_all_signal_types()
-            if issubclass(s, (TextHasher, BytesHasher))
+            if issubclass(s, (TextHasher, FileHasher))
         ]
 
         ap.add_argument(
@@ -95,22 +95,22 @@ class HashCommand(command_base.Command):
 
     def execute(self, settings: CLISettings) -> None:
         content_type = settings.get_content_type(self.content_type_str)
-
         all_signal_types = [
             s
             for s in settings.get_signal_types_for_content(content_type)
             if self.signal_type in (None, s.get_name())
         ]
-        byte_hashers = [s for s in all_signal_types if issubclass(s, BytesHasher)]
+
+        file_hashers = [s for s in all_signal_types if issubclass(s, FileHasher)]
         str_hashers = [s for s in all_signal_types if issubclass(s, TextHasher)]
 
         for file in self.files:
             for s_hasher in str_hashers:
                 hash_str = s_hasher.hash_from_str(file.read_text())
                 _print_hash(s_hasher, hash_str)
-            for b_hasher in byte_hashers:  # type: ignore  # mypy thinks its mixin
-                hash_str = b_hasher.hash_from_bytes(file.read_bytes())
-                _print_hash(b_hasher, hash_str)  # type: ignore  # mypy thinks its mixin
+            for f_hasher in file_hashers:  # type: ignore  # mypy thinks its mixin
+                hash_str = f_hasher.hash_from_file(file)
+                _print_hash(f_hasher, hash_str)  # type: ignore  # mypy thinks its mixin
 
 
 def _print_hash(s_type: t.Type[SignalType], hash_str: str) -> None:


### PR DESCRIPTION
Summary
---------

If a signal type class extends `signal_base.FileHasher` the hash_cmd wouldn't recognize it because it was only looking for subclasses of `BytesHasher` or `TextHasher (FileHasher is a parent of both)

both have an "is a" relationship with FileHasher so anything that inherits for BytesHasher or TextHasher should still by supported by the change.

Test Plan
---------

`threatexchange hash --signal-type video_md5 video <video-file>` still works

and if you install something like `video_vpdq` (docs WIP) it will now also work

`threatexchange hash --signal-type video_vpdq video <video-file>`

