### PR TITLE
[pytx] A helper alias on setup.py for installs needed for development

### DIFF
--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -22,11 +22,15 @@ for extension_dir in extensions_dir.iterdir():
         )
 
 all_extras = set(sum(extras_require.values(), []))
+# We might not get any value from splitting these all out
 extras_require["test"] = sorted({"pytest"} | all_extras)
 extras_require["package"] = ["wheel"]
 extras_require["lint"] = ["black"]
 extras_require["types"] = ["mypy", "types-python-dateutil", "types-requests"]
 extras_require["all"] = sorted(set(sum(extras_require.values(), [])))
+# If you are developing pytx, use this install
+# Note that without ffmpeg (for vpdq) you may get errors still
+extras_require["dev"] = extras_require["all"]
 
 setup(
     name="threatexchange",


### PR DESCRIPTION
Summary
---------

I confused myself trying to figure out what I needed to install, which I resolved by reading the .github ci, where it installs... everything. 

It actually still fails unless I also install ffmpeg, so that might be a fun surprise for future developers.

Test Plan
---------

pip install -e .[dev]
mypy
py.test

Everything green
