### PR TITLE
[pytx][dist][1/3]  Match Distance Cleanup: Replacement ComparisonResult

### DIFF
--- a/python-threatexchange/threatexchange/signal_type/index.py
+++ b/python-threatexchange/threatexchange/signal_type/index.py
@@ -20,11 +20,47 @@ At scale, the flow for matching looks something like:
 
 """
 
-import typing as t
+from dataclasses import dataclass
 import pickle
-
+import typing as t
 
 T = t.TypeVar("T")
+Self = t.TypeVar("Self")
+
+
+@dataclass
+class SignalComparisonResult:
+    match: bool
+
+    def distance_str(self) -> str:
+        """
+        Return a short string with data about the match for more context.
+
+        Displayed without spaces on the CLI in `threatexchange match`, so
+        prefer a format without spaces.
+        """
+        return str(self.match)
+
+
+@dataclass
+class SignalComparisonResultWithSimpleDistance(t.Generic[T]):
+    distance: T
+
+    @classmethod
+    def from_dist(cls: t.Type[Self], dist: T, threshold: T) -> Self:
+        return cls(dist <= threshold, dist)
+
+    def distance_str(self) -> str:
+        """
+        Return a short string with data about the match for more context.
+
+        Displayed without spaces on the CLI in `threatexchange match`, so
+        prefer a format without spaces.
+        """
+        return str(self.distance)
+
+
+SignalComparisonResultWithIntDistance = SignalComparisonResultWithSimpleDistance[int]
 
 
 class IndexMatch(t.Generic[T]):

--- a/python-threatexchange/threatexchange/signal_type/index.py
+++ b/python-threatexchange/threatexchange/signal_type/index.py
@@ -24,8 +24,16 @@ from dataclasses import dataclass
 import pickle
 import typing as t
 
+
 T = t.TypeVar("T")
-Self = t.TypeVar("Self")
+CT = t.TypeVar("CT", bound="Comparable")
+
+
+class Comparable(t.Protocol):
+    """Helper for annotating comparable types."""
+
+    def __le__(self: CT, other: CT) -> bool:
+        ...
 
 
 @dataclass
@@ -43,11 +51,13 @@ class SignalComparisonResult:
 
 
 @dataclass
-class SignalComparisonResultWithSimpleDistance(t.Generic[T]):
-    distance: T
+class SignalComparisonResultWithSimpleDistance(t.Generic[CT], SignalComparisonResult):
+    distance: CT
 
     @classmethod
-    def from_dist(cls: t.Type[Self], dist: T, threshold: T) -> Self:
+    def from_dist(
+        cls, dist: CT, threshold: CT
+    ) -> "SignalComparisonResultWithSimpleDistance[CT]":
         return cls(dist <= threshold, dist)
 
     def distance_str(self) -> str:


### PR DESCRIPTION
Summary
---------

This PR introduces a new comparison result, which now lives in index.py instead of signal base. It also provides a fast solution when you use only a float or a int as the distance.

Why live there? Because we can replace the match concept in index at the same time!

At the end of this, the default behavior might be:
```
$ threatexchange match blah input.file
pdq 17 'Foo Collab'
pdq_ocr 14(text:89%) 'Has OCR'
vpdq 78%(index:22%) 'Bar Collab'
tmk_pdqf 0.81,0.91 'no one uses tmk :"('
raw_text 41% 'Zed Collab yo'
trend_query True 'Trend Query Collab'
an_embedding 0.19 'Goes zero to one'
square_euclidean 14420 'Wow so big'
zalgo d̵͚͌ì̶̘s̵̠̎t̴̺̉a̴͎̾ṋ̸̛ć̸̣ë̸̝
```

Test Plan
---------

mypy && py.test
