### PR TITLE
[pytx] Add collab config to convert to signal

### DIFF
--- a/python-threatexchange/threatexchange/cli/tests/fake_extension.py
+++ b/python-threatexchange/threatexchange/cli/tests/fake_extension.py
@@ -88,6 +88,7 @@ class FakeSignalExchange(
     def naive_convert_to_signal_type(
         cls,
         signal_types: t.Sequence[t.Type[SignalType]],
+        collab: FakeCollabConfig,
         fetched: t.Mapping[str, str],
     ) -> t.Dict[t.Type[SignalType], t.Dict[str, FetchedSignalMetadata]]:
         return {}

--- a/python-threatexchange/threatexchange/exchanges/helpers.py
+++ b/python-threatexchange/threatexchange/exchanges/helpers.py
@@ -137,7 +137,7 @@ class SimpleFetchedStateStore(fetch_state.FetchedStateStoreBase):
             state = self._get_state(collab)
             if not state.empty:
                 by_signal = state.api_cls.naive_convert_to_signal_type(
-                    [signal_type], state.delta.updates
+                    [signal_type], collab, state.delta.updates
                 ).get(signal_type, {})
                 if by_signal:
                     ret[collab.name] = by_signal

--- a/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
@@ -299,6 +299,7 @@ class FBThreatExchangeSignalExchangeAPI(
     def naive_convert_to_signal_type(
         cls,
         signal_types: t.Sequence[t.Type[SignalType]],
+        collab: FBThreatExchangeCollabConfig,
         fetched: t.Mapping[
             t.Tuple[str, str], t.Optional[FBThreatExchangeIndicatorRecord]
         ],

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -307,6 +307,7 @@ class NCMECSignalExchangeAPI(
     def naive_convert_to_signal_type(
         cls,
         signal_types: t.Sequence[t.Type[SignalType]],
+        collab: NCMECCollabConfig,
         fetched: t.Mapping[str, api.NCMECEntryUpdate],
     ) -> t.Dict[t.Type[SignalType], t.Dict[str, NCMECSignalMetadata]]:
         mapping: t.Mapping[

--- a/python-threatexchange/threatexchange/exchanges/impl/tests/test_ncmec.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/tests/test_ncmec.py
@@ -58,7 +58,7 @@ def test_fetch(exchange: NCMECSignalExchangeAPI, monkeypatch: pytest.MonkeyPatch
     }
 
     as_signals = NCMECSignalExchangeAPI.naive_convert_to_signal_type(
-        [VideoMD5Signal], total_updates
+        [VideoMD5Signal], collab, total_updates
     )[VideoMD5Signal]
     assert as_signals == {
         "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1": NCMECSignalMetadata({42: set()}),

--- a/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
@@ -148,6 +148,7 @@ class SignalExchangeAPI(
     def naive_convert_to_signal_type(
         cls,
         signal_types: t.Sequence[t.Type[SignalType]],
+        collab: TCollabConfig,
         fetched: t.Mapping[state.TUpdateRecordKey, state.TUpdateRecordValue],
     ) -> t.Dict[t.Type[SignalType], t.Dict[str, state.TFetchedSignalMetadata]]:
         """
@@ -261,6 +262,7 @@ class SignalExchangeAPIWithSimpleUpdates(
     def naive_convert_to_signal_type(
         cls,
         signal_types: t.Sequence[t.Type[SignalType]],
+        collab: TCollabConfig,
         fetched: t.Mapping[t.Tuple[str, str], t.Optional[state.TFetchedSignalMetadata]],
     ) -> t.Dict[t.Type[SignalType], t.Dict[str, state.TFetchedSignalMetadata]]:
         ret: t.Dict[t.Type[SignalType], t.Dict[str, state.TFetchedSignalMetadata]] = {}

--- a/python-threatexchange/threatexchange/exchanges/tests/test_state.py
+++ b/python-threatexchange/threatexchange/exchanges/tests/test_state.py
@@ -102,6 +102,7 @@ class FakePerOwnerOpinionAPI(
     def naive_convert_to_signal_type(
         cls,
         signal_types: t.Sequence[t.Type[SignalType]],
+        collab: CollaborationConfigBase,
         fetched: t.Mapping[int, t.Optional[FakeUpdateRecord]],
     ) -> t.Dict[t.Type[SignalType], t.Dict[str, FakeSignalMetadata]]:
         if VideoMD5Signal not in signal_types:
@@ -187,11 +188,11 @@ def test_test_impls() -> None:
     )
 
     assert FakePerOwnerOpinionAPI.naive_convert_to_signal_type(
-        [VideoMD5Signal], delta.updates
+        [VideoMD5Signal], config, delta.updates
     ) == {VideoMD5Signal: {md5: record}}
     assert (
         FakePerOwnerOpinionAPI.naive_convert_to_signal_type(
-            [RawTextSignal], delta.updates
+            [RawTextSignal], config, delta.updates
         )
         == {}
     )


### PR DESCRIPTION
Summary
---------

Adds the collab config to converting to signal type, which allows us to filter after the state has been fetched in places like the NCMEC API without worrying about the state being invalid.

To keep the diff small, only update the interface.

At this point, every single method of SignalExchangeAPI now takes collab. We may want to consider making it standard that one API instance = for one collab, which prevents from needing to pass it around everywhere. 

If we choose to do so, it's potentially right now, so need to sync with @schatten .

Test Plan
---------

mypy && py.test
