### PR TITLE
[pytx] Rename signal type video_vpdq to vpdq

### DIFF
--- a/python-threatexchange/threatexchange/extensions/vpdq/manifest.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/manifest.py
@@ -1,9 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from threatexchange.extensions.manifest import ThreatExchangeExtensionManifest
-from threatexchange.extensions.vpdq.video_vpdq import VideoVPDQSignal
+from threatexchange.extensions.vpdq.vpdq import VPDQSignal
 
 
 TX_MANIFEST = ThreatExchangeExtensionManifest(
-    signal_types=(VideoVPDQSignal,),
+    signal_types=(VPDQSignal,),
 )

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -28,7 +28,7 @@ else:
         get_random_VPDQs,
         pdq_hashes_to_VPDQ_features,
     )
-    from threatexchange.extensions.vpdq.video_vpdq import VideoVPDQSignal
+    from threatexchange.extensions.vpdq.vpdq import VPDQSignal
     from threatexchange.tests.hashing.utils import (
         get_random_hash,
         get_similar_hash,
@@ -43,7 +43,7 @@ if not _DISABLED:
     VIDEO2_META_DATA = object()
     VIDEO3_META_DATA = object()
     VIDEO4_META_DATA = object()
-    hash = VideoVPDQSignal.get_examples()[0]
+    hash = VPDQSignal.get_examples()[0]
     features = prepare_vpdq_feature(hash, VPDQ_QUALITY_THRESHOLD)
     h1 = get_similar_hash(get_zero_hash(), 16)
     h2 = get_similar_hash(get_zero_hash(), 128)
@@ -56,7 +56,7 @@ if not _DISABLED:
 
 
 def test_utils():
-    example_hash = VideoVPDQSignal.get_examples()[0]
+    example_hash = VPDQSignal.get_examples()[0]
     example_features = json_to_vpdq(example_hash)
     assert example_hash == vpdq_to_json(example_features)
 
@@ -70,9 +70,9 @@ def test_utils():
     frame_counts = 100
     features = get_random_VPDQs(frame_counts)
     assert len(features) == frame_counts
-    VideoVPDQSignal.validate_signal_str(vpdq_to_json(features))
+    VPDQSignal.validate_signal_str(vpdq_to_json(features))
     pdq_hashes = [get_random_hash() for i in range(frame_counts)]
-    VideoVPDQSignal.validate_signal_str(
+    VPDQSignal.validate_signal_str(
         vpdq_to_json(pdq_hashes_to_VPDQ_features(pdq_hashes))
     )
 

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_hash_and_match.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_hash_and_match.py
@@ -10,7 +10,7 @@ try:
 except (ImportError, ModuleNotFoundError) as e:
     _DISABLED = True
 else:
-    from threatexchange.extensions.vpdq.video_vpdq import VideoVPDQSignal
+    from threatexchange.extensions.vpdq.vpdq import VPDQSignal
     from threatexchange.extensions.vpdq.vpdq_util import (
         vpdq_to_json,
         json_to_vpdq,
@@ -29,7 +29,7 @@ ROOTDIR = Path(__file__).parents[5]
 
 @pytest.mark.skipif(_DISABLED, reason="vpdq not installed")
 def test_vpdq_from_string_path():
-    computed_hash = VideoVPDQSignal.hash_from_file(ROOTDIR / VIDEO)
+    computed_hash = VPDQSignal.hash_from_file(ROOTDIR / VIDEO)
     expected_hash = read_file_to_hash(ROOTDIR / HASH)
     assert vpdq_to_json(json_to_vpdq(computed_hash)) == computed_hash
     res = match_VPDQ_hash_brute(

--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq.py
@@ -24,7 +24,7 @@ from threatexchange.signal_type.pdq.signal import PdqSignal
 from threatexchange.extensions.vpdq.vpdq_index import VPDQSimilarityInfo, VPDQIndex
 
 
-class VideoVPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
+class VPDQSignal(signal_base.SimpleSignalType, signal_base.FileHasher):
     """
     Simple signal type for video using VPDQ.
     VPDQ signal_str is the json serialization from a list of VPDQ features


### PR DESCRIPTION
Summary
---------

Rename VideoVPDQSignal to VPDQSignal

Test Plan
---------

Py.test and CLI manual test. Big shout out to the percentage match results.
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/44279163/183486954-3a68dcee-7d88-488a-a020-bcb9ef9f1577.png">
