### PR TITLE
[PYTX] VPDQ test utils

### DIFF
--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -3,6 +3,7 @@
 from cmath import sin
 import json
 import pytest
+import random
 from pathlib import Path
 import pickle
 
@@ -22,10 +23,16 @@ else:
         VPDQ_QUALITY_THRESHOLD,
     )
     from threatexchange.extensions.vpdq.video_vpdq import VideoVPDQSignal
-
+    from utils import (
+        get_random_hash,
+        get_similar_hash,
+        get_zero_hash,
+    )
     from threatexchange.signal_type.index import (
         VPDQIndexMatch,
     )
+    from threatexchange.hashing.pdq_utils import simple_distance
+
 
 pytestmark = pytest.mark.skipif(_DISABLED, reason="vpdq not installed")
 
@@ -33,6 +40,18 @@ if not _DISABLED:
     EXAMPLE_META_DATA = {"name": "example_video"}
     hash = VideoVPDQSignal.get_examples()[0]
     features = prepare_vpdq_feature(hash, VPDQ_QUALITY_THRESHOLD)
+
+
+def test_utils():
+    assert (
+        get_zero_hash()
+        == "0000000000000000000000000000000000000000000000000000000000000000"
+    )
+    for i in range(10):
+        random_dist = random.randint(0, 255)
+        random_hash = get_random_hash()
+        similar_hash = get_similar_hash(random_hash, random_dist)
+        assert simple_distance(similar_hash, random_hash) == random_dist
 
 
 def test_simple():

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -58,6 +58,7 @@ def test_utils():
     features = get_random_VPDQs(video_len)
     assert len(features) == video_len
     last_timestamp = -1
+    VideoVPDQSignal.validate_signal_str(vpdq_to_json(features))
     for feature in features:
         assert feature.quality == 100
         assert feature.timestamp == last_timestamp + 1

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -23,11 +23,7 @@ else:
         VPDQ_QUALITY_THRESHOLD,
     )
     from threatexchange.extensions.vpdq.video_vpdq import VideoVPDQSignal
-    from utils import (
-        get_random_hash,
-        get_similar_hash,
-        get_zero_hash,
-    )
+    from utils import get_random_hash, get_similar_hash, get_zero_hash, get_random_VPDQs
     from threatexchange.signal_type.index import (
         VPDQIndexMatch,
     )
@@ -58,6 +54,14 @@ def test_utils():
         assert False
     except ValueError:
         assert True
+    video_len = 100
+    features = get_random_VPDQs(video_len)
+    assert len(features) == video_len
+    last_timestamp = -1
+    for feature in features:
+        assert feature.quality == 100
+        assert feature.timestamp == last_timestamp + 1
+        last_timestamp = feature.timestamp
 
 
 def test_simple():

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -52,6 +52,12 @@ def test_utils():
         random_hash = get_random_hash()
         similar_hash = get_similar_hash(random_hash, random_dist)
         assert simple_distance(similar_hash, random_hash) == random_dist
+    try:
+        invalid_dist = 256
+        get_similar_hash(get_random_hash(), invalid_dist)
+        assert False
+    except ValueError:
+        assert True
 
 
 def test_simple():

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/utils.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/utils.py
@@ -24,7 +24,7 @@ def get_similar_hash(signal_str: str, dist: int) -> str:
     for i in order:
         if dist == 0:
             bin_str = "".join(bin_list)
-            # 2: ignores the 0x at the begining of the hex_str
+            # [2:] ignores the 0x at the begining of the hex_str
             hex_str = hex(int(bin_str, 2))[2:].zfill(BITS_IN_PDQ_HEX)
             return hex_str
         bin_list[i] = str(int(bin_list[i]) ^ 1)

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/utils.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/utils.py
@@ -13,12 +13,12 @@ def get_zero_hash() -> str:
 
 
 def get_random_hash() -> str:
-    """Return random pdq hash"""
+    """Return a random pdq hash"""
     return "".join(("%x" % random.randint(0, 15)) for i in range(BITS_IN_PDQ_HEX))
 
 
 def get_similar_hash(signal_str: str, dist: int) -> str:
-    """Return a pdq hash with hamming distance away from signal_str"""
+    """Return a pdq hash with dist hamming distance away from signal_str"""
     order = list(range(BITS_IN_PDQ))
     random.shuffle(order)
     bin_list = list(hex_to_binary_str(signal_str))
@@ -34,7 +34,7 @@ def get_similar_hash(signal_str: str, dist: int) -> str:
 
 
 def get_random_VPDQs(
-    video_length: int, seconds_per_hash: int = 1.0, quality: int = 100
+    video_length: int, seconds_per_hash: float = 1.0, quality: int = 100
 ) -> t.List[vpdq.VpdqFeature]:
     """Return a List of random VPDQ features with same quality and each feature's time stamp differs by seconds_per_hash"""
     ret: t.List[vpdq.VpdqFeature] = []

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/utils.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/utils.py
@@ -1,0 +1,45 @@
+import random
+import vpdq
+import typing as t
+from threatexchange.hashing.pdq_utils import hex_to_binary_str, BITS_IN_PDQ
+
+# Hex -> 4 digits Binary
+BITS_IN_PDQ_HEX = BITS_IN_PDQ / 4
+
+
+def get_zero_hash() -> str:
+    """Return a pdq hash str that is zero for every byte"""
+    return "".join("0" * BITS_IN_PDQ_HEX)
+
+
+def get_random_hash() -> str:
+    """Return random pdq hash"""
+    return "".join(("%x" % random.randint(0, 15)) for i in range(BITS_IN_PDQ_HEX))
+
+
+def get_similar_hash(signal_str: str, dist: int) -> str:
+    order = list(range(BITS_IN_PDQ))
+    random.shuffle(order)
+    bin_list = list(hex_to_binary_str(signal_str))
+    for i in order:
+        if dist == 0:
+            bin_str = "".join(bin_list)
+            # 2: ignores the 0x at the begining of the hex_str
+            hex_str = hex(int(bin_str, 2))[2:].zfill(BITS_IN_PDQ_HEX)
+            return hex_str
+        bin_list[i] = str(int(bin_list[i]) ^ 1)
+        dist -= 1
+    raise ValueError("Not possible")
+
+
+def get_random_VPDQs(
+    video_length: int, seconds_per_hash: int = 1.0, quality: int = 100
+) -> t.List[vpdq.VpdqFeature]:
+    ret: t.List[vpdq.VpdqFeature] = []
+    timestamp = 0.0
+    for i in range(video_length):
+        feature = vpdq.VpdqFeature(
+            quality, i, vpdq.str_to_hash(get_random_hash), timestamp
+        )
+        timestamp += seconds_per_hash
+        ret.append(feature)

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/utils.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/utils.py
@@ -4,7 +4,7 @@ import typing as t
 from threatexchange.hashing.pdq_utils import hex_to_binary_str, BITS_IN_PDQ
 
 # Hex -> 4 digits Binary
-BITS_IN_PDQ_HEX = BITS_IN_PDQ / 4
+BITS_IN_PDQ_HEX = int(BITS_IN_PDQ / 4)
 
 
 def get_zero_hash() -> str:

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/utils.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/utils.py
@@ -41,7 +41,8 @@ def get_random_VPDQs(
     timestamp = 0.0
     for i in range(video_length):
         feature = vpdq.VpdqFeature(
-            quality, i, vpdq.str_to_hash(get_random_hash), timestamp
+            quality, i, vpdq.str_to_hash(get_random_hash()), timestamp
         )
         timestamp += seconds_per_hash
         ret.append(feature)
+    return ret

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/utils.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/utils.py
@@ -18,6 +18,7 @@ def get_random_hash() -> str:
 
 
 def get_similar_hash(signal_str: str, dist: int) -> str:
+    """Return a pdq hash with hamming distance away from signal_str"""
     order = list(range(BITS_IN_PDQ))
     random.shuffle(order)
     bin_list = list(hex_to_binary_str(signal_str))
@@ -35,6 +36,7 @@ def get_similar_hash(signal_str: str, dist: int) -> str:
 def get_random_VPDQs(
     video_length: int, seconds_per_hash: int = 1.0, quality: int = 100
 ) -> t.List[vpdq.VpdqFeature]:
+    """Return a List of random VPDQ features with same quality and each feature's time stamp differs by seconds_per_hash"""
     ret: t.List[vpdq.VpdqFeature] = []
     timestamp = 0.0
     for i in range(video_length):

--- a/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
@@ -67,9 +67,10 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
                 raise ValueError("invalid VPDQ hash")
             if hash.quality < 0 or hash.quality > 100:
                 raise ValueError("invalid VPDQ quality")
-            if hash.frame_number < 0 or hash.frame_number <= last_frame_number:
+            frame_number = int(hash.frame_number)
+            if frame_number < 0 or frame_number <= last_frame_number:
                 raise ValueError("invalid VPDQ frame number")
-            last_frame_number = hash.frame_number
+            last_frame_number = frame_number
         return signal_str
 
     @classmethod

--- a/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
@@ -63,7 +63,7 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
         vpdq_hashes = json_to_vpdq(signal_str)
         last_frame_number = -1
         for hash in vpdq_hashes:
-            if not re.match("^[0-9a-f]{64}$", hash.hex):
+            if not re.match("^[0-9a-f]{64}$", str(hash.hex, "utf-8")):
                 raise ValueError("invalid VPDQ hash")
             if hash.quality < 0 or hash.quality > 100:
                 raise ValueError("invalid VPDQ quality")

--- a/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
@@ -67,10 +67,9 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
                 raise ValueError("invalid VPDQ hash")
             if hash.quality < 0 or hash.quality > 100:
                 raise ValueError("invalid VPDQ quality")
-            frame_number = int(hash.frame_number)
-            if frame_number < 0 or frame_number <= last_frame_number:
+            if hash.frame_number < 0 or hash.frame_number <= last_frame_number:
                 raise ValueError("invalid VPDQ frame number")
-            last_frame_number = frame_number
+            last_frame_number = hash.frame_number
         return signal_str
 
     @classmethod

--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq_util.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq_util.py
@@ -48,7 +48,7 @@ def json_to_vpdq(json_str: str) -> t.List[vpdq.VpdqFeature]:
     for frame_number, feature in vpdq_json.items():
         features.append(
             vpdq.VpdqFeature(
-                feature[QUALITY], frame_number, feature[HASH], feature[TIMESTAMP]
+                feature[QUALITY], int(frame_number), feature[HASH], feature[TIMESTAMP]
             )
         )
     return features


### PR DESCRIPTION
Summary
---------
Add utils for creating random pdqHash, similar pdqHash and a list of random VPDQ features for future tests and benchmarks.

Test Plan
---------

pytest
Run similar_hash for ten times and check if it meets the expected distance.
Check raise_error on invalid distance(256).
Create vpdq signal string and validate.