### PR TITLE
[pytx] Extensions SignalType ContentType fixups

### DIFF
--- a/python-threatexchange/threatexchange/cli/config_cmd.py
+++ b/python-threatexchange/threatexchange/cli/config_cmd.py
@@ -361,6 +361,9 @@ class ConfigExtensionsCommand(command_base.Command):
     def execute_add(self, settings: CLISettings) -> None:
         if not self.module:
             raise CommandError("module is required", 2)
+        if self.module in settings.get_persistent_config().extensions:
+            self.execute_list(settings)
+            return
 
         manifest = self.get_manifest(self.module)
 
@@ -390,7 +393,7 @@ class ConfigExtensionsCommand(command_base.Command):
         apis.extend(settings.apis.get_all())
         tx_meta.FetcherMapping(apis)
 
-        self.print_extension(manifest)
+        self.execute_list(settings)
 
         config = settings.get_persistent_config()
         config.extensions.add(self.module)

--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -79,8 +79,8 @@ class HashCommand(command_base.Command):
 
     def __init__(
         self,
-        content_type: ContentType,
-        signal_type: t.Optional[SignalType],
+        content_type: t.Type[ContentType],
+        signal_type: t.Optional[t.Type[SignalType]],
         files: t.List[pathlib.Path],
     ) -> None:
         self.content_type = content_type
@@ -97,9 +97,10 @@ class HashCommand(command_base.Command):
         if self.signal_type is not None:
             if self.signal_type not in hashers:
                 raise CommandError.user(
-                    f"{self.signal_type.get_name()} does not apply to {self.content_type.get_name()}"
+                    f"{self.signal_type.get_name()} "
+                    f"does not apply to {self.content_type.get_name()}"
                 )
-            hashers = [self.signal_type]
+            hashers = [self.signal_type]  # type: ignore  # can't detect intersection types
 
         for file in self.files:
             for hasher in hashers:

--- a/python-threatexchange/threatexchange/cli/match_cmd.py
+++ b/python-threatexchange/threatexchange/cli/match_cmd.py
@@ -79,7 +79,7 @@ class MatchCommand(command_base.Command):
 
         ap.add_argument(
             "content_type",
-            type=common.argparse_choices_pre_type(
+            **common.argparse_choices_pre_type_kwargs(
                 [c.get_name() for c in settings.get_all_content_types()],
                 settings.get_content_type,
             ),
@@ -89,7 +89,7 @@ class MatchCommand(command_base.Command):
         ap.add_argument(
             "--only-signal",
             "-S",
-            type=common.argparse_choices_pre_type(
+            **common.argparse_choices_pre_type_kwargs(
                 [s.get_name() for s in settings.get_all_signal_types()],
                 settings.get_signal_type,
             ),

--- a/python-threatexchange/threatexchange/cli/tests/config_cmd_extension_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/config_cmd_extension_test.py
@@ -1,0 +1,57 @@
+import pytest
+from threatexchange.cli.tests.e2e_test_helper import (
+    ThreatExchangeCLIE2eHelper,
+    te_cli,
+)
+from threatexchange.exchanges.clients.ncmec.hash_api import NCMECEnvironment
+
+
+@pytest.fixture
+def cli(
+    te_cli: ThreatExchangeCLIE2eHelper,
+) -> ThreatExchangeCLIE2eHelper:
+    te_cli.COMMON_CALL_ARGS = ("config", "extensions")
+    return te_cli
+
+
+def test_extension_manipulate(cli: ThreatExchangeCLIE2eHelper) -> None:
+    expected = [
+        "Signal:",
+        "  fake - FakeSignal",
+        "Content:",
+        "  fake - FakeContent",
+        "Content:",
+        "  fake - FakeSignalExchange",
+    ]
+    cli.assert_cli_output(["list"], "")
+    cli.assert_cli_output(["add", "threatexchange.cli.tests.fake_extension"], expected)
+    cli.assert_cli_output(
+        ["list"],
+        ["threatexchange.cli.tests.fake_extension"] + ["  " + e for e in expected],
+    )
+    cli.assert_cli_output(["list", "threatexchange.cli.tests.fake_extension"], expected)
+    # Double add ok
+    cli.assert_cli_output(["add", "threatexchange.cli.tests.fake_extension"], expected)
+
+    cli.assert_cli_output(["remove", "threatexchange.cli.tests.fake_extension"], "")
+    cli.assert_cli_output(["list"], "")
+
+    # Double remove
+    cli.assert_cli_usage_error(["remove", "threatexchange.cli.tests.fake_extension"])
+    # Add noexist
+    cli.assert_cli_usage_error(["list", "threatexchange.cli.tests.noexist"])
+
+
+def test_extensions_in_other_cmds(cli: ThreatExchangeCLIE2eHelper) -> None:
+    cli.cli_call("add", "threatexchange.cli.tests.fake_extension")
+    cli.COMMON_CALL_ARGS = ()
+    cli.assert_cli_output(
+        ["hash", "--signal-type=fake", "fake", "--", "lolol"], "fake fake"
+    )
+    cli.assert_cli_output(
+        ["hash", "--signal-type=fake", "fake", "--", "lolol"], "fake fake"
+    )
+    cli.assert_cli_output(
+        ["match", "--only-signal=fake", "fake", "--", "lolol"],
+        "fake - (Sample Signals) WORTH_INVESTIGATING",
+    )

--- a/python-threatexchange/threatexchange/cli/tests/fake_extension.py
+++ b/python-threatexchange/threatexchange/cli/tests/fake_extension.py
@@ -1,0 +1,85 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import pathlib
+import typing as t
+from threatexchange.exchanges.collab_config import CollaborationConfigBase
+from threatexchange.exchanges.fetch_state import (
+    FetchCheckpointBase,
+    FetchDelta,
+    FetchedSignalMetadata,
+)
+
+from threatexchange.extensions.manifest import ThreatExchangeExtensionManifest
+from threatexchange.signal_type.signal_base import (
+    FileHasher,
+    HashComparisonResult,
+    SignalType,
+)
+from threatexchange.content_type.content_base import ContentType
+from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
+
+
+class FakeContent(ContentType):
+    pass
+
+
+class FakeSignal(SignalType, FileHasher):
+    @classmethod
+    def get_content_types(self) -> t.List[t.Type[ContentType]]:
+        """Which content types this Signal applies to (usually just one)"""
+        return [FakeContent]
+
+    @classmethod
+    def compare_hash(
+        cls, hash1: str, hash2: str, distance_threshold: t.Optional[int] = None
+    ) -> HashComparisonResult:
+        return HashComparisonResult.from_bool(hash1 == hash2)
+
+    @classmethod
+    def hash_from_file(cls, file: pathlib.Path) -> str:
+        return "fake"  # A perfect hashing algorithm
+
+    @classmethod
+    def get_examples(cls) -> t.List[str]:
+        return ["fake", "not fake"]
+
+
+class FakeSignalExchange(
+    SignalExchangeAPI[
+        CollaborationConfigBase, FetchCheckpointBase, FetchedSignalMetadata, str, str
+    ]
+):
+    def naive_convert_to_signal_type(
+        cls,
+        signal_types: t.Sequence[t.Type[SignalType]],
+        fetched: t.Mapping[str, str],
+    ) -> t.Dict[t.Type[SignalType], t.Dict[str, FetchedSignalMetadata]]:
+        return {}
+
+    @classmethod
+    def naive_convert_to_signal_type(
+        cls,
+        signal_types: t.Sequence[t.Type[SignalType]],
+        fetched: t.Mapping[str, str],
+    ) -> t.Dict[t.Type[SignalType], t.Dict[str, FetchedSignalMetadata]]:
+        return {}
+
+    def fetch_iter(
+        self,
+        supported_signal_types: t.Sequence[t.Type[SignalType]],
+        collab: CollaborationConfigBase,
+        # None if fetching for the first time,
+        # otherwise the previous FetchDelta returned
+        checkpoint: t.Optional[FetchCheckpointBase],
+    ) -> t.Iterator[FetchDelta[str, str, FetchCheckpointBase]]:
+        return
+        yield  # how to write an empty generator
+
+
+TX_MANIFEST = ThreatExchangeExtensionManifest(
+    signal_types=(FakeSignal,),
+    content_types=(FakeContent,),
+    apis=(FakeSignalExchange,),
+)

--- a/python-threatexchange/threatexchange/cli/tests/fake_extension.py
+++ b/python-threatexchange/threatexchange/cli/tests/fake_extension.py
@@ -51,13 +51,6 @@ class FakeSignalExchange(
         CollaborationConfigBase, FetchCheckpointBase, FetchedSignalMetadata, str, str
     ]
 ):
-    def naive_convert_to_signal_type(
-        cls,
-        signal_types: t.Sequence[t.Type[SignalType]],
-        fetched: t.Mapping[str, str],
-    ) -> t.Dict[t.Type[SignalType], t.Dict[str, FetchedSignalMetadata]]:
-        return {}
-
     @classmethod
     def naive_convert_to_signal_type(
         cls,

--- a/python-threatexchange/threatexchange/common.py
+++ b/python-threatexchange/threatexchange/common.py
@@ -94,3 +94,24 @@ def argparse_choices_pre_type(choices: t.List[str], type: t.Callable[[str], t.An
         return type(s)
 
     return ret
+
+
+def argparse_choices_pre_type_kwargs(
+    choices: t.List[str], type: t.Callable[[str], t.Any]
+):
+    """
+    Argparse parses choices after type, which is sometimes undesirable.
+
+    So fix it with duct tape. type=argparse_choices_pre_type()
+    """
+
+    def ret(s: str):
+        if s not in choices:
+            raise argparse.ArgumentTypeError(
+                "invalid choice: {} (choose from {})".format(
+                    s, ", ".join(repr(c) for c in choices)
+                ),
+            )
+        return type(s)
+
+    return {"type": ret, "metavar": "{%s}" % ",".join(choices)}


### PR DESCRIPTION
Summary
---------

Reported by @tigerchensh , the behavior of these commands did not behave as he expected, doing some cleanups to help.

Also fix an older issue (that I could have sworn I fixed in another PR?) where the hash command is too restrictive on what it allows as a hasher.

Test Plan
---------

New test

## Hash --help
```
tx hash --help
usage: threatexchange hash [-h] [--signal-type {pdq,url_md5,video_md5}] {photo,text,url,video} ...

    Take content and convert it into signatures (aka hashes)

    # Input
    You can pass in data to the command in a few different ways:
    (Note - you may not be able to hash text without an extension)
    ```
    # As an input file that contains one signal
    $ threatexchange hash photo my_photo.jpg

    # As stdin
    $ echo This is my cool text | threatexchange hash text -

    # Inline
    $ threatexchange hash text -- This is my cool text
    ```

    # Output
    <SignalType> <hash string>
    

positional arguments:
  {photo,text,url,video}
                        what kind of content to hash
  files                 list of files, URLs, - for stdin, or -- to interpret remainder as a string

optional arguments:
  -h, --help            show this help message and exit
  --signal-type {pdq,url_md5,video_md5}, -S {pdq,url_md5,video_md5}
                        only generate these signal types
```

## Match --help

```
tx match --help
usage: threatexchange match [-h] [--only-signal {pdq,video_md5,raw_text,url,url_md5,trend_query}] [--hashes] [--show-false-positives] [--hide-disputed] {photo,video,url,text} ...

    Match content to fetched signals

    Runs the given content through applicable SignalTypes, and compare it
    with previously fetched signals stored in the index files. Only
    SignalTypes supported by the CLI and your extensions can be matched,
    even if you can fetch them. Any matches will be printed to screen.

    # Input
    You can pass in data to the command in a few different ways:
    ```
    # As an input file that contains one signal
    $ threatexchange match photo my_photo.jpg

    # As stdin
    $ echo This is my cool text | threatexchange match text -

    # Inline
    $ threatexchange match text -- This is my cool text
    ```

    # Output
    The output of this command is in the following format:

    <signal type> - (<Collab Name>) <opinion category> <label1>,<label2>,...

    The category is key to understanding what you might want to do with a match.
    Here's an explanation of the categories. Opinion categories:
    * TRUE_POSITIVE:
      All contributors of this signal believe that matching content should fit
      the collaboration
    * WORTH_INVESTIGATING:
      This content needs manual investigation to confirm or fanout to find the
      content that fits the collaboration
    * DISPUTED:
      Some members have said that this signal can be used to find content
      that fits the collaboration, but others have said it matches content
      that does not belong in the collaboration.
    * FALSE_POSITIVE:
      Members have said content that matches does not belong in the
      collaboration, or that this is information content that should not
      trigger normal side-effects (i.e. human review).
    

positional arguments:
  {photo,video,url,text}
                        what kind of content to match
  files                 list of files or -- to interpret remainder as a string

optional arguments:
  -h, --help            show this help message and exit
  --only-signal {pdq,video_md5,raw_text,url,url_md5,trend_query}, -S {pdq,video_md5,raw_text,url,url_md5,trend_query}
                        limit to this signal type
  --hashes, -H          force input to be interpreted as signals for the given signal type
  --show-false-positives
                        show matches even if you've marked them false_positive
  --hide-disputed       hide matches if someone has disputed them
```

## Hash --help after extension

```
tx config extensions add threatexchange.cli.tests.fake_extension
Signal:
  fake - FakeSignal
Content:
  fake - FakeContent
Content:
  fake - FakeSignalExchange

dcallies@eecd010a7c71:/workspaces/devcontainer-ThreatExchange/python-threatexchange$ tx hash --help
usage: threatexchange hash [-h] [--signal-type {fake,pdq,url_md5,video_md5}] {fake,photo,text,url,video} ...

    Take content and convert it into signatures (aka hashes)

    # Input
    You can pass in data to the command in a few different ways:
    (Note - you may not be able to hash text without an extension)
    ```
    # As an input file that contains one signal
    $ threatexchange hash photo my_photo.jpg

    # As stdin
    $ echo This is my cool text | threatexchange hash text -

    # Inline
    $ threatexchange hash text -- This is my cool text
    ```

    # Output
    <SignalType> <hash string>
    

positional arguments:
  {fake,photo,text,url,video}
                        what kind of content to hash
  files                 list of files, URLs, - for stdin, or -- to interpret remainder as a string

optional arguments:
  -h, --help            show this help message and exit
  --signal-type {fake,pdq,url_md5,video_md5}, -S {fake,pdq,url_md5,video_md5}
                        only generate these signal types
```