### PR TITLE
[pytx][cli] update outdated help text in match command for --hashes arg

### DIFF
--- a/python-threatexchange/threatexchange/cli/match_cmd.py
+++ b/python-threatexchange/threatexchange/cli/match_cmd.py
@@ -162,7 +162,10 @@ class MatchCommand(command_base.Command):
         signal_types = [s for s in signal_types if issubclass(s, types)]
         if self.as_hashes and len(signal_types) > 1:
             raise CommandError(
-                "Too many SignalTypes for --as-hashes. Use also --only-signal", 2
+                f"Error: '{self.content_type.get_name()}' supports more than one SignalType."
+                " for '--hashes' also use '--only-signal' to specify one of "
+                f"{[s.get_name() for s in signal_types]}",
+                2,
             )
 
         logging.info(


### PR DESCRIPTION
Summary
---------

Help text had an old name for the --hashes flag (--as-hashes) and didn't provide as much context.

TBH this could be changed to `--as-signal` but that it likely to be more confusing than helpful at this point naming is hard.

Test Plan
---------

$ tx config extensions add threatexchange.extensions.vpdq.manifest

before:
$ tx match --hashes video  -- "hi"
Too many SignalTypes for --as-hashes. Use also --only-signal

after:
$ tx match --hashes video  -- "hi"
Error: 'video' supports more than one SignalType. for '--hashes' also use '--only-signal' to specify one of ['video_md5', 'video_vpdq']
