### PR TITLE
[VPDQ] Update vpdq-release.py to only generate source distribution

### DIFF
--- a/vpdq/vpdq-release.py
+++ b/vpdq/vpdq-release.py
@@ -37,7 +37,7 @@ def main():
     shutil.copy(DIR / MANIFEST, PARENTDIR / MANIFEST)
     if args.release:
         print("build vpdq source distribution")
-        run_command(["python3", "setup.py", "sdist", "bdist_wheel"], PARENTDIR)
+        run_command(["python3", "setup.py", "sdist"], PARENTDIR)
         if (DIR / DIST).exists() and (DIR / DIST).is_dir():
             shutil.rmtree(DIR / DIST)
         shutil.move(PARENTDIR / DIST, DIR / DIST)


### PR DESCRIPTION
Summary
---------
Update vpdq-release script to only build source distribution since linux platform build wheel cannot be uploaded to PyPI.

