### PR TITLE
[Pytx] Vpdq move vpdq_index_match to vpdq_Index class

### DIFF
--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -14,7 +14,7 @@ except (ImportError, ModuleNotFoundError) as e:
     _DISABLED = True
 else:
     import typing as t
-    from threatexchange.extensions.vpdq.vpdq_index import VPDQIndex
+    from threatexchange.extensions.vpdq.vpdq_index import VPDQIndex, VPDQIndexMatch
     from threatexchange.extensions.vpdq.vpdq_util import (
         json_to_vpdq,
         prepare_vpdq_feature,
@@ -29,9 +29,7 @@ else:
     )
     from threatexchange.extensions.vpdq.video_vpdq import VideoVPDQSignal
     from tests.hashing.utils import get_random_hash, get_similar_hash, get_zero_hash
-    from threatexchange.signal_type.index import (
-        VPDQIndexMatch,
-    )
+
 
 pytestmark = pytest.mark.skipif(_DISABLED, reason="vpdq not installed")
 

--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
@@ -9,7 +9,6 @@ import typing as t
 import vpdq
 from threatexchange.signal_type.index import (
     SignalTypeIndex,
-    VPDQIndexMatch,
     IndexMatch,
     T as IndexT,
 )
@@ -20,6 +19,17 @@ from threatexchange.extensions.vpdq.vpdq_util import (
     VPDQ_DISTANCE_THRESHOLD,
 )
 
+class VPDQIndexMatch(IndexMatch[IndexT]):
+    def __init__(
+        self,
+        distance: int,
+        query_match_percent: float,
+        compared_match_percent: float,
+        metadata: T,
+    ) -> None:
+        super().__init__(distance, metadata)
+        self.query_match_percent = query_match_percent
+        self.compared_match_percent = compared_match_percent
 
 class VPDQIndex(SignalTypeIndex[IndexT]):
     """

--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
@@ -19,17 +19,19 @@ from threatexchange.extensions.vpdq.vpdq_util import (
     VPDQ_DISTANCE_THRESHOLD,
 )
 
+
 class VPDQIndexMatch(IndexMatch[IndexT]):
     def __init__(
         self,
         distance: int,
         query_match_percent: float,
         compared_match_percent: float,
-        metadata: T,
+        metadata: IndexT,
     ) -> None:
         super().__init__(distance, metadata)
         self.query_match_percent = query_match_percent
         self.compared_match_percent = compared_match_percent
+
 
 class VPDQIndex(SignalTypeIndex[IndexT]):
     """

--- a/python-threatexchange/threatexchange/signal_type/index.py
+++ b/python-threatexchange/threatexchange/signal_type/index.py
@@ -47,20 +47,6 @@ class IndexMatch(t.Generic[T]):
         self.distance = distance
         self.metadata = metadata
 
-
-class VPDQIndexMatch(IndexMatch[T]):
-    def __init__(
-        self,
-        distance: int,
-        query_match_percent: float,
-        compared_match_percent: float,
-        metadata: T,
-    ) -> None:
-        super().__init__(distance, metadata)
-        self.query_match_percent = query_match_percent
-        self.compared_match_percent = compared_match_percent
-
-
 Self = t.TypeVar("Self", bound="SignalTypeIndex")
 
 

--- a/python-threatexchange/threatexchange/signal_type/index.py
+++ b/python-threatexchange/threatexchange/signal_type/index.py
@@ -47,6 +47,7 @@ class IndexMatch(t.Generic[T]):
         self.distance = distance
         self.metadata = metadata
 
+
 Self = t.TypeVar("Self", bound="SignalTypeIndex")
 
 

--- a/vpdq/cpp/hashing/filehasher.cpp
+++ b/vpdq/cpp/hashing/filehasher.cpp
@@ -38,7 +38,7 @@ bool hashVideoFile(
   // FFMPEG command to process the downsampled video
 
   string ffmpegLogLevel =
-      verbose ? "" : "-loglevel warning -hide_banner -stats";
+      verbose ? "" : "-loglevel error -hide_banner -nostats";
   string command = ffmpegPath + " " + ffmpegLogLevel + " -nostdin -i " +
       escapedInputVideoFileName + " -s " + to_string(width) + ":" +
       to_string(height) + " -an -f rawvideo -c:v rawvideo -pix_fmt rgb24" +

--- a/vpdq/cpp/hashing/filehasher.cpp
+++ b/vpdq/cpp/hashing/filehasher.cpp
@@ -38,7 +38,7 @@ bool hashVideoFile(
   // FFMPEG command to process the downsampled video
 
   string ffmpegLogLevel =
-      verbose ? "" : "-loglevel error -hide_banner -nostats";
+      verbose ? "" : "-loglevel warning -hide_banner -stats";
   string command = ffmpegPath + " " + ffmpegLogLevel + " -nostdin -i " +
       escapedInputVideoFileName + " -s " + to_string(width) + ":" +
       to_string(height) + " -an -f rawvideo -c:v rawvideo -pix_fmt rgb24" +


### PR DESCRIPTION
Summary
---------

vpdq_index_match should be an internal implementation detail lives in vpdq_Index class. Thus, move it to the right place.

Test Plan
---------
vpdq pytests