### PR TITLE
[pytx] tie SignalExchangeAPI  instantiation with collab + authentication 

### DIFF
--- a/python-threatexchange/threatexchange/cli/cli_config.py
+++ b/python-threatexchange/threatexchange/cli/cli_config.py
@@ -17,23 +17,20 @@ import logging
 
 from dacite import WrongTypeError
 
-from threatexchange.exchanges.clients.stopncii import api as stopncii_api
 from threatexchange.exchanges import collab_config
 from threatexchange.exchanges.impl.stop_ncii_api import StopNCIICredentials
 from threatexchange.exchanges.signal_exchange_api import (
     SignalExchangeAPI,
     TCollabConfig,
-    TSignalExchangeAPI,
     TSignalExchangeAPICls,
 )
 from threatexchange.content_type import content_base
-from threatexchange.exchanges.fetch_state import FetchedStateStoreBase
 from threatexchange.exchanges import fetch_state
 from threatexchange.exchanges.impl.static_sample import StaticSampleSignalExchangeAPI
 from threatexchange.signal_type import signal_base
 from threatexchange.interface_validation import FunctionalityMapping
 from threatexchange.cli.cli_state import CliSimpleState, CliIndexStore
-from threatexchange.utils import dataclass_json as cli_json
+from threatexchange.utils import dataclass_json
 
 
 CONFIG_FILENAME = "config.json"
@@ -104,12 +101,12 @@ class CliState(collab_config.CollaborationConfigStoreBase):
         return self.collab_dir / f"{config.name}.json"
 
     def get_persistent_config(self) -> CLiConfig:
-        return cli_json.dataclass_load_file(
+        return dataclass_json.dataclass_load_file(
             self.config_file, CLiConfig, default=CLiConfig()
         )
 
     def update_persistent_config(self, config: CLiConfig):
-        cli_json.dataclass_dump_file(self.config_file, config)
+        dataclass_json.dataclass_dump_file(self.config_file, config)
 
     def dir_for_fetched_state(
         self,
@@ -147,7 +144,7 @@ class CliState(collab_config.CollaborationConfigStoreBase):
                         logging.warning("Ignoring collab config of unknown type: %s", f)
                         continue
                 try:
-                    config = cli_json.dataclass_load_dict(content, ctype)
+                    config = dataclass_json.dataclass_load_dict(content, ctype)
                     ret.append(config)
                 except WrongTypeError:
                     logging.exception("Failed to parse collab config: %s", f)
@@ -158,7 +155,7 @@ class CliState(collab_config.CollaborationConfigStoreBase):
         """Create or update a collaboration"""
         assert collab.api, "didn't set API?"
         path = self.path_for_collab_config(collab)
-        cli_json.dataclass_dump_file(path, collab)
+        dataclass_json.dataclass_dump_file(path, collab)
 
     def delete_collab(self, collab: collab_config.CollaborationConfigBase) -> None:
         """Delete a collaboration"""

--- a/python-threatexchange/threatexchange/cli/config_cmd.py
+++ b/python-threatexchange/threatexchange/cli/config_cmd.py
@@ -582,7 +582,7 @@ class ConfigThreatExchangeAPICommand(command_base.Command):
         self.action(settings)
 
     def get_te_api(self) -> ThreatExchangeAPI:
-        creds = FBThreatExchangeCredentials.get()
+        creds = FBThreatExchangeCredentials.get(FBThreatExchangeSignalExchangeAPI)
         return ThreatExchangeAPI(creds.api_token)
 
     def execute_list_collabs(self, settings: CLISettings) -> None:

--- a/python-threatexchange/threatexchange/cli/config_cmd.py
+++ b/python-threatexchange/threatexchange/cli/config_cmd.py
@@ -15,8 +15,6 @@ import os
 import typing as t
 
 from threatexchange.exchanges.clients.fb_threatexchange.api import ThreatExchangeAPI
-
-
 from threatexchange.extensions.manifest import ThreatExchangeExtensionManifest
 from threatexchange import common, interface_validation
 from threatexchange.cli.cli_config import CLISettings
@@ -24,6 +22,7 @@ from threatexchange.cli import command_base
 from threatexchange.cli.exceptions import CommandError
 from threatexchange.exchanges.impl.fb_threatexchange_api import (
     FBThreatExchangeCollabConfig,
+    FBThreatExchangeCredentials,
     FBThreatExchangeSignalExchangeAPI,
 )
 from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
@@ -47,8 +46,7 @@ class ConfigCollabListCommand(command_base.Command):
 
     def execute(self, settings: CLISettings) -> None:
         for collab in settings.get_all_collabs(default_to_sample=False):
-            api = settings.apis.get_for_collab(collab)
-            print(api.get_name(), collab.name)
+            print(collab.api, collab.name)
 
 
 class ConfigCollabPrintCommand(command_base.Command):
@@ -304,12 +302,12 @@ class ConfigCollabForAPICommand(command_base.CommandWithSubcommands):
 
     @classmethod
     def _create_command_for_api(
-        cls, api: SignalExchangeAPI
+        cls, api: t.Type[SignalExchangeAPI]
     ) -> t.Type[command_base.Command]:
         """Don't try this at home!"""
 
         class _GeneratedUpdateCommand(_UpdateCollabCommand):
-            _API_CLS = api.__class__
+            _API_CLS = api
 
         _GeneratedUpdateCommand.__name__ = (
             f"{_GeneratedUpdateCommand.__name__}_{api.get_name()}"
@@ -428,16 +426,7 @@ class ConfigExtensionsCommand(command_base.Command):
         )
 
         # For APIs, we also need to make sure they can be instanciated without args for the CLI
-        apis = []
-        for new_api in manifest.apis:
-            try:
-                instance = new_api()
-            except Exception as e:
-                logging.exception(f"Failed to instanciante API {new_api.get_name()}")
-                raise CommandError(
-                    f"Not able to instanciate API {new_api.get_name()} - throws {e}"
-                )
-            apis.append(instance)
+        apis = list(manifest.apis)
         apis.extend(settings.apis.get_all())
         interface_validation.SignalExchangeAPIMapping(apis)
 
@@ -592,20 +581,12 @@ class ConfigThreatExchangeAPICommand(command_base.Command):
     def execute(self, settings: CLISettings) -> None:
         self.action(settings)
 
-    def get_te_api(self, settings: CLISettings) -> ThreatExchangeAPI:
-        te = next(
-            (
-                api
-                for api in settings.apis
-                if isinstance(api, FBThreatExchangeSignalExchangeAPI)
-            ),
-            None,
-        )
-        assert te is not None
-        return te.api
+    def get_te_api(self) -> ThreatExchangeAPI:
+        creds = FBThreatExchangeCredentials.get()
+        return ThreatExchangeAPI(creds.api_token)
 
     def execute_list_collabs(self, settings: CLISettings) -> None:
-        api = self.get_te_api(settings)
+        api = self.get_te_api()
 
         unique_privacy_groups = {
             pg.id: pg for pg in api.get_threat_privacy_groups_member()
@@ -625,7 +606,7 @@ class ConfigThreatExchangeAPICommand(command_base.Command):
             print(line)
 
     def execute_import(self, settings: CLISettings, privacy_group_id: int) -> None:
-        api = self.get_te_api(settings)
+        api = self.get_te_api()
         pg = api.get_privacy_group(privacy_group_id)
         if settings.get_collab(pg.name) is not None:
             raise CommandError(

--- a/python-threatexchange/threatexchange/cli/config_cmd.py
+++ b/python-threatexchange/threatexchange/cli/config_cmd.py
@@ -425,7 +425,6 @@ class ConfigExtensionsCommand(command_base.Command):
             ),
         )
 
-        # For APIs, we also need to make sure they can be instanciated without args for the CLI
         apis = list(manifest.apis)
         apis.extend(settings.apis.get_all())
         interface_validation.SignalExchangeAPIMapping(apis)

--- a/python-threatexchange/threatexchange/cli/label_cmd.py
+++ b/python-threatexchange/threatexchange/cli/label_cmd.py
@@ -125,7 +125,7 @@ class LabelCommand(command_base.Command):
     def execute(self, settings: CLISettings) -> None:
         self.stderr("This command is not implemented yet, and most actions won't work")
 
-        api = settings.apis.get_for_collab(self.collab)
+        api = settings.apis.get_instance_for_collab(self.collab)
         # signal_types = self.only_signals or settings.get_signal_types_for_content(
         #     self.content_type
         # )
@@ -135,7 +135,6 @@ class LabelCommand(command_base.Command):
                 signal_type = self.as_hash
                 hash_val = signal_type.validate_signal_str(f.read_text())
                 api.report_opinion(
-                    self.collab,
                     signal_type,
                     hash_val,
                     SignalOpinion(

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -25,6 +25,7 @@ State is persisted between runs, entirely in the ~/.threatexchange directory
 """
 
 import argparse
+from contextlib import contextmanager
 import logging
 import inspect
 import os
@@ -34,6 +35,9 @@ import pathlib
 import shutil
 import warnings
 
+from threatexchange.cli.exceptions import CommandError
+
+
 # Import pdq first with its hash order warning squelched, it's before our time
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
@@ -42,18 +46,30 @@ with warnings.catch_warnings():
 from threatexchange import interface_validation
 from threatexchange.content_type.content_base import ContentType
 from threatexchange.extensions.manifest import ThreatExchangeExtensionManifest
+from threatexchange.exchanges.clients.stopncii import api as stopncii_api
 from threatexchange.exchanges.clients.fb_threatexchange import api as tx_api
 from threatexchange.exchanges.clients.ncmec import hash_api as ncmec_api
 from threatexchange.exchanges.impl.file_api import LocalFileSignalExchangeAPI
 from threatexchange.exchanges.impl.static_sample import StaticSampleSignalExchangeAPI
 from threatexchange.exchanges.impl.fb_threatexchange_api import (
+    FBThreatExchangeCredentials,
     FBThreatExchangeSignalExchangeAPI,
 )
-from threatexchange.exchanges.impl.stop_ncii_api import StopNCIISignalExchangeAPI
-from threatexchange.exchanges.impl.ncmec_api import NCMECSignalExchangeAPI
+from threatexchange.exchanges.impl.stop_ncii_api import (
+    StopNCIICredentials,
+    StopNCIISignalExchangeAPI,
+)
+from threatexchange.exchanges.impl.ncmec_api import (
+    NCMECCredentials,
+    NCMECSignalExchangeAPI,
+)
 
 from threatexchange.content_type import photo, video, text, url
-from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
+from threatexchange.exchanges.signal_exchange_api import (
+    SignalExchangeAPI,
+    SignalExchangeAPIInvalidAuthException,
+    SignalExchangeAPIMissingAuthException,
+)
 from threatexchange.signal_type import (
     md5,
     raw_text,
@@ -61,7 +77,7 @@ from threatexchange.signal_type import (
     url_md5,
     trend_query,
 )
-from threatexchange.cli.cli_config import CLiConfig, CliState, StopNCIIKeys
+from threatexchange.cli.cli_config import CLiConfig, CliState
 from threatexchange.cli.cli_config import CLISettings
 from threatexchange.cli import (
     command_base as base,
@@ -124,7 +140,7 @@ def get_argparse(settings: CLISettings) -> argparse.ArgumentParser:
 
 def execute_command(settings: CLISettings, namespace) -> None:
     assert hasattr(namespace, "command_cls")
-    command_cls = namespace.command_cls
+    command_cls: t.Type[base.Command] = namespace.command_cls
     logging.debug("Setup complete, handing off to %s", command_cls.__name__)
     # Init everything
     command_argspec = inspect.getfullargspec(command_cls.__init__)
@@ -134,133 +150,47 @@ def execute_command(settings: CLISettings, namespace) -> None:
     if "full_argparse_namespace" in arg_names:
         command_args["full_argparse_namespace"] = namespace
 
-    command = command_cls(**command_args)
+    command = command_cls(**command_args)  # type: ignore[call-arg]
     command.execute(settings)
 
 
-def _get_fb_tx_app_token(config: CLiConfig) -> t.Optional[str]:
-    """
-    Get the API key from a variety of fallback sources
+@contextmanager
+def _handle_api_creds(config: CLiConfig) -> t.Iterator[None]:
+    te_creds = None
+    ncmec_creds = None
+    stop_ncii_creds = config.stop_ncii_keys
 
-    Examples might be environment, files, etc
-    """
+    def cfg_cmd(src_api: t.Type[SignalExchangeAPI], flags: str) -> str:
+        return f"threatexchange config api {src_api.get_name()} {flags}"
 
-    file_loc = pathlib.Path("~/.txtoken").expanduser()
-    environment_var = "TX_ACCESS_TOKEN"
+    if config.fb_threatexchange_api_token:
+        te_creds = FBThreatExchangeCredentials(config.fb_threatexchange_api_token)
+    if config.ncmec_credentials:
+        ncmec_creds = NCMECCredentials(*config.ncmec_credentials)
 
-    potential_sources = (
-        (os.environ.get(environment_var), f"{environment_var} environment variable"),
-        (
-            config.fb_threatexchange_api_token,
-            "`config api fb_threat_exchange --api-token` command",
-        ),
-        (file_loc.exists() and file_loc.read_text(), f"{file_loc} file"),
-    )
-
-    for val, source in potential_sources:
-        if not val:
-            continue
-        val = val.strip()
-        if tx_api.is_valid_app_token(val):
-            return val
-        print(
-            (
-                f"Warning! Your current app token {val!r} (from {source}) is invalid.\n"
-                "Double check that it's an 'App Token' from "
-                "https://developers.facebook.com/tools/accesstoken/",
-            ),
-            file=sys.stderr,
-        )
-        # Don't throw because we don't want to block commands that fix this
-        return None  # We probably don't expect to fall back here
-    return None
-
-
-def _get_stopncii_tokens(
-    config: CLiConfig,
-) -> t.Tuple[t.Optional[str], t.Optional[str]]:
-    """
-    Get the API key from a variety of fallback sources
-
-    Examples might be environment, files, etc
-    """
-
-    environment_var = "TX_STOPNCII_KEYS"
-
-    def get_from_environ() -> t.Optional[StopNCIIKeys]:
-        val = os.environ.get(environment_var)
-        if val is None:
-            return None
-        subscription_key, _, fetch_key = val.partition(",")
-        return StopNCIIKeys(subscription_key, fetch_key)
-
-    potential_sources = (
-        (get_from_environ(), f"{environment_var} environment variable"),
-        (
-            config.stop_ncii_keys,
-            "`config api stop_ncii --api-keys` command",
-        ),
-    )
-
-    for val, source in potential_sources:
-        if not val:
-            continue
-        val.subscription_key = val.subscription_key.strip()
-        val.fetch_function_key = val.fetch_function_key.strip()
-
-        if val.keys_are_valid:
-            return val.subscription_key, val.fetch_function_key
-        print(
-            "Warning! Your current StopNCII.org keys "
-            f"{val!r} (from {source}) are invalid.",
-            file=sys.stderr,
-        )
-        # Don't throw because we don't want to block commands that fix this
-        return None, None  # We probably don't expect to fall back here
-    return None, None
-
-
-def _get_ncmec_credentials(config: CLiConfig) -> t.Tuple[str, str]:
-    """Get user+pass from NCMEC from the config"""
-    environment_var = "TX_NCMEC_CREDENTIALS"
-    not_found = "", ""
-
-    def get_from_environ() -> t.Optional[t.Tuple[str, str]]:
-        val = os.environ.get(environment_var)
-        if val is None:
-            return None
-        user, _, password = val.partition(",")
-        return user, password
-
-    potential_sources = (
-        (get_from_environ(), f"{environment_var} environment variable"),
-        (
-            config.ncmec_credentials,
-            "`config api ncmec --user --pass` command",
-        ),
-    )
-
-    for val, source in potential_sources:
-        if not val:
-            continue
-        user, password = val
-
-        if ncmec_api.is_valid_user_pass(user, password):
-            return user, password
-        print(
-            "Warning! Your current NCMEC credentials "
-            f"user={user!r} pass={password!r} (from {source}) are invalid.",
-            file=sys.stderr,
-        )
-        # Don't throw because we don't want to block commands that fix this
-        return not_found  # We probably don't expect to fall back here
-    return not_found
+    with FBThreatExchangeCredentials.set_default(
+        te_creds, cfg_cmd(FBThreatExchangeCredentials.API_CLS, "--api-token")
+    ), NCMECCredentials.set_default(
+        ncmec_creds, cfg_cmd(NCMECCredentials.API_CLS, "--user --pass")
+    ), StopNCIICredentials.set_default(
+        stop_ncii_creds, cfg_cmd(StopNCIICredentials.API_CLS, "<TBD>")  # TODO
+    ):
+        try:
+            yield
+        except SignalExchangeAPIInvalidAuthException as ia:
+            logging.exception("Original invalid auth error")
+            raise CommandError.user(
+                f"Invalid auth for {ia.src_api.get_name()}: {ia.message}"
+            ) from ia
+        except SignalExchangeAPIMissingAuthException as ma:
+            logging.exception("Original missing auth error")
+            raise CommandError.user(ma.pretty_str()) from ma
 
 
 class _ExtendedTypes(t.NamedTuple):
     content_types: t.List[t.Type[ContentType]]
     signal_types: t.List[t.Type[SignalType]]
-    api_instances: t.List[SignalExchangeAPI]
+    api_instances: t.List[t.Type[SignalExchangeAPI]]
     load_failures: t.List[str]
 
     def assert_no_errors(self) -> None:
@@ -286,7 +216,7 @@ def _get_extended_functionality(config: CLiConfig) -> _ExtendedTypes:
         else:
             ret.signal_types.extend(manifest.signal_types)
             ret.content_types.extend(manifest.content_types)
-            ret.api_instances.extend(api() for api in manifest.apis)
+            ret.api_instances.extend(manifest.apis)
     return ret
 
 
@@ -304,12 +234,12 @@ def _get_settings(
         + extensions.content_types,
         list(_DEFAULT_SIGNAL_TYPES) + extensions.signal_types,
     )
-    base_apis: t.List[SignalExchangeAPI] = [
-        StaticSampleSignalExchangeAPI(),
-        LocalFileSignalExchangeAPI(),
-        StopNCIISignalExchangeAPI(*_get_stopncii_tokens(config)),
-        NCMECSignalExchangeAPI(*_get_ncmec_credentials(config)),
-        FBThreatExchangeSignalExchangeAPI(_get_fb_tx_app_token(config)),
+    base_apis: t.List[t.Type[SignalExchangeAPI]] = [
+        StaticSampleSignalExchangeAPI,
+        LocalFileSignalExchangeAPI,
+        StopNCIISignalExchangeAPI,
+        NCMECSignalExchangeAPI,
+        FBThreatExchangeSignalExchangeAPI,
     ]
     apis = interface_validation.SignalExchangeAPIMapping(
         base_apis + extensions.api_instances
@@ -360,7 +290,8 @@ def inner_main(
     if not namespace.toplevel_command_name:
         ap.print_help()
         return
-    execute_command(settings, namespace)
+    with _handle_api_creds(settings.get_persistent_config()):
+        execute_command(settings, namespace)
 
 
 def main():

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -169,11 +169,11 @@ def _handle_api_creds(config: CLiConfig) -> t.Iterator[None]:
         ncmec_creds = NCMECCredentials(*config.ncmec_credentials)
 
     with FBThreatExchangeCredentials.set_default(
-        te_creds, cfg_cmd(FBThreatExchangeCredentials.API_CLS, "--api-token")
+        te_creds, cfg_cmd(FBThreatExchangeSignalExchangeAPI, "--api-token")
     ), NCMECCredentials.set_default(
-        ncmec_creds, cfg_cmd(NCMECCredentials.API_CLS, "--user --pass")
+        ncmec_creds, cfg_cmd(NCMECSignalExchangeAPI, "--user --pass")
     ), StopNCIICredentials.set_default(
-        stop_ncii_creds, cfg_cmd(StopNCIICredentials.API_CLS, "<TBD>")  # TODO
+        stop_ncii_creds, cfg_cmd(StopNCIISignalExchangeAPI, "<TBD>")  # TODO
     ):
         try:
             yield
@@ -190,7 +190,7 @@ def _handle_api_creds(config: CLiConfig) -> t.Iterator[None]:
 class _ExtendedTypes(t.NamedTuple):
     content_types: t.List[t.Type[ContentType]]
     signal_types: t.List[t.Type[SignalType]]
-    api_instances: t.List[t.Type[SignalExchangeAPI]]
+    api_types: t.List[t.Type[SignalExchangeAPI]]
     load_failures: t.List[str]
 
     def assert_no_errors(self) -> None:
@@ -216,7 +216,7 @@ def _get_extended_functionality(config: CLiConfig) -> _ExtendedTypes:
         else:
             ret.signal_types.extend(manifest.signal_types)
             ret.content_types.extend(manifest.content_types)
-            ret.api_instances.extend(manifest.apis)
+            ret.api_types.extend(manifest.apis)
     return ret
 
 
@@ -242,7 +242,7 @@ def _get_settings(
         FBThreatExchangeSignalExchangeAPI,
     ]
     apis = interface_validation.SignalExchangeAPIMapping(
-        base_apis + extensions.api_instances
+        base_apis + extensions.api_types
     )
     state = CliState(list(apis.api_by_name.values()), dir=dir)
 

--- a/python-threatexchange/threatexchange/cli/tests/fake_extension.py
+++ b/python-threatexchange/threatexchange/cli/tests/fake_extension.py
@@ -96,7 +96,6 @@ class FakeSignalExchange(
     def fetch_iter(
         self,
         supported_signal_types: t.Sequence[t.Type[SignalType]],
-        collab: FakeCollabConfig,
         # None if fetching for the first time,
         # otherwise the previous FetchDelta returned
         checkpoint: t.Optional[FetchCheckpointBase],

--- a/python-threatexchange/threatexchange/exchanges/clients/fb_threatexchange/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/fb_threatexchange/api.py
@@ -113,7 +113,10 @@ class ThreatExchangeAPI:
     }
 
     def __init__(
-        self, api_token: str, *, endpoint_override: t.Optional[str] = None
+        self,
+        api_token: str,
+        *,
+        endpoint_override: t.Optional[str] = None,
     ) -> None:
         self.api_token = api_token
         self._base_url = endpoint_override or self._TE_BASE_URL

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
@@ -255,7 +255,7 @@ class NCMECHashAPI:
         self.password = password
         self._base_url = environment.value
 
-    def _get_session(self, endpoint: NCMECEndpoint) -> requests.Session:
+    def _get_session(self) -> requests.Session:
         """
         Custom requests sesson
 
@@ -295,7 +295,7 @@ class NCMECHashAPI:
             url = self._base_url + next_
             params = {}
 
-        with self._get_session(endpoint) as session:
+        with self._get_session() as session:
             response = session.get(url, params=params)
         # Gate this log just in case decode() blows up
         if logging.getLogger().isEnabledFor(logging.DEBUG):
@@ -317,7 +317,7 @@ class NCMECHashAPI:
         """
 
         url = "/".join((self._base_url, endpoint.value))
-        with self._get_session(endpoint) as session:
+        with self._get_session() as session:
             response = session.post(url, data=data)
             response.raise_for_status()
             return response

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
@@ -176,7 +176,7 @@ def api(monkeypatch: pytest.MonkeyPatch):
         __enter__=lambda _: session,
         __exit__=lambda *args: None,
     )
-    monkeypatch.setattr(api, "_get_session", lambda e: session)
+    monkeypatch.setattr(api, "_get_session", lambda: session)
     return api
 
 

--- a/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
@@ -324,6 +324,6 @@ class StopNCIIAPI:
 
 def is_valid_key(key: str) -> bool:
     """
-    Returns true if the string looks like a valid access token
+    Returns true if the string looks like a valid stopncii key
     """
     return bool(key)  # TODO

--- a/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
@@ -9,7 +9,6 @@ https://developers.facebook.com/docs/threat-exchange/reference/apis/
 
 
 from collections import defaultdict
-import logging
 import typing as t
 import time
 from dataclasses import dataclass, field
@@ -17,10 +16,14 @@ from threatexchange.exchanges.clients.fb_threatexchange.threat_updates import (
     ThreatUpdateJSON,
 )
 
-from threatexchange.exchanges.clients.fb_threatexchange.api import ThreatExchangeAPI
+from threatexchange.exchanges.clients.fb_threatexchange.api import (
+    ThreatExchangeAPI,
+    is_valid_app_token,
+)
 
 from threatexchange.exchanges import fetch_state as state
 from threatexchange.exchanges.signal_exchange_api import (
+    CredentialHelper,
     SignalExchangeAPIWithSimpleUpdates,
 )
 from threatexchange.exchanges.collab_config import CollaborationConfigWithDefaults
@@ -231,16 +234,19 @@ class FBThreatExchangeSignalExchangeAPI(
         FBThreatExchangeIndicatorRecord,
     ]
 ):
-    def __init__(self, fb_app_token: t.Optional[str] = None) -> None:
-        self._api = None
-        if fb_app_token is not None:
-            self._api = ThreatExchangeAPI(fb_app_token)
+    def __init__(
+        self, client: ThreatExchangeAPI, collab: FBThreatExchangeCollabConfig
+    ) -> None:
+        self.client = client
+        self.collab = collab
 
-    @property
-    def api(self) -> ThreatExchangeAPI:
-        if self._api is None:
-            raise Exception("App Developer token not configured.")
-        return self._api
+    @classmethod
+    def for_collab(
+        cls, collab: FBThreatExchangeCollabConfig
+    ) -> "FBThreatExchangeSignalExchangeAPI":
+        creds = FBThreatExchangeCredentials.get()
+        client = ThreatExchangeAPI(creds.api_token)
+        return FBThreatExchangeSignalExchangeAPI(client, collab)
 
     @classmethod
     def get_name(cls) -> str:
@@ -258,24 +264,16 @@ class FBThreatExchangeSignalExchangeAPI(
     def get_config_class(cls) -> t.Type[FBThreatExchangeCollabConfig]:
         return FBThreatExchangeCollabConfig
 
-    def resolve_owner(self, id: int) -> str:
-        # TODO -This is supported by the API
-        raise NotImplementedError
-
-    def get_own_owner_id(self, collab: FBThreatExchangeCollabConfig) -> int:
-        return self.api.app_id
-
     def fetch_iter(
         self,
         supported_signal_types: t.Sequence[t.Type[SignalType]],
-        collab: FBThreatExchangeCollabConfig,
         # None if fetching for the first time,
         # otherwise the previous FetchDelta returned
         checkpoint: t.Optional[FBThreatExchangeCheckpoint],
     ) -> t.Iterator[ThreatExchangeDelta]:
         start_time = None if checkpoint is None else checkpoint.update_time
-        cursor = self.api.get_threat_updates(
-            collab.privacy_group,
+        cursor = self.client.get_threat_updates(
+            self.collab.privacy_group,
             start_time=start_time,
             page_size=100,
             fields=ThreatUpdateJSON.te_threat_updates_fields(),
@@ -292,7 +290,7 @@ class FBThreatExchangeSignalExchangeAPI(
             updates = {}
             for u in batch:
                 updates[u.threat_type, u.indicator] = _indicator_applies(
-                    self.api.app_id, u, type_mapping
+                    self.client.app_id, u, type_mapping
                 )
 
             yield ThreatExchangeDelta(
@@ -448,3 +446,21 @@ def _make_indicator_type_mapping(
             ret[type_][tag].append(st)
 
     return ret
+
+
+@dataclass
+class FBThreatExchangeCredentials(CredentialHelper):
+    API_CLS: t.ClassVar[
+        t.Type[FBThreatExchangeSignalExchangeAPI]
+    ] = FBThreatExchangeSignalExchangeAPI
+    ENV_VARIABLE: t.ClassVar[str] = "TX_ACCESS_TOKEN"
+    FILE_NAME: t.ClassVar[str] = "~/.txtoken"
+
+    api_token: str
+
+    @classmethod
+    def _from_str(cls, s: str) -> t.Optional["FBThreatExchangeCredentials"]:
+        return cls(s.strip())
+
+    def _are_valid(self) -> bool:
+        return is_valid_app_token(self.api_token)

--- a/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
@@ -242,11 +242,13 @@ class FBThreatExchangeSignalExchangeAPI(
 
     @classmethod
     def for_collab(
-        cls, collab: FBThreatExchangeCollabConfig
+        cls,
+        collab: FBThreatExchangeCollabConfig,
+        credentials: t.Optional["FBThreatExchangeCredentials"] = None,
     ) -> "FBThreatExchangeSignalExchangeAPI":
-        creds = FBThreatExchangeCredentials.get()
-        client = ThreatExchangeAPI(creds.api_token)
-        return FBThreatExchangeSignalExchangeAPI(client, collab)
+        credentials = credentials or FBThreatExchangeCredentials.get(cls)
+        client = ThreatExchangeAPI(credentials.api_token)
+        return cls(client, collab)
 
     @classmethod
     def get_name(cls) -> str:

--- a/python-threatexchange/threatexchange/exchanges/impl/file_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/file_api.py
@@ -69,7 +69,7 @@ class LocalFileSignalExchangeAPI(
     def for_collab(
         cls, collab: FileCollaborationConfig
     ) -> "LocalFileSignalExchangeAPI":
-        return LocalFileSignalExchangeAPI(collab)
+        return cls(collab)
 
     def fetch_iter(
         self,

--- a/python-threatexchange/threatexchange/exchanges/impl/file_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/file_api.py
@@ -47,6 +47,7 @@ class FileCollaborationConfig(
     )
 
 
+@dataclass
 class LocalFileSignalExchangeAPI(
     SignalExchangeAPIWithSimpleUpdates[
         FileCollaborationConfig,
@@ -58,20 +59,25 @@ class LocalFileSignalExchangeAPI(
     Read simple signal files off the local disk.
     """
 
+    collab: FileCollaborationConfig
+
     @classmethod
     def get_config_class(cls) -> t.Type[FileCollaborationConfig]:
         return FileCollaborationConfig
 
+    @classmethod
+    def for_collab(
+        cls, collab: FileCollaborationConfig
+    ) -> "LocalFileSignalExchangeAPI":
+        return LocalFileSignalExchangeAPI(collab)
+
     def fetch_iter(
         self,
         _supported_signal_types: t.Sequence[t.Type[SignalType]],
-        collab: FileCollaborationConfig,
-        # None if fetching for the first time,
-        # otherwise the previous FetchDelta returned
         checkpoint: t.Optional[state.TFetchCheckpoint],
     ) -> t.Iterator[_TypedDelta]:
         """Fetch the whole file"""
-        path = Path(collab.filename)
+        path = Path(self.collab.filename)
         assert path.exists(), f"No such file {path}"
         assert path.is_file(), f"{path} is not a file (is it a dir?)"
 
@@ -81,7 +87,7 @@ class LocalFileSignalExchangeAPI(
 
         updates: t.Dict[t.Tuple[str, str], t.Optional[state.FetchedSignalMetadata]] = {}
         for line in lines:
-            signal_type = collab.signal_type
+            signal_type = self.collab.signal_type
             signal = line.strip()
             if signal_type is None:
                 signal_type, _, signal = signal.partition(" ")
@@ -92,7 +98,6 @@ class LocalFileSignalExchangeAPI(
 
     def report_opinion(
         self,
-        collab: FileCollaborationConfig,
         s_type: t.Type[SignalType],
         signal: str,
         opinion: state.SignalOpinion,
@@ -101,7 +106,7 @@ class LocalFileSignalExchangeAPI(
             raise NotImplementedError
         if opinion.tags:
             raise NotImplementedError
-        path = Path(collab.filename)
+        path = Path(self.collab.filename)
         with path.open("rb") as rf:
             rf.seek(-1, os.SEEK_END)
             has_newline = rf.read1(1) == b"\n"  # type: ignore  # mypy bug? read1 noexist

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -153,9 +153,13 @@ class NCMECSignalExchangeAPI(
         self._password = password
 
     @classmethod
-    def for_collab(cls, collab: NCMECCollabConfig) -> "NCMECSignalExchangeAPI":
-        creds = NCMECCredentials.get()
-        return NCMECSignalExchangeAPI(collab, creds.user, creds.password)
+    def for_collab(
+        cls,
+        collab: NCMECCollabConfig,
+        credentials: t.Optional["NCMECCredentials"] = None,
+    ) -> "NCMECSignalExchangeAPI":
+        credentials = credentials or NCMECCredentials.get(cls)
+        return cls(collab, credentials.user, credentials.password)
 
     @classmethod
     def get_name(cls) -> str:

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -138,17 +138,24 @@ class NCMECSignalExchangeAPI(
         3. As of 5/2022 there are no false positive or seen statuses
     """
 
-    MAX_FETCH_SIZE = 400000
-    FETCH_SHRINK_FACTOR = 4
+    MAX_FETCH_SIZE: t.ClassVar[int] = 400000
+    FETCH_SHRINK_FACTOR: t.ClassVar[int] = 4
 
     def __init__(
         self,
-        username: str = "",
-        password: str = "",
+        collab: NCMECCollabConfig,
+        username: str,
+        password: str,
     ) -> None:
         super().__init__()
+        self.collab = collab
         self._username = username
         self._password = password
+
+    @classmethod
+    def for_collab(cls, collab: NCMECCollabConfig) -> "NCMECSignalExchangeAPI":
+        creds = NCMECCredentials.get()
+        return NCMECSignalExchangeAPI(collab, creds.user, creds.password)
 
     @classmethod
     def get_name(cls) -> str:
@@ -174,7 +181,6 @@ class NCMECSignalExchangeAPI(
     def fetch_iter(
         self,
         _supported_signal_types: t.Sequence[t.Type[SignalType]],
-        collab: NCMECCollabConfig,
         checkpoint: t.Optional[NCMECCheckpoint],
     ) -> t.Iterator[state.FetchDelta[str, api.NCMECEntryUpdate, NCMECCheckpoint]]:
         """
@@ -205,7 +211,7 @@ class NCMECSignalExchangeAPI(
         # times in the fetch, since entries are not ordered by time
         end_time = int(time.time()) - 5
 
-        client = self.get_client(collab.environment)
+        client = self.get_client(self.collab.environment)
         # We could probably mutate start time, but new variable for clarity
         current_start = start_time
         # The range we are fetching
@@ -338,3 +344,21 @@ class NCMECSignalExchangeAPI(
                     if entry.classification:
                         tags.add(entry.classification)
         return ret
+
+
+@dataclass
+class NCMECCredentials(signal_exchange_api.CredentialHelper):
+    API_CLS: t.ClassVar[t.Type[NCMECSignalExchangeAPI]] = NCMECSignalExchangeAPI
+    ENV_VARIABLE: t.ClassVar[str] = "TX_NCMEC_CREDENTIALS"
+    FILE_NAME: t.ClassVar[str] = "~/.tx_ncmec_credentials"
+
+    user: str
+    password: str
+
+    @classmethod
+    def _from_str(cls, s: str) -> "NCMECCredentials":
+        user, _, passw = s.strip().partition(":")
+        return cls(user, passw)
+
+    def _are_valid(self) -> bool:
+        return bool(self.user and self.password)

--- a/python-threatexchange/threatexchange/exchanges/impl/static_sample.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/static_sample.py
@@ -42,12 +42,15 @@ class StaticSampleSignalExchangeAPI(
     def get_name(cls) -> str:
         return "sample"
 
+    @classmethod
+    def for_collab(
+        cls, collab: CollaborationConfigBase
+    ) -> "StaticSampleSignalExchangeAPI":
+        return StaticSampleSignalExchangeAPI()
+
     def fetch_iter(
         self,
         supported_signal_types: t.Sequence[t.Type[SignalType]],
-        collab: CollaborationConfigBase,
-        # None if fetching for the first time,
-        # otherwise the previous FetchDelta returned
         checkpoint: t.Optional[state.TFetchCheckpoint],
     ) -> t.Iterator[_TypedDelta]:
         sample_signals: t.List[

--- a/python-threatexchange/threatexchange/exchanges/impl/static_sample.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/static_sample.py
@@ -46,7 +46,7 @@ class StaticSampleSignalExchangeAPI(
     def for_collab(
         cls, collab: CollaborationConfigBase
     ) -> "StaticSampleSignalExchangeAPI":
-        return StaticSampleSignalExchangeAPI()
+        return cls()
 
     def fetch_iter(
         self,

--- a/python-threatexchange/threatexchange/exchanges/impl/tests/test_ncmec.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/tests/test_ncmec.py
@@ -21,7 +21,8 @@ from threatexchange.signal_type.md5 import VideoMD5Signal
 
 @pytest.fixture
 def exchange(api: NCMECHashAPI, monkeypatch: pytest.MonkeyPatch):
-    signal_exchange = NCMECSignalExchangeAPI("user", "pass")
+    collab = NCMECCollabConfig(NCMECEnvironment.Industry, "Test")
+    signal_exchange = NCMECSignalExchangeAPI(collab, "user", "pass")
     monkeypatch.setattr(signal_exchange, "get_client", lambda _environment: api)
     return signal_exchange
 
@@ -29,8 +30,7 @@ def exchange(api: NCMECHashAPI, monkeypatch: pytest.MonkeyPatch):
 def test_fetch(exchange: NCMECSignalExchangeAPI, monkeypatch: pytest.MonkeyPatch):
     frozen_time = 1664496000
     monkeypatch.setattr("time.time", lambda: frozen_time)
-    collab = NCMECCollabConfig(NCMECEnvironment.Industry, "Test")
-    it = exchange.fetch_iter([], collab, None)
+    it = exchange.fetch_iter([], None)
     # Since our test data from test_hash_api is is all in one fetch sequence,
     # we'd have to craft some specialized data to get the NCMECSignalAPI split it
     # into multiple updates

--- a/python-threatexchange/threatexchange/exchanges/impl/tests/test_ncmec.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/tests/test_ncmec.py
@@ -57,7 +57,7 @@ def test_fetch(exchange: NCMECSignalExchangeAPI, monkeypatch: pytest.MonkeyPatch
     }
 
     as_signals = NCMECSignalExchangeAPI.naive_convert_to_signal_type(
-        [VideoMD5Signal], collab, total_updates
+        [VideoMD5Signal], exchange.collab, total_updates
     )[VideoMD5Signal]
     assert as_signals == {
         "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1": NCMECSignalMetadata({42: set()}),
@@ -67,6 +67,7 @@ def test_fetch(exchange: NCMECSignalExchangeAPI, monkeypatch: pytest.MonkeyPatch
     assert next(it, None) is None
 
     # Test esp_id filter
+    collab = NCMECCollabConfig(NCMECEnvironment.Industry, "Test")
     collab.only_esp_ids = {101}
     as_signals = NCMECSignalExchangeAPI.naive_convert_to_signal_type(
         [VideoMD5Signal], collab, total_updates

--- a/python-threatexchange/threatexchange/exchanges/impl/tests/test_stopncii.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/tests/test_stopncii.py
@@ -14,15 +14,13 @@ from threatexchange.exchanges.clients.stopncii.api import StopNCIIAPI
 
 @pytest.fixture
 def exchange(api: StopNCIIAPI):
-    signal_exchange = StopNCIISignalExchangeAPI(None, None)
-    signal_exchange._api = api
-    return signal_exchange
+    collab = CollaborationConfigWithDefaults("Test")
+    return StopNCIISignalExchangeAPI(collab, api)
 
 
 def test_fetch(exchange: StopNCIISignalExchangeAPI, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("time.time", lambda: 10**8)
-    collab = CollaborationConfigWithDefaults("Test")
-    it = exchange.fetch_iter([], collab, None)
+    it = exchange.fetch_iter([], None)
     delta = next(it)
 
     assert len(delta.updates) == 2

--- a/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
@@ -7,7 +7,12 @@ The SignalExchangeAPI talks to external APIs to read/write signals
 """
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from contextlib import contextmanager
+import contextlib
+from genericpath import isfile
+import logging
+import os
+import pathlib
 import typing as t
 
 from threatexchange import common
@@ -53,19 +58,20 @@ class SignalExchangeAPI(
     for your API, or it's mostly a toy implementation, empty string is a
     valid key, and the value can be the entire dataset.
 
-    = On Owner IDs =
-    Some APIs may not have any concept of owner ID (because the owner is the
-    API itself). In that case, it's suggested to use 0 for all IDs. If the you
-    own the API, it may also make sense to have 0 be the return of
-    get_own_owner_id, which is used by matching to tell if a signal be
-    considered "confirmed" or not. If your API does support the concept of
-    owners, make sure to implement resolve_owner and get_own_owner_id
+    = On Authentification =
+    It's expected that an instance of the class is fully authenticated,
+    and in general, auth should be passible by the constructor.
+
+    If an API is constructed via the for_collab classmethod constructor,
+    it should attempt to authenticate itself via discovering it from the
+    execution environment and passing it via __init__(). If constructed
+    directly, it should not search for credentials.
 
     """
 
-    @classmethod
+    @staticmethod
     @abstractmethod
-    def for_collab(cls, collab: TCollabConfig) -> "SignalExchangeAPI":
+    def for_collab(collab: TCollabConfig) -> "SignalExchangeAPI":
         """
         An alternative constructor to get a working instance of the API.
 
@@ -78,13 +84,13 @@ class SignalExchangeAPI(
         default authentification from known locations. Your general options
         are:
         1. From an environment variable
-        2. From a file in a known location (ideally chmod 500)
+        2. From a file in a known location (ideally chmod 400)
         3. From a keychain service or similar running in the background
         4. From the collaboration config itself
 
         If you aren't able to get required authentification, it's best to
-        include what options a user has - even if that's just a link to
-        the README.
+        include what options a user has in the exception - even if that's
+        just a link to the README.
 
         Don't:
         * Prompt the user via stdin
@@ -94,6 +100,7 @@ class SignalExchangeAPI(
         when they have an API call to make - all methods for manipulating
         local state are classmethods.
         """
+        raise NotImplementedError
 
     @classmethod
     def get_name(cls) -> str:
@@ -307,3 +314,148 @@ class SignalExchangeAPIWithSimpleUpdates(
                 ret[s_type] = inner
             inner[signal_str] = metadata
         return ret
+
+
+class SignalExchangeAPIInvalidAuthException(Exception):
+    """
+    An exception you can use to hint users their authentification is bad
+
+    This can be because it's incorrectly formatted, it's been expired,
+    or a multitude of other reasons.
+    """
+
+    def __init__(self, src_api: TSignalExchangeAPICls, message: str) -> None:
+        self.src_api = src_api
+        self.message = message
+
+
+class SignalExchangeAPIMissingAuthException(Exception):
+    """
+    An exception you can use to hint users how to authentificate your API
+    """
+
+    def __init__(
+        self, src_api: TSignalExchangeAPICls, *, file_hint: str = "", env_hint: str = ""
+    ) -> None:
+        self.src_api = src_api
+        self.hints: t.List[str] = []
+        if env_hint:
+            self.add_env_hint(env_hint)
+        if file_hint:
+            self.add_file_hint(file_hint)
+
+    def add_file_hint(self, filename: str) -> None:
+        self.hints.append(
+            f"creating (and maybe `chmod 400`) a file with credentials at {filename}"
+        )
+
+    def add_env_hint(self, variable_name: str) -> None:
+        self.hints.append(f"populating an environment variable called {variable_name}")
+
+    def pretty_str(self) -> str:
+        lines = [
+            f"Couldn't authenticate {self.src_api.get_name()}, "
+            "it's missing authentification!"
+        ]
+        if self.hints:
+            lines.append("You can fix this by:")
+            for i, hint in enumerate(self.hints, 1):
+                lines.append(f"  {i}. {hint}")
+        return "\n".join(lines)
+
+
+CredentialSelf = t.TypeVar("CredentialSelf", bound="CredentialHelper")
+
+
+class CredentialHelper:
+    """
+    Wrapper to help standardize credential sources, and tie to exceptions
+    """
+
+    API_CLS: t.ClassVar[t.Type[SignalExchangeAPI]]
+    ENV_VARIABLE: t.ClassVar[str] = ""
+    FILE_NAME: t.ClassVar[str] = ""
+
+    _DEFAULT: t.ClassVar[t.Optional["CredentialHelper"]] = None  # t.Self
+    _DEFAULT_SRC: t.ClassVar[str] = ""
+
+    @classmethod
+    def get(cls: t.Type[CredentialSelf]) -> CredentialSelf:
+        srcs: t.List[t.Tuple[t.Callable[[], t.Optional[CredentialSelf]], str]] = [
+            ((lambda: cls._DEFAULT), cls._DEFAULT_SRC),  # type: ignore[list-item,return-value]
+            (cls._from_env, f"environment variable {cls.ENV_VARIABLE}"),
+            (cls._from_file, f"file {cls.FILE_NAME}"),
+        ]
+        for fn, src in srcs:
+            try:
+                creds = fn()
+                if creds is None:
+                    continue
+                if creds._are_valid():
+                    return creds
+            except Exception:
+                logging.exception("Exception during parsing %s", src)
+                pass
+            raise SignalExchangeAPIInvalidAuthException(
+                cls.API_CLS, f"Invalid credentials from {src}"
+            )
+        ex = SignalExchangeAPIMissingAuthException(cls.API_CLS)
+        if cls._DEFAULT_SRC:
+            ex.hints.append(cls._DEFAULT_SRC)
+        if cls.ENV_VARIABLE:
+            ex.add_env_hint(cls.ENV_VARIABLE)
+        if cls.FILE_NAME:
+            ex.add_file_hint(cls.FILE_NAME)
+        raise ex
+
+    @classmethod
+    def set_default(
+        cls: t.Type[CredentialSelf], new_default: t.Optional[CredentialSelf], src: str
+    ) -> contextlib.AbstractContextManager:
+        """
+        Set the default (highest preferred) credentials manually.
+
+        They won't be checked for validity until a future get()
+        """
+        cls._DEFAULT = new_default  # type: ignore[assignment]  # need t.Self
+        cls._DEFAULT_SRC = src
+        return cls._unset_default_context()
+
+    @classmethod
+    @contextlib.contextmanager
+    def _unset_default_context(cls: t.Type[CredentialSelf]) -> t.Iterator[None]:
+        yield
+        cls.clear_default()
+
+    @classmethod
+    def clear_default(cls) -> None:
+        """Reset the default"""
+        cls.set_default(None, "")
+
+    @classmethod
+    def _from_str(cls: t.Type[CredentialSelf], s: str) -> t.Optional[CredentialSelf]:
+        """Parse credentials from a string"""
+        return None
+
+    @classmethod
+    def _from_file(cls: t.Type[CredentialSelf]) -> t.Optional[CredentialSelf]:
+        """Parse credentials from a file"""
+        if not cls.FILE_NAME:
+            return None
+        path = pathlib.Path(cls.FILE_NAME).expanduser()
+        if not path.is_file():
+            return None
+        return cls._from_str(path.read_text().strip())
+
+    @classmethod
+    def _from_env(cls: t.Type[CredentialSelf]) -> t.Optional[CredentialSelf]:
+        """Parse credentials from an environment variable"""
+        if not cls.ENV_VARIABLE:
+            return None
+        s = os.environ.get(cls.ENV_VARIABLE)
+        if not s:
+            return None
+        return cls._from_str(s)
+
+    def _are_valid(self) -> bool:
+        return True

--- a/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
@@ -64,6 +64,38 @@ class SignalExchangeAPI(
     """
 
     @classmethod
+    @abstractmethod
+    def for_collab(cls, collab: TCollabConfig) -> "SignalExchangeAPI":
+        """
+        An alternative constructor to get a working instance of the API.
+
+        An instance provided by this class is expected to:
+        1. Be fully authenticated or throw an exception
+        2. All methods are callable if supported by the base implementation
+
+        For implementations that do need additional configuration or
+        authentification, this method is a good place to attempt to pull in
+        default authentification from known locations. Your general options
+        are:
+        1. From an environment variable
+        2. From a file in a known location (ideally chmod 500)
+        3. From a keychain service or similar running in the background
+        4. From the collaboration config itself
+
+        If you aren't able to get required authentification, it's best to
+        include what options a user has - even if that's just a link to
+        the README.
+
+        Don't:
+        * Prompt the user via stdin
+        * Return an instance that will throw when any methods are called
+
+        Usages of this library will only attempt to instanciate an API
+        when they have an API call to make - all methods for manipulating
+        local state are classmethods.
+        """
+
+    @classmethod
     def get_name(cls) -> str:
         """
         A simple string name unique to SignalExchangeAPIs in use.
@@ -164,7 +196,6 @@ class SignalExchangeAPI(
     def fetch_iter(
         self,
         supported_signal_types: t.Sequence[t.Type[SignalType]],
-        collab: TCollabConfig,
         # None if fetching for the first time,
         # otherwise the previous FetchDelta returned
         checkpoint: t.Optional[state.TFetchCheckpoint],
@@ -210,7 +241,6 @@ class SignalExchangeAPI(
 
     def report_opinion(
         self,
-        collab: TCollabConfig,
         s_type: t.Type[SignalType],
         signal: str,
         opinion: state.SignalOpinion,

--- a/python-threatexchange/threatexchange/interface_validation.py
+++ b/python-threatexchange/threatexchange/interface_validation.py
@@ -21,7 +21,9 @@ from dataclasses import dataclass
 
 from threatexchange.content_type.content_base import ContentType
 from threatexchange.signal_type.signal_base import SignalType
-from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
+from threatexchange.exchanges.signal_exchange_api import (
+    TSignalExchangeAPICls,
+)
 from threatexchange.exchanges.collab_config import CollaborationConfigStoreBase
 
 
@@ -51,8 +53,8 @@ class SignalTypeMapping:
 
 
 class SignalExchangeAPIMapping:
-    def __init__(self, apis: t.Sequence[SignalExchangeAPI]) -> None:
-        _validate_signal_apis(f.__class__ for f in apis)
+    def __init__(self, apis: t.Sequence[TSignalExchangeAPICls]) -> None:
+        _validate_signal_apis(apis)
         self.api_by_name = {f.get_name(): f for f in apis}
 
 
@@ -70,7 +72,7 @@ class FunctionalityMapping:
     collabs: CollaborationConfigStoreBase
 
 
-def _validate_signal_apis(apis: t.Iterable[t.Type[SignalExchangeAPI]]):
+def _validate_signal_apis(apis: t.Iterable[TSignalExchangeAPICls]):
     names = set()
     for a in apis:
         name = a.get_name()


### PR DESCRIPTION
Summary
---------

Potentially the last interface change for 1.0.0. Put up for discussion with @schatten 

Test Plan
---------

mypy && py.test

```
$ tx --factory-reset

$ tx config api fb_threatexchange -L
Couldn't authenticate fb_threatexchange, it's missing authentification!
You can fix this by:
  1. threatexchange config api fb_threatexchange --api-token
  2. populating an environment variable called TX_ACCESS_TOKEN
  3. creating (and maybe `chmod 400`) a file with credentials at ~/.txtoken

$ TX_ACCESS_TOKEN='a' tx config api fb_threatexchange -L
Invalid auth for fb_threatexchange: Invalid credentials from environment variable TX_ACCESS_TOKEN

$ TX_ACCESS_TOKEN="$(cat ~/.txtoken.bak)" tx config api fb_threatexchange -L
<works>
```

NCMEC

```
$ tx config collab edit ncmec -C ncmec --environment test_NGO

$ tx fetch
Couldn't authenticate ncmec, it's missing authentification!
You can fix this by:
  1. threatexchange config api ncmec --user --pass
  2. populating an environment variable called TX_NCMEC_CREDENTIALS
  3. creating (and maybe `chmod 400`) a file with credentials at ~/.tx_ncmec_credentials


$ tx fetch
$ code -r ~/.tx_ncmec_credentials
$ chmod 400 ~/.tx_ncmec_credentials
[ncmec] ncmec - Fetching... 
<Gets things>
```
