### PR TITLE
Support overriding BASE_URL for stopncii.org APIs

### DIFF
--- a/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
@@ -128,10 +128,13 @@ class StopNCIIAPI:
         subscription_key: str,
         fetch_function_key: str,
         additional_function_keys: t.Optional[t.Dict[StopNCIIEndpoint, str]] = None,
+        base_url_override: t.Optional[str] = None,
     ) -> None:
         self._function_keys = dict(additional_function_keys or {})
         self._function_keys[StopNCIIEndpoint.FetchHashes] = fetch_function_key
         self._subscription_key = subscription_key
+
+        self._base_url = base_url_override or self.BASE_URL
 
     def _get_session(self, endpoint: StopNCIIEndpoint):
         """
@@ -160,7 +163,7 @@ class StopNCIIAPI:
             }
         )
         session.mount(
-            self.BASE_URL,
+            self._base_url,
             adapter=TimeoutHTTPAdapter(
                 timeout=60,
                 max_retries=Retry(
@@ -181,7 +184,7 @@ class StopNCIIAPI:
         Same timeouts and retry strategy as `_get_session` above.
         """
 
-        url = "/".join((self.BASE_URL, endpoint.value))
+        url = "/".join((self._base_url, endpoint.value))
         with self._get_session(endpoint) as session:
             response = session.get(url, params=params)
             response.raise_for_status()
@@ -194,7 +197,7 @@ class StopNCIIAPI:
         No timeout or retry strategy.
         """
 
-        url = "/".join((self.BASE_URL, endpoint.value))
+        url = "/".join((self._base_url, endpoint.value))
         with self._get_session(endpoint) as session:
             response = session.post(url, json=json)
             response.raise_for_status()

--- a/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
@@ -78,8 +78,12 @@ class StopNCIICredentials(auth.CredentialHelper):
         if len(parts) == 2:
             fetch_function_key, subscription_key = parts
             base_url_override = None
-        else:
+        elif len(parts) == 3:
             fetch_function_key, subscription_key, base_url_override = parts
+        else:
+            raise ValueError(
+                "Invalid stopNCII credentials format. Should be 'function_key,subscription_key' OR 'function_key_subscription_key,base_url_override'."
+            )
 
         return cls(
             subscription_key=subscription_key,

--- a/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
@@ -70,12 +70,21 @@ class StopNCIICredentials(auth.CredentialHelper):
 
     fetch_function_key: str
     subscription_key: str
+    base_url_override: t.Optional[str]
 
     @classmethod
     def _from_str(cls, s: str) -> "StopNCIICredentials":
-        fetch_function_key, _, subscription_key = s.strip().partition(",")
+        parts = s.strip().split(",")
+        if len(parts) == 2:
+            fetch_function_key, subscription_key = parts
+            base_url_override = None
+        else:
+            fetch_function_key, subscription_key, base_url_override = parts
+
         return cls(
-            subscription_key=subscription_key, fetch_function_key=fetch_function_key
+            subscription_key=subscription_key,
+            fetch_function_key=fetch_function_key,
+            base_url_override=base_url_override,
         )
 
     def _are_valid(self) -> bool:
@@ -135,7 +144,9 @@ class StopNCIISignalExchangeAPI(
         return cls(
             collab,
             api.StopNCIIAPI(
-                credentials.subscription_key, credentials.fetch_function_key
+                credentials.subscription_key,
+                credentials.fetch_function_key,
+                base_url_override=credentials.base_url_override,
             ),
         )
 


### PR DESCRIPTION
Summary
---------
StopNCII.org has a test instance with benign hashes that can be used to test an integration. This allows pytx fetch to work transparently.

Until today, the stopncii credentials string looked like

**Format 1**
```
<function_key>,<subscription_key>
```

Now, it can be

**Format 2**
```
<function_key>,<subscription_key>,<base_url>
```

This is optional. If base_url is not provided, the default one is used.


Test Plan
---------
```
$ threatexchange --factory-reset 
$ threatexchange config collab edit stop_ncii --create test-stop-ncii
$ ... edit ~/.tx_stopncii_keys...
$ cat ~/.tx_stop_ncii_keys
<FetchHashesFunctionKey>,<subscriptionKey>,[https://devapi.stopncii.org/api]

$ threatexchange fetch
...
Building index for pdq with 2668 signals...
Index for pdq ready
...
$ threatexchange match -H photo -- <a hash I know is in the collab, but slightly edited>
pdq 7 (test-stop-ncii) INVESTIGATION_SEED
```


To verify that the backwards compatible Format 1 style credentials works, I ran it with threatexchange fetch. That led to an error:
```
requests.exceptions.HTTPError: 401 Client Error: Access Denied for url: https://api.stopncii.org/v1/FetchHashes?startTimestamp=1661305147&pageSize=800
```

This indicates that the default URL gets used.

Quick Follows
---
Version bump on pytx. Minor version bump because CLI is backwards compatible and so is API.