### PR TITLE
[multi] Store generic bank_info against each bank; connect tx_collab_configs to bank_ids

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_info.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_info.py
@@ -1,0 +1,43 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import typing as t
+from dataclasses import dataclass
+import unittest
+
+from hmalib.common.tests.mapping_common import get_default_signal_type_mapping
+
+from hmalib.common.models.bank import BanksTable
+from hmalib.common.models.tests.test_signal_uniqueness import BanksTableTestBase
+
+
+@dataclass
+class _BankRandomInfo:
+    foo: str
+    bar: int
+    body: t.Set[int]
+    ping: str
+
+
+class BankInfoTestCase(BanksTableTestBase, unittest.TestCase):
+    def _create_bank(self) -> str:
+        table_manager = BanksTable(
+            self.get_table(), signal_type_mapping=get_default_signal_type_mapping()
+        )
+
+        bank = table_manager.create_bank("TEST_Bank", "Test bank description")
+        return bank.bank_id
+
+    def test_bank_info_serialization_deserialization(self):
+        with self.fresh_dynamodb():
+            table_manager = BanksTable(
+                self.get_table(), get_default_signal_type_mapping()
+            )
+            bank_id = self._create_bank()
+
+            bank_info = _BankRandomInfo(
+                foo="propah", bar=199, body={1, 2, 3, 4, 5}, ping="pong"
+            )
+            table_manager.update_bank_info(bank_id, bank_info)
+
+            retrieved = table_manager.get_bank_info(bank_id)
+            self.assertEquals(bank_info, retrieved)


### PR DESCRIPTION
Summary
---------
Please review commit by commit.

### [`55b52f38`](https://github.com/facebook/ThreatExchange/pull/1176/commits/55b52f3851a9b3203066c1fd14bad019847ef27b) Update and retrieve bank_info objects against a bank_id
We allow any serializable object to be written and retrieved from the bank. We'll start storing fetch checkpoints here.  
### [`8a673921`](https://github.com/facebook/ThreatExchange/pull/1176/commits/8a673921df9abb09a042c8a991fd25db5718d267) Collab configs now are connected to a bank_id
Each collab config must be connected to a bank_id, otherwise what do we do with this collab?  To make the API feel more natural, allow users to deal with `EditableCollaborationConfig` objects rather than the actualized `CollaborationConfigBase` object. This allows free access to the `import_as_bank_id` property.  

Test Plan
---------
Test cases for each change.