### PR TITLE
[UnbreakingFetch][1/n]: Allow adding / toggling SignalExchangeAPIs

### DIFF
--- a/.github/workflows/hma-ci.yaml
+++ b/.github/workflows/hma-ci.yaml
@@ -58,6 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/hasher-matcher-actioner/hmalib/common/configs/tests/test_tx_apis.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tests/test_tx_apis.py
@@ -1,0 +1,67 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+
+
+from hmalib.common.config import HMAConfig
+from hmalib.common.models.tests.ddb_test_common import HMAConfigTestBase
+from hmalib.common.configs.tx_apis import (
+    ToggleableSignalExchangeAPIConfig,
+    disable_signal_exchange_api,
+    add_signal_exchange_api,
+    AddSignalExchangeAPIResult,
+)
+
+
+class TXApiConfigsTestCase(HMAConfigTestBase, unittest.TestCase):
+    TABLE_NAME = f"test-config-{__name__}"
+
+    def test_get_all_empty(self):
+        with self.fresh_dynamodb():
+            HMAConfig.initialize(self.TABLE_NAME)
+            self.assertEqual(ToggleableSignalExchangeAPIConfig.get_all(), [])
+
+    def test_write_to_empty(self):
+        with self.fresh_dynamodb():
+            HMAConfig.initialize(self.TABLE_NAME)
+            self.assertEqual(ToggleableSignalExchangeAPIConfig.get_all(), [])
+
+            resp = add_signal_exchange_api(
+                klass="threatexchange.exchanges.impl.fb_threatexchange_api.FBThreatExchangeSignalExchangeAPI"
+            )
+            self.assertEqual(resp, AddSignalExchangeAPIResult.ADDED)
+
+            self.assertEqual(len(ToggleableSignalExchangeAPIConfig.get_all()), 1)
+
+    def test_rewrite(self):
+        with self.fresh_dynamodb():
+            HMAConfig.initialize(self.TABLE_NAME)
+            add_signal_exchange_api(
+                klass="threatexchange.exchanges.impl.fb_threatexchange_api.FBThreatExchangeSignalExchangeAPI"
+            )
+            resp = add_signal_exchange_api(
+                klass="threatexchange.exchanges.impl.fb_threatexchange_api.FBThreatExchangeSignalExchangeAPI"
+            )
+            self.assertEqual(resp, AddSignalExchangeAPIResult.ALREADY_EXISTS)
+            self.assertEqual(len(ToggleableSignalExchangeAPIConfig.get_all()), 1)
+
+    def test_fail(self):
+        with self.fresh_dynamodb():
+            HMAConfig.initialize(self.TABLE_NAME)
+            resp = add_signal_exchange_api(
+                klass="does.not.contain.class.FBThreatExchangeSignalExchangeAPI"
+            )
+            self.assertEqual(resp, AddSignalExchangeAPIResult.FAILED)
+
+    def test_disable(self):
+        with self.fresh_dynamodb():
+            HMAConfig.initialize(self.TABLE_NAME)
+            add_signal_exchange_api(
+                "threatexchange.exchanges.impl.ncmec_api.NCMECCollabConfig"
+            )
+
+            self.assertTrue(ToggleableSignalExchangeAPIConfig.get_all()[0].enabled)
+            disable_signal_exchange_api(
+                "threatexchange.exchanges.impl.ncmec_api.NCMECCollabConfig"
+            )
+            self.assertFalse(ToggleableSignalExchangeAPIConfig.get_all()[0].enabled)

--- a/hasher-matcher-actioner/hmalib/common/configs/tx_apis.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tx_apis.py
@@ -1,0 +1,94 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+DynamoDB backed SignalExchangeAPI objects.
+"""
+
+from dataclasses import dataclass
+import typing as t
+from enum import Enum
+
+from botocore.exceptions import ClientError
+from jinja2 import ModuleLoader
+from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
+
+from hmalib.common.config import HMAConfig, create_config, update_config
+from hmalib.common.logging import get_logger
+from hmalib.common.mappings import full_class_name, import_class
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ToggleableSignalExchangeAPIConfig(HMAConfig):
+    signal_exchange_api_class: str
+
+    # Allow soft disables
+    enabled: bool = True
+
+    @staticmethod
+    def get_name_from_type(signal_exchange_api: t.Type[SignalExchangeAPI]) -> str:
+        return f"signal_exchange_api:{full_class_name(signal_exchange_api)}"
+
+    def to_concrete_class(self):
+        return import_class(self.signal_exchange_api_class)
+
+
+class AddSignalExchangeAPIResult(Enum):
+    FAILED = 1
+    ALREADY_EXISTS = 2
+    ADDED = 3
+
+
+def add_signal_exchange_api(
+    klass: str,
+) -> AddSignalExchangeAPIResult:
+    try:
+        cls = import_class(klass)
+    except (ModuleNotFoundError, AttributeError) as e:
+        logger.warning("Failed to add SignalExchangeAPI with class: %s", klass)
+        logger.exception(e)
+        return AddSignalExchangeAPIResult.FAILED
+
+    try:
+        create_config(
+            ToggleableSignalExchangeAPIConfig(
+                name=ToggleableSignalExchangeAPIConfig.get_name_from_type(cls),
+                signal_exchange_api_class=full_class_name(cls),
+                enabled=True,
+            )
+        )
+    except ClientError:
+        logger.warning(
+            "Attempted to add SignalExchangeAPI with class: %s, but it already exists.",
+            klass,
+        )
+        return AddSignalExchangeAPIResult.ALREADY_EXISTS
+
+    return AddSignalExchangeAPIResult.ADDED
+
+
+class DisableSignalExchangeAPIResult(Enum):
+    DISABLED = 1
+    FAILED = 2
+
+
+def disable_signal_exchange_api(
+    klass: str,
+) -> DisableSignalExchangeAPIResult:
+    """
+    Convenience method. Will fail if klass does not translate to an actual
+    SignalExchangeAPI.
+    """
+    try:
+        cls = import_class(klass)
+    except (ModuleNotFoundError, AttributeError) as ex:
+        logger.error("Can't load class to disable SignalExchangeAPI: %s", klass)
+        logger.exception(ex)
+        return DisableSignalExchangeAPIResult.FAILED
+
+    config = ToggleableSignalExchangeAPIConfig.get(
+        ToggleableSignalExchangeAPIConfig.get_name_from_type(cls)
+    )
+    config.enabled = False
+    update_config(config)

--- a/hasher-matcher-actioner/hmalib/common/configs/tx_apis.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tx_apis.py
@@ -30,7 +30,7 @@ class ToggleableSignalExchangeAPIConfig(HMAConfig):
     def get_name_from_type(signal_exchange_api: t.Type[SignalExchangeAPI]) -> str:
         return f"signal_exchange_api:{full_class_name(signal_exchange_api)}"
 
-    def to_concrete_class(self):
+    def to_concrete_class(self) -> t.Type[SignalExchangeAPI]:
         return import_class(self.signal_exchange_api_class)
 
 

--- a/hasher-matcher-actioner/hmalib/common/configs/tx_apis.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tx_apis.py
@@ -90,5 +90,11 @@ def disable_signal_exchange_api(
     config = ToggleableSignalExchangeAPIConfig.get(
         ToggleableSignalExchangeAPIConfig.get_name_from_type(cls)
     )
+
+    if not config:
+        return DisableSignalExchangeAPIResult.FAILED
+
+    config = t.cast(ToggleableSignalExchangeAPIConfig, config)
     config.enabled = False
     update_config(config)
+    return DisableSignalExchangeAPIResult.DISABLED

--- a/hasher-matcher-actioner/hmalib/common/mappings.py
+++ b/hasher-matcher-actioner/hmalib/common/mappings.py
@@ -23,8 +23,8 @@ from threatexchange.meta import (
     CollaborationConfigStoreBase,
 )
 from threatexchange.signal_type.signal_base import SignalType
-from threatexchange.fetcher.fetch_api import SignalExchangeAPI
-from threatexchange.fetcher.apis.fb_threatexchange_api import (
+from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
+from threatexchange.exchanges.impl.fb_threatexchange_api import (
     FBThreatExchangeSignalExchangeAPI,
 )
 from threatexchange.content_type.photo import PhotoContent

--- a/hasher-matcher-actioner/hmalib/common/models/tests/ddb_test_common.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/ddb_test_common.py
@@ -36,6 +36,7 @@ class DynamoDBTableTestBase:
         os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
         os.environ["AWS_SECURITY_TOKEN"] = "testing"
         os.environ["AWS_SESSION_TOKEN"] = "testing"
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
 
     @classmethod
     def setUpClass(cls):

--- a/hasher-matcher-actioner/hmalib/scripts/migrations/2022_07_24_default_signal_exchange_apis.py
+++ b/hasher-matcher-actioner/hmalib/scripts/migrations/2022_07_24_default_signal_exchange_apis.py
@@ -1,0 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from hmalib.common.configs.tx_apis import add_signal_exchange_api
+from hmalib.scripts.migrations.migrations_base import MigrationBase
+
+
+class _Migration(MigrationBase):
+    def do_migrate(self):
+        # By default, we are only adding threatexchange as the supported API.
+        # This could change.
+        add_signal_exchange_api(
+            klass="threatexchange.exchanges.impl.fb_threatexchange_api.FBThreatExchangeSignalExchangeAPI"
+        )
+        add_signal_exchange_api(
+            klass="threatexchange.exchanges.impl.file_api.LocalFileSignalExchangeAPI"
+        )

--- a/hasher-matcher-actioner/terraform/migrations/main.tf
+++ b/hasher-matcher-actioner/terraform/migrations/main.tf
@@ -10,3 +10,9 @@ resource "null_resource" "default_signal_content_type_configs" {
     command = "python -m hmalib.scripts.cli.main migrate 2022_04_02_default_content_signal_type_configs --config-table ${var.config_table.name}"
   }
 }
+
+resource "null_resource" "default_signal_exchange_apis" {
+  provisioner "local-exec" {
+    command = "python -m hmalib.scripts.cli.main migrate 2022_07_24_default_signal_exchange_apis --config-table ${var.config_table.name}"
+  }
+}


### PR DESCRIPTION
Summary
---
Hashing has been made to work with pytx-1.0. Fetchers are next, because without them, matchers can't function.

For fetchers to work, they need to get all collabs. To get all collabs, we need to get all supported signal exchanges.

This PR adds toggle-able signal exchanges.

You can add a signal-exchange using their fully-qualified class name. By default, add FBThreatExchange and LocalFile.

Test Plan
---
Added unit tests.

Ran migration using `$ terraform -chdir=terraform apply`.

Then, in console, verified that both are 'enabled'.

```
$ python
>>> [
   t.to_concrete_class()
   for t in ToggleableSignalExchangeAPIConfig.get_all()
   if t.enabled
]
[
  <class 'threatexchange.exchanges.impl.fb_threatexchange_api.FBThreatExchangeSignalExchangeAPI'>,
  <class 'threatexchange.exchanges.impl.file_api.LocalFileSignalExchangeAPI'>
]
```
