### PR TITLE
[pytx][ncmec] Handle NCMEC API returning out-of-order entries in NCMECSignalExchangeAPI

### DIFF
--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
@@ -176,7 +176,7 @@ class GetEntriesResponse:
         start = parsed.get("start")
         size = parsed.get("size")
         max_ = parsed.get("max")
-        if None in (start, size, max_):
+        if start is None or size is None or max_ is None:
             return None
         return int(start[0]), int(size[0]), int(max_[0])
 

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
@@ -7,7 +7,6 @@ You can find the complete documentation at
 https://report.cybertip.org/hashsharing/v2/documentation.pdf
 """
 
-import re
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from dataclasses import dataclass

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -47,6 +47,14 @@ class NCMECCheckpoint(
     def from_ncmec_fetch(cls, response: api.GetEntriesResponse) -> "NCMECCheckpoint":
         return cls(response.max_timestamp)
 
+    def __setstate__(self, d: t.Dict[str, t.Any]) -> None:
+        """Implemented for pickle version compatibility."""
+        # 0.99.0 => 1.0.0:
+        ### field 'max_timestamp' renamed to 'get_entries_max_ts'
+        if "max_timestamp" in d:
+            d["get_entries_max_ts"] = d.pop("max_timestamp")
+        self.__dict__ = d
+
 
 @dataclass
 class _NCMECCollabConfigRequiredFields:

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -37,10 +37,11 @@ class NCMECCheckpoint(
     NCMEC IDs seem to stay around forever, so no need for is_stale()
     """
 
-    max_timestamp: int
+    # The biggest value of "to", and the next "from"
+    get_entries_max_ts: int
 
     def get_progress_timestamp(self) -> t.Optional[int]:
-        return self.max_timestamp
+        return self.get_entries_max_ts
 
     @classmethod
     def from_ncmec_fetch(cls, response: api.GetEntriesResponse) -> "NCMECCheckpoint":
@@ -183,7 +184,7 @@ class NCMECSignalExchangeAPI(
         """
         start_time = 0
         if checkpoint is not None:
-            start_time = checkpoint.max_timestamp
+            start_time = checkpoint.get_entries_max_ts
         # Avoid being exactly at end time for updates showing up multiple
         # times in the fetch, since entries are not ordered by time
         end_time = int(time.time()) - 5

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -200,19 +200,15 @@ class NCMECSignalExchangeAPI(
         def log(event: str) -> None:
             """Helper to log fetch events"""
             if duration < 1800:
-                duration_str = "seconds"
-                duration_val = duration
+                duration_str = f"{duration} seconds"
             elif duration < 43200:
-                duration_str = "hours"
-                duration_val = duration / 3600
+                duration_str = f"{duration / 3600:.2f} hours"
             else:
-                duration_str = "days"
-                duration_val = duration / (3600 * 24)
+                duration_str = f"{duration / (3600 * 24):.2f} days"
             logging.info(
-                "NCMEC API %s @%s (%0.2f %s)",
+                "NCMEC API %s @%s (%s)",
                 event,
                 api._date_format(current_time),
-                duration_val,
                 duration_str,
             )
 

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -8,6 +8,7 @@ SignalExchangeAPI impl for the NCMEC hash exchange API
 
 
 import logging
+import time
 import typing as t
 from dataclasses import dataclass, field
 
@@ -120,6 +121,9 @@ class NCMECSignalExchangeAPI(
         3. As of 5/2022 there are no false positive or seen statuses
     """
 
+    MAX_FETCH_SIZE = 400000
+    FETCH_SHRINK_FACTOR = 4
+
     def __init__(
         self,
         username: str = "",
@@ -156,20 +160,119 @@ class NCMECSignalExchangeAPI(
         collab: NCMECCollabConfig,
         checkpoint: t.Optional[NCMECCheckpoint],
     ) -> t.Iterator[state.FetchDelta[str, api.NCMECEntryUpdate, NCMECCheckpoint]]:
+        """
+        Use flow control to efficiently fetch from the NCMEC API.
+
+        The NCMEC API does not provide entries in a strictly ascending time order.
+        As a result, the only checkpoint we can safely return is if we have
+        exhausted an entire time range of fetching.
+
+        However, the data within the NCMEC hash dbs are randomly distributed,
+        with the following observed behavior:
+            1. Fetching an empty range (0 entries) is fast
+            2. We can estimate the number of entries in a range based on the
+               parameters of the "next" field
+            3. Fetching from a cursor of data is significantly faster than
+               generating a new cursor.
+
+        Therefore, we can aim for the following strategy:
+            1. Prefer fetching empty ranges repeatedly rather than potentially
+               generating an overfetch. (Shrink quickly, grow slowly)
+            2. Be very generous with overfetch limits, since if we've generated
+               the cursor
+        """
         start_time = 0
         if checkpoint is not None:
             start_time = checkpoint.max_timestamp
+        # Avoid being exactly at end time for updates showing up multiple
+        # times in the fetch, since entries are not ordered by time
+        end_time = int(time.time()) - 5
+
         client = self.get_client(collab.environment)
-        for result in client.get_entries_iter(start_timestamp=start_time):
-            updates = result.updates
-            if collab.only_esp_ids:
-                updates = [
-                    entry for entry in updates if entry.member_id in collab.only_esp_ids
-                ]
-            yield state.FetchDelta(
-                {f"{entry.member_id}-{entry.id}": entry for entry in updates},
-                NCMECCheckpoint.from_ncmec_fetch(result),
+        # We could probably mutate start time, but new variable for clarity
+        current_time = start_time
+        # The range we are fetching
+        duration = end_time - current_time
+        # A counter for when we want to increase our duration
+        # We want to be conservative
+        low_fetch_counter = 0
+
+        def log(event: str) -> None:
+            """Helper to log fetch events"""
+            if duration < 1800:
+                duration_str = "seconds"
+                duration_val = duration
+            elif duration < 43200:
+                duration_str = "hours"
+                duration_val = duration / 3600
+            else:
+                duration_str = "days"
+                duration_val = duration / (3600 * 24)
+            logging.info(
+                "NCMEC API %s @%s (%0.2f %s)",
+                event,
+                api._date_format(current_time),
+                duration_val,
+                duration_str,
             )
+
+        while current_time < end_time:
+            duration = max(1, duration)  # Infinite loop defense
+            # Don't fetch past our designated end
+            current_end = min(end_time, current_time + duration)
+            updates: t.List[api.NCMECEntryUpdate] = []
+            for i, entry in enumerate(
+                client.get_entries_iter(
+                    start_timestamp=current_time, end_timestamp=current_end
+                )
+            ):
+                if i == 0:  # First batch, check for overfetch
+                    if entry.entries_in_range > self.MAX_FETCH_SIZE and duration > 1:
+                        log(
+                            f"est {entry.entries_in_range} is over max fetch, duration reduced"
+                        )
+                        # We want to at last shrink by our shrink factor
+                        duration = min(
+                            duration // self.FETCH_SHRINK_FACTOR,
+                            # Especially in early fetches, we are overfetching
+                            # by a huge amount, so shrink in proportion to overfetch
+                            duration * self.MAX_FETCH_SIZE // entry.entries_in_range,
+                        )
+                        low_fetch_counter = 0  # Don't grow right after a shrink
+                        break  # Retry get_entries_iter with new parameters
+                    else:
+                        # Our entry estimatation (based on the cursor parameters)
+                        # occasionally seem to over-estimate
+                        log(f"est {entry.entries_in_range} entries")
+                elif i % 100 == 0:
+                    # If we get down to one second, we can potentially be
+                    # fetching an arbitrary large amount of data in one go,
+                    # so log something occasionally
+                    log(f"large fetch ({i}), up to {len(updates)}")
+                updates.extend(entry.updates)
+            else:  # AKA a successful fetch
+                # If we're hovering near the single-fetch limit for a period
+                # of time, we can likely safely expand our range.
+                if len(updates) < api.NCMECHashAPI.ENTRIES_PER_FETCH * 2:
+                    low_fetch_counter += 1
+                    if low_fetch_counter >= self.FETCH_SHRINK_FACTOR:
+                        log("multiple low fetches, increasing duration")
+                        # Grow slower than we shrink
+                        duration *= self.FETCH_SHRINK_FACTOR // 2
+                        low_fetch_counter = 0
+                # If we are not quite at our limit, but getting close to it,
+                # pre-emptively shrink to try and stay under the limit
+                elif len(updates) > self.MAX_FETCH_SIZE / self.FETCH_SHRINK_FACTOR:
+                    log("close to overfetch limit, reducing duration")
+                    duration //= self.FETCH_SHRINK_FACTOR
+                    low_fetch_counter = 0
+                else:  # Not too small, not too large, just right
+                    low_fetch_counter = 0
+                yield state.FetchDelta(
+                    {f"{entry.member_id}-{entry.id}": entry for entry in updates},
+                    NCMECCheckpoint(current_end),
+                )
+                current_time = current_end
 
     @classmethod
     def fetch_value_merge(


### PR DESCRIPTION
Summary
---------

This PR is the result of stress testing on the NCMEC hash DB API, and fixes some issues discovered.

Fixes #1105

## Fixing Checkpointing Behavior
The largest one is that checkpointing behavior wasn't sane, due to the NCMEC API's behavior of not returning entries in entry order. Though https://report.cybertip.org/hashsharing/v2/documentation.pdf suggests that we can use maxTimestamp from each return in order to plan the next fetch, observed behavior doesn't seem to support this.

However, [to, from) behavior seems to be correct, (to = inclusive, from=exclusive), and so instead of using from=0 to=now() and relying on maxTimestamp, we can instead try and pick correctly-sized time ranges.

However, the actual data in the database is randomly distributed, so the "correct" time range must be discovered through probing, and if the probed time range becomes one second, we have to fetch it no matter what.

It's possible that the the next=URLs are durable, and we could have checkpointed using those instead of time ranges, as long as our end time didn't include a mutable range (such as now() or the future). However, looking at the next= parameters, I couldn't convince myself that the storage didn't use offsets for pagination, which might become invalid if an old record is updated (based on the documentation saying that to/from also considers update time), and so an offset that included a large amount of time might miss records, and paginating larger ranges for larger periods of time increase the chance that records are leaked.

There are more considerations on the probing strategy, but they are documented in the code.

Test Plan
---------

```
$ tx config collab edit ncmec -C ncmec_test_industry --environment test_Industry
$ TX_VERBOSE=1 tx fetch
<pretty scroll, exact record counts and timestamps omitted for security>
```