### PR TITLE
[pytx][vpdq] Fix typo in match str

### DIFF
--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
@@ -33,7 +33,7 @@ class VPDQSimilarityInfo(SignalSimilarityInfo):
     compared_match_percent: float
 
     def pretty_str(self) -> str:
-        return f"{self.query_match_percent:.0f}%[{self.compared_match_percent:.0f}%])"
+        return f"{self.query_match_percent:.0f}%[{self.compared_match_percent:.0f}%]"
 
 
 class VPDQIndex(SignalTypeIndex[IndexT]):


### PR DESCRIPTION
Summary
---------

A definite facepalm by me. Left over from switching () to []

Test Plan
---------

Before:
```
tx match video https://github.com/facebook/ThreatExchange/blob/main/tmk/sample-videos/chair-19-sd-bar.mp4?raw=true
vpdq 100%[100%]) (video_bank) INVESTIGATION_SEED
```

After:
```
tx match video https://github.com/facebook/ThreatExchange/blob/main/tmk/sample-videos/chair-19-sd-bar.mp4?raw=true
vpdq 100%[100%] (video_bank) INVESTIGATION_SEED
```
