### PR TITLE
[pytx] Begin making mypy more strict

### DIFF
--- a/python-threatexchange/mypy.ini
+++ b/python-threatexchange/mypy.ini
@@ -1,4 +1,12 @@
 [mypy]
+strict_optional = True
+; disallow_any_generics = True
+; disallow_untyped_calls = True
+; disallow_incomplete_defs = True
+; check_untyped_defs = True
+; disallow_untyped_decorators = True
+; no_implicit_optional = True
+
 
 [mypy-PIL.*]
 ignore_missing_imports = True

--- a/python-threatexchange/threatexchange/exchanges/clients/fb_threatexchange/descriptor.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/fb_threatexchange/descriptor.py
@@ -179,7 +179,7 @@ class SimpleDescriptorRollup:
         return self.first_descriptor_id, self.added_on, " ".join(self.labels)
 
     @classmethod
-    def from_row(cls, row: t.List) -> "SimpleDescriptorRollup":
+    def from_row(cls, row: t.List[str]) -> "SimpleDescriptorRollup":
         """Simple conversion from CSV row"""
         labels = []
         if row[2]:


### PR DESCRIPTION
Summary
---------

mypy has a lot of flags that can enforce stricter typing. You only get out of typing what you put in.

Turning these all on causes a lot of errors, and I'm not even sure how to fix all of them. Instead mark what our intentions are, and then slowly turn it up.

We have a few strategies to deal with the backlog: try and enable everything, then blocklist all the old files. Turn one at a time on and fix as we go.

Test Plan
---------

If we enable all these flags right now:
```
Found 287 errors in 53 files (checked 102 source files)
```

mypy it passes
