### PR TITLE
[PYTX] Add vpdq_index as the default matching type for video_vpdq signal type

### DIFF
--- a/.github/workflows/python-threatexchange-ci.yaml
+++ b/.github/workflows/python-threatexchange-ci.yaml
@@ -28,8 +28,6 @@ jobs:
           python-version: "3.8"
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install ffmpeg
           python -m pip install --upgrade pip
           python3 -m pip install -e .[all]
       - name: Check code format

--- a/.github/workflows/python-threatexchange-ci.yaml
+++ b/.github/workflows/python-threatexchange-ci.yaml
@@ -28,6 +28,8 @@ jobs:
           python-version: "3.8"
       - name: Install dependencies
         run: |
+          sudo apt-get update
+          sudo apt-get install ffmpeg
           python -m pip install --upgrade pip
           python3 -m pip install -e .[all]
       - name: Check code format

--- a/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
@@ -54,7 +54,7 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
 
     @classmethod
     def get_index_cls(cls):
-        return VPDQHashIndex
+        return VPDQIndex
 
     @classmethod
     def validate_signal_str(cls, signal_str: str) -> str:
@@ -117,7 +117,3 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
             timestamp += 1.0
             frame_number += 1
         return [vpdq_to_json(VPDQ_features)]
-
-
-class VPDQHashIndex(VPDQIndex):
-    _SIGNAL_TYPE = VideoVPDQSignal

--- a/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
@@ -19,6 +19,7 @@ from threatexchange.content_type.video import VideoContent
 import re
 from threatexchange.signal_type import signal_base
 from threatexchange.signal_type.pdq import PdqSignal
+from threatexchange.extensions.vpdq.vpdq_index import VPDQIndex
 
 
 class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
@@ -50,6 +51,10 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
     @classmethod
     def get_content_types(self) -> t.List[t.Type[ContentType]]:
         return [VideoContent]
+
+    @classmethod
+    def get_index_cls(cls):
+        return VPDQHashIndex
 
     @classmethod
     def validate_signal_str(cls, signal_str: str) -> str:
@@ -112,3 +117,7 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
             timestamp += 1.0
             frame_number += 1
         return [vpdq_to_json(VPDQ_features)]
+
+
+class VPDQHashIndex(VPDQIndex):
+    _SIGNAL_TYPE = VideoVPDQSignal


### PR DESCRIPTION
Summary
---------

Add vpdq_index as the index type for video_vpdq. So, when matching with videos, it can utilize the vpdq_index.

Test Plan
---------
Manually hash, fetch, match and check
```
threatexchange config extensions add threatexchange.extensions.vpdq

threatexchange hash --signal-type video_vpdq video ../ThreatExchange/tmk/sample-videos/chair-19-sd-bar.mp4 >> file.txt

threatexchange config collab edit local_file --filename file.txt  'file.txt' --create

threatexchange fetch

threatexchange match video ../ThreatExchange/tmk/sample-videos/chair-19-sd-bar.mp4
```
Result
```
video_vpdq - (file.txt) WORTH_INVESTIGATING
```
If add some print to show the matching percentage result(videos used to match are chair-19... and chair-20..., the latter one is a second longer in video duration):
```
(pytx) xiangnan@xiangnan-mbp vpdq % threatexchange match video /Users/xiangnan/Documents/GitHub/ThreatExchange-public/tmk/sample-videos/chair-19-sd-bar.mp4
 
query_matched_percent 100.0
index_matched_percent 100.0
video_vpdq - (file.txt) WORTH_INVESTIGATING

(pytx) xiangnan@xiangnan-mbp vpdq % threatexchange match video /Users/xiangnan/Documents/GitHub/ThreatExchange-public/tmk/sample-videos/chair-20-sd-bar.mp4
 
query_matched_percent 92.76315789473684
index_matched_percent 100.0
video_vpdq - (file.txt) WORTH_INVESTIGATING
```