### PR TITLE
[pytx] --version to print the version

### DIFF
--- a/python-threatexchange/threatexchange/cli/.local_install_detection.txt
+++ b/python-threatexchange/threatexchange/cli/.local_install_detection.txt
@@ -1,0 +1,2 @@
+This file is used in the CLI version printout to detect if it's a local installation or not.
+This depends on this file not being distributed!

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -26,9 +26,11 @@ State is persisted between runs, entirely in the ~/.threatexchange directory
 
 import argparse
 from contextlib import contextmanager
+from importlib import metadata
 import logging
 import inspect
 import os
+import subprocess
 import sys
 import typing as t
 import pathlib
@@ -116,6 +118,12 @@ def get_argparse(settings: CLISettings) -> argparse.ArgumentParser:
         "--factory-reset",
         action="store_true",
         help="Remove all state, bringing you back to a fresh install",
+    )
+    ap.add_argument(
+        "--version",
+        action="store_true",
+        dest="print_version",
+        help="print the version and exit",
     )
     ap.add_argument(
         "--verbose",
@@ -279,6 +287,13 @@ def inner_main(
     if namespace.factory_reset:
         print("Resetting to factory defaults.", file=sys.stderr)
         shutil.rmtree(str(state_dir.expanduser().absolute()))
+        return
+    if namespace.print_version:
+        here = pathlib.Path(os.path.realpath(__file__)).parent
+        version = metadata.version("threatexchange")
+        if (here / ".local_install_detection.txt").is_file():
+            version += " dev-" + subprocess.getoutput("git rev-parse HEAD")
+        print(version)
         return
     if not namespace.is_config:
         extensions.assert_no_errors()

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -290,9 +290,12 @@ def inner_main(
         return
     if namespace.print_version:
         here = pathlib.Path(os.path.realpath(__file__)).parent
-        version = metadata.version("threatexchange")
         if (here / ".local_install_detection.txt").is_file():
-            version += " dev-" + subprocess.getoutput("git rev-parse HEAD")
+            version_txt = (here.parent.parent / "version.txt").read_text().strip()
+            git_hash = subprocess.getoutput("git rev-parse HEAD")
+            version = f"{version_txt} dev-{git_hash or '???'}"
+        else:
+            version = metadata.version("threatexchange")
         print(version)
         return
     if not namespace.is_config:

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -292,8 +292,13 @@ def inner_main(
         here = pathlib.Path(os.path.realpath(__file__)).parent
         if (here / ".local_install_detection.txt").is_file():
             version_txt = (here.parent.parent / "version.txt").read_text().strip()
-            git_hash = subprocess.getoutput("git rev-parse HEAD")
-            version = f"{version_txt} dev-{git_hash or '???'}"
+            git_hash = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=str(here.absolute()),
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            version = f"{version_txt or '???'} dev-{git_hash or '???'}"
         else:
             version = metadata.version("threatexchange")
         print(version)


### PR DESCRIPTION
Summary
---------

I keep reaching for this command and not finding it, so add it. Prints either the version from pip, or if it can tell its a local install, tries to read the git hash

Test Plan
---------

```
$ threatexchange --version
1.0.3 dev-4cfde6eb6a5d8c8629dd616ea73a23fcf147c28d

# Hardcode to take other path
$ threatexchange --version
1.0.3
```
