### PR TITLE
Correct Methods for boxAlongCols and boxAlongRows to ensure proper jarroz window sizes match dimensions

### DIFF
--- a/pdq/php/pdqhasher.php
+++ b/pdq/php/pdqhasher.php
@@ -213,7 +213,7 @@ class PDQHasher {
   // ----------------------------------------------------------------
 
   // ----------------------------------------------------------------
-  static function boxAlongRows(
+  static function boxAlongCols(
     &$in_image, // 2D array of float
     &$out_image, // 2D array of float
     $num_rows,
@@ -272,7 +272,7 @@ class PDQHasher {
     }
   }
 
-  static function boxAlongCols(
+  static function boxAlongRows(
     &$in_image, // 2D array of float
     &$out_image, // 2D array of float
     $num_rows,

--- a/pdq/php/pdqhasher.php
+++ b/pdq/php/pdqhasher.php
@@ -858,7 +858,8 @@ class PDQHasher {
   static function computeHashAndQualityFromFilename(
     $filename,
     $show_timings = false,
-    $dump = false
+    $dump = false,
+    $downsample = false
   ) {
 
     $t01 = microtime(true);
@@ -879,7 +880,7 @@ class PDQHasher {
 
     //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     $t1 = microtime(true);
-    $image = self::readImageFromFilename($filename, true);
+    $image = self::readImageFromFilename($filename, $downsample);
     $t2 = microtime(true);
     if ($show_timings) {
       printf("X000-READ %.6f\n", $t2-$t1);

--- a/pdq/php/pdqhashertest.php
+++ b/pdq/php/pdqhashertest.php
@@ -14,13 +14,18 @@ $show_timings = false;
 //$show_timings = true;
 $dump = false;
 
+$downsample = false;
+
 foreach ($filenames as $filename) {
 
-  list ($hash, $quality) = PDQHasher::computeHashAndQualityFromFilename($filename, $show_timings, $dump);
+  list ($hash, $quality) = PDQHasher::computeHashAndQualityFromFilename($filename, $show_timings, $dump, $downsample);
   $s = $hash->toHexString();
   echo "$s,$quality,purephp,$filename\n";
-
-  list ($hash, $quality) = PDQHasher::computeStringHashAndQualityFromFilenameUsingExtension($filename, $show_timings, $dump);
-  echo "$hash,$quality,extnphp,$filename\n";
+  if (function_exists('pdq_compute_string_hash_and_quality_from_image_resource')) {
+    list ($hash, $quality) = PDQHasher::computeStringHashAndQualityFromFilenameUsingExtension($filename, $show_timings, $dump);
+    echo "$hash,$quality,extnphp,$filename\n";
+  } else {
+    echo "php extension not available";
+  }
 
 }


### PR DESCRIPTION
Summary
---------
The pure php implementation appears to have the methods for boxAlongRows and boxAlongCols mixed up.  This is obfuscated by the fact that in the pure php example. images are "downsampled" to 128x128. With the same number of rows and columns `computeJaroszFilterWindowSize` will end up the same for both `boxAlongRows` and `boxAlongCols`.
however if downsampling were to be removed the values passed to these two meethods would be mixed and you receive undefined index warnings.
```
Warning: Undefined array key 2 in /Volumes/code/ThreatExchange/pdq/php/pdqhasher.php on line 247
PHP Warning:  Trying to access array offset on value of type null in /Volumes/code/ThreatExchange/pdq/php/pdqhasher.php on line 247
```


Test Plan
---------
after removing downsampling
![2x418x](https://user-images.githubusercontent.com/1457923/181255134-2d80933f-3dd4-42a8-b20c-fad9c78ad851.png)

Using a 2px x 418px pixel image I tested with and without swapping the method names and compared to python pdq output.

with out swapping names (current implementaton)
b3bab3bab3284c674c45b39ab38f4c77b388b39ab30a4c41b30ab3be4c054c45,5
with swapping names (my fix)
b3b94c45b3aab3bc4c554c44b3bab3aab3b84c06b398b3b8b33bb3a84c074c47,0
python pdq
b3ba4c55b3b9b3aa4c554c65b3abb3bab39a4c45b3bbb302b39e0000b39a4c47,0,
