### PR TITLE
[pytx][dist][stacked 2/3] Swap HashComparison to distance

### DIFF
--- a/python-threatexchange/threatexchange/cli/tests/fake_extension.py
+++ b/python-threatexchange/threatexchange/cli/tests/fake_extension.py
@@ -19,7 +19,7 @@ from threatexchange.exchanges.fetch_state import (
 from threatexchange.extensions.manifest import ThreatExchangeExtensionManifest
 from threatexchange.signal_type.signal_base import (
     FileHasher,
-    HashComparisonResult,
+    SignalComparisonResult,
     SignalType,
     TrivialSignalTypeIndex,
 )
@@ -67,8 +67,8 @@ class FakeSignal(SignalType, FileHasher):
         return TrivialSignalTypeIndex
 
     @classmethod
-    def compare_hash(cls, hash1: str, hash2: str) -> HashComparisonResult:
-        return HashComparisonResult.from_bool(hash1 == hash2)
+    def compare_hash(cls, hash1: str, hash2: str) -> SignalComparisonResult:
+        return SignalComparisonResult.from_bool_only(hash1 == hash2)
 
     @classmethod
     def hash_from_file(cls, file: pathlib.Path) -> str:

--- a/python-threatexchange/threatexchange/extensions/pdq_ocr/pdq_ocr.py
+++ b/python-threatexchange/threatexchange/extensions/pdq_ocr/pdq_ocr.py
@@ -62,7 +62,7 @@ class PdqOcrSignal(
         hash1: str,
         hash2: str,
         pdq_dist_threshold: int = PDQ_PLUS_OCR_CONFIDENT_MATCH_THRESHOLD,
-    ) -> signal_base.HashComparisonResult:
+    ) -> signal_base.SignalComparisonResult:
         assert 0 <= pdq_dist_threshold <= 256
         pdq_hash_1, _, ocr_text_1 = hash1.partition(",")
         pdq_hash_2, _, ocr_text_2 = hash2.partition(",")
@@ -76,7 +76,9 @@ class PdqOcrSignal(
         text_result = RawTextSignal.matches_str(
             ocr_text_1, ocr_text_2, cls.LEVENSHTEIN_DISTANCE_PERCENT_THRESHOLD
         )
-        return signal_base.HashComparisonResult(text_result.match, pdq_result.distance)
+        return signal_base.SignalComparisonResult(
+            text_result.match, pdq_result.distance
+        )
 
     @staticmethod
     def get_examples() -> t.List[str]:

--- a/python-threatexchange/threatexchange/extensions/tlsh/text_tlsh.py
+++ b/python-threatexchange/threatexchange/extensions/tlsh/text_tlsh.py
@@ -51,9 +51,9 @@ class TextTLSHSignal(signal_base.SimpleSignalType, signal_base.TextHasher):
         hash1: str,
         hash2: str,
         tlsh_threshold: int = TLSH_CONFIDENT_MATCH_THRESHOLD,
-    ) -> signal_base.HashComparisonResult:
-        dist = tlsh.diffxlen(hash1, hash2)
-        return signal_base.HashComparisonResult.from_dist(dist, tlsh_threshold)
+    ) -> signal_base.SignalComparisonResult:
+        dist: int = tlsh.diffxlen(hash1, hash2)
+        return signal_base.SignalComparisonResult.from_simple_dist(dist, tlsh_threshold)
 
     @staticmethod
     def get_examples() -> t.List[str]:

--- a/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
@@ -83,7 +83,7 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
         return vpdq_to_json(vpdq_hashes)
 
     @classmethod
-    def compare_hash(cls, hash1: str, hash2: str) -> signal_base.HashComparisonResult:
+    def compare_hash(cls, hash1: str, hash2: str) -> signal_base.SignalComparisonResult:
         """If the max of the two match percentages is over VPDQ_CONFIDENT_MATCH_THRESHOLD
         with VPDQ_DISTANCE_THRESHOLD, it's a match."""
         vpdq_hash1 = json_to_vpdq(hash1)
@@ -98,7 +98,8 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
             match_percent.query_match_percent, match_percent.compared_match_percent
         )
         is_match = max_match_percent >= cls.VPDQ_CONFIDENT_MATCH_THRESHOLD
-        return signal_base.HashComparisonResult(is_match, int(max_match_percent))
+        # TODO vPDQ distance type
+        return signal_base.SignalComparisonResult.from_bool_only(is_match)
 
     @staticmethod
     def get_examples() -> t.List[str]:

--- a/python-threatexchange/threatexchange/signal_type/pdq/signal.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq/signal.py
@@ -66,9 +66,11 @@ class PdqSignal(
         hash1: str,
         hash2: str,
         pdq_dist_threshold: int = PDQ_CONFIDENT_MATCH_THRESHOLD,
-    ) -> signal_base.HashComparisonResult:
+    ) -> signal_base.SignalComparisonResult:
         dist = simple_distance(hash1, hash2)
-        return signal_base.HashComparisonResult.from_dist(dist, pdq_dist_threshold)
+        return signal_base.SignalComparisonResult.from_simple_dist(
+            dist, pdq_dist_threshold
+        )
 
     @classmethod
     def hash_from_bytes(cls, bytes_: bytes) -> str:

--- a/python-threatexchange/threatexchange/signal_type/raw_text.py
+++ b/python-threatexchange/threatexchange/signal_type/raw_text.py
@@ -42,7 +42,7 @@ class RawTextSignal(
     @classmethod
     def matches_str(
         cls, signal: str, haystack: str, pct_diff_threshold: int = 5
-    ) -> signal_base.HashComparisonResult:
+    ) -> signal_base.SignalComparisonResult:
         assert 0 < pct_diff_threshold <= 100
         a = common.normalize_string(signal)
         b = common.normalize_string(haystack)
@@ -51,11 +51,13 @@ class RawTextSignal(
         ldiff = abs(len(a) - len(b))
 
         if ldiff > max_match_distance:
-            return signal_base.HashComparisonResult.from_no_match(ldiff)
+            return signal_base.SignalComparisonResult.from_simple_dist(
+                ldiff, max_match_distance
+            )
 
         distance = Levenshtein.distance(a, b)
-        return signal_base.HashComparisonResult(
-            distance <= max_match_distance, distance
+        return signal_base.SignalComparisonResult.from_simple_dist(
+            distance, max_match_distance
         )
 
     @classmethod

--- a/python-threatexchange/threatexchange/signal_type/tests/signal_type_test_helper.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/signal_type_test_helper.py
@@ -120,11 +120,10 @@ class MatchesStrAutoTest(SignalTypeAutoTest):
 
     def test_matches_str(self):
         for t in self.get_matches_str_cases():
-            print(t)
             signal, haystack = t[:2]
             expect_match = t[2] if len(t) > 2 else True
 
             result = self.TYPE.matches_str(signal, haystack)
             assert result.match == expect_match, f"Case: {t}"
             if len(t) > 3:
-                assert result.distance == t[3], f"Case: {t}"
+                assert result.distance.distance == t[3], f"Case: {t}"

--- a/python-threatexchange/threatexchange/signal_type/trend_query.py
+++ b/python-threatexchange/threatexchange/signal_type/trend_query.py
@@ -76,9 +76,11 @@ class TrendQuerySignal(
         return signal_str
 
     @classmethod
-    def matches_str(cls, hash: str, haystack: str) -> signal_base.HashComparisonResult:
+    def matches_str(
+        cls, hash: str, haystack: str
+    ) -> signal_base.SignalComparisonResult:
         tq = TrendQuery(json.loads(hash))
-        return signal_base.HashComparisonResult.from_bool(tq.matches(haystack))
+        return signal_base.SignalComparisonResult.from_bool_only(tq.matches(haystack))
 
     @classmethod
     def get_index_cls(cls) -> t.Type[index.SignalTypeIndex]:

--- a/python-threatexchange/threatexchange/signal_type/url.py
+++ b/python-threatexchange/threatexchange/signal_type/url.py
@@ -39,9 +39,9 @@ class URLSignal(
     @classmethod
     def matches_str(
         cls, signal: str, haystack: str
-    ) -> signal_base.HashComparisonResult:
+    ) -> signal_base.SignalComparisonResult:
         # TODO - normalization
-        return signal_base.HashComparisonResult.from_bool(signal == haystack)
+        return signal_base.SignalComparisonResult.from_bool_only(signal == haystack)
 
     @staticmethod
     def get_examples() -> t.List[str]:


### PR DESCRIPTION
Summary
---------

We now swap out HashComparisonResult (soon to SignalComparisonResult) to the new struct.

Also some fixes to the base revision that I was too lazy to change.

Test Plan
---------

py.test && mypy
