### PR TITLE
[pytx] Squelch pdq warning

### DIFF
--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -32,6 +32,12 @@ import sys
 import typing as t
 import pathlib
 import shutil
+import warnings
+
+# Import pdq first with its hash order warning squelched, it's before our time
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from threatexchange.signal_type import pdq
 
 from threatexchange import interface_validation
 from threatexchange.content_type.content_base import ContentType
@@ -49,7 +55,6 @@ from threatexchange.exchanges.impl.ncmec_api import NCMECSignalExchangeAPI
 from threatexchange.content_type import photo, video, text, url
 from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
 from threatexchange.signal_type import (
-    pdq,
     md5,
     raw_text,
     url as url_signal,


### PR DESCRIPTION
Summary
---------

This warning doesn't apply to the library, since we aren't compatible with any state that existed before this.

Test Plan
---------

Before:
```
ThreatExchange/pdq/data/bridge-mods$ tx hash photo *
/home/dcallies/.local/lib/python3.8/site-packages/pdqhash/__init__.py:3: UserWarning: Hash vector order changed between version 0.1.8 and 0.2.0. See https://github.com/faustomorales/pdqhash-python/issues/1 for more details.
  warnings.warn(
pdq f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22
pdq f8f8f0cee0f4a84f06370a2a038f63f0b36e26d596621e1d33e6b39c4e9c9b22
```

After:
```
ThreatExchange/pdq/data/bridge-mods$ tx hash photo *
pdq f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22
pdq f8f8f0cee0f4a84f06370a2a038f63f0b36e26d596621e1d33e6b39c4e9c9b22
pdq f8f8f0cee0f4a84f0637022a038f67f0b36e26d596621e1d33e6b39c4e9c9b22
```
