### PR TITLE
[pdq][cpp] support Apple M1 by adding -Wno-deprecated-declarations

### DIFF
--- a/pdq/cpp/Makefile
+++ b/pdq/cpp/Makefile
@@ -1,18 +1,18 @@
 # ================================================================
 ifneq ($(findstring wasm, $(MAKECMDGOALS)), wasm)
-CXX=g++ # please customize according to your system --- Note: Apple clang on M1 is not currently supported 
+CXX=g++ # please customize according to your system --- Note: Apple clang on M1 is not currently supported
 CC=$(CXX) -g -std=c++11
-WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation -Wno-unknown-warning-option -Werror
+WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation -Wno-unknown-warning-option -Werror -Wno-deprecated-declarations
 LFLAGS=-lm -lpthread
 else
 CC=emcc -g -std=c++11 -D BUILD_WASM -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s EXPORTED_RUNTIME_METHODS=['ccall','UTF8ToString ']  -s  EXPORTED_FUNCTIONS=['_getHash'] -s FORCE_FILESYSTEM=1 -s LLD_REPORT_UNDEFINED -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s DISABLE_EXCEPTION_CATCHING=0 -s ALLOW_MEMORY_GROWTH=1
-WFLAGS=-Wall -Wno-char-subscripts -Werror
+WFLAGS=-Wall -Wno-char-subscripts -Werror -Wno-deprecated-declarations
 LFLAGS=-lm
 endif
 
 IFLAGS=-I../.. -I.
 # -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation is because of CImg.h
-WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation -Wno-unknown-warning-option -Werror
+WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation -Wno-unknown-warning-option -Werror -Wno-deprecated-declarations
 LFLAGS=-lm -lpthread
 
 CCOPT=$(CC) $(CFLAGS) $(IFLAGS) $(WFLAGS) -O3


### PR DESCRIPTION
_Note: Submission of Facebook corporate CLA is pending._

Summary
---------

Support build of PDQ C++ implementation on Apple M1 by adding `-Wno-deprecated-declarations`

Essentially the only build failures I got on M1 (before this PR) were some deprecated function errors, such as `error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.`. Adding the flag `-Wno-deprecated-declarations` makes it ignore those errors.

AFAICS this is a stop gap solution to make it build, while the real fix would be to replace these functions with their newer/safer versions.

This worked using an Apple M1 Max, running `macOS 12.6` and  this `g++` version:

```
Apple clang version 14.0.0 (clang-1400.0.29.201)
Target: arm64-apple-darwin21.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

Test Plan
---------

Unfortunately tests run from the Makefile did fail. It seems the actual hashes are identical, but the "delta" values are different (I have no clue what that means).

Here is a snippet of `git diff output-regtest/` showing examples of this:

```
 pdq-photo-hasher --details ./reg_test/../../data/reg-test-input/dih/bridge-1-original.jpg ./reg_test/../../data/reg-test-input/dih/bridge-2-rotate-90.jpg ./reg_test/../../data/reg-test-input/dih/bridge-3-rotate-180.jpg ./reg_test/../../data/reg-test-input/dih/bridge-4-rotate-270.jpg ./reg_test/../../data/reg-test-input/dih/bridge-5-flipx.jpg ./reg_test/../../data/reg-test-input/dih/bridge-6-flipy.jpg ./reg_test/../../data/reg-test-input/dih/bridge-7-flip-plus-1.jpg ./reg_test/../../data/reg-test-input/dih/bridge-8-flip-minus-1.jpg
 
 hash=d8f8f0cee0f4a84f0637022a078f67f0b36e2ed596621e1d33e6339c4e9c9b22,norm=128,delta=0,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-1-original.jpg
-hash=30a10efdf1c83f429013d48d0ffffc52e34e0e35ada952a9d29605215aa9e5af,norm=128,delta=118,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-2-rotate-90.jpg
-hash=2dad5a64b1a142e7d362a09857da895ae63b8c7fc23794b766b319361fc93188,norm=128,delta=112,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-3-rotate-180.jpg
-hash=a5f0a457248995e8c9065c275aaa5498b61ba4bdf8fcf80387c32f8b5bfc4f05,norm=128,delta=126,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-4-rotate-270.jpg
-hash=d8f80f33e0f417b20e37f5cd028f980fb36ed02a9662c1e233e64c634e9c64dd,norm=128,delta=124,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-5-flipx.jpg
-hash=2da9259bb1a1bd1a5362576552da32a5e63b7380c2774b4866b346c91b89ce77,norm=128,delta=116,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-6-flipy.jpg
-hash=f0a1e10271ccc0bd90530b720fff038de34ef1e8ada9a956d6967ade5ea91a50,norm=128,delta=118,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-7-flip-plus-1.jpg
-hash=2df05aa8a4896a17c14682da5aaaab07b61b5b42f8fc07fc87c3d0741bfcb0fa,norm=128,delta=124,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-8-flip-minus-1.jpg

+hash=30a10efdf1c83f429013d48d0ffffc52e34e0e35ada952a9d29605215aa9e5af,norm=128,delta=4198,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-2-rotate-90.jpg
+hash=2dad5a64b1a142e7d362a09857da895ae63b8c7fc23794b766b319361fc93188,norm=128,delta=3682,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-3-rotate-180.jpg
+hash=a5f0a457248995e8c9065c275aaa5498b61ba4bdf8fcf80387c32f8b5bfc4f05,norm=128,delta=4206,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-4-rotate-270.jpg
+hash=d8f80f33e0f417b20e37f5cd028f980fb36ed02a9662c1e233e64c634e9c64dd,norm=128,delta=3949,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-5-flipx.jpg
+hash=2da9259bb1a1bd1a5362576552da32a5e63b7380c2774b4866b346c91b89ce77,norm=128,delta=3686,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-6-flipy.jpg
+hash=f0a1e10271ccc0bd90530b720fff038de34ef1e8ada9a956d6967ade5ea91a50,norm=128,delta=3688,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-7-flip-plus-1.jpg
+hash=2df05aa8a4896a17c14682da5aaaab07b61b5b42f8fc07fc87c3d0741bfcb0fa,norm=128,delta=3694,quality=100,filename=./reg_test/../../data/reg-test-input/dih/bridge-8-flip-minus-1.jpg
```

FWIW, here is what I get if I calculate the PDQ hashes for the bridge images:

```
> ./pdq-photo-hasher ../data/bridge-mods/*
d8f8f0cee0f4a84f0637022a078f67f0b36e2ed596621e1d33e6339c4e9c9b22,100,../data/bridge-mods/aaa-orig.jpg
d8f8f0cee0f4a84f0637022a078f67f0b36e2ed596621e1d33e6339c4e9c9b22,100,../data/bridge-mods/blur-a-little.jpg
d8f8f0cee0f4a84f0637022a078f67f0b36e2ed596621e1d33e6339c4e9c9b22,100,../data/bridge-mods/blur-a-lot.jpg
d8f8f0cee0f4a84f0637022a078f67f0b36e2ed596621e1d33e6339c4e9c9b22,100,../data/bridge-mods/high-contrast.jpg
d8f8f0cee0f4a84f0637022a038f67f0b36e2ed596631e1d33e6339c4e9c9b22,100,../data/bridge-mods/high-saturation.jpg
d8f8f0cee0f4a84f0e370222038f67f0b36e2ed596231e1d33e6b39c4e9c9b22,100,../data/bridge-mods/sharpen-a-little.jpg
d0f8f0cec0f4a84f0e370a22238f67f0b36a2ef596231e1d73e6a39c4e9c9b22,100,../data/bridge-mods/sharpen-a-lot.jpg
d8f8f0cee0f4a84f0e370a22038f67f0b36e2ed596621e1d33e6339c4e9c9b22,100,../data/bridge-mods/shrink-a-little.jpg
d0f8f1ccc0f4a84d0a370a3a228f67f0b36e2ed5b6623e1d33e6339c4e9c9b22,100,../data/bridge-mods/shrink-a-lot.jpg
d8f8f1eec0f4a84f0e37022a078f63f0b36e2ed596621e1d33e6239c4e9c9b22,100,../data/bridge-mods/square-128x128.jpg
d8f8f0cec4f4a84f0637022a078f67f0b36e2ee5b6621e1d33e6239c4e9c9b22,100,../data/bridge-mods/square-256x256.jpg
d8f8f0cec0f4a84f0637022a278f67f0b36e2ed596621e1d33e6339c4e9c9b22,100,../data/bridge-mods/square-512x512.jpg
```
