### PR TITLE
[pytx][setup] Set minimum numpy version

### DIFF
--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -55,7 +55,7 @@ setup(
         "Pillow",  # pdq
         "pdqhash>=0.2.2",  # pdq
         "faiss-cpu>=1.6.3",  # faiss
-        "numpy",  # faiss
+        "numpy>=1.23.2",  # faiss
     ],
     extras_require=extras_require,
     entry_points={"console_scripts": ["threatexchange = threatexchange.cli.main:main"]},


### PR DESCRIPTION
Summary
---------

Attempt to fix an error reported when trying to install python-threatexchange with older numpy version already installed. 

Debating if we should add version requirements to the other libraries without them as well...

Test Plan
---------

`python-threatexchange $ make local_install`
without error