### PR TITLE
[pytx][fb_threatexchange] fix fetch() impl re-using state

### DIFF
--- a/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
@@ -278,14 +278,11 @@ class FBThreatExchangeSignalExchangeAPI(
         )
         type_mapping = _make_indicator_type_mapping(supported_signal_types)
 
-        batch: t.List[ThreatUpdateJSON] = []
-        highest_time = 0
-        for fetch in cursor:
-            for update in fetch:
-                # TODO catch errors here
-                batch.append(update)
-                # Is supposed to be strictly increasing
-                highest_time = max(update.time, highest_time)
+        highest_time = start_time or 0
+        batch: t.List[ThreatUpdateJSON]
+        for batch in cursor:
+            assert batch, "empty update?"
+            highest_time = max(highest_time, max(update.time for update in batch))
 
             updates = {}
             for u in batch:


### PR DESCRIPTION
Summary
---------

Noticed stress testing fb_threatexchange, the numbers didn't match what I expected at all. Turns out we were using the same list for everything for some reason.

This doesn't have any affect on correctness, but does waste a lot of memory.

Test Plan
---------

Before:

```
$ TX_VERBOSE=1 tx fetch
2022-08-05 19:18:14,660 I] Fetching all sample's configs
2022-08-05 19:18:14,660 I] Fetching all local_file's configs
2022-08-05 19:18:14,660 I] Fetching all stop_ncii's configs
2022-08-05 19:18:14,660 I] Fetching all ncmec's configs
2022-08-05 19:18:14,660 I] Fetching all fb_threatexchange's configs
2022-08-05 19:18:17,683 I] fetch() with 100 new records
2022-08-05 19:18:19,258 I] fetch() with 200 new records
2022-08-05 19:18:20,765 I] fetch() with 300 new records
[fb_threatexchange] Collab - Downloaded 600 updates at 2020-12-14T05:00:07
2022-08-05 19:18:22,522 I] fetch() with 400 new records
2022-08-05 19:18:24,317 I] fetch() with 500 new records
2022-08-05 19:18:25,448 I] fetch() with 600 new records
2022-08-05 19:18:26,658 I] fetch() with 700 new records
2022-08-05 19:18:28,231 I] fetch() with 800 new records
2022-08-05 19:18:29,996 I] fetch() with 900 new records
2022-08-05 19:18:31,616 I] fetch() with 1000 new records
2022-08-05 19:18:33,074 I] fetch() with 1100 new records
2022-08-05 19:18:34,545 I] fetch() with 1200 new records
2022-08-05 19:18:36,031 I] fetch() with 1300 new records
2022-08-05 19:18:37,316 I] fetch() with 1400 new records
2022-08-05 19:18:39,167 I] fetch() with 1500 new records
2022-08-05 19:18:40,687 I] fetch() with 1600 new records
2022-08-05 19:18:41,938 I] fetch() with 1700 new records
2022-08-05 19:18:43,374 I] fetch() with 1800 new records
2022-08-05 19:18:44,682 I] fetch() with 1900 new records
2022-08-05 19:18:45,935 I] fetch() with 2000 new records
2022-08-05 19:18:47,363 I] fetch() with 2100 new records
2022-08-05 19:18:48,676 I] fetch() with 2200 new records
2022-08-05 19:18:50,050 I] fetch() with 2300 new records
2022-08-05 19:18:51,540 I] fetch() with 2400 new records
[fb_threatexchange] Collab - Downloaded 30000 updates at 2020-12-14T05:00:18
2022-08-05 19:18:52,531 I] fetch() with 2500 new records
```

After:
```
$ TX_VERBOSE=1 tx fetch
2022-08-05 19:14:13,799 I] Fetching all fb_threatexchange's configs
2022-08-05 19:14:15,323 I] fetch() with 100 new records
2022-08-05 19:14:16,647 I] fetch() with 100 new records
2022-08-05 19:14:17,984 I] fetch() with 100 new records
2022-08-05 19:14:19,547 I] fetch() with 100 new records
[fb_threatexchange] Collab - Downloaded 400 updates at 2020-12-14T04:59:40
2022-08-05 19:14:20,959 I] fetch() with 100 new records
2022-08-05 19:14:22,495 I] fetch() with 100 new records
2022-08-05 19:14:24,167 I] fetch() with 100 new records
2022-08-05 19:14:25,232 I] fetch() with 100 new records
2022-08-05 19:14:26,964 I] fetch() with 100 new records
2022-08-05 19:14:28,345 I] fetch() with 100 new records
2022-08-05 19:14:29,780 I] fetch() with 100 new records
2022-08-05 19:14:31,117 I] fetch() with 100 new records
2022-08-05 19:14:32,550 I] fetch() with 100 new records
2022-08-05 19:14:33,978 I] fetch() with 100 new records
2022-08-05 19:14:35,367 I] fetch() with 100 new records
2022-08-05 19:14:36,718 I] fetch() with 100 new records
2022-08-05 19:14:38,235 I] fetch() with 100 new records
2022-08-05 19:14:39,724 I] fetch() with 100 new records
2022-08-05 19:14:41,198 I] fetch() with 100 new records
2022-08-05 19:14:42,529 I] fetch() with 100 new records
2022-08-05 19:14:43,987 I] fetch() with 100 new records
2022-08-05 19:14:45,402 I] fetch() with 100 new records
2022-08-05 19:14:46,801 I] fetch() with 100 new records
2022-08-05 19:14:48,275 I] fetch() with 100 new records
2022-08-05 19:14:49,728 I] fetch() with 100 new records
[fb_threatexchange] Collab - Downloaded 2500 updates at 2020-12-14T04:59:49
2022-08-05 19:14:51,182 I] fetch() with 100 new records
```
