### PR TITLE
[py-tx][stopncii] Fix auth bugs

### DIFF
--- a/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
@@ -92,7 +92,9 @@ class FetchHashesResponse:
     """
 
     count: int  # How many records are there?
-    nextPageToken: str  # Cursor for paginating, not valid over long periods of time
+    nextPageToken: t.Optional[
+        str
+    ]  # Cursor for paginating, not valid over long periods of time
     nextSetTimestamp: int  # The best timestamp to use to store as a checkpoint
     hasMoreRecords: bool  # If the cursor is fully played out
     hashRecords: t.List[StopNCIIHashRecord]  # The records
@@ -248,7 +250,7 @@ class StopNCIIAPI:
                 start_timestamp=start_timestamp, next_page=next_page
             )
             has_more = result.hasMoreRecords
-            next_page = result.nextPageToken
+            next_page = result.nextPageToken or ""
             yield result
 
     def submit_hash(

--- a/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
@@ -68,16 +68,16 @@ class StopNCIICredentials(auth.CredentialHelper):
     ENV_VARIABLE: t.ClassVar[str] = "TX_STOPNCII_KEYS"
     FILE_NAME: t.ClassVar[str] = "~/.tx_stopncii_keys"
 
-    function_key: str
     subscription_key: str
+    fetch_function_key: str
 
     @classmethod
     def _from_str(cls, s: str) -> "StopNCIICredentials":
-        user, _, passw = s.strip().partition(",")
-        return cls(user, passw)
+        subscription_key, _, fetch_function_key = s.strip().partition(",")
+        return cls(fetch_function_key, subscription_key)
 
     def _are_valid(self) -> bool:
-        return bool(self.function_key and self.subscription_key)
+        return bool(self.fetch_function_key and self.subscription_key)
 
 
 class StopNCIISignalExchangeAPI(
@@ -132,7 +132,9 @@ class StopNCIISignalExchangeAPI(
         credentials = credentials or StopNCIICredentials.get(cls)
         return cls(
             collab,
-            api.StopNCIIAPI(credentials.function_key, credentials.subscription_key),
+            api.StopNCIIAPI(
+                credentials.subscription_key, credentials.fetch_function_key
+            ),
         )
 
     def fetch_iter(

--- a/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
@@ -68,13 +68,15 @@ class StopNCIICredentials(auth.CredentialHelper):
     ENV_VARIABLE: t.ClassVar[str] = "TX_STOPNCII_KEYS"
     FILE_NAME: t.ClassVar[str] = "~/.tx_stopncii_keys"
 
-    subscription_key: str
     fetch_function_key: str
+    subscription_key: str
 
     @classmethod
     def _from_str(cls, s: str) -> "StopNCIICredentials":
-        subscription_key, _, fetch_function_key = s.strip().partition(",")
-        return cls(fetch_function_key, subscription_key)
+        fetch_function_key, _, subscription_key = s.strip().partition(",")
+        return cls(
+            subscription_key=subscription_key, fetch_function_key=fetch_function_key
+        )
 
     def _are_valid(self) -> bool:
         return bool(self.fetch_function_key and self.subscription_key)


### PR DESCRIPTION
Summary
---------

This is what I get for not thoroughly testing. Better late then never I suppose.

This looks like it's backwards compatible, but I'm actually swapping the order twice - so anyone who got the API fetching previously by putting them in the "wrong" order will still be okay.

Test Plan
---------
1. Put credentials in ~/.tx_stopncii_keys
2. tx config collab edit stop_ncii -C stop_ncii_prod
3. tx fetch

This uncovers a new bug - we're not picking up the vMD5s...
