### PR TITLE
[pytx] Fix NCMEC esp-filter, add too many more features

### DIFF
--- a/python-threatexchange/threatexchange/cli/dataclass_json.py
+++ b/python-threatexchange/threatexchange/cli/dataclass_json.py
@@ -29,7 +29,7 @@ def dataclass_dump(fp: t.IO[str], obj) -> None:
     return json.dump(json_dict, fp, indent=2, default=_json_cast_default)
 
 
-def dataclass_dumps(fp: t.IO[str], obj) -> str:
+def dataclass_dumps(obj) -> str:
     json_dict = _as_dict(obj)
     return json.dumps(json_dict, indent=2, default=_json_cast_default)
 

--- a/python-threatexchange/threatexchange/cli/tests/config_cmd_collabs_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/config_cmd_collabs_test.py
@@ -22,3 +22,45 @@ def test_required_argument(cli: ThreatExchangeCLIE2eHelper) -> None:
     )
     cli.assert_cli_output((), expected_output=f"ncmec {name}")  # Defaults to list
     cli.assert_cli_output(("list",), expected_output=f"ncmec {name}")
+
+
+def test_complex_types(cli: ThreatExchangeCLIE2eHelper) -> None:
+    cli.cli_call(
+        "tx",
+        "config",
+        "extensions",
+        "add",
+        "threatexchange.cli.tests.fake_extension",
+    )
+    cli.cli_call(
+        "edit",
+        "fake",
+        "fake",
+        "--an-int=1",
+        "--a-str=a",
+        "--an-enum=OPTION_A",
+        "--a-list=1,2,3",
+        "--a-set=3,2",
+        "--create",
+    )
+    expected = """
+{
+  "an_int": 1,
+  "a_str": "a",
+  "a_list": [
+    "1",
+    "2",
+    "3"
+  ],
+  "a_set": [
+    2,
+    3
+  ],
+  "an_enum": "a",
+  "name": "fake",
+  "api": "fake",
+  "enabled": true,
+  "optional": null
+}
+    """.strip()
+    cli.assert_cli_output(["print", "fake"], expected)

--- a/python-threatexchange/threatexchange/cli/tests/config_cmd_extension_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/config_cmd_extension_test.py
@@ -44,14 +44,13 @@ def test_extension_manipulate(cli: ThreatExchangeCLIE2eHelper) -> None:
 
 def test_extensions_in_other_cmds(cli: ThreatExchangeCLIE2eHelper) -> None:
     cli.cli_call("add", "threatexchange.cli.tests.fake_extension")
-    cli.COMMON_CALL_ARGS = ()
     cli.assert_cli_output(
-        ["hash", "--signal-type=fake", "fake", "--", "lolol"], "fake fake"
+        ["tx", "hash", "--signal-type=fake", "fake", "--", "lolol"], "fake fake"
     )
     cli.assert_cli_output(
-        ["hash", "--signal-type=fake", "fake", "--", "lolol"], "fake fake"
+        ["tx", "hash", "--signal-type=fake", "fake", "--", "lolol"], "fake fake"
     )
     cli.assert_cli_output(
-        ["match", "--only-signal=fake", "fake", "--", "lolol"],
+        ["tx", "match", "--only-signal=fake", "fake", "--", "lolol"],
         "fake - (Sample Signals) WORTH_INVESTIGATING",
     )

--- a/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
+++ b/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
@@ -23,12 +23,23 @@ class E2ETestSystemExit(Exception):
 
 class ThreatExchangeCLIE2eHelper:
 
+    # A keystroke saver, prefix these args to the beginning
+    # of every call.
+    # You can bypass by making the first arg "tx" or
+    # "threatexchange".
     COMMON_CALL_ARGS: t.Sequence[str] = ()
 
     _state_dir: pathlib.Path
 
     def cli_call(self, *given_args: str) -> str:
-        args = list(self.COMMON_CALL_ARGS)
+        """
+        Call the threatexchange CLI
+        """
+        args: t.List[str] = []
+        if next(iter(given_args), None) in ("tx", "threatexchange"):
+            given_args = given_args[1:]
+        else:
+            args.extend(self.COMMON_CALL_ARGS)
         args.extend(given_args)
         print("Calling: $ threatexchange", " ".join(args), file=sys.stderr)
         with patch("sys.stdout", new=StringIO(newline=None)) as fake_out, patch(

--- a/python-threatexchange/threatexchange/cli/tests/fake_extension.py
+++ b/python-threatexchange/threatexchange/cli/tests/fake_extension.py
@@ -2,9 +2,14 @@
 
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from dataclasses import dataclass, field
+import enum
 import pathlib
 import typing as t
-from threatexchange.exchanges.collab_config import CollaborationConfigBase
+from threatexchange.exchanges.collab_config import (
+    CollaborationConfigBase,
+    CollaborationConfigWithDefaults,
+)
 from threatexchange.exchanges.fetch_state import (
     FetchCheckpointBase,
     FetchDelta,
@@ -23,6 +28,31 @@ from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
 
 class FakeContent(ContentType):
     pass
+
+
+class FakeEnum(enum.Enum):
+    OPTION_A = "a"
+    OPTION_B = "b"
+    CamelCase = "camels"
+    lower_under = "under score"
+
+
+@dataclass
+class _FakeCollabConfigRequiredFields:
+    an_int: int = field(metadata={"help": "Demonstrate int"})
+    a_str: str = field(metadata={"help": "Demonstrate str"})
+    a_list: t.List[str] = field(metadata={"help": "Demonstrate list"})
+    a_set: t.Set[int] = field(metadata={"help": "Demonstrate set"})
+    an_enum: FakeEnum = field(metadata={"help": "Demonstrate enum"})
+
+
+@dataclass
+class FakeCollabConfig(
+    CollaborationConfigWithDefaults, _FakeCollabConfigRequiredFields
+):
+    optional: t.Optional[float] = field(
+        default=None, metadata={"help": "Demonstrate optional float"}
+    )
 
 
 class FakeSignal(SignalType, FileHasher):
@@ -48,9 +78,13 @@ class FakeSignal(SignalType, FileHasher):
 
 class FakeSignalExchange(
     SignalExchangeAPI[
-        CollaborationConfigBase, FetchCheckpointBase, FetchedSignalMetadata, str, str
+        FakeCollabConfig, FetchCheckpointBase, FetchedSignalMetadata, str, str
     ]
 ):
+    @classmethod
+    def get_config_class(cls) -> t.Type[FakeCollabConfig]:
+        return FakeCollabConfig
+
     @classmethod
     def naive_convert_to_signal_type(
         cls,
@@ -62,7 +96,7 @@ class FakeSignalExchange(
     def fetch_iter(
         self,
         supported_signal_types: t.Sequence[t.Type[SignalType]],
-        collab: CollaborationConfigBase,
+        collab: FakeCollabConfig,
         # None if fetching for the first time,
         # otherwise the previous FetchDelta returned
         checkpoint: t.Optional[FetchCheckpointBase],


### PR DESCRIPTION
Summary
---------

It started as a fix for the fact that set types weren't being parsed correctly. It completely got away from me.

Test Plan
---------

Added unittest, also run
```
$ tx config extensions add threatexchange.cli.tests.fake_extension
$ tx config collab edit fake fake --an-int 1 --a-str a --an-enum OPTION_A --a-list 1,2,3 --a-set 3,2 -C
$ tx config collab print fake
{
  "an_int": 1,
  "a_str": "a",
  "a_list": [
    "1",
    "2",
    "3"
  ],
  "a_set": [
    2,
    3
  ],
  "an_enum": "a",
  "name": "fake",
  "api": "fake",
  "enabled": true,
  "optional": null
}
```
