### PR TITLE
[pytx] dataset command signals_only => print_signals_only

### DIFF
--- a/python-threatexchange/threatexchange/cli/dataset_cmd.py
+++ b/python-threatexchange/threatexchange/cli/dataset_cmd.py
@@ -117,10 +117,10 @@ class DatasetCommand(command_base.Command):
         )
         csv_mutual_group = ap.add_mutually_exclusive_group()
         csv_mutual_group.add_argument(
-            "--signals-only",
+            "--print-signals-only",
             "-S",
             action="store_true",
-            help="[-P] only print signals",
+            help="[-P] only print signals, no metadata",
         )
         csv_mutual_group.add_argument(
             "--csv",
@@ -144,7 +144,7 @@ class DatasetCommand(command_base.Command):
         only_tags: t.Sequence[str] = (),
         # Print stuff
         print_zeroes: bool = False,
-        signals_only: bool = False,
+        print_signals_only: bool = False,
         csv: bool = False,
     ) -> None:
         self.clear_indices = clear_indices
@@ -160,7 +160,7 @@ class DatasetCommand(command_base.Command):
         self.only_tags = set(only_tags)
 
         self.print_zeroes = print_zeroes
-        self.signals_only = signals_only
+        self.print_signals_only = print_signals_only
         self.csv = csv
 
     def execute(self, settings: CLISettings) -> None:
@@ -255,7 +255,7 @@ class DatasetCommand(command_base.Command):
 
         for signal_type, per_signal in signals.items():
             for signal_str, collab_signals in per_signal.items():
-                if self.signals_only:
+                if self.print_signals_only:
                     print_fn("", signal_type, signal_str, None)
                     continue
                 for collab_name, metadata in collab_signals:
@@ -295,12 +295,12 @@ class DatasetCommand(command_base.Command):
         signal_str: str,
         metadata: t.Optional[FetchedSignalMetadata],
     ) -> None:
-        if not self.signals_only and len(self.only_collabs) != 1:
+        if not self.print_signals_only and len(self.only_collabs) != 1:
             print(repr(collab_name), end=" ")
         if len(self.only_signals) != 1:
             print(signal_type.get_name(), end=" ")
         print(signal_str, end="")
-        if not self.signals_only:
+        if not self.print_signals_only:
             print("", metadata, end="")
         print()
 

--- a/python-threatexchange/threatexchange/cli/dataset_cmd.py
+++ b/python-threatexchange/threatexchange/cli/dataset_cmd.py
@@ -120,7 +120,7 @@ class DatasetCommand(command_base.Command):
             "--print-signals-only",
             "-S",
             action="store_true",
-            help="[-P] only print signals, no metadata",
+            help="[-P] print type and signal only, no metadata",
         )
         csv_mutual_group.add_argument(
             "--csv",


### PR DESCRIPTION
Summary
---------

Flagged by @BarrettOlson , this one is a little confusing given we also have --only-signals

Test Plan
---------

```
x dataset --help
usage: threatexchange dataset [-h] [--rebuild-indices | --clear-indices | --signal-summary | --print-signals] [--only-signals SIGNAL_TYPE [SIGNAL_TYPE ...] | --only-content CONTENT_TYPE [CONTENT_TYPE ...]] [--print-zeroes] [--only-collabs NAME [NAME ...]] [--only-tags STR [STR ...]] [--print-signals-only | --csv]

    Introspect fetched data.

    Can print out contents in simple formats
    (ideal for sending to another system), or regenerate
    index files (ideal if distributing indices for some reason)

    Example commands:

    ```
    # Show total size of known signals
    $ threatexchange dataset

    # Show the size of one collaboration
    $ threatexchange dataset -c 'Sample Data'

    # Generate a simple CSV file for one collaboration for ease of distribution
    $ threatexchange dataset -c 'Sample Data' -P --csv > collab.csv
    ```
    

optional arguments:
  -h, --help            show this help message and exit
  --rebuild-indices, -r
                        rebuild indices from fetched data
  --clear-indices, -X   clear all indices
  --signal-summary      print summary in terms of signals (default action)
  --print-signals, -P   print signals to screen
  --only-signals SIGNAL_TYPE [SIGNAL_TYPE ...], -s SIGNAL_TYPE [SIGNAL_TYPE ...]
                        only use signals of this type
  --only-content CONTENT_TYPE [CONTENT_TYPE ...], -C CONTENT_TYPE [CONTENT_TYPE ...]
                        only use signals for these content types
  --print-zeroes, -z    [--signal-summary] print counts of 0
  --only-collabs NAME [NAME ...], -c NAME [NAME ...]
                        [-S|-P] only use items with this tag
  --only-tags STR [STR ...], -t STR [STR ...]
                        [-S|-P] only use items with these tags
  --print-signals-only, -S
                        [-P] print type and signal only, no metadata
  --csv                 [-P] print in csv format (including header)
```

```
$tx dataset -PS | head -n5
video_md5 ac4a04edab987b7...
video_md5 d886694dfddaf42f...
video_md5 635e06867ef5e33e8...
video_md5 f566a47207003fc74...
video_md5 796330e9f2529c901...
```
