### PR TITLE
[pytx] Mixin for SignalExchange with Auth

### DIFF
--- a/python-threatexchange/mypy.ini
+++ b/python-threatexchange/mypy.ini
@@ -1,4 +1,7 @@
 [mypy]
+warn_unused_configs = true
+warn_redundant_casts = True
+warn_unused_ignores = True
 strict_optional = True
 ; disallow_any_generics = True
 ; disallow_untyped_calls = True
@@ -6,8 +9,24 @@ strict_optional = True
 ; check_untyped_defs = True
 ; disallow_untyped_decorators = True
 ; no_implicit_optional = True
+; strict = True
 
+; Strict migration files
+[mypy-threatexchange.exchanges.auth]
+; strict = True seems to apply to everything :/ 
+; so type out flags one at a time
+disallow_any_generics = True
+disallow_untyped_calls = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+disallow_subclassing_any = True
+warn_return_any = True
+no_implicit_reexport = True
+strict_equality = True
 
+; Dependent libraries
 [mypy-PIL.*]
 ignore_missing_imports = True
 

--- a/python-threatexchange/threatexchange/cli/cli_config.py
+++ b/python-threatexchange/threatexchange/cli/cli_config.py
@@ -61,9 +61,7 @@ class CliState(collab_config.CollaborationConfigStoreBase):
     ):
         self._dir = dir.expanduser()
 
-        self._name_to_ctype = {
-            ft.get_name(): ft.get_config_class() for ft in fetch_types
-        }
+        self._name_to_ctype = {ft.get_name(): ft.get_config_cls() for ft in fetch_types}
 
         self._cache: t.Optional[
             t.Dict[str, collab_config.CollaborationConfigBase]
@@ -181,10 +179,7 @@ class _SignalExchangeAccessor:
         t.Any,
     ]:
         api_cls = self._parent._mapping.exchange.api_by_name[collab.api]
-        # This is a hard typing challenge, and cast() doesn't seem to work
-        # By lookup by name, we are guaranteed to pick an API with the right
-        # typing signature, but of an unknown class
-        return api_cls.for_collab(collab)  # type: ignore[arg-type]
+        return api_cls.for_collab(collab)
 
     def __iter__(self) -> t.Iterator[TSignalExchangeAPICls]:
         yield from self.get_all()

--- a/python-threatexchange/threatexchange/cli/config_cmd.py
+++ b/python-threatexchange/threatexchange/cli/config_cmd.py
@@ -120,7 +120,7 @@ class _UpdateCollabCommand(command_base.Command):
 
     @classmethod
     def init_argparse(cls, settings: CLISettings, ap: argparse.ArgumentParser) -> None:
-        cfg_cls = cls._API_CLS.get_config_class()
+        cfg_cls = cls._API_CLS.get_config_cls()
         assert is_dataclass(cfg_cls)
 
         ap.add_argument("collab_name", help="the name of the collab")
@@ -247,7 +247,7 @@ class _UpdateCollabCommand(command_base.Command):
         if enable is not None:
             self.edit_kwargs["enabled"] = bool(enable)
 
-        for field in fields(self._API_CLS.get_config_class()):
+        for field in fields(self._API_CLS.get_config_cls()):
             if not field.init:
                 if field.name == "api":
                     self.edit_kwargs.pop("api", None)
@@ -272,14 +272,14 @@ class _UpdateCollabCommand(command_base.Command):
                     2,
                 )
             assert (
-                existing.__class__ == self._API_CLS.get_config_class()
+                existing.__class__ == self._API_CLS.get_config_cls()
             ), "api name the same, but class different?"
             for name, val in self.edit_kwargs.items():
                 setattr(existing, name, val)
             settings._state.update_collab(existing)
         elif self.create:
             logging.debug("Creating config with args: %s", self.edit_kwargs)
-            to_create = self._API_CLS.get_config_class()(**self.edit_kwargs)
+            to_create = self._API_CLS.get_config_cls()(**self.edit_kwargs)
             settings._state.update_collab(to_create)
         else:
             raise CommandError("no such config! Did you mean to use --create?", 2)

--- a/python-threatexchange/threatexchange/cli/config_cmd.py
+++ b/python-threatexchange/threatexchange/cli/config_cmd.py
@@ -218,7 +218,7 @@ class _UpdateCollabCommand(command_base.Command):
             f"--{field.name.replace('_', '-')}",
             type=argparse_type,
             metavar=metavar,
-            required=field.default is MISSING and field.default_factory is MISSING,  # type: ignore
+            required=field.default is MISSING and field.default_factory is MISSING,
             help=help,
         )
 

--- a/python-threatexchange/threatexchange/cli/dataset/simple_serialization.py
+++ b/python-threatexchange/threatexchange/cli/dataset/simple_serialization.py
@@ -50,7 +50,7 @@ class CliIndicatorSerialization(threat_updates.ThreatUpdateSerialization):
 
     # ToDo this violates Liskov but is already used in Prod and will require a larger refactor
     @classmethod
-    def store(  # type: ignore
+    def store(
         cls, state_dir: pathlib.Path, contents: t.Iterable["CliIndicatorSerialization"]
     ) -> t.List[pathlib.Path]:
         # Stores in multiple files split by indicator type

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -145,7 +145,7 @@ def execute_command(settings: CLISettings, namespace) -> None:
     if "full_argparse_namespace" in arg_names:
         command_args["full_argparse_namespace"] = namespace
 
-    command = command_cls(**command_args)  # type: ignore[call-arg]
+    command = command_cls(**command_args)
     command.execute(settings)
 
 

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -35,20 +35,15 @@ import pathlib
 import shutil
 import warnings
 
-from threatexchange.cli.exceptions import CommandError
-
-
 # Import pdq first with its hash order warning squelched, it's before our time
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     from threatexchange.signal_type.pdq import signal
 
+from threatexchange.cli.exceptions import CommandError
 from threatexchange import interface_validation
 from threatexchange.content_type.content_base import ContentType
 from threatexchange.extensions.manifest import ThreatExchangeExtensionManifest
-from threatexchange.exchanges.clients.stopncii import api as stopncii_api
-from threatexchange.exchanges.clients.fb_threatexchange import api as tx_api
-from threatexchange.exchanges.clients.ncmec import hash_api as ncmec_api
 from threatexchange.exchanges.impl.file_api import LocalFileSignalExchangeAPI
 from threatexchange.exchanges.impl.static_sample import StaticSampleSignalExchangeAPI
 from threatexchange.exchanges.impl.fb_threatexchange_api import (
@@ -65,8 +60,8 @@ from threatexchange.exchanges.impl.ncmec_api import (
 )
 
 from threatexchange.content_type import photo, video, text, url
-from threatexchange.exchanges.signal_exchange_api import (
-    SignalExchangeAPI,
+from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
+from threatexchange.exchanges.auth import (
     SignalExchangeAPIInvalidAuthException,
     SignalExchangeAPIMissingAuthException,
 )

--- a/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
+++ b/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
@@ -74,7 +74,7 @@ class ThreatExchangeCLIE2eHelper:
     def assert_cli_usage_error(
         self, args: t.Iterable[str], msg_regex: str = None
     ) -> None:
-        with pytest.raises((CommandError, E2ETestSystemExit), match=msg_regex) as ex:  # type: ignore
+        with pytest.raises((CommandError, E2ETestSystemExit), match=msg_regex) as ex:
             self.cli_call(*args)
         exception = t.cast(t.Union[CommandError, E2ETestSystemExit], ex.value)
         assert exception.returncode == 2

--- a/python-threatexchange/threatexchange/cli/tests/fake_extension.py
+++ b/python-threatexchange/threatexchange/cli/tests/fake_extension.py
@@ -81,7 +81,7 @@ class FakeSignalExchange(
     ]
 ):
     @classmethod
-    def get_config_class(cls) -> t.Type[FakeCollabConfig]:
+    def get_config_cls(cls) -> t.Type[FakeCollabConfig]:
         return FakeCollabConfig
 
     @classmethod

--- a/python-threatexchange/threatexchange/exchanges/auth.py
+++ b/python-threatexchange/threatexchange/exchanges/auth.py
@@ -1,0 +1,205 @@
+#  Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Helpers for handling authentification and credentials for SignalExchangeAPI
+"""
+
+from abc import ABCMeta, abstractmethod
+import contextlib
+import logging
+import os
+import pathlib
+import typing as t
+
+from threatexchange.exchanges.signal_exchange_api import (
+    AnySignalExchangeAPI,
+    TCollabConfig,
+)
+
+
+class SignalExchangeAPIInvalidAuthException(Exception):
+    """
+    An exception you can use to hint users their authentification is bad
+
+    This can be because it's incorrectly formatted, it's been expired,
+    or a multitude of other reasons.
+    """
+
+    def __init__(self, src_api: t.Type[AnySignalExchangeAPI], message: str) -> None:
+        self.src_api = src_api
+        self.message = message
+
+
+class SignalExchangeAPIMissingAuthException(Exception):
+    """
+    An exception you can use to hint users how to authentificate your API
+    """
+
+    def __init__(
+        self,
+        src_api: t.Type[AnySignalExchangeAPI],
+        *,
+        file_hint: str = "",
+        env_hint: str = "",
+    ) -> None:
+        self.src_api = src_api
+        self.hints: t.List[str] = []
+        if env_hint:
+            self.add_env_hint(env_hint)
+        if file_hint:
+            self.add_file_hint(file_hint)
+
+    def add_file_hint(self, filename: str) -> None:
+        self.hints.append(
+            f"creating (and maybe `chmod 400`) a file with credentials at {filename}"
+        )
+
+    def add_env_hint(self, variable_name: str) -> None:
+        self.hints.append(f"populating an environment variable called {variable_name}")
+
+    def pretty_str(self) -> str:
+        lines = [
+            f"Couldn't authenticate {self.src_api.get_name()}, "
+            "it's missing authentification!"
+        ]
+        if self.hints:
+            lines.append("You can fix this by:")
+            for i, hint in enumerate(self.hints, 1):
+                lines.append(f"  {i}. {hint}")
+        return "\n".join(lines)
+
+
+CredentialSelf = t.TypeVar("CredentialSelf", bound="CredentialHelper")
+
+
+class CredentialHelper:
+    """
+    Wrapper to help standardize credential sources, and tie to exceptions
+    """
+
+    ENV_VARIABLE: t.ClassVar[str] = ""
+    FILE_NAME: t.ClassVar[str] = ""
+
+    # This is slated to be removed in a future version!
+    # It's a placeholder approach while for_collab() gains the auth argument
+    _DEFAULT: t.ClassVar[t.Optional["CredentialHelper"]] = None  # t.Self
+    _DEFAULT_SRC: t.ClassVar[str] = ""
+
+    @classmethod
+    def get(
+        cls: t.Type[CredentialSelf], for_cls: t.Type[AnySignalExchangeAPI]
+    ) -> CredentialSelf:
+        srcs: t.List[t.Tuple[t.Callable[[], t.Optional[CredentialSelf]], str]] = [
+            ((lambda: cls._DEFAULT), cls._DEFAULT_SRC),  # type: ignore[list-item,return-value]
+            (cls._from_env, f"environment variable {cls.ENV_VARIABLE}"),
+            (cls._from_file, f"file {cls.FILE_NAME}"),
+        ]
+        for fn, src in srcs:
+            try:
+                creds = fn()
+                if creds is None:
+                    continue
+                if creds._are_valid():
+                    return creds
+            except Exception:
+                logging.exception("Exception during parsing %s", src)
+                pass
+            raise SignalExchangeAPIInvalidAuthException(
+                for_cls, f"Invalid credentials from {src}"
+            )
+        ex = SignalExchangeAPIMissingAuthException(for_cls)
+        if cls._DEFAULT_SRC:
+            ex.hints.append(cls._DEFAULT_SRC)
+        if cls.ENV_VARIABLE:
+            ex.add_env_hint(cls.ENV_VARIABLE)
+        if cls.FILE_NAME:
+            ex.add_file_hint(cls.FILE_NAME)
+        raise ex
+
+    @classmethod
+    def set_default(
+        cls: t.Type[CredentialSelf], new_default: t.Optional[CredentialSelf], src: str
+    ) -> t.ContextManager[None]:
+        """
+        Set the default (highest preferred) credentials manually.
+
+        They won't be checked for validity until a future get()
+
+        This call can be used as contextmanager to unset within a `with` statement
+        """
+        cls._DEFAULT = new_default
+        cls._DEFAULT_SRC = src
+        return cls._unset_default_context()
+
+    @classmethod
+    @contextlib.contextmanager
+    def _unset_default_context(cls: t.Type[CredentialSelf]) -> t.Iterator[None]:
+        yield
+        cls.clear_default()
+
+    @classmethod
+    def clear_default(cls) -> None:
+        """Reset the default"""
+        cls.set_default(None, "")
+
+    @classmethod
+    def _from_str(cls: t.Type[CredentialSelf], s: str) -> t.Optional[CredentialSelf]:
+        """Parse credentials from a string"""
+        return None
+
+    @classmethod
+    def _from_file(cls: t.Type[CredentialSelf]) -> t.Optional[CredentialSelf]:
+        """Parse credentials from a file"""
+        if not cls.FILE_NAME:
+            return None
+        path = pathlib.Path(cls.FILE_NAME).expanduser()
+        if not path.is_file():
+            return None
+        return cls._from_str(path.read_text().strip())
+
+    @classmethod
+    def _from_env(cls: t.Type[CredentialSelf]) -> t.Optional[CredentialSelf]:
+        """Parse credentials from an environment variable"""
+        if not cls.ENV_VARIABLE:
+            return None
+        s = os.environ.get(cls.ENV_VARIABLE)
+        if not s:
+            return None
+        return cls._from_str(s)
+
+    def _are_valid(self) -> bool:
+        return True
+
+
+TCredentials = t.TypeVar("TCredentials", bound=CredentialHelper)
+Self = t.TypeVar("Self")
+
+
+class SignalExchangeWithAuth(t.Generic[TCollabConfig, TCredentials], metaclass=ABCMeta):
+    """
+    A mixin for SignalExchange APIs that need authentification/credentials
+
+    The promises made by for_collab are the same - if no credentials are passed in,
+    the class can search for its own credentials (though the CredentialHelper class
+    makes it easy to do there).
+    """
+
+    @staticmethod
+    @abstractmethod
+    def get_credential_cls() -> t.Type[TCredentials]:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def for_collab(
+        cls: t.Type[Self],
+        collab: TCollabConfig,
+        credentials: t.Optional[TCredentials] = None,
+    ) -> Self:
+        """
+        @see SignalExchangeAPI.for_collab
+
+        If credentials are passed in, the API should use those rather than
+        trying to discover its own.
+        """
+        pass

--- a/python-threatexchange/threatexchange/exchanges/impl/file_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/file_api.py
@@ -61,9 +61,17 @@ class LocalFileSignalExchangeAPI(
 
     collab: FileCollaborationConfig
 
-    @classmethod
-    def get_config_class(cls) -> t.Type[FileCollaborationConfig]:
+    @staticmethod
+    def get_config_cls() -> t.Type[FileCollaborationConfig]:
         return FileCollaborationConfig
+
+    @staticmethod
+    def get_checkpoint_cls() -> t.Type[state.FetchCheckpointBase]:
+        return state.FetchCheckpointBase
+
+    @staticmethod
+    def get_record_cls() -> t.Type[state.FetchedSignalMetadata]:
+        return state.FetchedSignalMetadata
 
     @classmethod
     def for_collab(

--- a/python-threatexchange/threatexchange/exchanges/impl/file_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/file_api.py
@@ -117,7 +117,7 @@ class LocalFileSignalExchangeAPI(
         path = Path(self.collab.filename)
         with path.open("rb") as rf:
             rf.seek(-1, os.SEEK_END)
-            has_newline = rf.read1(1) == b"\n"  # type: ignore  # mypy bug? read1 noexist
+            has_newline = rf.read1(1) == b"\n"
         # Appending will overwrite previous ones, and compaction is for scrubs
         with path.open("wta") as wf:
             nl = "" if has_newline else "\n"

--- a/python-threatexchange/threatexchange/exchanges/impl/static_sample.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/static_sample.py
@@ -34,13 +34,23 @@ class StaticSampleSignalExchangeAPI(
         state.FetchedSignalMetadata,
     ]
 ):
-    """
-    Return a static set of sample data for demonstration.
-    """
+    """Return a static set of sample data for demonstration"""
 
     @classmethod
     def get_name(cls) -> str:
         return "sample"
+
+    @staticmethod
+    def get_config_cls() -> t.Type[CollaborationConfigBase]:
+        return CollaborationConfigBase
+
+    @staticmethod
+    def get_checkpoint_cls() -> t.Type[state.FetchCheckpointBase]:
+        return state.FetchCheckpointBase
+
+    @staticmethod
+    def get_record_cls() -> t.Type[state.FetchedSignalMetadata]:
+        return state.FetchedSignalMetadata
 
     @classmethod
     def for_collab(

--- a/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
@@ -12,6 +12,7 @@ from threatexchange.exchanges.clients.stopncii import api
 
 from threatexchange.exchanges import fetch_state as state
 from threatexchange.exchanges import signal_exchange_api
+from threatexchange.exchanges import auth
 from threatexchange.exchanges.collab_config import (
     CollaborationConfigBase,
 )
@@ -63,7 +64,7 @@ class StopNCIISignalMetadata(state.FetchedSignalMetadata):
 
 
 @dataclass
-class StopNCIICredentials(signal_exchange_api.CredentialHelper):
+class StopNCIICredentials(auth.CredentialHelper):
     ENV_VARIABLE: t.ClassVar[str] = "TX_STOPNCII_KEYS"
     FILE_NAME: t.ClassVar[str] = "~/.tx_stopncii_keys"
 
@@ -80,11 +81,12 @@ class StopNCIICredentials(signal_exchange_api.CredentialHelper):
 
 
 class StopNCIISignalExchangeAPI(
+    auth.SignalExchangeWithAuth[CollaborationConfigBase, StopNCIICredentials],
     signal_exchange_api.SignalExchangeAPIWithSimpleUpdates[
         CollaborationConfigBase,
         StopNCIICheckpoint,
         StopNCIISignalMetadata,
-    ]
+    ],
 ):
     """
     Conversion for the StopNCII.org API
@@ -104,6 +106,22 @@ class StopNCIISignalExchangeAPI(
         super().__init__()
         self.collab = collab
         self.api = client
+
+    @staticmethod
+    def get_config_cls() -> t.Type[CollaborationConfigBase]:
+        return CollaborationConfigBase
+
+    @staticmethod
+    def get_checkpoint_cls() -> t.Type[StopNCIICheckpoint]:
+        return StopNCIICheckpoint
+
+    @staticmethod
+    def get_record_cls() -> t.Type[StopNCIISignalMetadata]:
+        return StopNCIISignalMetadata
+
+    @staticmethod
+    def get_credential_cls() -> t.Type[StopNCIICredentials]:
+        return StopNCIICredentials
 
     @classmethod
     def for_collab(

--- a/python-threatexchange/threatexchange/exchanges/tests/test_state.py
+++ b/python-threatexchange/threatexchange/exchanges/tests/test_state.py
@@ -80,6 +80,18 @@ class _FakeAPIMixin(t.Generic[TUpdateRecordKey, TUpdateRecordValue]):
     def get_fake_collab_config(cls) -> CollaborationConfigBase:
         return CollaborationConfigWithDefaults("Test State", cls.get_name())  # type: ignore
 
+    @staticmethod
+    def get_config_cls() -> t.Type[CollaborationConfigBase]:
+        return CollaborationConfigBase
+
+    @staticmethod
+    def get_checkpoint_cls() -> t.Type[FakeCheckpoint]:
+        return FakeCheckpoint
+
+    @staticmethod
+    def get_record_cls() -> t.Type[FakeSignalMetadata]:
+        return FakeSignalMetadata
+
     def fetch_iter(
         self,
         supported_signal_types: t.Sequence[t.Type[SignalType]],

--- a/python-threatexchange/threatexchange/extensions/manifest.py
+++ b/python-threatexchange/threatexchange/extensions/manifest.py
@@ -42,7 +42,7 @@ class ThreatExchangeExtensionManifest:
             raise ValueError(f"No such module '{module_name}'")
 
         try:
-            manifest = module.TX_MANIFEST  # type: ignore
+            manifest = module.TX_MANIFEST
         except AttributeError:
             raise ValueError(f"Module is missing TX_MANIFEST")
 

--- a/python-threatexchange/threatexchange/signal_type/pdq/pdq_faiss_matcher.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq/pdq_faiss_matcher.py
@@ -1,9 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import typing as t
-import faiss  # type: ignore
+import faiss
 import binascii
-import numpy  # type: ignore
+import numpy
 from abc import ABC, abstractmethod
 
 from threatexchange.signal_type.pdq.pdq_utils import BITS_IN_PDQ


### PR DESCRIPTION
Summary
---------

It turns out that this change would have been backwards compatible :/ 

At least it gives us a model for how to go forward - we can use mixins to add functionality a little at a time, and merge into the base class during major versions.

Adds a mixin for SignalExchanges with authentication, which is compatible with the superclasses version.

Test Plan
---------

mypy && py.test

Also added the template for increasing strictness over time, and applied it to the new auth.py module
