### PR TITLE
Allow bank-members with known keys to be inserted; error when re-inserting

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/models/bank.py
+++ b/hasher-matcher-actioner/hmalib/common/models/bank.py
@@ -603,6 +603,44 @@ class BanksTable:
         bank_member.write_to_table(self._table)
         return bank_member
 
+    def add_bank_member_with_key(
+        self,
+        bank_id: str,
+        bank_member_id: str,
+        content_type: t.Type[ContentType],
+        storage_bucket: t.Optional[str],
+        storage_key: t.Optional[str],
+        raw_content: t.Optional[str],
+        notes: str,
+        is_media_unavailable: bool = False,
+        bank_member_tags: t.Set[str] = set(),
+    ) -> BankMember:
+        """
+        Very similar to add_bank_member(). Except, this allows the caller to
+        specify a bank_member_id rather than generate one automatically.
+
+        If bank_member_id already exists, will throw a KeyError.
+        """
+        now = datetime.now()
+        bank_member = BankMember(
+            bank_id=bank_id,
+            bank_member_id=bank_member_id,
+            content_type=content_type,
+            storage_bucket=storage_bucket,
+            storage_key=storage_key,
+            raw_content=raw_content,
+            notes=notes,
+            created_at=now,
+            updated_at=now,
+            is_media_unavailable=is_media_unavailable,
+            bank_member_tags=bank_member_tags,
+        )
+
+        written = bank_member.write_to_table_if_not_found(self._table)
+        if not written:
+            raise KeyError
+        return bank_member
+
     def update_bank_member(
         self, bank_member_id: str, notes: str, bank_member_tags: t.Set[str]
     ):

--- a/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_member_with_key.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_member_with_key.py
@@ -1,0 +1,54 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import typing as t
+from dataclasses import dataclass
+import unittest
+
+from threatexchange.content_type.photo import PhotoContent
+
+from hmalib.common.tests.mapping_common import get_default_signal_type_mapping
+
+from hmalib.common.models.bank import BanksTable
+from hmalib.common.models.tests.test_signal_uniqueness import BanksTableTestBase
+
+
+class BankMemberWithKeyTestCase(BanksTableTestBase, unittest.TestCase):
+    def _create_bank(self) -> str:
+        table_manager = BanksTable(
+            self.get_table(), signal_type_mapping=get_default_signal_type_mapping()
+        )
+
+        bank = table_manager.create_bank("TEST_Bank", "Test bank description")
+        return bank.bank_id
+
+    def test_add_bank_member_with_key(self):
+        with self.fresh_dynamodb():
+            table_manager = BanksTable(
+                self.get_table(), get_default_signal_type_mapping()
+            )
+
+            bank_id = self._create_bank()
+            bank_member_id = "fooofofofofoof"
+
+            table_manager.add_bank_member_with_key(
+                bank_id=bank_id,
+                bank_member_id=bank_member_id,
+                content_type=PhotoContent,
+                storage_bucket=None,
+                storage_key=None,
+                raw_content=None,
+                notes="",
+                is_media_unavailable=True,
+            )
+
+            with self.assertRaises(KeyError):
+                table_manager.add_bank_member_with_key(
+                    bank_id=bank_id,
+                    bank_member_id=bank_member_id,
+                    content_type=PhotoContent,
+                    storage_bucket=None,
+                    storage_key=None,
+                    raw_content=None,
+                    notes="",
+                    is_media_unavailable=True,
+                )


### PR DESCRIPTION
Summary
---
Items fetched from hash exchanges will have a known key. This is codified in the [SignalExchangeAPI](https://github.com/facebook/ThreatExchange/blob/main/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py#L25). This change allows you to use the bank_member_key as a the SignalExchangeAPI's `TUpdateRecordKey`.

There are other mechanisms which might be more appropriate to signal that a bank_member with the id already exists. (eg. silently fail; switch to update; or return False instead of raising an error). I'm not sure which one I want. Consider this to likely change in subsequent PRs as the fetching code starts using the new `add_bank_member_with_key` method.

Test Plan
---
added test to verify that repeat usage with same id causes a key error to be thrown.
