### PR TITLE
[vPDQ] Benchmark CPP and python-binding implmentations

### DIFF
--- a/vpdq/benchmark/README.MD
+++ b/vpdq/benchmark/README.MD
@@ -1,0 +1,63 @@
+# pytx-vpdq
+Benchmark vPDQ CPP implementation and python-binding library
+
+
+# Observed Performance
+MacBook Pro (16-inch, 2021), Apple M1 Pro, 32 GB Ram
+
+Results:
+-------
+```
+% python3 benchmark.py      
+Python hashing time: 34.1643s
+  Total hash:7069  Per hash: 4.8330ms
+CPP hashing time: 34.3673s
+  Total hash:7069  Per hash: 4.8617ms
+
+% python3 benchmark.py -r 1 
+Python hashing time: 6.9934s
+  Total hash:241  Per hash: 29.0182ms
+CPP hashing time: 7.3139s
+  Total hash:241  Per hash: 30.3483ms
+
+% python3 benchmark.py -s 540
+Python hashing time: 20.5453s
+  Total hash:7069  Per hash: 2.9064ms
+CPP hashing time: 20.9247s
+  Total hash:7069  Per hash: 2.9601ms
+Calculate deviations in downsampled hashes, since hash resolution is non-native
+Original resolution Python hashing time: 33.9340s
+  Number of mismatches:0, 0.00 percent in total.
+  Average 7.99 hamming distance away.
+
+% python3 benchmark.py -s 360
+Python hashing time: 9.8740s
+  Total hash:7069  Per hash: 1.3968ms
+CPP hashing time: 10.2460s
+  Total hash:7069  Per hash: 1.4494ms
+Calculate deviations in downsampled hashes, since hash resolution is non-native
+Original resolution Python hashing time: 34.5316s
+  Number of mismatches:0, 0.00 percent in total.
+  Average 8.57 hamming distance away.
+
+% python3 benchmark.py -s 180
+Python hashing time: 4.8490s
+  Total hash:7069  Per hash: 0.6860ms
+CPP hashing time: 5.4182s
+  Total hash:7069  Per hash: 0.7665ms
+Calculate deviations in downsampled hashes, since hash resolution is non-native
+Original resolution Python hashing time: 34.8951s
+  Number of mismatches:121, 0.02 percent in total.
+  Average 17.63 hamming distance away.
+
+
+% python3 benchmark.py -s 60 
+Python hashing time: 3.0915s
+  Total hash:7069  Per hash: 0.4373ms
+CPP hashing time: 3.3920s
+  Total hash:7069  Per hash: 0.4798ms
+Calculate deviations in downsampled hashes, since hash resolution is non-native
+Original resolution Python hashing time: 34.4134s
+  Number of mismatches:153, 0.02 percent in total.
+  Average 17.71 hamming distance away.
+```

--- a/vpdq/benchmark/README.MD
+++ b/vpdq/benchmark/README.MD
@@ -50,6 +50,15 @@ Original resolution Python hashing time: 34.8951s
   Number of mismatches:121, 0.02 percent in total.
   Average 17.63 hamming distance away.
 
+python3 benchmark.py -s 64
+Python hashing time: 3.1143s
+  Total hash:7069  Per hash: 0.4406ms
+CPP hashing time: 3.5193s
+  Total hash:7069  Per hash: 0.4979ms
+Calculate deviations in downsampled hashes, since hash resolution is non-native
+Original resolution Python hashing time: 35.2615s
+  Number of mismatches:20, 0.00 percent in total.
+  Average 9.39 hamming distance away.
 
 % python3 benchmark.py -s 60 
 Python hashing time: 3.0915s

--- a/vpdq/benchmark/README.MD
+++ b/vpdq/benchmark/README.MD
@@ -27,7 +27,7 @@ CPP hashing time: 20.9247s
   Total hash:7069  Per hash: 2.9601ms
 Calculate deviations in downsampled hashes, since hash resolution is non-native
 Original resolution Python hashing time: 33.9340s
-  Number of mismatches:0, 0.00 percent in total.
+  Number of mismatches: 0, 0.00 percent in total.
   Average 7.99 hamming distance away.
 
 % python3 benchmark.py -s 360
@@ -37,7 +37,7 @@ CPP hashing time: 10.2460s
   Total hash:7069  Per hash: 1.4494ms
 Calculate deviations in downsampled hashes, since hash resolution is non-native
 Original resolution Python hashing time: 34.5316s
-  Number of mismatches:0, 0.00 percent in total.
+  Number of mismatches: 0, 0.00 percent in total.
   Average 8.57 hamming distance away.
 
 % python3 benchmark.py -s 180
@@ -47,7 +47,7 @@ CPP hashing time: 5.4182s
   Total hash:7069  Per hash: 0.7665ms
 Calculate deviations in downsampled hashes, since hash resolution is non-native
 Original resolution Python hashing time: 34.8951s
-  Number of mismatches:121, 0.02 percent in total.
+  Number of mismatches: 121, 0.02 percent in total.
   Average 17.63 hamming distance away.
 
 python3 benchmark.py -s 64
@@ -57,7 +57,7 @@ CPP hashing time: 3.5193s
   Total hash:7069  Per hash: 0.4979ms
 Calculate deviations in downsampled hashes, since hash resolution is non-native
 Original resolution Python hashing time: 35.2615s
-  Number of mismatches:20, 0.00 percent in total.
+  Number of mismatches: 20, 0.00 percent in total.
   Average 9.39 hamming distance away.
 
 % python3 benchmark.py -s 60 
@@ -67,6 +67,6 @@ CPP hashing time: 3.3920s
   Total hash:7069  Per hash: 0.4798ms
 Calculate deviations in downsampled hashes, since hash resolution is non-native
 Original resolution Python hashing time: 34.4134s
-  Number of mismatches:153, 0.02 percent in total.
+  Number of mismatches: 153, 0.02 percent in total.
   Average 17.71 hamming distance away.
 ```

--- a/vpdq/benchmark/README.MD
+++ b/vpdq/benchmark/README.MD
@@ -10,21 +10,21 @@ Results:
 ```
 % python3 benchmark.py      
 Python hashing time: 34.1643s
-  Total hash:7069  Per hash: 4.8330ms
+  Total hash: 7069  Per hash: 4.8330ms
 CPP hashing time: 34.3673s
-  Total hash:7069  Per hash: 4.8617ms
+  Total hash: 7069  Per hash: 4.8617ms
 
 % python3 benchmark.py -r 1 
 Python hashing time: 6.9934s
-  Total hash:241  Per hash: 29.0182ms
+  Total hash: 241  Per hash: 29.0182ms
 CPP hashing time: 7.3139s
-  Total hash:241  Per hash: 30.3483ms
+  Total hash: 241  Per hash: 30.3483ms
 
 % python3 benchmark.py -s 540
 Python hashing time: 20.5453s
-  Total hash:7069  Per hash: 2.9064ms
+  Total hash: 7069  Per hash: 2.9064ms
 CPP hashing time: 20.9247s
-  Total hash:7069  Per hash: 2.9601ms
+  Total hash: 7069  Per hash: 2.9601ms
 Calculate deviations in downsampled hashes, since hash resolution is non-native
 Original resolution Python hashing time: 33.9340s
   Number of mismatches: 0, 0.00 percent in total.
@@ -32,9 +32,9 @@ Original resolution Python hashing time: 33.9340s
 
 % python3 benchmark.py -s 360
 Python hashing time: 9.8740s
-  Total hash:7069  Per hash: 1.3968ms
+  Total hash: 7069  Per hash: 1.3968ms
 CPP hashing time: 10.2460s
-  Total hash:7069  Per hash: 1.4494ms
+  Total hash: 7069  Per hash: 1.4494ms
 Calculate deviations in downsampled hashes, since hash resolution is non-native
 Original resolution Python hashing time: 34.5316s
   Number of mismatches: 0, 0.00 percent in total.
@@ -42,9 +42,9 @@ Original resolution Python hashing time: 34.5316s
 
 % python3 benchmark.py -s 180
 Python hashing time: 4.8490s
-  Total hash:7069  Per hash: 0.6860ms
+  Total hash: 7069  Per hash: 0.6860ms
 CPP hashing time: 5.4182s
-  Total hash:7069  Per hash: 0.7665ms
+  Total hash: 7069  Per hash: 0.7665ms
 Calculate deviations in downsampled hashes, since hash resolution is non-native
 Original resolution Python hashing time: 34.8951s
   Number of mismatches: 121, 0.02 percent in total.
@@ -52,9 +52,9 @@ Original resolution Python hashing time: 34.8951s
 
 python3 benchmark.py -s 64
 Python hashing time: 3.1143s
-  Total hash:7069  Per hash: 0.4406ms
+  Total hash: 7069  Per hash: 0.4406ms
 CPP hashing time: 3.5193s
-  Total hash:7069  Per hash: 0.4979ms
+  Total hash: 7069  Per hash: 0.4979ms
 Calculate deviations in downsampled hashes, since hash resolution is non-native
 Original resolution Python hashing time: 35.2615s
   Number of mismatches: 20, 0.00 percent in total.
@@ -62,9 +62,9 @@ Original resolution Python hashing time: 35.2615s
 
 % python3 benchmark.py -s 60 
 Python hashing time: 3.0915s
-  Total hash:7069  Per hash: 0.4373ms
+  Total hash: 7069  Per hash: 0.4373ms
 CPP hashing time: 3.3920s
-  Total hash:7069  Per hash: 0.4798ms
+  Total hash: 7069  Per hash: 0.4798ms
 Calculate deviations in downsampled hashes, since hash resolution is non-native
 Original resolution Python hashing time: 34.4134s
   Number of mismatches: 153, 0.02 percent in total.

--- a/vpdq/benchmark/benchmark.py
+++ b/vpdq/benchmark/benchmark.py
@@ -28,7 +28,7 @@ def timer(context: str, print_on_enter: bool = False):
 
 
 def get_argparse() -> argparse.ArgumentParser:
-    ap = argparse.ArgumentParser(description=__doc__)
+    ap = argparse.ArgumentParser()
     ap.add_argument(
         "-f",
         "--ffmpegPath",
@@ -63,17 +63,22 @@ def run_benchmark(
             ffmpegPath, secondsPerHash, downsampleFrameDimension
         )
     feature_size = 0
-    for feature in python_features:
-        feature_size += len(feature)
+    feature_size = sum(len(feature) for feature in python_features)
     python_time = pt()
     print(
-        f"  Total hash:{ feature_size}  Per hash: {1000*python_time /  feature_size:.4f}ms"
+        "  Total hash:",
+        feature_size,
+        "Per hash:",
+        f"{1000*python_time /  feature_size:.4f}ms",
     )
     with timer("CPP hashing time") as ct:
         run_cpp(ffmpegPath, secondsPerHash, downsampleFrameDimension)
     cpp_time = ct()
     print(
-        f"  Total hash:{ feature_size}  Per hash: {1000*cpp_time /  feature_size:.4f}ms"
+        "  Total hash:",
+        feature_size,
+        "Per hash:",
+        f"{1000*cpp_time /  feature_size:.4f}ms",
     )
     if downsampleFrameDimension != 0:
         print(
@@ -90,7 +95,7 @@ def run_benchmark(
                     mis_match += 1
                 total_dist += dist
         print(
-            f"  Number of mismatches:{mis_match}, {mis_match/ feature_size:.2f} percent in total."
+            f"  Number of mismatches: {mis_match}, {mis_match/ feature_size:.2f} percent in total."
         )
         print(f"  Average {total_dist/ feature_size:.2f} hamming distance away.")
 
@@ -105,7 +110,7 @@ def run_python(
         if file.endswith(".mp4"):
             hash_list.append(
                 vpdq.computeHash(
-                    str(VIDEOS) + "/" + file,
+                    str(VIDEOS / file),
                     ffmpeg_path=ffmpegPath,
                     seconds_per_hash=secondsPerHash,
                     downsample_width=downsampleFrameDimension,
@@ -122,7 +127,7 @@ def run_cpp(
 ):
     for file in os.listdir(VIDEOS):
         if file.endswith(".mp4"):
-            subprocess.call(
+            subprocess.check_call(
                 [
                     str(CPP_EXEC),
                     "-f",
@@ -136,8 +141,6 @@ def run_cpp(
                     "-i",
                     str(VIDEOS) + "/" + file,
                 ],
-                stderr=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
             )
 
 

--- a/vpdq/benchmark/benchmark.py
+++ b/vpdq/benchmark/benchmark.py
@@ -1,0 +1,151 @@
+from numpy import hamming
+import vpdq
+import subprocess
+import os
+import sys
+import argparse
+from pathlib import Path
+from contextlib import contextmanager, nullcontext
+from enum import Enum
+import time
+
+VPDQ_MATCH_DIST = 31
+DIR = Path(__file__).parents[2]
+VIDEOS = DIR / "tmk/sample-videos"
+OUTPUT = "hashes"
+CPP_EXEC = Path(__file__).parents[1] / "cpp/build/vpdq-hash-video"
+
+
+@contextmanager
+def timer(context: str, print_on_enter: bool = False):
+    if print_on_enter:
+        print(f"{context}...")
+    start = time.perf_counter()
+    end = start
+    yield lambda: end - start
+    end = time.perf_counter()
+    print(f"{context}: {end - start:.4f}s")
+
+
+def get_argparse() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "-f",
+        "--ffmpegPath",
+        help="Specific path to ffmpeg you want to use",
+        default="ffmpeg",
+    )
+    ap.add_argument(
+        "-r",
+        "--secondsPerHash",
+        help="The frequence(per second) a hash is generated from the video. If it is 0, will generate every frame's hash",
+        default=0,
+        type=float,
+    )
+    ap.add_argument(
+        "-s",
+        "--downsampleFrameDimension",
+        metavar="Downsample_Frame_Dimension",
+        help="Resolution to downsample the video to before hashing frames.. If it is 0, will use the original dimension of the video to hash",
+        default=0,
+        type=int,
+    )
+    return ap
+
+
+def run_benchmark(
+    ffmpegPath: str,
+    secondsPerHash: int,
+    downsampleFrameDimension: int,
+):
+    with timer("Python hashing time") as pt:
+        python_features = run_python(
+            ffmpegPath, secondsPerHash, downsampleFrameDimension
+        )
+    feature_size = 0
+    for feature in python_features:
+        feature_size += len(feature)
+    python_time = pt()
+    print(
+        f"  Total hash:{ feature_size}  Per hash: {1000*python_time /  feature_size:.4f}ms"
+    )
+    with timer("CPP hashing time") as ct:
+        run_cpp(ffmpegPath, secondsPerHash, downsampleFrameDimension)
+    cpp_time = ct()
+    print(
+        f"  Total hash:{ feature_size}  Per hash: {1000*cpp_time /  feature_size:.4f}ms"
+    )
+    if downsampleFrameDimension != 0:
+        print(
+            "Calculate deviations in downsampled hashes, since hash resolution is non-native"
+        )
+        with timer("Original resolution Python hashing time"):
+            original_features = run_python(ffmpegPath, secondsPerHash, 0)
+        total_dist = 0
+        mis_match = 0
+        for original_hash, downsample_hash in zip(original_features, python_features):
+            for original_frame, downsample_frame in zip(original_hash, downsample_hash):
+                dist = original_frame.hamming_distance(downsample_frame)
+                if dist >= VPDQ_MATCH_DIST:
+                    mis_match += 1
+                total_dist += dist
+        print(
+            f"  Number of mismatches:{mis_match}, {mis_match/ feature_size:.2f} percent in total."
+        )
+        print(f"  Average {total_dist/ feature_size:.2f} hamming distance away.")
+
+
+def run_python(
+    ffmpegPath: str,
+    secondsPerHash: int,
+    downsampleFrameDimension: int,
+):
+    hash_list = []
+    for file in os.listdir(VIDEOS):
+        if file.endswith(".mp4"):
+            hash_list.append(
+                vpdq.computeHash(
+                    str(VIDEOS) + "/" + file,
+                    ffmpeg_path=ffmpegPath,
+                    seconds_per_hash=secondsPerHash,
+                    downsample_width=downsampleFrameDimension,
+                    downsample_height=downsampleFrameDimension,
+                )
+            )
+    return hash_list
+
+
+def run_cpp(
+    ffmpegPath: str,
+    secondsPerHash: int,
+    downsampleFrameDimension: int,
+):
+    for file in os.listdir(VIDEOS):
+        if file.endswith(".mp4"):
+            subprocess.call(
+                [
+                    str(CPP_EXEC),
+                    "-f",
+                    str(ffmpegPath),
+                    "-r",
+                    str(secondsPerHash),
+                    "-d",
+                    str(OUTPUT),
+                    "-s",
+                    str(downsampleFrameDimension),
+                    "-i",
+                    str(VIDEOS) + "/" + file,
+                ],
+                stderr=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+            )
+
+
+def main():
+    ap = get_argparse()
+    ns = ap.parse_args()
+    run_benchmark(**ns.__dict__)
+
+
+if __name__ == "__main__":
+    main()

--- a/vpdq/cpp/CMakeLists.txt
+++ b/vpdq/cpp/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.17)
 
+set(CMAKE_CXX_FLAGS "-O2")
 project(VPDQ)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET


### PR DESCRIPTION
Summary
---------

Benchmark on vPDQ with CPP and python-binding implementations. Both benchmarks run through the sample video set (fourteen 480x720 videos and one 1280x720 video). CPP implementation uses -02 flag and python-binding uses vpdq 0.0.6. Benchmark mark runs on MacBook Pro (16-inch, 2021), Apple M1 Pro, 32 GB Ram and the result is in README.MD. vPDQ performs well on 64 x 64 which comes from the pdq algorithm's support on this "magic" resolution.
