### PR TITLE
Allow import of threatexchange.signal_type.pdq.PdqSignal

### DIFF
--- a/python-threatexchange/threatexchange/signal_type/pdq/__init__.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq/__init__.py
@@ -1,1 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+# Allow import of threatexchange.signal_type.pdq.PdqSignal consistent with other
+# signal types.
+from .signal import PdqSignal


### PR DESCRIPTION
Summary
---
This change makes tx.signal_type.pdq consistent with other modules like
tx.signal_type.md5 and tx.signal_type.raw_text.

pdq is the only module that is also a subpackage,

Test
---
CI.
