### PR TITLE
[pytx] Expose access to verbose from help

### DIFF
--- a/python-threatexchange/threatexchange/cli/fetch_cmd.py
+++ b/python-threatexchange/threatexchange/cli/fetch_cmd.py
@@ -30,6 +30,9 @@ class FetchCommand(command_base.Command):
 
     Some APIs require that you regularly re-fetch them within some number
     of days or else the stored data becomes invalid.
+
+    This command is laconic by default, try `threatexchange -v fetch` for
+    more granular details.
     """
 
     PROGRESS_PRINT_INTERVAL_SEC = 30


### PR DESCRIPTION
Summary
---------

Expose access to the verbose logging, which is especially useful during fetch.

Test Plan
---------

```
$ tx --help
usage: threatexchange [-h] [--factory-reset] [--verbose] {config,fetch,match,label,dataset,hash} ...

Wrapper for the `threatexchange` library, can serve as a simple e2e solution.

The flow the CLI is generally:
  1. Configure collaborations and APIs with (or skip to use fake sample data)
     $ threatexchange config collab edit
     $ threatexchange config api  # to set up credentials if needed
  2. Fetch data and build match indices
     $ threatexchange fetch
  3. Match data
     $ threatexchange match photo my_photo.jpg
  4. Contribute labels to external APIs
     $ threatexchange label photo my_photo.jpg dog 
     $ threatexchange label photo my_photo.jpg --false-positive

Additionally, there are a number of utility commands:
  * threatexchange dataset
  * threatexchange hash

See the --help of subcommands for more information.

State is persisted between runs, entirely in the ~/.threatexchange directory

optional arguments:
  -h, --help            show this help message and exit
  --factory-reset       Remove all state, bringing you back to a fresh install
  --verbose, -v         display logging output (repeat for more)

verbs:
  {config,fetch,match,label,dataset,hash}
                        which action to do
    config              configure the CLI
    fetch               download content from signal exchange APIs to disk
    match               match content to fetched signals
    label               [WIP] Label signals and content for sharing
    dataset             introspect fetched data
    hash                take content and convert it into signatures (aka hashes)
```

```
$ tx -v fetch
2022-08-05 18:46:45,097 I] Fetching all sample's configs
2022-08-05 18:46:45,098 I] Fetching all local_file's configs
2022-08-05 18:46:45,098 I] Fetching all stop_ncii's configs
2022-08-05 18:46:45,098 I] Fetching all ncmec's configs
2022-08-05 18:46:45,098 I] Fetching all fb_threatexchange's configs
2022-08-05 18:46:56,886 I] fetch() with 100 new records
[fb_threatexchange] Media Hash Sharing - Downloaded 100 updates at 2020-12-14T04:59:37
2022-08-05 18:47:10,057 I] fetch() with 200 new records
2022-08-05 18:47:11,732 I] fetch() with 300 new records
2022-08-05 18:47:26,137 I] fetch() with 400 new records
^C[fb_threatexchange] Test Collab - Interrupted, writing a checkpoint...

$ tx -v -v fetch
2022-08-05 18:47:33,421 D] Setup complete, handing off to FetchCommand
2022-08-05 18:47:33,422 I] Fetching all sample's configs
2022-08-05 18:47:33,422 I] Fetching all local_file's configs
2022-08-05 18:47:33,422 I] Fetching all stop_ncii's configs
2022-08-05 18:47:33,422 I] Fetching all ncmec's configs
2022-08-05 18:47:33,422 I] Fetching all fb_threatexchange's configs
2022-08-05 18:47:33,422 D] Loading state for Media Hash Sharing
2022-08-05 18:47:33,547 D] Loaded Test Collab with 28937 records
2022-08-05 18:47:33,551 D] Starting new HTTPS connection (1): graph.facebook.com:443
2022-08-05 18:47:34,439 D] https://graph.facebook.com:443 "GET /v9.0/xxx/threat_updates/?
```
