### PR TITLE
[pytx] No more dist in SignalType.compare_hash

### DIFF
--- a/python-threatexchange/threatexchange/cli/tests/fake_extension.py
+++ b/python-threatexchange/threatexchange/cli/tests/fake_extension.py
@@ -67,9 +67,7 @@ class FakeSignal(SignalType, FileHasher):
         return TrivialSignalTypeIndex
 
     @classmethod
-    def compare_hash(
-        cls, hash1: str, hash2: str, distance_threshold: t.Optional[int] = None
-    ) -> HashComparisonResult:
+    def compare_hash(cls, hash1: str, hash2: str) -> HashComparisonResult:
         return HashComparisonResult.from_bool(hash1 == hash2)
 
     @classmethod

--- a/python-threatexchange/threatexchange/extensions/pdq_ocr/pdq_ocr.py
+++ b/python-threatexchange/threatexchange/extensions/pdq_ocr/pdq_ocr.py
@@ -58,12 +58,12 @@ class PdqOcrSignal(
 
     @classmethod
     def compare_hash(
-        cls, hash1: str, hash2: str, distance_threshold: t.Optional[int] = None
+        cls,
+        hash1: str,
+        hash2: str,
+        pdq_dist_threshold: int = PDQ_PLUS_OCR_CONFIDENT_MATCH_THRESHOLD,
     ) -> signal_base.HashComparisonResult:
-        pdq_dist_threshold = cls.PDQ_PLUS_OCR_CONFIDENT_MATCH_THRESHOLD
-        if distance_threshold is not None:
-            assert 0 <= distance_threshold <= 256
-            pdq_dist_threshold = distance_threshold
+        assert 0 <= pdq_dist_threshold <= 256
         pdq_hash_1, _, ocr_text_1 = hash1.partition(",")
         pdq_hash_2, _, ocr_text_2 = hash2.partition(",")
         assert all(

--- a/python-threatexchange/threatexchange/extensions/tlsh/text_tlsh.py
+++ b/python-threatexchange/threatexchange/extensions/tlsh/text_tlsh.py
@@ -47,12 +47,13 @@ class TextTLSHSignal(signal_base.SimpleSignalType, signal_base.TextHasher):
 
     @classmethod
     def compare_hash(
-        cls, hash1: str, hash2: str, distance_threshold: t.Optional[int] = None
+        cls,
+        hash1: str,
+        hash2: str,
+        tlsh_threshold: int = TLSH_CONFIDENT_MATCH_THRESHOLD,
     ) -> signal_base.HashComparisonResult:
-        if distance_threshold is None:
-            distance_threshold = TLSH_CONFIDENT_MATCH_THRESHOLD
         dist = tlsh.diffxlen(hash1, hash2)
-        return signal_base.HashComparisonResult.from_dist(dist, distance_threshold)
+        return signal_base.HashComparisonResult.from_dist(dist, tlsh_threshold)
 
     @staticmethod
     def get_examples() -> t.List[str]:

--- a/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
@@ -83,9 +83,7 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
         return vpdq_to_json(vpdq_hashes)
 
     @classmethod
-    def compare_hash(
-        cls, hash1: str, hash2: str, distance_threshold: t.Optional[int] = None
-    ) -> signal_base.HashComparisonResult:
+    def compare_hash(cls, hash1: str, hash2: str) -> signal_base.HashComparisonResult:
         """If the max of the two match percentages is over VPDQ_CONFIDENT_MATCH_THRESHOLD
         with VPDQ_DISTANCE_THRESHOLD, it's a match."""
         vpdq_hash1 = json_to_vpdq(hash1)

--- a/python-threatexchange/threatexchange/signal_type/pdq.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq.py
@@ -61,13 +61,13 @@ class PdqSignal(
 
     @classmethod
     def compare_hash(
-        cls, hash1: str, hash2: str, distance_threshold: t.Optional[int] = None
+        cls,
+        hash1: str,
+        hash2: str,
+        pdq_dist_threshold: int = PDQ_CONFIDENT_MATCH_THRESHOLD,
     ) -> signal_base.HashComparisonResult:
-        thresh = cls.PDQ_CONFIDENT_MATCH_THRESHOLD
-        if distance_threshold is not None:
-            thresh = distance_threshold
         dist = simple_distance(hash1, hash2)
-        return signal_base.HashComparisonResult.from_dist(dist, thresh)
+        return signal_base.HashComparisonResult.from_dist(dist, pdq_dist_threshold)
 
     @classmethod
     def hash_from_file(cls, file: pathlib.Path) -> str:

--- a/python-threatexchange/threatexchange/signal_type/raw_text.py
+++ b/python-threatexchange/threatexchange/signal_type/raw_text.py
@@ -41,15 +41,12 @@ class RawTextSignal(
 
     @classmethod
     def matches_str(
-        cls, signal: str, haystack: str, distance_threshold: t.Optional[int] = None
+        cls, signal: str, haystack: str, pct_diff_threshold: int = 5
     ) -> signal_base.HashComparisonResult:
-        threshold = 5  # Match considered if 95% match
-        if distance_threshold is not None:
-            assert 0 < distance_threshold <= 100
-            threshold = distance_threshold
+        assert 0 < pct_diff_threshold <= 100
         a = common.normalize_string(signal)
         b = common.normalize_string(haystack)
-        max_match_distance = len(a) - len(a) * (100 - threshold) / 100
+        max_match_distance = len(a) - len(a) * (100 - pct_diff_threshold) / 100
 
         ldiff = abs(len(a) - len(b))
 

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -15,7 +15,7 @@ from threatexchange.signal_type import index
 
 class HashComparisonResult(t.NamedTuple):
     match: bool
-    distance: int
+    distance: int  # TODO - remove
 
     @classmethod
     def from_match(cls, dist: int = 0) -> "HashComparisonResult":
@@ -73,9 +73,7 @@ class SignalType:
         raise NotImplementedError
 
     @classmethod
-    def compare_hash(
-        cls, hash1: str, hash2: str, distance_threshold: t.Optional[int] = None
-    ) -> HashComparisonResult:
+    def compare_hash(cls, hash1: str, hash2: str) -> HashComparisonResult:
         """
         Compare the distance of two hashes, the key operation for matching.
 
@@ -133,9 +131,7 @@ class TextHasher(FileHasher):
 
 class MatchesStr:
     @classmethod
-    def matches_str(
-        cls, signal: str, haystack: str, distance_threshold: t.Optional[int] = None
-    ) -> HashComparisonResult:
+    def matches_str(cls, signal: str, haystack: str) -> HashComparisonResult:
         """
         Compare the distance of two hashes, the key operation for matching.
 
@@ -168,11 +164,7 @@ class SimpleSignalType(SignalType):
     """
 
     @classmethod
-    def compare_hash(
-        cls, hash1: str, hash2: str, distance_threshold: t.Optional[int] = None
-    ) -> HashComparisonResult:
-        if distance_threshold is not None:
-            raise ValueError("distance_threshold not supported")
+    def compare_hash(cls, hash1: str, hash2: str) -> HashComparisonResult:
         return HashComparisonResult.from_bool(hash1 == hash2)
 
 

--- a/python-threatexchange/threatexchange/signal_type/trend_query.py
+++ b/python-threatexchange/threatexchange/signal_type/trend_query.py
@@ -76,11 +76,7 @@ class TrendQuerySignal(
         return signal_str
 
     @classmethod
-    def matches_str(
-        cls, hash: str, haystack: str, distance_threshold: t.Optional[int] = None
-    ) -> signal_base.HashComparisonResult:
-        if distance_threshold is not None:
-            raise ValueError("distance_threshold not supported")
+    def matches_str(cls, hash: str, haystack: str) -> signal_base.HashComparisonResult:
         tq = TrendQuery(json.loads(hash))
         return signal_base.HashComparisonResult.from_bool(tq.matches(haystack))
 

--- a/python-threatexchange/threatexchange/signal_type/url.py
+++ b/python-threatexchange/threatexchange/signal_type/url.py
@@ -38,7 +38,7 @@ class URLSignal(
 
     @classmethod
     def matches_str(
-        cls, signal: str, haystack: str, distance_threshold: t.Optional[int] = None
+        cls, signal: str, haystack: str
     ) -> signal_base.HashComparisonResult:
         # TODO - normalization
         return signal_base.HashComparisonResult.from_bool(signal == haystack)


### PR DESCRIPTION
Summary
---------

This is confusing since not all SignalTypes support distance. In addition, not all signal types support the same distance. 

Mypy is smart enough to tell that new arguments are backwards compatible.

Test Plan
---------

mypy & py.test
