### PR TITLE
[pytx][vpdq][stacked] vpdq distance

### DIFF
--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -3,7 +3,7 @@
 import pytest
 import pickle
 import random
-from threatexchange.extensions.vpdq.vpdq_index import VPDQDistance
+from threatexchange.extensions.vpdq.vpdq_index import VPDQSimilarityInfo
 
 from threatexchange.signal_type.index import IndexMatch
 
@@ -83,20 +83,20 @@ def test_simple():
     assert len(index._index_idx_to_vpdqHex_and_entry) == len(features)
     res = index.query(hash)
     # A complete match to itself
-    assert res[0] == IndexMatch(VPDQDistance(100.0, 100.0), EXAMPLE_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(100.0, 100.0), EXAMPLE_META_DATA)
 
 
 def test_half_match():
     index = VPDQIndex.build([[hash, EXAMPLE_META_DATA]], query_match_threshold_pct=0)
     half_hash = features[0 : int(len(features) / 2)]
     res = index.query(vpdq_to_json(half_hash))
-    assert res[0] == IndexMatch(VPDQDistance(100.0, 50.0), EXAMPLE_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(100.0, 50.0), EXAMPLE_META_DATA)
 
     index = VPDQIndex.build(
         [[vpdq_to_json(half_hash), EXAMPLE_META_DATA]], query_match_threshold_pct=0
     )
     res = index.query(hash)
-    assert res[0] == IndexMatch(VPDQDistance(50.0, 100.0), EXAMPLE_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(50.0, 100.0), EXAMPLE_META_DATA)
 
 
 def test_serialize():
@@ -104,7 +104,7 @@ def test_serialize():
     pickled_data = pickle.dumps(index)
     reconstructed_index = pickle.loads(pickled_data)
     res = reconstructed_index.query(hash)
-    assert res[0] == IndexMatch(VPDQDistance(100.0, 100.0), EXAMPLE_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(100.0, 100.0), EXAMPLE_META_DATA)
 
 
 def test_empty_video_():
@@ -133,8 +133,8 @@ def test_duplicate_hashes():
     index.add(hash, VIDEO2_META_DATA)
     res = index.query(hash)
     # A complete match to itself
-    assert res[0] == IndexMatch(VPDQDistance(100.0, 100.0), VIDEO1_META_DATA)
-    assert res[1] == IndexMatch(VPDQDistance(100.0, 100.0), VIDEO2_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(100.0, 100.0), VIDEO1_META_DATA)
+    assert res[1] == IndexMatch(VPDQSimilarityInfo(100.0, 100.0), VIDEO2_META_DATA)
 
 
 def test_no_match():
@@ -184,10 +184,10 @@ def test_match_below_and_above_80pct_query_threshold():
     assert len(res) == 0
 
     res = index.query(vpdq_to_json(video2))
-    assert res[0] == IndexMatch(VPDQDistance(80.0, 100.0), VIDEO4_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(80.0, 100.0), VIDEO4_META_DATA)
 
     res = index.query(vpdq_to_json(video3))
-    assert res[0] == IndexMatch(VPDQDistance(90.0, 100.0), VIDEO4_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(90.0, 100.0), VIDEO4_META_DATA)
 
 
 def test_match_below_and_above_80pct_index_threshold():
@@ -216,14 +216,14 @@ def test_match_below_and_above_80pct_index_threshold():
         index_match_threshold_pct=80,
     )
     res = index.query(vpdq_to_json(video4))
-    assert res[0] == IndexMatch(VPDQDistance(100.0, 80.0), VIDEO2_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(100.0, 80.0), VIDEO2_META_DATA)
 
     index = VPDQIndex.build(
         [[vpdq_to_json(video3), VIDEO3_META_DATA]],
         index_match_threshold_pct=80,
     )
     res = index.query(vpdq_to_json(video4))
-    assert res[0] == IndexMatch(VPDQDistance(100.0, 90.0), VIDEO3_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(100.0, 90.0), VIDEO3_META_DATA)
 
 
 def test_matches():
@@ -243,22 +243,22 @@ def test_matches():
     )
     index = VPDQIndex.build([[vpdq_to_json(video1), VIDEO1_META_DATA]])
     res = index.query(vpdq_to_json(video2))
-    assert res[0] == IndexMatch(VPDQDistance(90.0, 90.0), VIDEO1_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(90.0, 90.0), VIDEO1_META_DATA)
 
     index = VPDQIndex.build([[vpdq_to_json(video2), VIDEO2_META_DATA]])
     res = index.query(vpdq_to_json(video1))
-    assert res[0] == IndexMatch(VPDQDistance(90.0, 90.0), VIDEO2_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(90.0, 90.0), VIDEO2_META_DATA)
 
     del video1[-1]
     index = VPDQIndex.build([[vpdq_to_json(video1), VIDEO1_META_DATA]])
     res = index.query(vpdq_to_json(video2))
-    assert res[0] == IndexMatch(VPDQDistance(90.0, 100.0), VIDEO1_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(90.0, 100.0), VIDEO1_META_DATA)
 
     del video2[-1]
     index = VPDQIndex.build([[vpdq_to_json(video1), VIDEO1_META_DATA]])
     res = index.query(vpdq_to_json(video2))
 
-    assert res[0] == IndexMatch(VPDQDistance(100.0, 100.0), VIDEO1_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(100.0, 100.0), VIDEO1_META_DATA)
 
 
 def test_duplicate_matches():
@@ -272,7 +272,7 @@ def test_duplicate_matches():
 
     index = VPDQIndex.build([[vpdq_to_json(video1), VIDEO1_META_DATA]])
     res = index.query(vpdq_to_json(video2))
-    assert res[0] == IndexMatch(VPDQDistance(100.0, 100.0), VIDEO1_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(100.0, 100.0), VIDEO1_META_DATA)
 
 
 def test_duplicate_video_matches():
@@ -290,5 +290,5 @@ def test_duplicate_video_matches():
         ]
     )
     res = index.query(vpdq_to_json(video3))
-    assert res[0] == IndexMatch(VPDQDistance(100.0, 100.0), VIDEO1_META_DATA)
-    assert res[1] == IndexMatch(VPDQDistance(50.0, 100.0), VIDEO2_META_DATA)
+    assert res[0] == IndexMatch(VPDQSimilarityInfo(100.0, 100.0), VIDEO1_META_DATA)
+    assert res[1] == IndexMatch(VPDQSimilarityInfo(50.0, 100.0), VIDEO2_META_DATA)

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -1,10 +1,11 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-import json
 import pytest
-from pathlib import Path
 import pickle
 import random
+from threatexchange.extensions.vpdq.vpdq_index import VPDQDistance
+
+from threatexchange.signal_type.index import IndexMatch
 
 try:
     import vpdq
@@ -14,7 +15,7 @@ except (ImportError, ModuleNotFoundError) as e:
     _DISABLED = True
 else:
     import typing as t
-    from threatexchange.extensions.vpdq.vpdq_index import VPDQIndex, VPDQIndexMatch
+    from threatexchange.extensions.vpdq.vpdq_index import VPDQIndex
     from threatexchange.extensions.vpdq.vpdq_util import (
         json_to_vpdq,
         prepare_vpdq_feature,
@@ -33,7 +34,6 @@ else:
         get_similar_hash,
         get_zero_hash,
     )
-
 
 pytestmark = pytest.mark.skipif(_DISABLED, reason="vpdq not installed")
 
@@ -83,21 +83,20 @@ def test_simple():
     assert len(index._index_idx_to_vpdqHex_and_entry) == len(features)
     res = index.query(hash)
     # A complete match to itself
-    assert compare_match_result(
-        res[0], VPDQIndexMatch(100, 100, 100, EXAMPLE_META_DATA)
-    )
+    assert res[0] == IndexMatch(VPDQDistance(100.0, 100.0), EXAMPLE_META_DATA)
 
 
 def test_half_match():
     index = VPDQIndex.build([[hash, EXAMPLE_META_DATA]], query_match_threshold_pct=0)
     half_hash = features[0 : int(len(features) / 2)]
     res = index.query(vpdq_to_json(half_hash))
-    assert compare_match_result(res[0], VPDQIndexMatch(100, 100, 50, EXAMPLE_META_DATA))
+    assert res[0] == IndexMatch(VPDQDistance(100.0, 50.0), EXAMPLE_META_DATA)
+
     index = VPDQIndex.build(
         [[vpdq_to_json(half_hash), EXAMPLE_META_DATA]], query_match_threshold_pct=0
     )
     res = index.query(hash)
-    assert compare_match_result(res[0], VPDQIndexMatch(100, 50, 100, EXAMPLE_META_DATA))
+    assert res[0] == IndexMatch(VPDQDistance(50.0, 100.0), EXAMPLE_META_DATA)
 
 
 def test_serialize():
@@ -105,9 +104,7 @@ def test_serialize():
     pickled_data = pickle.dumps(index)
     reconstructed_index = pickle.loads(pickled_data)
     res = reconstructed_index.query(hash)
-    assert compare_match_result(
-        res[0], VPDQIndexMatch(100, 100, 100, EXAMPLE_META_DATA)
-    )
+    assert res[0] == IndexMatch(VPDQDistance(100.0, 100.0), EXAMPLE_META_DATA)
 
 
 def test_empty_video_():
@@ -136,8 +133,8 @@ def test_duplicate_hashes():
     index.add(hash, VIDEO2_META_DATA)
     res = index.query(hash)
     # A complete match to itself
-    assert compare_match_result(res[0], VPDQIndexMatch(100, 100, 100, VIDEO1_META_DATA))
-    assert compare_match_result(res[1], VPDQIndexMatch(100, 100, 100, VIDEO2_META_DATA))
+    assert res[0] == IndexMatch(VPDQDistance(100.0, 100.0), VIDEO1_META_DATA)
+    assert res[1] == IndexMatch(VPDQDistance(100.0, 100.0), VIDEO2_META_DATA)
 
 
 def test_no_match():
@@ -187,10 +184,10 @@ def test_match_below_and_above_80pct_query_threshold():
     assert len(res) == 0
 
     res = index.query(vpdq_to_json(video2))
-    assert compare_match_result(res[0], VPDQIndexMatch(100, 80, 100, VIDEO4_META_DATA))
+    assert res[0] == IndexMatch(VPDQDistance(80.0, 100.0), VIDEO4_META_DATA)
 
     res = index.query(vpdq_to_json(video3))
-    assert compare_match_result(res[0], VPDQIndexMatch(100, 90, 100, VIDEO4_META_DATA))
+    assert res[0] == IndexMatch(VPDQDistance(90.0, 100.0), VIDEO4_META_DATA)
 
 
 def test_match_below_and_above_80pct_index_threshold():
@@ -219,14 +216,14 @@ def test_match_below_and_above_80pct_index_threshold():
         index_match_threshold_pct=80,
     )
     res = index.query(vpdq_to_json(video4))
-    assert compare_match_result(res[0], VPDQIndexMatch(100, 100, 80, VIDEO2_META_DATA))
+    assert res[0] == IndexMatch(VPDQDistance(100.0, 80.0), VIDEO2_META_DATA)
 
     index = VPDQIndex.build(
         [[vpdq_to_json(video3), VIDEO3_META_DATA]],
         index_match_threshold_pct=80,
     )
     res = index.query(vpdq_to_json(video4))
-    assert compare_match_result(res[0], VPDQIndexMatch(100, 100, 90, VIDEO3_META_DATA))
+    assert res[0] == IndexMatch(VPDQDistance(100.0, 90.0), VIDEO3_META_DATA)
 
 
 def test_matches():
@@ -246,22 +243,22 @@ def test_matches():
     )
     index = VPDQIndex.build([[vpdq_to_json(video1), VIDEO1_META_DATA]])
     res = index.query(vpdq_to_json(video2))
-    assert compare_match_result(res[0], VPDQIndexMatch(90, 90, 90, VIDEO1_META_DATA))
+    assert res[0] == IndexMatch(VPDQDistance(90.0, 90.0), VIDEO1_META_DATA)
 
     index = VPDQIndex.build([[vpdq_to_json(video2), VIDEO2_META_DATA]])
     res = index.query(vpdq_to_json(video1))
-    assert compare_match_result(res[0], VPDQIndexMatch(90, 90, 90, VIDEO2_META_DATA))
+    assert res[0] == IndexMatch(VPDQDistance(90.0, 90.0), VIDEO2_META_DATA)
 
     del video1[-1]
     index = VPDQIndex.build([[vpdq_to_json(video1), VIDEO1_META_DATA]])
     res = index.query(vpdq_to_json(video2))
-    assert compare_match_result(res[0], VPDQIndexMatch(100, 90, 100, VIDEO1_META_DATA))
+    assert res[0] == IndexMatch(VPDQDistance(90.0, 100.0), VIDEO1_META_DATA)
 
     del video2[-1]
     index = VPDQIndex.build([[vpdq_to_json(video1), VIDEO1_META_DATA]])
     res = index.query(vpdq_to_json(video2))
 
-    assert compare_match_result(res[0], VPDQIndexMatch(100, 100, 100, VIDEO1_META_DATA))
+    assert res[0] == IndexMatch(VPDQDistance(100.0, 100.0), VIDEO1_META_DATA)
 
 
 def test_duplicate_matches():
@@ -275,7 +272,7 @@ def test_duplicate_matches():
 
     index = VPDQIndex.build([[vpdq_to_json(video1), VIDEO1_META_DATA]])
     res = index.query(vpdq_to_json(video2))
-    assert compare_match_result(res[0], VPDQIndexMatch(100, 100, 100, VIDEO1_META_DATA))
+    assert res[0] == IndexMatch(VPDQDistance(100.0, 100.0), VIDEO1_META_DATA)
 
 
 def test_duplicate_video_matches():
@@ -293,14 +290,5 @@ def test_duplicate_video_matches():
         ]
     )
     res = index.query(vpdq_to_json(video3))
-    assert compare_match_result(res[0], VPDQIndexMatch(100, 100, 100, VIDEO1_META_DATA))
-    assert compare_match_result(res[1], VPDQIndexMatch(100, 50, 100, VIDEO2_META_DATA))
-
-
-def compare_match_result(res1: VPDQIndexMatch, res2: VPDQIndexMatch) -> bool:
-    return (
-        res1.compared_match_percent == res2.compared_match_percent
-        and res1.query_match_percent == res2.query_match_percent
-        and res1.metadata == res2.metadata
-        and res1.similarity_info == res2.similarity_info
-    )
+    assert res[0] == IndexMatch(VPDQDistance(100.0, 100.0), VIDEO1_META_DATA)
+    assert res[1] == IndexMatch(VPDQDistance(50.0, 100.0), VIDEO2_META_DATA)

--- a/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
@@ -5,13 +5,15 @@ Wrapper around the vpdq signal type.
 """
 
 import vpdq
-from .vpdq_util import (
+from threatexchange.extensions.vpdq.vpdq_util import (
+    VPDQ_INDEX_MATCH_THRESHOLD_PERCENT,
     json_to_vpdq,
     vpdq_to_json,
     VPDQ_DISTANCE_THRESHOLD,
+    VPDQ_QUERY_MATCH_THRESHOLD_PERCENT,
     VPDQ_QUALITY_THRESHOLD,
 )
-from .vpdq_brute_matcher import match_VPDQ_hash_brute
+from threatexchange.extensions.vpdq.vpdq_brute_matcher import match_VPDQ_hash_brute
 import pathlib
 import typing as t
 from threatexchange.content_type.content_base import ContentType
@@ -19,7 +21,7 @@ from threatexchange.content_type.video import VideoContent
 import re
 from threatexchange.signal_type import signal_base
 from threatexchange.signal_type.pdq.signal import PdqSignal
-from threatexchange.extensions.vpdq.vpdq_index import VPDQIndex
+from threatexchange.extensions.vpdq.vpdq_index import VPDQDistance, VPDQIndex
 
 
 class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
@@ -44,9 +46,6 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
     }
     Read about VPDQ at https://github.com/facebook/ThreatExchange/tree/main/vpdq
     """
-
-    INDICATOR_TYPE = "HASH_VIDEO_VPDQ"
-    VPDQ_CONFIDENT_MATCH_THRESHOLD = 80.0
 
     @classmethod
     def get_content_types(cls) -> t.List[t.Type[ContentType]]:
@@ -83,9 +82,13 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
         return vpdq_to_json(vpdq_hashes)
 
     @classmethod
-    def compare_hash(cls, hash1: str, hash2: str) -> signal_base.SignalComparisonResult:
-        """If the max of the two match percentages is over VPDQ_CONFIDENT_MATCH_THRESHOLD
-        with VPDQ_DISTANCE_THRESHOLD, it's a match."""
+    def compare_hash(
+        cls,
+        hash1: str,
+        hash2: str,
+        query_match_pct_thresh: float = VPDQ_QUERY_MATCH_THRESHOLD_PERCENT,
+        compare_match_pct_thresh: float = VPDQ_INDEX_MATCH_THRESHOLD_PERCENT,
+    ) -> signal_base.SignalComparisonResult:
         vpdq_hash1 = json_to_vpdq(hash1)
         vpdq_hash2 = json_to_vpdq(hash2)
         match_percent = match_VPDQ_hash_brute(
@@ -94,12 +97,15 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
             VPDQ_QUALITY_THRESHOLD,
             VPDQ_DISTANCE_THRESHOLD,
         )
-        max_match_percent = max(
-            match_percent.query_match_percent, match_percent.compared_match_percent
+        return signal_base.SignalComparisonResult(
+            (
+                match_percent.query_match_percent >= query_match_pct_thresh
+                and match_percent.compared_match_percent >= compare_match_pct_thresh
+            ),
+            VPDQDistance(
+                match_percent.query_match_percent, match_percent.compared_match_percent
+            ),
         )
-        is_match = max_match_percent >= cls.VPDQ_CONFIDENT_MATCH_THRESHOLD
-        # TODO vPDQ distance type
-        return signal_base.SignalComparisonResult.from_bool_only(is_match)
 
     @staticmethod
     def get_examples() -> t.List[str]:

--- a/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/video_vpdq.py
@@ -21,7 +21,7 @@ from threatexchange.content_type.video import VideoContent
 import re
 from threatexchange.signal_type import signal_base
 from threatexchange.signal_type.pdq.signal import PdqSignal
-from threatexchange.extensions.vpdq.vpdq_index import VPDQDistance, VPDQIndex
+from threatexchange.extensions.vpdq.vpdq_index import VPDQSimilarityInfo, VPDQIndex
 
 
 class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
@@ -102,7 +102,7 @@ class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
                 match_percent.query_match_percent >= query_match_pct_thresh
                 and match_percent.compared_match_percent >= compare_match_pct_thresh
             ),
-            VPDQDistance(
+            VPDQSimilarityInfo(
                 match_percent.query_match_percent, match_percent.compared_match_percent
             ),
         )

--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
@@ -33,7 +33,7 @@ class VPDQDistance(SignalSimilarityInfo):
     compared_match_percent: float
 
     def pretty_str(self) -> str:
-        return f"{self.query_match_percent:.2f}%(vs-{self.compared_match_percent:.2f}%)"
+        return f"{self.query_match_percent:.0f}%[{self.compared_match_percent:.0f}%])"
 
 
 class VPDQIndex(SignalTypeIndex[IndexT]):

--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
@@ -28,7 +28,7 @@ Self = t.TypeVar("Self", bound="VPDQIndex")
 
 
 @dataclass
-class VPDQDistance(SignalSimilarityInfo):
+class VPDQSimilarityInfo(SignalSimilarityInfo):
     query_match_percent: float
     compared_match_percent: float
 
@@ -137,7 +137,9 @@ class VPDQIndex(SignalTypeIndex[IndexT]):
             ):
                 matches.append(
                     IndexMatch(
-                        VPDQDistance(query_matched_percent, index_matched_percent),
+                        VPDQSimilarityInfo(
+                            query_matched_percent, index_matched_percent
+                        ),
                         self._entry_idx_to_features_and_entires[entry_id][1],
                     )
                 )

--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
@@ -5,13 +5,14 @@ Implementation of SignalTypeIndex abstraction for VPDQ by wrapping
 vpdq_faiss.
 """
 
+from dataclasses import dataclass
 import typing as t
 import vpdq
 
 from threatexchange.signal_type.index import (
+    SignalSimilarityInfo,
     SignalTypeIndex,
     IndexMatch,
-    SignalSimilarityInfoWithIntDistance,
     T as IndexT,
 )
 from threatexchange.extensions.vpdq.vpdq_faiss import VPDQHashIndex
@@ -26,17 +27,13 @@ from threatexchange.extensions.vpdq.vpdq_util import (
 Self = t.TypeVar("Self", bound="VPDQIndex")
 
 
-class VPDQIndexMatch(IndexMatch[IndexT]):
-    def __init__(
-        self,
-        distance: int,
-        query_match_percent: float,
-        compared_match_percent: float,
-        metadata: IndexT,
-    ) -> None:
-        super().__init__(SignalSimilarityInfoWithIntDistance(distance), metadata)
-        self.query_match_percent = query_match_percent
-        self.compared_match_percent = compared_match_percent
+@dataclass
+class VPDQDistance(SignalSimilarityInfo):
+    query_match_percent: float
+    compared_match_percent: float
+
+    def pretty_str(self) -> str:
+        return f"{self.query_match_percent:.2f}%(vs-{self.compared_match_percent:.2f}%)"
 
 
 class VPDQIndex(SignalTypeIndex[IndexT]):
@@ -134,18 +131,13 @@ class VPDQIndex(SignalTypeIndex[IndexT]):
                 * 100
                 / len(self._entry_idx_to_features_and_entires[entry_id][0])
             )
-            # max_matched_percent is returned as dist(int) here for a temporal solution
-            # TODO: Make dist attribute internal detail in IndexMatch Class
-            max_matched_percent = int(max(query_matched_percent, index_matched_percent))
             if (
                 query_matched_percent >= self.query_match_threshold_pct
                 and index_matched_percent >= self.index_match_threshold_pct
             ):
                 matches.append(
-                    VPDQIndexMatch(
-                        max_matched_percent,
-                        query_matched_percent,
-                        index_matched_percent,
+                    IndexMatch(
+                        VPDQDistance(query_matched_percent, index_matched_percent),
                         self._entry_idx_to_features_and_entires[entry_id][1],
                     )
                 )

--- a/python-threatexchange/threatexchange/signal_type/index.py
+++ b/python-threatexchange/threatexchange/signal_type/index.py
@@ -62,9 +62,8 @@ class SignalSimilarityInfo:
         # Provide a default impl
         return self < other or self == other
 
-    # # Don't define __gt__ or __ge__ because of unexpected interactions with
-    # # functools.total_ordering
-
+    # Don't define __gt__ or __ge__ because of unexpected interactions with
+    # functools.total_ordering
     def pretty_str(self) -> str:
         """
         A short string without whitespace about a match with more context.
@@ -127,6 +126,14 @@ class IndexMatchUntyped(t.Generic[S_Co, T]):
     def __init__(self, similarity_info: S_Co, metadata: T) -> None:
         self.similarity_info = similarity_info
         self.metadata = metadata
+
+    def __eq__(self, other: t.Any) -> bool:
+        if isinstance(other, IndexMatchUntyped):
+            return (
+                self.similarity_info == other.similarity_info
+                and self.metadata == other.metadata
+            )
+        return super().__eq__(other)
 
 
 IndexMatch = IndexMatchUntyped[SignalSimilarityInfo, T]


### PR DESCRIPTION
Summary
---------

Adds a distance impl with the new interface.

```
$ tx match -S video_vpdq -H video ~/hash.txt 
video_vpdq 99%[62%] (Sample Signals) INVESTIGATION_SEED
```

Alternatives:
```
video_vpdq 99.27%(98.55%)
video_vpdq 99.27%(i:98.55%)
video_vpdq 99.27%(c:98.55%)
video_vpdq 99.27%(vs98.55%)
video_vpdq 99.27%(v.98.55%) 
video_vpdq 99.27%(vs.98.55%)
video_vpdq 99.27%(vs-98.55%)
video_vpdq 99.27%(vs_98.55%)
video_vpdq 99.27%(comp:98.55%)
video_vpdq 99.27%(index:98.55%)

# Less precision is probably easier to read
video_vpdq 99%(98%)
video_vpdq 99%(index:98%)
video_vpdq 99/98%
video_vpdq 99|98%
video_vpdq 99[98%]
video_vpdq 99v98%
video_vpdq 99x98%
video_vpdq 99%(banked:98%)
```

Test Plan
---------

You saw it live! Copy sample hash to file, manually edit it to change the distance.

mypy and py.test

With new ==, here's what unittest looks like when IndexMatch doesn't match:
```
E       assert <threatexchange.signal_type.index.IndexMatchUntyped object at 0x7f30cef4c790> == <threatexchange.signal_type.index.IndexMatchUntyped object at 0x7f30cef4c310>
E        +  where <threatexchange.signal_type.index.IndexMatchUntyped object at 0x7f30cef4c310> = IndexMatch(VPDQDistance(query_match_percent=50.1, compared_match_percent=100.0), <object object at 0x7f30cf4e8140>)
E        +    where VPDQDistance(query_match_percent=50.1, compared_match_percent=100.0) = VPDQDistance(50.1, 100.0)

threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py:294: AssertionError
```
