### PR TITLE
[py-tx] pytest.ini and handle warns

### DIFF
--- a/python-threatexchange/pytest.ini
+++ b/python-threatexchange/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    error
+    ignore:Hash vector order changed between version 0.1.8 and 0.2.0.:UserWarning

--- a/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/hash_cmd_test.py
@@ -46,11 +46,12 @@ def test_stdin(
 ):
     tmp_file.write_text("http://evil.com")
 
-    monkeypatch.setattr("sys.stdin", tmp_file.open())
-    hash_cli.assert_cli_output(
-        ("url", "-"),
-        "url_md5 6d3af727a4e7b025fd59a5469b3a9c57",
-    )
+    with tmp_file.open() as fake_stin:
+        monkeypatch.setattr("sys.stdin", fake_stin)
+        hash_cli.assert_cli_output(
+            ("url", "-"),
+            "url_md5 6d3af727a4e7b025fd59a5469b3a9c57",
+        )
 
 
 def test_mixed(hash_cli: ThreatExchangeCLIE2eHelper, tmp_path: pathlib.Path):


### PR DESCRIPTION
Summary
---------

This adds a pytest.ini file to ignore the pdq warning, and also convert future warnings into errors.

This also found one minor error, which is also fixed.

Test Plan
---------

py.test
