### PR TITLE
[pytx] Update print order in dataset_cmd

### DIFF
--- a/python-threatexchange/threatexchange/cli/dataset_cmd.py
+++ b/python-threatexchange/threatexchange/cli/dataset_cmd.py
@@ -248,7 +248,7 @@ class DatasetCommand(command_base.Command):
         print_fn = self._print_stdout
         if self.csv:
             csv_writer = csv.DictWriter(
-                sys.stdout, ["collab", "signal_type", "signal_str", "category", "tags"]
+                sys.stdout, ["signal_type", "signal_str", "collab", "category", "tags"]
             )
             csv_writer.writeheader()
             print_fn = lambda *args: self._print_csv(csv_writer, *args)
@@ -295,14 +295,16 @@ class DatasetCommand(command_base.Command):
         signal_str: str,
         metadata: t.Optional[FetchedSignalMetadata],
     ) -> None:
-        if not self.print_signals_only and len(self.only_collabs) != 1:
-            print(repr(collab_name), end=" ")
         if len(self.only_signals) != 1:
             print(signal_type.get_name(), end=" ")
+
         print(signal_str, end="")
+
         if not self.print_signals_only:
+            if len(self.only_collabs) != 1:
+                print("", repr(collab_name), end="")
             print("", metadata, end="")
-        print()
+        print()  # Complete line
 
     def _print_csv(
         self,
@@ -316,9 +318,9 @@ class DatasetCommand(command_base.Command):
         agg = metadata.get_as_aggregate_opinion()
         csvwriter.writerow(
             {
-                "collab": collab_name,
-                "signal_str": signal_str,
                 "signal_type": signal_type.get_name(),
+                "signal_str": signal_str,
+                "collab": collab_name,
                 "category": agg.category.name,
                 "tags": " ".join(agg.tags),
             }

--- a/python-threatexchange/threatexchange/cli/tests/dataset_cmd_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/dataset_cmd_test.py
@@ -43,15 +43,16 @@ class DatasetCommandTest(ThreatExchangeCLIE2eTest):
         output = self.cli_call("dataset", "-P")
         assert output.count("\n") == signal_count
         assert (
-            "'Sample Signals' url "
+            "url "
             "https://developers.facebook.com/docs/threat-exchange/reference/apis/ "
+            "'Sample Signals' "
             "INVESTIGATION_SEED"
         ) in output
         # The filters change the print output
         self.assert_cli_output(
             ("dataset", "-P", "-s", "url"),
-            "'Sample Signals' "
             "https://developers.facebook.com/docs/threat-exchange/reference/apis/ "
+            "'Sample Signals' "
             "INVESTIGATION_SEED",
         )
         self.assert_cli_output(
@@ -67,23 +68,24 @@ class DatasetCommandTest(ThreatExchangeCLIE2eTest):
         output = self.cli_call("dataset", "-P", "--csv")
         assert output.count("\n") - 1 == signal_count  # -1 for header
         assert (
-            "Sample Signals,url,"
+            "url,"
             "https://developers.facebook.com/docs/threat-exchange/reference/apis/,"
+            "Sample Signals,"
             "INVESTIGATION_SEED,"
         ) in output
         # Repeat same filters - however, these don't change the output format except -S\
-        csv_header = "collab,signal_type,signal_str,category,tags\n"
+        csv_header = "signal_type,signal_str,collab,category,tags\n"
         self.assert_cli_output(
             ("dataset", "-P", "--csv", "-s", "url"),
-            csv_header + "Sample Signals,url,"
+            csv_header + "url,"
             "https://developers.facebook.com/docs/threat-exchange/reference/apis/,"
-            "INVESTIGATION_SEED,",
+            "Sample Signals,INVESTIGATION_SEED,",
         )
         self.assert_cli_output(
             ("dataset", "-P", "--csv", "-s", "url", "-c", "Sample Signals"),
-            csv_header + "Sample Signals,url,"
+            csv_header + "url,"
             "https://developers.facebook.com/docs/threat-exchange/reference/apis/,"
-            "INVESTIGATION_SEED,",
+            "Sample Signals,INVESTIGATION_SEED,",
         )
         # --csv and -S not combinable
         self.assert_cli_usage_error(("dataset", "-P", "--csv", "-S"))


### PR DESCRIPTION
Summary
---------

A tiny tweak that would have to be made pre-1.0.0, re-order the print output to make it slightly easier to use `cut` rather than `grep -o` to parse these into signals for other commands.

I think there are some other suspicious behaviors of the output of the command that might be worth looking into (I'm not sure the conditional print behavior will be fully understandable by users, but that can be a future problem.

Test Plan
---------

Update unittests
```
$ tx dataset -P | head -n 5
Looks like you haven't set up a collaboration config, so using the sample one against sample data
trend_query {"and": [{"or": ["basketball", "basket ball", "basket-ball", "bball", "hoops"]}, {"or": ["play", "tonight", "today", "now"]}], "not": ["tomorrow", "baseball", "hockey", "football", "soccer"]} 'Sample Signals' INVESTIGATION_SEED
pdq acecf3355e3125c8e24e2f30e0d4ec4f8482b878b3c34cdbdf063278db275992 'Sample Signals' INVESTIGATION_SEED
pdq 8fb70f36e1c4181e82fde7d0f80138430e1e31f07b628e31ccbb687e87e1f307 'Sample Signals' INVESTIGATION_SEED
pdq 36b4665bca0c91f6aecb8948e3381e57e509ae7210e3cd1bd768288e56a95af9 'Sample Signals' INVESTIGATION_SEED
pdq e875634b9df48df5bd7f1695c796287e8a0ec0603c0c478170fc9d0f81ea60f4 'Sample Signals' INVESTIGATION_SEED
```
