### PR TITLE
[pytx] PDQ Quality filter

### DIFF
--- a/python-threatexchange/threatexchange/hashing/pdq_hasher.py
+++ b/python-threatexchange/threatexchange/hashing/pdq_hasher.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import io

--- a/python-threatexchange/threatexchange/signal_type/pdq.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq.py
@@ -5,10 +5,9 @@ Wrapper around the Photo PDQ signal type.
 """
 
 import typing as t
-import pathlib
 import re
 
-from threatexchange.hashing.pdq_hasher import pdq_from_bytes, pdq_from_file
+from threatexchange.hashing.pdq_hasher import pdq_from_bytes
 from threatexchange.content_type.content_base import ContentType
 from threatexchange.content_type.photo import PhotoContent
 from threatexchange.signal_type import signal_base
@@ -43,6 +42,8 @@ class PdqSignal(
     # This may need to be updated (TODO make more configurable)
     # Hashes of distance less than or equal to this threshold are considered a 'match'
     PDQ_CONFIDENT_MATCH_THRESHOLD = 31
+    # Images with less than quality 50 are too unreliable to match on
+    QUALITY_THRESHOLD = 50
 
     @classmethod
     def get_content_types(cls) -> t.List[t.Type[ContentType]]:
@@ -70,13 +71,10 @@ class PdqSignal(
         return signal_base.HashComparisonResult.from_dist(dist, thresh)
 
     @classmethod
-    def hash_from_file(cls, file: pathlib.Path) -> str:
-        pdq_hash, _quality = pdq_from_file(file)
-        return pdq_hash
-
-    @classmethod
     def hash_from_bytes(cls, bytes_: bytes) -> str:
-        pdq_hash, _quality = pdq_from_bytes(bytes_)
+        pdq_hash, quality = pdq_from_bytes(bytes_)
+        if quality < cls.QUALITY_THRESHOLD:
+            return ""
         return pdq_hash
 
     @staticmethod

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -112,7 +112,11 @@ class FileHasher:
 
     @classmethod
     def hash_from_file(cls, file: pathlib.Path) -> str:
-        """Get a string representation of the hash from a file"""
+        """
+        Get a string representation of the hash from a file.
+
+        If a hash cannot be generated, empty string should be returned.
+        """
         raise NotImplementedError
 
 
@@ -123,7 +127,11 @@ class TextHasher(FileHasher):
 
     @classmethod
     def hash_from_str(cls, text: str) -> str:
-        """Get a string representation of the hash from a string"""
+        """
+        Get a string representation of the hash from a string.
+
+        If a hash cannot be generated, empty string should be returned.
+        """
         raise NotImplementedError
 
     @classmethod
@@ -152,7 +160,11 @@ class BytesHasher(FileHasher):
 
     @classmethod
     def hash_from_bytes(cls, bytes_: bytes) -> str:
-        """Get a string representation of the hash from bytes."""
+        """
+        Get a string representation of the hash from bytes.
+
+        If a hash cannot be generated, empty string should be returned.
+        """
         raise NotImplementedError
 
     @classmethod


### PR DESCRIPTION
Summary
---------

We generally consider quality score < 50 to not be usable. Sadly we don't expose the quality score in the hash (though I think we should in the future). 

When a hash is not computable, the interface is expected to return empty string (see hash_cmd), but it's undocumented, so fix that too.

Test Plan
---------

There's not a test suite for this currently. I'll plead for regression testing post 1.x, but would accept a block for test.
