### PR TITLE
Dynamically generate ddb-backed HMAConfigs from CollaborationConfigBase subclasses

### DIFF
--- a/.github/workflows/hma-ci.yaml
+++ b/.github/workflows/hma-ci.yaml
@@ -71,4 +71,4 @@ jobs:
           bash ./scripts/set_threatexchange_source local
       - name: Test with pytest
         run: |
-          python -m py.test
+          python -m py.test hmalib

--- a/hasher-matcher-actioner/hmalib/common/configs/tests/test_tx_collab_config.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tests/test_tx_collab_config.py
@@ -96,8 +96,14 @@ class TXCollabConfigsTestCase(HMAConfigTestBase, unittest.TestCase):
             self.assertEqual(3, len(all_configs))
 
             ncmec_config = next(
-                iter([_ for _ in all_configs if isinstance(_, NCMECCollabConfig)])
+                iter(
+                    [
+                        conf
+                        for conf in all_configs
+                        if isinstance(conf, NCMECCollabConfig)
+                    ]
+                )
             )
             self.assertEqual(ncmec_config.environment, NCMECEnvironment.Exploitative)
-            self.assertEqual(ncmec_config.only_esp_ids, set([1, 2, 3]))
+            self.assertEqual(ncmec_config.only_esp_ids, {1, 2, 3})
             self.assertEqual(ncmec_config.name, "child-safety")

--- a/hasher-matcher-actioner/hmalib/common/configs/tests/test_tx_collab_config.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tests/test_tx_collab_config.py
@@ -1,0 +1,103 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+from threatexchange.exchanges.clients import ncmec
+from threatexchange.exchanges.clients.ncmec.hash_api import NCMECEnvironment
+
+from threatexchange.exchanges.impl.fb_threatexchange_api import (
+    FBThreatExchangeCollabConfig,
+)
+from threatexchange.exchanges.impl.ncmec_api import (
+    NCMECCollabConfig,
+)
+
+
+from hmalib.common.models.tests.ddb_test_common import HMAConfigTestBase
+from hmalib.common.configs import tx_collab_config
+
+
+class TXCollabConfigsTestCase(HMAConfigTestBase, unittest.TestCase):
+    TABLE_NAME = f"test-config-{__name__}"
+
+    def test_get_no_collab_config(self):
+        with self.fresh_dynamodb():
+            self.assertEqual([], tx_collab_config.get_all_collab_configs())
+
+    def test_write_one_config(self):
+        with self.fresh_dynamodb():
+            tx_collab_config.create_collab_config(
+                FBThreatExchangeCollabConfig(
+                    name="Threatcollaboration Something", privacy_group=1212312
+                )
+            )
+            all_configs = tx_collab_config.get_all_collab_configs()
+            self.assertEqual(1, len(all_configs))
+            self.assertEqual("Threatcollaboration Something", all_configs[0].name)
+            self.assertEqual(1212312, all_configs[0].privacy_group)
+
+    def test_write_and_retrieve(self):
+        with self.fresh_dynamodb():
+            tx_collab_config.create_collab_config(
+                FBThreatExchangeCollabConfig(
+                    name="Threatcollaboration Something", privacy_group=1212312
+                )
+            )
+            config = tx_collab_config.get_collab_config(
+                FBThreatExchangeCollabConfig, name="Threatcollaboration Something"
+            )
+            self.assertEqual("Threatcollaboration Something", config.name)
+            self.assertEqual(1212312, config.privacy_group)
+
+    def test_write_and_update(self):
+        with self.fresh_dynamodb():
+            tx_collab_config.create_collab_config(
+                FBThreatExchangeCollabConfig(
+                    name="Threatcollaboration Something", privacy_group=1212312
+                )
+            )
+            config = tx_collab_config.get_collab_config(
+                FBThreatExchangeCollabConfig, name="Threatcollaboration Something"
+            )
+            self.assertEqual("Threatcollaboration Something", config.name)
+            self.assertEqual(1212312, config.privacy_group)
+
+            # Now update
+            config.privacy_group = 444333
+            tx_collab_config.update_collab_config(config)
+
+            config = tx_collab_config.get_collab_config(
+                FBThreatExchangeCollabConfig, name="Threatcollaboration Something"
+            )
+            self.assertEqual(444333, config.privacy_group)
+
+    def test_write_multiple_configs(self):
+        with self.fresh_dynamodb():
+            tx_collab_config.create_collab_config(
+                FBThreatExchangeCollabConfig(
+                    name="ThreatCollaboration something", privacy_group=121344
+                ),
+            )
+
+            tx_collab_config.create_collab_config(
+                FBThreatExchangeCollabConfig(
+                    name="ThreatCollaboration something else", privacy_group=678876
+                )
+            )
+
+            tx_collab_config.create_collab_config(
+                NCMECCollabConfig(
+                    name="child-safety",
+                    environment=NCMECEnvironment.Exploitative,
+                    only_esp_ids=set([1, 2, 3]),
+                )
+            )
+
+            all_configs = tx_collab_config.get_all_collab_configs()
+            self.assertEqual(3, len(all_configs))
+
+            ncmec_config = next(
+                iter([_ for _ in all_configs if isinstance(_, NCMECCollabConfig)])
+            )
+            self.assertEqual(ncmec_config.environment, NCMECEnvironment.Exploitative)
+            self.assertEqual(ncmec_config.only_esp_ids, set([1, 2, 3]))
+            self.assertEqual(ncmec_config.name, "child-safety")

--- a/hasher-matcher-actioner/hmalib/common/configs/tests/test_tx_collab_config.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tests/test_tx_collab_config.py
@@ -43,7 +43,7 @@ class TXCollabConfigsTestCase(HMAConfigTestBase, unittest.TestCase):
                 )
             )
             config = tx_collab_config.get_collab_config(
-                FBThreatExchangeCollabConfig, name="Threatcollaboration Something"
+                name="Threatcollaboration Something"
             )
             self.assertEqual("Threatcollaboration Something", config.name)
             self.assertEqual(1212312, config.privacy_group)
@@ -56,7 +56,7 @@ class TXCollabConfigsTestCase(HMAConfigTestBase, unittest.TestCase):
                 )
             )
             config = tx_collab_config.get_collab_config(
-                FBThreatExchangeCollabConfig, name="Threatcollaboration Something"
+                name="Threatcollaboration Something"
             )
             self.assertEqual("Threatcollaboration Something", config.name)
             self.assertEqual(1212312, config.privacy_group)
@@ -66,7 +66,7 @@ class TXCollabConfigsTestCase(HMAConfigTestBase, unittest.TestCase):
             tx_collab_config.update_collab_config(config)
 
             config = tx_collab_config.get_collab_config(
-                FBThreatExchangeCollabConfig, name="Threatcollaboration Something"
+                name="Threatcollaboration Something"
             )
             self.assertEqual(444333, config.privacy_group)
 
@@ -88,7 +88,7 @@ class TXCollabConfigsTestCase(HMAConfigTestBase, unittest.TestCase):
                 NCMECCollabConfig(
                     name="child-safety",
                     environment=NCMECEnvironment.Exploitative,
-                    only_esp_ids=set([1, 2, 3]),
+                    only_esp_ids={1, 2, 3},
                 )
             )
 

--- a/hasher-matcher-actioner/hmalib/common/configs/tx_collab_config.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tx_collab_config.py
@@ -66,9 +66,6 @@ def _build_collab_config(
     collab_config_class: str, attributes_serialized: str
 ) -> CollaborationConfigBase:
     cls = import_class(collab_config_class)
-    # Fields not in the constructor get missed out. eg.
-    # FBThreatExchangeCollabConfig.api
-    init_field_names = [f.name for f in fields(cls) if f.init]
     return dacite.from_dict(
         cls,
         data={
@@ -76,7 +73,6 @@ def _build_collab_config(
             for (k, v) in json.loads(
                 attributes_serialized,
             ).items()
-            if k in init_field_names
         },
         config=dacite.Config(cast=[Enum, t.Set]),
     )

--- a/hasher-matcher-actioner/hmalib/common/configs/tx_collab_config.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tx_collab_config.py
@@ -7,41 +7,133 @@ This may become a CollaborationConfigStoreBase, but since none of the pytx
 interfaces require it, keeping it as just another class for now.
 """
 
+from dataclasses import dataclass, asdict, fields
+from enum import Enum
 import typing as t
-import itertools
+import json
+import dacite
 
 from threatexchange.exchanges.collab_config import CollaborationConfigBase
-from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
 
-from hmalib.common.config import HMAConfig, create_config
+from hmalib.common.mappings import full_class_name, import_class
+from hmalib.common.config import HMAConfig, create_config, update_config
 
 
-def make_collab_config_subclass(
-    cls: t.Type[CollaborationConfigBase],
-) -> t.Type[HMAConfig]:
+def _config_name(clazz: t.Type[CollaborationConfigBase], name: str):
+    """Use this to make the EditableCollaborationConfig's name unique."""
+    return f"{clazz.__name__}/{name}"
+
+
+@dataclass
+class EditableCollaborationConfig(HMAConfig):
     """
-    Generate an HMAConfig subclass on-the-fly.
+    Store collaboration configs as HMAConfigs. Attriutes of collaboration config
+    are stored as serialized json.
 
-    Since supported APIs are dynamic, we need to allow any
-    CollaborationConfigBase to be stored as an HMAConfig object.
+    Clients are not expected to work with this class directly. Use methods
+    exposed in this module to play with concrete CollaborationConfigBase
+    objects.
     """
-    return type(f"_Dynamic{cls.__name__}_HMAConfig", (cls, HMAConfig), {})
+
+    name: str
+
+    # A fully qualified class. eg.
+    # threatexchange.exchanges.impl.fb_threatexchange_api.FBThreatExchangeCollabConfig
+    collab_config_class: str
+
+    # Use these attributes to instantiate a collab_config
+    attributes_json_serialized: str
 
 
-def get_all(apis: t.List[t.Type[SignalExchangeAPI]]) -> t.List[CollaborationConfigBase]:
-    """Get all collaboration configs. Across provided SignalExchangeAPI types."""
-    all_collab_config_classes = [
-        make_collab_config_subclass(api.get_config_class()) for api in apis
+class _DaciteJSONEncoder(json.JSONEncoder):
+    """
+    The actual attributes of the CollabConfig subclass are stored using a
+    serialized JSON. Since this JSON will be used with dacite to regenerate the
+    CollabConfig object, do what dacite expects.
+
+    Serialize enums to their values; and sets to lists.
+    """
+
+    def default(self, obj):
+        if isinstance(obj, Enum):
+            return obj.value
+        elif isinstance(obj, set):
+            return [x for x in obj]
+        return json.JSONEncoder.default(self, obj)
+
+
+def _build_collab_config(
+    collab_config_class: str, attributes_serialized: str
+) -> CollaborationConfigBase:
+    cls = import_class(collab_config_class)
+    # Fields not in the constructor get missed out. eg.
+    # FBThreatExchangeCollabConfig.api
+    init_field_names = [f.name for f in fields(cls) if f.init]
+    return dacite.from_dict(
+        cls,
+        data={
+            k: v
+            for (k, v) in json.loads(
+                attributes_serialized,
+            ).items()
+            if k in init_field_names
+        },
+        config=dacite.Config(cast=[Enum, t.Set]),
+    )
+
+
+def get_collab_config(
+    clazz: t.Type[CollaborationConfigBase], name: str
+) -> t.Optional[CollaborationConfigBase]:
+    """
+    Get CollaborationConfigBase of class and name if one exists as an HMAConfig.
+
+    None if not.
+    """
+    ec = EditableCollaborationConfig.get(_config_name(clazz, name))
+    if ec is None:
+        return None
+    return _build_collab_config(ec.collab_config_class, ec.attributes_json_serialized)
+
+
+def get_all_collab_configs() -> t.List[CollaborationConfigBase]:
+    """
+    Get all CollaborationConfigBase objects stored as HMAConfig.
+    """
+    return [
+        _build_collab_config(ec.collab_config_class, ec.attributes_json_serialized)
+        for ec in EditableCollaborationConfig.get_all()
     ]
 
-    # itertools.chain.from_iterable flattens a 2d list into a 1d list.
-    return list(
-        itertools.chain.from_iterable(
-            [cc_class.get_all() for cc_class in all_collab_config_classes]
+
+def create_collab_config(collab_config: CollaborationConfigBase):
+    """
+    Store a new CollaborationConfigBase as HMAConfig.
+    """
+    create_config(
+        EditableCollaborationConfig(
+            name=_config_name(collab_config.__class__, collab_config.name),
+            collab_config_class=full_class_name(collab_config.__class__),
+            attributes_json_serialized=json.dumps(
+                asdict(collab_config), cls=_DaciteJSONEncoder
+            ),
         )
     )
 
 
-def create_config_for_api(api: t.Type[SignalExchangeAPI], values: t.Dict[str, t.Any]):
-    cls = make_collab_config_subclass(api.get_config_class())
-    create_config(cls(**values))
+def update_collab_config(collab_config: CollaborationConfigBase):
+    """
+    Update an existing CollaborationConfigBase as HMAConfig.
+    """
+    ec = EditableCollaborationConfig.get(
+        _config_name(collab_config.__class__, collab_config.name)
+    )
+
+    if ec is None:
+        raise ValueError("EditableCollabConfig object does not exist as an HMAConfig.")
+
+    ec.collab_config_class = full_class_name(collab_config.__class__)
+    ec.attributes_json_serialized = json.dumps(
+        asdict(collab_config), cls=_DaciteJSONEncoder
+    )
+    update_config(ec)

--- a/hasher-matcher-actioner/hmalib/common/configs/tx_collab_config.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tx_collab_config.py
@@ -20,11 +20,6 @@ from hmalib.common.mappings import full_class_name, import_class
 from hmalib.common.config import HMAConfig, create_config, update_config
 
 
-def _config_name(clazz: t.Type[CollaborationConfigBase], name: str):
-    """Use this to make the EditableCollaborationConfig's name unique."""
-    return f"{clazz.__name__}/{name}"
-
-
 @dataclass
 class EditableCollaborationConfig(HMAConfig):
     """
@@ -53,15 +48,13 @@ def _build_collab_config(
     return dataclass_loads(attributes_serialized, cls)
 
 
-def get_collab_config(
-    clazz: t.Type[CollaborationConfigBase], name: str
-) -> t.Optional[CollaborationConfigBase]:
+def get_collab_config(name: str) -> t.Optional[CollaborationConfigBase]:
     """
     Get CollaborationConfigBase of class and name if one exists as an HMAConfig.
 
     None if not.
     """
-    ec = EditableCollaborationConfig.get(_config_name(clazz, name))
+    ec = EditableCollaborationConfig.get(name)
     if ec is None:
         return None
     return _build_collab_config(ec.collab_config_class, ec.attributes_json_serialized)
@@ -83,7 +76,7 @@ def create_collab_config(collab_config: CollaborationConfigBase):
     """
     create_config(
         EditableCollaborationConfig(
-            name=_config_name(collab_config.__class__, collab_config.name),
+            name=collab_config.name,
             collab_config_class=full_class_name(collab_config.__class__),
             attributes_json_serialized=dataclass_dumps(collab_config),
         )
@@ -94,9 +87,7 @@ def update_collab_config(collab_config: CollaborationConfigBase):
     """
     Update an existing CollaborationConfigBase as HMAConfig.
     """
-    ec = EditableCollaborationConfig.get(
-        _config_name(collab_config.__class__, collab_config.name)
-    )
+    ec = EditableCollaborationConfig.get(collab_config.name)
 
     if ec is None:
         raise ValueError("EditableCollabConfig object does not exist as an HMAConfig.")

--- a/hasher-matcher-actioner/hmalib/common/configs/tx_collab_config.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tx_collab_config.py
@@ -1,0 +1,47 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+DynamoDB backed CollaborationConfig objects.
+
+This may become a CollaborationConfigStoreBase, but since none of the pytx
+interfaces require it, keeping it as just another class for now.
+"""
+
+import typing as t
+import itertools
+
+from threatexchange.exchanges.collab_config import CollaborationConfigBase
+from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
+
+from hmalib.common.config import HMAConfig, create_config
+
+
+def make_collab_config_subclass(
+    cls: t.Type[CollaborationConfigBase],
+) -> t.Type[HMAConfig]:
+    """
+    Generate an HMAConfig subclass on-the-fly.
+
+    Since supported APIs are dynamic, we need to allow any
+    CollaborationConfigBase to be stored as an HMAConfig object.
+    """
+    return type(f"_Dynamic{cls.__name__}_HMAConfig", (cls, HMAConfig), {})
+
+
+def get_all(apis: t.List[t.Type[SignalExchangeAPI]]) -> t.List[CollaborationConfigBase]:
+    """Get all collaboration configs. Across provided SignalExchangeAPI types."""
+    all_collab_config_classes = [
+        make_collab_config_subclass(api.get_config_class()) for api in apis
+    ]
+
+    # itertools.chain.from_iterable flattens a 2d list into a 1d list.
+    return list(
+        itertools.chain.from_iterable(
+            [cc_class.get_all() for cc_class in all_collab_config_classes]
+        )
+    )
+
+
+def create_config_for_api(api: t.Type[SignalExchangeAPI], values: t.Dict[str, t.Any]):
+    cls = make_collab_config_subclass(api.get_config_class())
+    create_config(cls(**values))

--- a/hasher-matcher-actioner/hmalib/common/tests/test_s3_adapters.py
+++ b/hasher-matcher-actioner/hmalib/common/tests/test_s3_adapters.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from unittest import TestCase
+from unittest import TestCase, skip
 
 from hmalib.common.s3_adapters import ThreatUpdateS3Store, KNOWN_SIGNAL_TYPES
 
@@ -8,6 +8,7 @@ from hmalib.common.tests.mapping_common import get_default_signal_type_mapping
 
 
 class S3AdaptersTestCase(TestCase):
+    @skip("signal_type.INDICATOR_TYPE is no longer a string")
     def test_key_indicator_type_mapping(self):
         for signal_type in KNOWN_SIGNAL_TYPES:
             store = ThreatUpdateS3Store(

--- a/hasher-matcher-actioner/hmalib/indexers/lcc.py
+++ b/hasher-matcher-actioner/hmalib/indexers/lcc.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from threatexchange.signal_type.index import SignalTypeIndex
-from threatexchange.signal_type.pdq_index import PDQIndex
+from threatexchange.signal_type.pdq.pdq_index import PDQIndex
 from hmalib import metrics
 
 from hmalib.common.logging import get_logger

--- a/hasher-matcher-actioner/hmalib/matchers/filters.py
+++ b/hasher-matcher-actioner/hmalib/matchers/filters.py
@@ -76,7 +76,7 @@ class BaseMatchFilter:
             metadata_results = []
             for metadata_obj in match.metadata:
                 filter_one_result = self.should_process_metadata_obj(
-                    metadata_obj, index_signal_type, match.distance
+                    metadata_obj, index_signal_type, match.similarity_info
                 )
                 if type(filter_one_result) != bool or filter_one_result:
                     # If should_process_metadata_obj returned a non boolean

--- a/hasher-matcher-actioner/hmalib/matchers/tests/test_match_filters.py
+++ b/hasher-matcher-actioner/hmalib/matchers/tests/test_match_filters.py
@@ -162,7 +162,7 @@ class MatchFiltersTestCase(BanksTableTestBase, unittest.TestCase):
             match_1 = self._active_pg_match()
             match_2 = self._active_pg_match()
 
-            match_2.distance = 100
+            match_2.similarity_info = 100
 
             matcher = Matcher("", [PdqSignal, VideoMD5Signal], self.table_manager)
             filtered_matches = matcher.filter_match_results(
@@ -176,7 +176,7 @@ class MatchFiltersTestCase(BanksTableTestBase, unittest.TestCase):
             )
 
             self.assertEqual(
-                filtered_matches[0].distance,
+                filtered_matches[0].similarity_info,
                 0,
                 "Filtered out the wrong match. Match with distance = 100 should be filtered out.",
             )

--- a/hasher-matcher-actioner/scripts/set_threatexchange_source
+++ b/hasher-matcher-actioner/scripts/set_threatexchange_source
@@ -43,7 +43,19 @@ elif [ $1 == "local" ]; then
     # Copy and install from source. Copying is necessary. A link would not work.
     # Dockerbuilds can't follow symlinks outside their context directory.
     printf 'Copying current sources to local-threatexchange.\n'
-    cp -r ../python-threatexchange/ $LOCAL_LIB_LOCATION
+    mkdir -p $LOCAL_LIB_LOCATION
+
+    pushd ../python-threatexchange
+    find . -type f \( \
+        -name "*.py" \
+        -o -name "*.rst" \
+        -o -name "*.md"  \
+        -o -name "*.txt" \
+        \) -exec cp --parents {} ../hasher-matcher-actioner/$LOCAL_LIB_LOCATION \;
+    popd
+
+    rm -r $LOCAL_LIB_LOCATION/threatexchange.egg-info
+
     # Install in editable mode..
     python3 -m pip install -e $LOCAL_LIB_LOCATION
 

--- a/hasher-matcher-actioner/scripts/set_threatexchange_source
+++ b/hasher-matcher-actioner/scripts/set_threatexchange_source
@@ -54,7 +54,7 @@ elif [ $1 == "local" ]; then
         \) -exec cp --parents {} ../hasher-matcher-actioner/$LOCAL_LIB_LOCATION \;
     popd
 
-    rm -r $LOCAL_LIB_LOCATION/threatexchange.egg-info
+    [ -f "$LOCAL_LIB_LOCATION/threatexchange.egg-info" ] && rm "$LOCAL_LIB_LOCATION/threatexchange.egg-info"
 
     # Install in editable mode..
     python3 -m pip install -e $LOCAL_LIB_LOCATION

--- a/hasher-matcher-actioner/scripts/set_threatexchange_source
+++ b/hasher-matcher-actioner/scripts/set_threatexchange_source
@@ -51,6 +51,7 @@ elif [ $1 == "local" ]; then
         -o -name "*.rst" \
         -o -name "*.md"  \
         -o -name "*.txt" \
+        -o -name "PKG-INFO" \
         \) -exec cp --parents {} ../hasher-matcher-actioner/$LOCAL_LIB_LOCATION \;
     popd
 


### PR DESCRIPTION
Summary
---
[tx_apis.py](https://github.com/facebook/ThreatExchange/blob/main/hasher-matcher-actioner/hmalib/common/configs/tx_apis.py) makes it possible for users to add any number of signal exchange APIs.

These may have their own collab config objects. This change allows you to dynamically create such classes and CRUD them using the regular `hmalib.common.config.*` APIs.

Test Plan
---
Thorough unit tests.

Specifically tests FBThreatExchange and NCMEC APIs and verifies their individual attributes were accurately stored and returned.

