### PR TITLE
[pytx] SignalType now abstract compare_hash moved to FileHasher

### DIFF
--- a/python-threatexchange/threatexchange/cli/match_cmd.py
+++ b/python-threatexchange/threatexchange/cli/match_cmd.py
@@ -200,7 +200,7 @@ class MatchCommand(command_base.Command):
                             continue
                         seen.add(collab)
                         # Supposed to be without whitespace, but let's make sure
-                        distance_str = "".join(r.match_info.pretty_str().split())
+                        distance_str = "".join(r.similarity_info.pretty_str().split())
                         print(
                             s_type.get_name(),
                             distance_str,

--- a/python-threatexchange/threatexchange/cli/tests/fake_extension.py
+++ b/python-threatexchange/threatexchange/cli/tests/fake_extension.py
@@ -67,10 +67,6 @@ class FakeSignal(SignalType, FileHasher):
         return TrivialSignalTypeIndex
 
     @classmethod
-    def compare_hash(cls, hash1: str, hash2: str) -> SignalComparisonResult:
-        return SignalComparisonResult.from_bool_only(hash1 == hash2)
-
-    @classmethod
     def hash_from_file(cls, file: pathlib.Path) -> str:
         return "fake"  # A perfect hashing algorithm
 

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -302,5 +302,5 @@ def compare_match_result(res1: VPDQIndexMatch, res2: VPDQIndexMatch) -> bool:
         res1.compared_match_percent == res2.compared_match_percent
         and res1.query_match_percent == res2.query_match_percent
         and res1.metadata == res2.metadata
-        and res1.match_info == res2.match_info
+        and res1.similarity_info == res2.similarity_info
     )

--- a/python-threatexchange/threatexchange/signal_type/index.py
+++ b/python-threatexchange/threatexchange/signal_type/index.py
@@ -120,12 +120,12 @@ class IndexMatchUntyped(t.Generic[S_Co, T]):
     NamedTuple can't be made generic, so here's an equivalent
     """
 
-    __slots__ = ["match_info", "metadata"]
-    match_info: S_Co
+    __slots__ = ["similarity_info", "metadata"]
+    similarity_info: S_Co
     metadata: T
 
-    def __init__(self, match_info: S_Co, metadata: T) -> None:
-        self.match_info = match_info
+    def __init__(self, similarity_info: S_Co, metadata: T) -> None:
+        self.similarity_info = similarity_info
         self.metadata = metadata
 
 

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 """
 Core abstractions for signal types.
 """
 
+import abc
 import pathlib
 import typing as t
 
@@ -53,7 +53,7 @@ class SignalComparisonResult(t.NamedTuple):
         )
 
 
-class SignalType:
+class SignalType(abc.ABC):
     """
     Abstraction for different signal types.
 
@@ -76,11 +76,13 @@ class SignalType:
         return common.class_name_to_human_name(cls.__name__, "Signal")
 
     @classmethod
+    @abc.abstractmethod
     def get_content_types(cls) -> t.List[t.Type[content_base.ContentType]]:
         """Which content types this Signal applies to (usually just one)"""
-        raise NotImplementedError
+        pass
 
     @classmethod
+    @abc.abstractmethod
     def get_index_cls(cls) -> t.Type[index.SignalTypeIndex]:
         """Return the index class that handles this signal type"""
         # Confused about which one to start with?
@@ -89,17 +91,7 @@ class SignalType:
         #   2. TrivialLinearSearchMatchIndex: If you are MatchesStr
         # Or if you only support exact matching (like MD5):
         #   3. TrivialSignalTypeIndex
-        raise NotImplementedError
-
-    @classmethod
-    def compare_hash(cls, hash1: str, hash2: str) -> SignalComparisonResult:
-        """
-        Compare the distance of two hashes, the key operation for matching.
-
-        Note that this can just be a reference/helper, and the efficient
-        version of the algorithm can live in the index class.
-        """
-        raise NotImplementedError
+        pass
 
     @classmethod
     def validate_signal_str(cls, signal_str: str) -> str:
@@ -111,6 +103,7 @@ class SignalType:
         return signal_str.strip()
 
     @staticmethod
+    @abc.abstractmethod
     def get_examples() -> t.List[str]:
         """
         Return example signals, which can be used for tests or demos.
@@ -122,19 +115,31 @@ class SignalType:
         return []
 
 
-class FileHasher:
+class FileHasher(abc.ABC):
     """
     This class can hash files.
     """
 
     @classmethod
+    @abc.abstractmethod
+    def compare_hash(cls, hash1: str, hash2: str) -> SignalComparisonResult:
+        """
+        Compare the distance of two hashes, the key operation for matching.
+
+        Note that this can just be a reference/helper, and the efficient
+        version of the algorithm can live in the index class.
+        """
+        pass
+
+    @classmethod
+    @abc.abstractmethod
     def hash_from_file(cls, file: pathlib.Path) -> str:
         """
         Get a string representation of the hash from a file.
 
         If a hash cannot be generated, empty string should be returned.
         """
-        raise NotImplementedError
+        pass
 
 
 class TextHasher(FileHasher):
@@ -143,21 +148,23 @@ class TextHasher(FileHasher):
     """
 
     @classmethod
+    @abc.abstractmethod
     def hash_from_str(cls, text: str) -> str:
         """
         Get a string representation of the hash from a string.
 
         If a hash cannot be generated, empty string should be returned.
         """
-        raise NotImplementedError
+        pass
 
     @classmethod
     def hash_from_file(cls, file: pathlib.Path) -> str:
         return cls.hash_from_str(file.read_text())
 
 
-class MatchesStr:
+class MatchesStr(abc.ABC):
     @classmethod
+    @abc.abstractmethod
     def matches_str(cls, signal: str, haystack: str) -> SignalComparisonResult:
         """
         Compare the distance of two hashes, the key operation for matching.
@@ -165,7 +172,7 @@ class MatchesStr:
         Note that this can just be a reference/helper, and the efficient
         version of the algorithm can live in the index class.
         """
-        raise NotImplementedError
+        pass
 
 
 class BytesHasher(FileHasher):
@@ -174,13 +181,14 @@ class BytesHasher(FileHasher):
     """
 
     @classmethod
+    @abc.abstractmethod
     def hash_from_bytes(cls, bytes_: bytes) -> str:
         """
         Get a string representation of the hash from bytes.
 
         If a hash cannot be generated, empty string should be returned.
         """
-        raise NotImplementedError
+        pass
 
     @classmethod
     def hash_from_file(cls, file: pathlib.Path) -> str:
@@ -230,7 +238,7 @@ class TrivialLinearSearchHashIndex(index.SignalTypeIndex[index.T]):
 
     # You'll have to override with each usecase, because I wasn't sure
     # If pickle would behave expectedly here
-    _SIGNAL_TYPE: t.Type[SignalType]
+    _SIGNAL_TYPE: t.Type[FileHasher]
 
     def __init__(self) -> None:
         self.state: t.List[t.Tuple[str, index.T]] = []

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -167,7 +167,7 @@ class MatchesStr(abc.ABC):
     @abc.abstractmethod
     def matches_str(cls, signal: str, haystack: str) -> SignalComparisonResult:
         """
-        Compare the distance of two hashes, the key operation for matching.
+        Compare the signal and text, the key operation for matching.
 
         Note that this can just be a reference/helper, and the efficient
         version of the algorithm can live in the index class.

--- a/python-threatexchange/threatexchange/signal_type/tests/signal_type_test_helper.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/signal_type_test_helper.py
@@ -3,7 +3,12 @@
 import pytest
 import typing as t
 
-from threatexchange.signal_type.signal_base import SignalType
+from threatexchange.signal_type.signal_base import (
+    FileHasher,
+    MatchesStr,
+    SignalType,
+    TextHasher,
+)
 
 
 class SignalTypeHashTest:
@@ -63,7 +68,10 @@ class SignalTypeAutoTest(SignalTypeHashTest):
         assert examples, f"Add some examples to {self.TYPE.__name__}.get_examples()"
         for example in examples:
             self.assert_signal_str_valid(example)
-            assert self.TYPE.compare_hash(example, example).match, f"Case: {example}"
+            if issubclass(self.TYPE, FileHasher):
+                assert self.TYPE.compare_hash(
+                    example, example
+                ).match, f"Case: {example}"
 
     def get_validate_hash_cases(self) -> t.Iterable[THashValidateCase]:
         raise NotImplementedError
@@ -83,6 +91,7 @@ class SignalTypeAutoTest(SignalTypeHashTest):
 
     def test_compare_hash(self):
         for t in self.get_compare_hash_cases():
+            assert issubclass(self.TYPE, FileHasher)  # For typing
             a, b = t[:2]
             expect_match = t[2] if len(t) > 2 else True
 
@@ -101,6 +110,7 @@ class TextHasherAutoTest(SignalTypeAutoTest):
         raise NotImplementedError
 
     def test_hash_from_str(self):
+        assert issubclass(self.TYPE, TextHasher)  # For typing
         for s, hashed in self.get_hashes_from_str_cases():
             assert self.TYPE.hash_from_str(s) == hashed, f"Case: {(s, hashed)}"
 

--- a/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index.py
@@ -82,10 +82,12 @@ class TestPDQIndex(unittest.TestCase):
         def quality_indexed_dict_reducer(
             acc: accum_type, item: PDQIndexMatch
         ) -> accum_type:
-            acc[item.match_info.distance] = acc.get(item.match_info.distance, set())
+            acc[item.similarity_info.distance] = acc.get(
+                item.similarity_info.distance, set()
+            )
             # Instead of storing the unhashable item.metadata dict, store its
             # hash so we can compare using self.assertSetEqual
-            acc[item.match_info.distance].add(hash(frozenset(item.metadata)))
+            acc[item.similarity_info.distance].add(hash(frozenset(item.metadata)))
             return acc
 
         # Convert results to distance -> set of metadata map

--- a/python-threatexchange/threatexchange/signal_type/tests/test_raw_text.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/test_raw_text.py
@@ -16,10 +16,7 @@ class TestRawTextSignal(MatchesStrAutoTest):
         ]
 
     def get_compare_hash_cases(self):
-        return [
-            ("a", "a"),
-            ("a", "b", False),
-        ]
+        return []
 
     def get_matches_str_cases(self):
         return [


### PR DESCRIPTION
Summary
---------

Various followups from the discussion on distance, that I was bad about keeping separate:
1. match_info => similarity_info
2. Comparing signals now lives in either MatchesStr or FileHasher, since those are the only contexts where it makes sense to do so.

Test Plan
---------

mypy && py.test
