### PR TITLE
[VPDQ] Silence ffmpeg for nonverbose option

### DIFF
--- a/vpdq/cpp/hashing/filehasher.cpp
+++ b/vpdq/cpp/hashing/filehasher.cpp
@@ -38,7 +38,7 @@ bool hashVideoFile(
   // FFMPEG command to process the downsampled video
 
   string ffmpegLogLevel =
-      verbose ? "" : "-loglevel warning -hide_banner -stats";
+      verbose ? "" : "-loglevel error -hide_banner -nostats";
   string command = ffmpegPath + " " + ffmpegLogLevel + " -nostdin -i " +
       escapedInputVideoFileName + " -s " + to_string(width) + ":" +
       to_string(height) + " -an -f rawvideo -c:v rawvideo -pix_fmt rgb24" +


### PR DESCRIPTION
Summary
---------

One of the todos in (https://github.com/facebook/ThreatExchange/projects/4)
Silence ffmpeg for non-verbose options. Thus, in python-binding library vpdq will produce hashes silently working with python-threatexchange.

Test
---------

Run through regression test nonverbose and see if ffmpeg prints anything.