### PR TITLE
[fix] add undefined in StopNCIICSPFeedbackValue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ pdq/java/bazel-testlogs/
 .mypy_cache/
 .vscode/
 *.d.ts
+.idea/

--- a/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
@@ -44,6 +44,7 @@ class StopNCIICSPFeedbackValue(enum.Enum):
     """The feedback that a CSP has given on a hash"""
 
     Unknown = "Unknown"
+    # While undocumented, the API appears to use this value
     Undefined = "Undefined"
     None_ = "None"  # Allows you to tag without associating a state
     QualityUnknown = "QualityUnknown"  # Unsure what this is used for

--- a/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
@@ -3,6 +3,7 @@
 """Simple implementation for the StopNCII REST API"""
 
 from dataclasses import dataclass, asdict, field
+import copy
 import enum
 import logging
 import time
@@ -228,11 +229,25 @@ class StopNCIIAPI:
         logging.debug("StopNCII FetchHashes called: %s", params)
         json_val = self._get(StopNCIIEndpoint.FetchHashes, **params)
         logging.debug("StopNCII FetchHashes returns: %s", json_val)
-        return dacite.from_dict(
+        records: t.List[StopNCIIHashRecord] = []
+        for record in json_val.get("hashRecords", []):
+            try:
+                records.append(
+                    dacite.from_dict(
+                        data_class=StopNCIIHashRecord,
+                        data=record,
+                        config=dacite.Config(cast=[enum.Enum, set]),
+                    )
+                )
+            except ValueError as e:
+                logging.error("Convert response from JSON to Dataclass failed, err: %s, record: %s", e, record)
+        response: FetchHashesResponse = dacite.from_dict(
             data_class=FetchHashesResponse,
-            data=json_val,
+            data={**json_val, "hashRecords": []},
             config=dacite.Config(cast=[enum.Enum, set]),
         )
+        response.hashRecords = records
+        return response
 
     def fetch_hashes_iter(
         self, start_timestamp: int = DEFAULT_START_TIME

--- a/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
@@ -44,6 +44,7 @@ class StopNCIICSPFeedbackValue(enum.Enum):
     """The feedback that a CSP has given on a hash"""
 
     Unknown = "Unknown"
+    Undefined = "Undefined"
     None_ = "None"  # Allows you to tag without associating a state
     QualityUnknown = "QualityUnknown"  # Unsure what this is used for
     PendingReview = "PendingReview"  # There was a match

--- a/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
@@ -45,8 +45,6 @@ class StopNCIICSPFeedbackValue(enum.Enum):
     """The feedback that a CSP has given on a hash"""
 
     Unknown = "Unknown"
-    # While undocumented, the API appears to use this value
-    Undefined = "Undefined"
     None_ = "None"  # Allows you to tag without associating a state
     QualityUnknown = "QualityUnknown"  # Unsure what this is used for
     PendingReview = "PendingReview"  # There was a match
@@ -229,6 +227,9 @@ class StopNCIIAPI:
         logging.debug("StopNCII FetchHashes called: %s", params)
         json_val = self._get(StopNCIIEndpoint.FetchHashes, **params)
         logging.debug("StopNCII FetchHashes returns: %s", json_val)
+        # If there is a malformed record or a change that would prevent the deserialization
+        # of a record, skip over it instead of crashing. Please open an issue if you see the logging
+        # statement below.
         records: t.List[StopNCIIHashRecord] = []
         for record in json_val.get("hashRecords", []):
             try:

--- a/python-threatexchange/threatexchange/exchanges/clients/stopncii/tests/test_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/stopncii/tests/test_api.py
@@ -163,3 +163,94 @@ def test_mocked_get_hashes_iter(api: StopNCIIAPI):
     assert_first_record(one)
     assert_second_record(two)
     assert_third_record(three)
+
+
+def mock_get_impl_error_enum(endpoint: str, **json):
+    assert endpoint == StopNCIIEndpoint.FetchHashes
+    return {
+        "count": 3,
+        "nextSetTimestamp": 1625167824,
+        "nextPageToken": PAGE_TOKEN[:-1] + "4",
+        "hasMoreRecords": False,
+        "hashRecords": [
+            {
+                "lastModtimestamp": 1625175071,
+                "hashValue": "9def0b7dafa86a1c90f2abd78e79ceb25ec3d1a4b3d4bc7a4354baf7717ea038",
+                "hashStatus": "Active",
+                "caseNumbers": {"cc592711-7068-442f-b5d2-24d50d389751": "Active"},
+                "signalType": "ImagePDQ",
+                "CSPFeedbacks": [
+                    {
+                        "source": "Facebook",
+                        "feedbackValue": "Blocked",
+                        "tags": ["Nude", "Objectionable"],
+                    }
+                ],
+            },
+            {
+                "lastModtimestamp": 1625175071,
+                "hashValue": "9def0b7dafa86a1c90f2abd78e79ceb25ec3d1a4b3d4bc7a4354baf7717ea038",
+                "hashStatus": "Active",
+                "caseNumbers": {"cc592711-7068-442f-b5d2-24d50d389751": "Active"},
+                "signalType": "ImagePDQ",
+                "CSPFeedbacks": [
+                    {
+                        "source": "Facebook",
+                        "feedbackValue": "RandomFeedbackValue",
+                        "tags": ["Nude", "Objectionable"],
+                    }
+                ],
+            },
+            {
+                "lastModtimestamp": 1661426988,
+                "hashValue": "95d087d087f8f41cf00771c707f713c7675d07f8c618f00ef00f07f307e37087",
+                "hashStatus": "Active",
+                "caseNumbers": {
+                    "bce008ff-e114-4815-9de8-8f4a50bfd471": "Active",
+                    "df018705-fb65-4481-a036-cce0ab02168a": "Active",
+                    "504b123a-0fd9-4b95-b7ad-42abf88a1d09": "Received",
+                    "ab2754fb-836d-4947-b633-e0c6c7d55255": "Active",
+                    "cfaa8342-4f7e-4f5f-88bd-9fd083eafe57": "Active"
+                },
+                "signalType": "ImagePDQ",
+                "hashRegions": [
+                    "UK"
+                ],
+                "CSPFeedbacks": [
+                    {
+                        "source": "TikTok",
+                        "feedbackValue": "Undefined",
+                        "tags": [
+                            "Tag-One",
+                            "Tag-eight"
+                        ]
+                    },
+                    {
+                        "source": "Twitter",
+                        "feedbackValue": "Undefined",
+                        "tags": [
+                            "Tag-One",
+                            "Tag-eight"
+                        ]
+                    },
+                ]
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def error_enum_api(monkeypatch: pytest.MonkeyPatch):
+    error_enum_api = StopNCIIAPI("", "")
+    monkeypatch.setattr(error_enum_api, "_get", mock_get_impl_error_enum)
+    return error_enum_api
+
+
+def test_mocked_get_hashes_with_undefined_enum(error_enum_api: StopNCIIAPI):
+    try:
+        result = error_enum_api.fetch_hashes()
+        assert result.count == 3
+        assert len(result.hashRecords) == 2
+        assert any(i.feedbackValue == StopNCIICSPFeedbackValue.Undefined for i in result.hashRecords[1].CSPFeedbacks)
+    except Exception as exc:
+        assert False, f"fetch_hashes raised an exception {exc}"

--- a/python-threatexchange/threatexchange/exchanges/clients/stopncii/tests/test_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/stopncii/tests/test_api.py
@@ -239,18 +239,9 @@ def mock_get_impl_error_enum(endpoint: str, **json):
     }
 
 
-@pytest.fixture
-def error_enum_api(monkeypatch: pytest.MonkeyPatch):
+def test_mocked_get_hashes_with_undefined_enum(monkeypatch: pytest.MonkeyPatch):
     error_enum_api = StopNCIIAPI("", "")
     monkeypatch.setattr(error_enum_api, "_get", mock_get_impl_error_enum)
-    return error_enum_api
-
-
-def test_mocked_get_hashes_with_undefined_enum(error_enum_api: StopNCIIAPI):
-    try:
-        result = error_enum_api.fetch_hashes()
-        assert result.count == 3
-        assert len(result.hashRecords) == 2
-        assert any(i.feedbackValue == StopNCIICSPFeedbackValue.Undefined for i in result.hashRecords[1].CSPFeedbacks)
-    except Exception as exc:
-        assert False, f"fetch_hashes raised an exception {exc}"
+    result = error_enum_api.fetch_hashes()
+    assert result.count == 3
+    assert len(result.hashRecords) == 1  # since only one record has valid feedbackValue


### PR DESCRIPTION
Summary
---------

The StopNCII.org API is emitting undocumented enum values (see #1211). This will allow them to be loadable.

Test Plan
---------

Call `StopNCIIAPI.fetch_hashes()` on the [Test | Production] instance.

Before: `ValueError: 'Undefined' is not a valid StopNCIICSPFeedbackValue`

After: 
- will not raise error to block fetching process.
- will omit `StopNCIIHashRecord` that fails to `dacite`.
- will print an error log to notice user, including error message, original json string of the omitted `StopNCIIHashRecord`. 


