### PR TITLE
[PYTX] VPDQ fix incorrect pytest init import

### DIFF
--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/__init__.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/__init__.py
@@ -1,1 +1,0 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -23,7 +23,7 @@ else:
         dedupe,
         quality_filter,
     )
-    from threatexchange.extensions.vpdq.tests.utils import (
+    from utils import (
         get_random_VPDQs,
         pdq_hashes_to_VPDQ_features,
     )


### PR DESCRIPTION
Summary
---------

Remove the unnecessary pytest init which calls prepend import from threatexchange packages. Thus, pytest can correctly check if the import library is not installed and skip. Otherwise, pytest will first prepend import and fail on vpdq import before checking & skipping it. 
(Why pytest relied on init and used prepend import before? See https://github.com/facebook/ThreatExchange/pull/1123)

Test Plan
---------

Before the change (No vpdq installed):
<img width="1061" alt="image" src="https://user-images.githubusercontent.com/44279163/181825811-489add5d-e5cc-41af-9359-d1a656ddf0a7.png">

After the change:
<img width="1061" alt="image" src="https://user-images.githubusercontent.com/44279163/181825763-29c87393-5d26-417c-be01-3d3a444688b0.png">

