### PR TITLE
[PYTX]VPDQ Add support for detecting and handling empty video

### DIFF
--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -104,20 +104,23 @@ def test_serialize():
     )
 
 
-def test_empty_video_and_signal_str():
+def test_empty_video_():
     empty_video = []
-    empty_signal_str = ""
     video1 = pdq_hashes_to_VPDQ_features(g1)
 
     index = VPDQIndex.build([[vpdq_to_json(video1), VIDEO1_META_DATA]])
     res = index.query(vpdq_to_json(empty_video))
     assert len(res) == 0
-
-    res = index.query(empty_signal_str)
-    assert len(res) == 0
-
     with pytest.raises(ValueError):
         VPDQIndex.build([[vpdq_to_json(empty_video), VIDEO2_META_DATA]])
+
+
+def test_empty_signal_str():
+    empty_signal_str = ""
+    video1 = pdq_hashes_to_VPDQ_features(g1)
+    index = VPDQIndex.build([[vpdq_to_json(video1), VIDEO1_META_DATA]])
+    res = index.query(empty_signal_str)
+    assert len(res) == 0
     with pytest.raises(ValueError):
         VPDQIndex.build([[vpdq_to_json(empty_signal_str), VIDEO2_META_DATA]])
 

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -104,7 +104,7 @@ def test_serialize():
     )
 
 
-def test_empty_video():
+def test_empty_video_and_signal_str():
     empty_video = []
     empty_signal_str = ""
     video1 = pdq_hashes_to_VPDQ_features(g1)
@@ -115,8 +115,11 @@ def test_empty_video():
 
     res = index.query(empty_signal_str)
     assert len(res) == 0
+    
     with pytest.raises(ValueError):
         VPDQIndex.build([[vpdq_to_json(empty_video), VIDEO2_META_DATA]])
+    with pytest.raises(ValueError):
+        VPDQIndex.build([[vpdq_to_json(empty_signal_str), VIDEO2_META_DATA]])
 
 
 def test_duplicate_hashes():

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -106,10 +106,14 @@ def test_serialize():
 
 def test_empty_video():
     empty_video = []
+    empty_signal_str = ""
     video1 = pdq_hashes_to_VPDQ_features(g1)
 
     index = VPDQIndex.build([[vpdq_to_json(video1), VIDEO1_META_DATA]])
     res = index.query(vpdq_to_json(empty_video))
+    assert len(res) == 0
+
+    res = index.query(empty_signal_str)
     assert len(res) == 0
     with pytest.raises(ValueError):
         VPDQIndex.build([[vpdq_to_json(empty_video), VIDEO2_META_DATA]])

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -115,7 +115,7 @@ def test_empty_video_and_signal_str():
 
     res = index.query(empty_signal_str)
     assert len(res) == 0
-    
+
     with pytest.raises(ValueError):
         VPDQIndex.build([[vpdq_to_json(empty_video), VIDEO2_META_DATA]])
     with pytest.raises(ValueError):

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -104,6 +104,17 @@ def test_serialize():
     )
 
 
+def test_empty_video():
+    empty_video = []
+    video1 = pdq_hashes_to_VPDQ_features(g1)
+
+    index = VPDQIndex.build([[vpdq_to_json(video1), VIDEO1_META_DATA]])
+    res = index.query(vpdq_to_json(empty_video))
+    assert len(res) == 0
+    with pytest.raises(ValueError):
+        VPDQIndex.build([[vpdq_to_json(empty_video), VIDEO2_META_DATA]])
+
+
 def test_duplicate_hashes():
     index = VPDQIndex.build([[hash, VIDEO1_META_DATA]])
     index.add(hash, VIDEO2_META_DATA)

--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
@@ -42,6 +42,10 @@ class VPDQIndex(SignalTypeIndex[IndexT]):
     def add(self, signal_str: str, entry: IndexT) -> None:
         entry_id = len(self._entry_idx_to_features_and_entires)
         features = prepare_vpdq_feature(signal_str, self.quality_threshold)
+        if not features:
+            raise ValueError(
+                "Empty video after deduping/filtering should not be indexed"
+            )
         self._entry_idx_to_features_and_entires.append((features, entry))
         # Use hex to represent the feature because it saves the space
         unique_features = []
@@ -67,6 +71,8 @@ class VPDQIndex(SignalTypeIndex[IndexT]):
             List of VPDQIndexMatch
         """
         features = prepare_vpdq_feature(query_hash, self.quality_threshold)
+        if not features:
+            return []
         results = self.index.search_with_distance_in_result(
             features, VPDQ_DISTANCE_THRESHOLD
         )

--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq_util.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq_util.py
@@ -124,6 +124,7 @@ def prepare_vpdq_feature(
     quality_tolerance : The quality tolerance of VPDQ Feature.
     If VPDQ Feature is below this quality level then it will not be added
     """
-
+    if not signal_str:
+        return []
     features = json_to_vpdq(signal_str)
     return dedupe(quality_filter(features, quality_tolerance))

--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq_util.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq_util.py
@@ -40,6 +40,8 @@ def vpdq_to_json(vpdq_features: t.List[vpdq.VpdqFeature]) -> str:
 
 def json_to_vpdq(json_str: str) -> t.List[vpdq.VpdqFeature]:
     """Load a str as a json object and convert from json object to VPDQ features"""
+    if not json_str:
+        return []
     features = []
     # VPDQ feature's timestamp is round to 3 decimals
     vpdq_json = json.loads(
@@ -124,7 +126,5 @@ def prepare_vpdq_feature(
     quality_tolerance : The quality tolerance of VPDQ Feature.
     If VPDQ Feature is below this quality level then it will not be added
     """
-    if not signal_str:
-        return []
     features = json_to_vpdq(signal_str)
     return dedupe(quality_filter(features, quality_tolerance))


### PR DESCRIPTION
Summary
---------

Before the fix in vpdq_index.py, the test which queries/indexs an empty video will fail at the stage of converting to faiss vector at faiss_index.range_search.
<img width="995" alt="image" src="https://user-images.githubusercontent.com/44279163/181305591-79f3dad9-e48a-4cef-84d1-4d1242d6b216.png">

Before the fix in vpdq_util.py, the test which queries/indexs an empty signal_str will fail for json converting an empty string at function json_to_vpdq.
<img width="971" alt="image" src="https://user-images.githubusercontent.com/44279163/181306745-609328d7-775e-4c65-b871-5ef57b18f924.png">

Test Plan
---------

Pass test cases for querying and indexing empty video/signal string.
