### PR TITLE
[pytx] Dynamically Generate valid index classes based on SignalType

### DIFF
--- a/python-threatexchange/threatexchange/cli/cli_state.py
+++ b/python-threatexchange/threatexchange/cli/cli_state.py
@@ -16,7 +16,10 @@ import typing as t
 import logging
 
 from threatexchange.signal_type.index import SignalTypeIndex
-from threatexchange.signal_type.signal_base import SignalType
+from threatexchange.signal_type.signal_base import (
+    SignalType,
+    is_correct_index_for_signal_type,
+)
 from threatexchange.cli.exceptions import CommandError
 from threatexchange.exchanges.collab_config import CollaborationConfigBase
 from threatexchange.exchanges.fetch_state import (
@@ -74,7 +77,9 @@ class CliIndexStore:
         self, signal_type: t.Type[signal_base.SignalType], index: SignalTypeIndex
     ) -> None:
         """Persist a SignalTypeIndex to disk"""
-        assert signal_type.get_index_cls() == index.__class__
+        assert is_correct_index_for_signal_type(
+            signal_type, index
+        ), f"{signal_type} vs {index}"
         path = self._index_file(signal_type)
         with path.open("wb") as fout:
             index.serialize(fout)

--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
@@ -8,7 +8,7 @@ vpdq_faiss.
 import typing as t
 import vpdq
 from threatexchange.signal_type.index import (
-    PickledSignalTypeIndex,
+    SignalTypeIndex,
     VPDQIndexMatch,
     IndexMatch,
     T as IndexT,
@@ -21,7 +21,7 @@ from threatexchange.extensions.vpdq.vpdq_util import (
 )
 
 
-class VPDQIndex(PickledSignalTypeIndex[IndexT]):
+class VPDQIndex(SignalTypeIndex[IndexT]):
     """
     Wrapper around the vpdq faiss index lib using VPDQHashIndex
     """

--- a/python-threatexchange/threatexchange/signal_type/index.py
+++ b/python-threatexchange/threatexchange/signal_type/index.py
@@ -162,21 +162,9 @@ class SignalTypeIndex(t.Generic[T]):
 
         Could also be premature optimization, you decide!
         """
-        raise NotImplementedError
+        fout.write(pickle.dumps(self))
 
     @classmethod
     def deserialize(cls: t.Type[Self], fin: t.BinaryIO) -> Self:
         """Instanciate an index from a previous call to serialize"""
-        raise NotImplementedError
-
-
-PickedSelf = t.TypeVar("PickedSelf", bound=SignalTypeIndex)
-
-
-class PickledSignalTypeIndex(SignalTypeIndex[T]):
-    def serialize(self, fout: t.BinaryIO) -> None:
-        fout.write(pickle.dumps(self))
-
-    @classmethod
-    def deserialize(cls: t.Type[PickedSelf], fin: t.BinaryIO) -> PickedSelf:
         return pickle.loads(fin.read())

--- a/python-threatexchange/threatexchange/signal_type/pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq_index.py
@@ -10,7 +10,6 @@ import typing as t
 import pickle
 
 from threatexchange.signal_type.index import (
-    PickledSignalTypeIndex,
     SignalTypeIndex,
     IndexMatch,
     T as IndexT,
@@ -22,7 +21,7 @@ from threatexchange.hashing.pdq_faiss_matcher import (
 )
 
 
-class PDQIndex(PickledSignalTypeIndex):
+class PDQIndex(SignalTypeIndex[IndexT]):
     """
     Wrapper around the pdq faiss index lib using PDQMultiHashIndex
     """

--- a/python-threatexchange/threatexchange/signal_type/raw_text.py
+++ b/python-threatexchange/threatexchange/signal_type/raw_text.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 """
 Wrapper around the raw text signal type.
 """
 
-import math
 import typing as t
 
 import Levenshtein
@@ -61,10 +59,6 @@ class RawTextSignal(
             distance <= max_match_distance, distance
         )
 
-    @classmethod
-    def get_index_cls(cls) -> t.Type[index.SignalTypeIndex]:
-        return LevenshteinLinearSearch
-
     @staticmethod
     def get_examples() -> t.List[str]:
         return [
@@ -79,8 +73,3 @@ class RawTextSignal(
             ),
             "bball now?",
         ]
-
-
-class LevenshteinLinearSearch(signal_base.TrivialLinearSearchMatchIndex):
-    _SIGNAL_TYPE = RawTextSignal
-    # Could also convert these on ingestion

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -166,7 +166,7 @@ class SimpleSignalType(SignalType):
         return HashComparisonResult.from_bool(hash1 == hash2)
 
 
-class TrivialSignalTypeIndex(index.PickledSignalTypeIndex[index.T]):
+class TrivialSignalTypeIndex(index.SignalTypeIndex[index.T]):
     """
     Index that does only exact matches
     """
@@ -185,7 +185,7 @@ class TrivialSignalTypeIndex(index.PickledSignalTypeIndex[index.T]):
         l.append(entry)
 
 
-class TrivialLinearSearchHashIndex(index.PickledSignalTypeIndex[index.T]):
+class TrivialLinearSearchHashIndex(index.SignalTypeIndex[index.T]):
     """
     Index that does a linear search and serializes with pickle
 
@@ -211,15 +211,14 @@ class TrivialLinearSearchHashIndex(index.PickledSignalTypeIndex[index.T]):
         self.state.append((signal_str, entry))
 
 
-class TrivialLinearSearchMatchIndex(index.PickledSignalTypeIndex[index.T]):
+class TrivialLinearSearchMatchIndex(index.SignalTypeIndex[index.T]):
     """
     Index that does a linear search and serializes with pickle
 
     O(n) is the best n, clearly.
     """
 
-    # You'll have to override with each usecase, because I wasn't sure
-    # If pickle would behave expectedly here
+    # You'll have to override with each usecase
     _SIGNAL_TYPE: t.Type[MatchesStr]
 
     def __init__(self) -> None:

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -6,6 +6,7 @@ Core abstractions for signal types.
 """
 
 import pathlib
+import importlib
 import typing as t
 
 from threatexchange import common
@@ -64,7 +65,7 @@ class SignalType:
     @classmethod
     def get_index_cls(cls) -> t.Type[index.SignalTypeIndex]:
         """Return the index class that handles this signal type"""
-        return TrivialSignalTypeIndex
+        return _MagicDefaultSignalTypeIndex.get_index_for_signal_type(cls)
 
     @classmethod
     def compare_hash(
@@ -185,53 +186,101 @@ class TrivialSignalTypeIndex(index.SignalTypeIndex[index.T]):
         l.append(entry)
 
 
-class TrivialLinearSearchHashIndex(index.SignalTypeIndex[index.T]):
+class _MagicDefaultSignalTypeIndex(index.SignalTypeIndex[index.T]):
+    """ """
+
+    def __init__(self, signal_type: t.Type[SignalType]) -> None:
+        self.state: t.List[t.Tuple[str, index.T]] = []
+        self._signal_type: t.Type[SignalType] = signal_type
+
+    @classmethod
+    def build(cls, entries: t.Iterable[t.Tuple[str, index.T]]):
+        raise NotImplementedError("Should not be called directly")
+
+    def add(self, signal_str: str, entry: index.T) -> None:
+        self.state.append((signal_str, entry))
+
+    def is_index_for_signal_type(self, other: SignalType) -> bool:
+        return self._signal_type == other
+
+    @classmethod
+    def get_index_for_signal_type(
+        cls, signal_type: t.Type[SignalType]
+    ) -> t.Type[index.SignalTypeIndex[index.T]]:
+
+        parent: t.Type[_MagicDefaultSignalTypeIndex]
+        if issubclass(signal_type, MatchesStr):
+            parent = _LinearSearchMatchIndex
+        else:
+            parent = _LinearSearchHashIndex
+
+        class _GeneratedMagicDefaultSignalTypeIndex(parent):  # type: ignore  # too weird for mypy
+            @staticmethod
+            def build(entries: t.Iterable[t.Tuple[str, index.T]]):
+                ret = parent(signal_type)
+                ret.add_all(entries)
+                return ret
+
+        return _GeneratedMagicDefaultSignalTypeIndex
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state[
+            "_signal_type"
+        ] = f"{self._signal_type.__module__}.{self._signal_type.__qualname__}"
+        return state
+
+    def __setstate__(self, state) -> None:
+        self.__dict__.update(state)
+        module_name, _, signal_cls_name = state["_signal_type"].rpartition(".")
+        module = importlib.import_module(module_name)
+        self._signal_type = getattr(module, signal_cls_name)
+
+
+class _LinearSearchHashIndex(_MagicDefaultSignalTypeIndex[index.T]):
     """
     Index that does a linear search and serializes with pickle
 
     O(n) is the best n, clearly.
     """
-
-    # You'll have to override with each usecase, because I wasn't sure
-    # If pickle would behave expectedly here
-    _SIGNAL_TYPE: t.Type[SignalType]
-
-    def __init__(self) -> None:
-        self.state: t.List[t.Tuple[str, index.T]] = []
 
     def query(self, query_hash: str) -> t.List[index.IndexMatch[index.T]]:
         ret = []
         for hash, payload in self.state:
-            res = self._SIGNAL_TYPE.compare_hash(hash, query_hash)
+            res = self._signal_type.compare_hash(hash, query_hash)
             if res.match:
                 ret.append(index.IndexMatch(res.distance, payload))
         return ret
 
-    def add(self, signal_str: str, entry: index.T) -> None:
-        self.state.append((signal_str, entry))
 
-
-class TrivialLinearSearchMatchIndex(index.SignalTypeIndex[index.T]):
+class _LinearSearchMatchIndex(_MagicDefaultSignalTypeIndex[index.T]):
     """
     Index that does a linear search and serializes with pickle
 
     O(n) is the best n, clearly.
     """
 
-    # You'll have to override with each usecase
-    _SIGNAL_TYPE: t.Type[MatchesStr]
-
-    def __init__(self) -> None:
-        self.state: t.List[t.Tuple[str, index.T]] = []
-        assert issubclass(self._SIGNAL_TYPE, MatchesStr)
+    _signal_type: MatchesStr  # type: ignore[assignment]
 
     def query(self, query_hash: str) -> t.List[index.IndexMatch[index.T]]:
         ret = []
         for signal, payload in self.state:
-            res = self._SIGNAL_TYPE.matches_str(signal, query_hash)
+            res = self._signal_type.matches_str(signal, query_hash)
             if res.match:
                 ret.append(index.IndexMatch(res.distance, payload))
         return ret
 
-    def add(self, signal_str: str, entry: index.T) -> None:
-        self.state.append((signal_str, entry))
+
+def is_correct_index_for_signal_type(
+    st: t.Type[SignalType], i: index.SignalTypeIndex
+) -> bool:
+    """
+    A validator that takes into account some weirdness with the magic defaults
+
+    Returns true if this is an instance of the correct index type for the
+    given signal type.
+    """
+    if isinstance(i, _MagicDefaultSignalTypeIndex):
+        return i._signal_type == st
+    else:
+        return st.get_index_cls() == i.__class__

--- a/python-threatexchange/threatexchange/signal_type/trend_query.py
+++ b/python-threatexchange/threatexchange/signal_type/trend_query.py
@@ -111,7 +111,7 @@ class TrendQuerySignal(
         ]
 
 
-class TrendQueryIndex(index.PickledSignalTypeIndex[index.T]):
+class TrendQueryIndex(index.SignalTypeIndex[index.T]):
     def __init__(self) -> None:
         self.state: t.Dict[str, t.Tuple[TrendQuery, t.List[index.T]]] = {}
 


### PR DESCRIPTION
Summary
---------

This is the most disgusting code I think I've written in this project, and I'm very worried I skipped a much simpler solution along the way.

Using dynamic class generation, abuse of pickle, and more, make it possible for a default linear search to exist for each type.

This might not be worth having classes do what they were doing before, which is to create the trivial linear searches.

Test Plan
---------

mypy && py.test
