### PR TITLE
Support Enums in aws_dataclass     

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/configs/tests/test_tx_apis.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tests/test_tx_apis.py
@@ -18,12 +18,10 @@ class TXApiConfigsTestCase(HMAConfigTestBase, unittest.TestCase):
 
     def test_get_all_empty(self):
         with self.fresh_dynamodb():
-            HMAConfig.initialize(self.TABLE_NAME)
             self.assertEqual(ToggleableSignalExchangeAPIConfig.get_all(), [])
 
     def test_write_to_empty(self):
         with self.fresh_dynamodb():
-            HMAConfig.initialize(self.TABLE_NAME)
             self.assertEqual(ToggleableSignalExchangeAPIConfig.get_all(), [])
 
             resp = add_signal_exchange_api(
@@ -35,7 +33,6 @@ class TXApiConfigsTestCase(HMAConfigTestBase, unittest.TestCase):
 
     def test_rewrite(self):
         with self.fresh_dynamodb():
-            HMAConfig.initialize(self.TABLE_NAME)
             add_signal_exchange_api(
                 klass="threatexchange.exchanges.impl.fb_threatexchange_api.FBThreatExchangeSignalExchangeAPI"
             )
@@ -47,7 +44,6 @@ class TXApiConfigsTestCase(HMAConfigTestBase, unittest.TestCase):
 
     def test_fail(self):
         with self.fresh_dynamodb():
-            HMAConfig.initialize(self.TABLE_NAME)
             resp = add_signal_exchange_api(
                 klass="does.not.contain.class.FBThreatExchangeSignalExchangeAPI"
             )
@@ -55,7 +51,6 @@ class TXApiConfigsTestCase(HMAConfigTestBase, unittest.TestCase):
 
     def test_disable(self):
         with self.fresh_dynamodb():
-            HMAConfig.initialize(self.TABLE_NAME)
             add_signal_exchange_api(
                 "threatexchange.exchanges.impl.ncmec_api.NCMECCollabConfig"
             )

--- a/hasher-matcher-actioner/hmalib/common/mappings.py
+++ b/hasher-matcher-actioner/hmalib/common/mappings.py
@@ -16,10 +16,11 @@ import typing as t
 from numpy import append
 
 from threatexchange.content_type.content_base import ContentType
-from threatexchange.meta import (
+from threatexchange.interface_validation import (
     FunctionalityMapping,
+    SignalExchangeAPIMapping,
     SignalTypeMapping,
-    FetcherMapping,
+    SignalExchangeAPIMapping,
     CollaborationConfigStoreBase,
 )
 from threatexchange.signal_type.signal_base import SignalType
@@ -172,7 +173,7 @@ class HMAFunctionalityMapping(FunctionalityMapping):
     # mypy has this weird behaviour where not overriding all fields leads to a
     # "Too many arguments error". Either type:ignore at __init__ callsites or
     # re-define them here.
-    fetcher: FetcherMapping
+    fetcher: SignalExchangeAPIMapping
     collabs: CollaborationConfigStoreBase
 
 
@@ -191,6 +192,6 @@ def get_pytx_functionality_mapping() -> HMAFunctionalityMapping:
 
     return HMAFunctionalityMapping(
         HMASignalTypeMapping.get_from_config(),
-        FetcherMapping(fetchers=fetchers),
+        SignalExchangeAPIMapping(fetchers=fetchers),
         None,
     )

--- a/hasher-matcher-actioner/hmalib/common/models/tests/ddb_test_common.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/ddb_test_common.py
@@ -6,6 +6,8 @@ import boto3
 import typing as t
 from contextlib import contextmanager
 
+from hmalib.common.config import HMAConfig
+
 
 class DynamoDBTableTestBase:
     # Note, the MRO requires this be the first class to inherit. _before_
@@ -95,3 +97,12 @@ class HMAConfigTestBase(DynamoDBTableTestBase):
         from hmalib.common import config
 
         config._TABLE_NAME = None
+
+    @contextmanager
+    def fresh_dynamodb(self):
+        try:
+            with super().fresh_dynamodb():
+                HMAConfig.initialize(self.TABLE_NAME)
+                yield
+        finally:
+            pass

--- a/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_member_signals_to_process.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_member_signals_to_process.py
@@ -5,7 +5,7 @@ import unittest
 import random
 
 from threatexchange.content_type.video import VideoContent
-from threatexchange.meta import SignalTypeMapping
+from threatexchange.interface_validation import SignalTypeMapping
 from threatexchange.signal_type.md5 import VideoMD5Signal
 
 from hmalib.common.config import HMAConfig

--- a/hasher-matcher-actioner/hmalib/common/tests/aws_dataclass_test.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/aws_dataclass_test.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 import unittest
+from enum import Enum
 import typing as t
 
 from hmalib.common import aws_dataclass
@@ -72,6 +73,15 @@ class SkipInit(SkipInitBase):
     a: int = field(default=2, init=False)
 
 
+class States(Enum):
+    FIRST = "https://FIRST.org/"
+
+
+@dataclass
+class HasEnum(aws_dataclass.HasAWSSerialization):
+    an_enum: States
+
+
 class AWSDataclassTest(unittest.TestCase):
 
     DEFAULT_OBJECTS = [
@@ -111,6 +121,14 @@ class AWSDataclassTest(unittest.TestCase):
     def test_all_objects(self):
         for o in self.DEFAULT_OBJECTS:
             self.assertSerializesCorrectly(o)
+
+    def test_enum(self):
+        obj = HasEnum(an_enum=States.FIRST)
+        serialized = obj.to_aws()
+        unserialized = HasEnum.from_aws(serialized)
+
+        self.assertEqual(obj, unserialized)
+        self.assertIsInstance(unserialized.an_enum, Enum)
 
     @unittest.skip("Not yet supported")
     def test_self_nested_object(self):

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -21,7 +21,7 @@ from threatexchange.signal_type.pdq import PdqSignal
 from threatexchange.content_type.content_base import ContentType
 from threatexchange.content_type.photo import PhotoContent
 from threatexchange.content_type.video import VideoContent
-from threatexchange.meta import FunctionalityMapping, SignalTypeMapping
+from threatexchange.interface_validation import FunctionalityMapping, SignalTypeMapping
 
 from hmalib.common.models.pipeline import MatchRecord
 from hmalib.common.models.signal import (

--- a/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
+++ b/hasher-matcher-actioner/hmalib/matchers/matchers_base.py
@@ -11,7 +11,7 @@ from mypy_boto3_sns.client import SNSClient
 from mypy_boto3_dynamodb.service_resource import Table
 import typing as t
 
-from threatexchange.meta import FunctionalityMapping
+from threatexchange.interface_validation import FunctionalityMapping
 from threatexchange.signal_type.index import IndexMatch, SignalTypeIndex
 from threatexchange.signal_type.signal_base import SignalType
 


### PR DESCRIPTION
Summary
---
For HMAConfig to represent NCMECCollabConfig, it needs to support Enums. Add that support and a test guarding it.

There is also a quality of life improvement as part of a second commit, I recommend reviewing commit by commit. 

There is also a third commit which applies name changes done as part of #1095. If reviewer would like, I'd be happy to break things up into 3 diff PRs, but decided against because the change is simple enough.

P.S. I'm strongly considering dropping our clearly lagging implementation in favour of dacite, but that would throw a wrench into the current project.


## Helpful links to sweeten the pie.
### [`17091a9c`](https://github.com/facebook/ThreatExchange/pull/1100/commits/17091a9c5986ce600de7d167c8f3d6dd4191a646) dev-experience: remove need for calling HMAConfig.initialize() during tests of HMAConfig

### [`42b2e07`](https://github.com/facebook/ThreatExchange/pull/1100/commits/42b2e07c849a6ce6fde7fe5146c68a977448c956) Support Enums in aws_dataclass
For HMAConfig to represent NCMECCollabConfig, it needs to support Enums. Add that support and a test guarding it.  P.S. I'm strongly considering dropping our clearly lagging implementation in favour of dacite, but that would throw a wrench into the current project. 
### [`346afce2d`](https://github.com/facebook/ThreatExchange/pull/1100/commits/346afce2d7e313543cd16065e13aad2e5722f8b8) fix: Apply name changes from #1095


Test Plan
---
Added unit test.
