### PR TITLE
[PYTX] Add pytest conftest for skipping extension init

### DIFF
--- a/python-threatexchange/threatexchange/conftest.py
+++ b/python-threatexchange/threatexchange/conftest.py
@@ -1,0 +1,7 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import sys
+def pytest_configure(config):
+    sys._called_from_test = True
+
+def pytest_unconfigure(config):
+    del sys._called_from_test

--- a/python-threatexchange/threatexchange/conftest.py
+++ b/python-threatexchange/threatexchange/conftest.py
@@ -1,7 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import sys
+
+
 def pytest_configure(config):
     sys._called_from_test = True
+
 
 def pytest_unconfigure(config):
     del sys._called_from_test

--- a/python-threatexchange/threatexchange/extensions/vpdq/__init__.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/__init__.py
@@ -1,9 +1,11 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-
-from threatexchange.extensions.manifest import ThreatExchangeExtensionManifest
-from threatexchange.extensions.vpdq.video_vpdq import VideoVPDQSignal
-
-
-TX_MANIFEST = ThreatExchangeExtensionManifest(
-    signal_types=(VideoVPDQSignal,),
-)
+import sys
+if hasattr(sys, '_called_from_test'):
+    # called from within a py test run
+    pass
+else:
+    from threatexchange.extensions.manifest import ThreatExchangeExtensionManifest
+    from threatexchange.extensions.vpdq.video_vpdq import VideoVPDQSignal
+    TX_MANIFEST = ThreatExchangeExtensionManifest(
+        signal_types=(VideoVPDQSignal,),
+    )

--- a/python-threatexchange/threatexchange/extensions/vpdq/__init__.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/__init__.py
@@ -1,11 +1,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import sys
-if hasattr(sys, '_called_from_test'):
+
+if hasattr(sys, "_called_from_test"):
     # called from within a py test run
     pass
 else:
     from threatexchange.extensions.manifest import ThreatExchangeExtensionManifest
     from threatexchange.extensions.vpdq.video_vpdq import VideoVPDQSignal
+
     TX_MANIFEST = ThreatExchangeExtensionManifest(
         signal_types=(VideoVPDQSignal,),
     )


### PR DESCRIPTION
Summary
---------

This should be the correct approach to solve the problem describe in https://github.com/facebook/ThreatExchange/pull/1124.
The root problem in the unempty init which will loads the VideoVPDQSignal and causes import error when testing.
Conftest.py will let the init know it is during a test run and ignore to init, but it won't affect the real test process. (i.e. if we install vpdq back, it still runs the tests)

Test Plan
---------
No VPDQ installed:
<img width="1343" alt="image" src="https://user-images.githubusercontent.com/44279163/182151076-8f3e50b3-7151-470c-9b0a-3a3457237d6a.png">

Pip install VPDQ and test:
<img width="1343" alt="image" src="https://user-images.githubusercontent.com/44279163/182151188-86337a28-9318-48bc-8aae-8e218bd7d593.png">

And CLI add extension still works:
<img width="1343" alt="image" src="https://user-images.githubusercontent.com/44279163/182151860-fd440537-5fc5-4e58-8ad5-16ffa82a0f39.png">
