### PR TITLE
Add API + UI to view collaborations

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/configs/tx_collab_config.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tx_collab_config.py
@@ -9,6 +9,7 @@ interfaces require it, keeping it as just another class for now.
 
 from dataclasses import dataclass, asdict, fields
 import typing as t
+import json
 
 from threatexchange.exchanges.collab_config import CollaborationConfigBase
 from threatexchange.utils.dataclass_json import (
@@ -51,6 +52,15 @@ class EditableCollaborationConfig(HMAConfig):
     def to_pytx_collab_config(self) -> CollaborationConfigBase:
         cls = import_class(self.collab_config_class)
         return dataclass_loads(self.attributes_json_serialized, cls)
+
+    def to_json(self) -> t.Dict:
+        # Used in APIs.
+        return {
+            "name": self.name,
+            "import_as_bank_id": self.import_as_bank_id,
+            "collab_config_class": self.collab_config_class,
+            "attributes": json.loads(self.attributes_json_serialized),
+        }
 
 
 def get_collab_config(name: str) -> t.Optional[EditableCollaborationConfig]:

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -28,6 +28,7 @@ from hmalib.lambdas.api.submit import (
     get_submit_api,
     submit_content_request_from_s3_object,
 )
+from hmalib.lambdas.api.collabs import get_collabs_api
 
 # Set to 10MB for images
 bottle.BaseRequest.MEMFILE_MAX = 10 * 1024 * 1024
@@ -146,10 +147,12 @@ def bottle_init_once() -> t.Tuple[
         get_actions_api(hma_config_table=HMA_CONFIG_TABLE),
     )
 
+    bank_table = dynamodb.Table(BANKS_TABLE)
+
     app.mount(
         "/banks/",
         get_bank_api(
-            bank_table=dynamodb.Table(BANKS_TABLE),
+            bank_table=bank_table,
             bank_user_media_bucket=BANKS_MEDIA_BUCKET_NAME,
             submissions_queue_url=SUBMISSIONS_QUEUE_URL,
             signal_type_mapping=functionality_mapping.signal_and_content,
@@ -168,6 +171,15 @@ def bottle_init_once() -> t.Tuple[
         "/lcc/",
         get_lcc_api(
             storage_path=LCC_DURABLE_FS_PATH,
+            signal_type_mapping=functionality_mapping.signal_and_content,
+        ),
+    )
+
+    app.mount(
+        "/collabs/",
+        get_collabs_api(
+            hma_config_table=HMA_CONFIG_TABLE,
+            bank_table=bank_table,
             signal_type_mapping=functionality_mapping.signal_and_content,
         ),
     )

--- a/hasher-matcher-actioner/hmalib/lambdas/api/bank.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/bank.py
@@ -305,7 +305,7 @@ def get_bank_api(
         )
 
     @bank_api.post("/update-bank-member/<bank_member_id>", apply=[jsoninator])
-    def update_bank_member(bank_member_id=None) -> Bank:
+    def update_bank_member(bank_member_id=None) -> BankMember:
         """
         Update notes and tags for a bank_member_id.
         """

--- a/hasher-matcher-actioner/hmalib/lambdas/api/collabs.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/collabs.py
@@ -1,0 +1,81 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+APIs to power viewing and editing of collaborations.
+"""
+
+import bottle
+from dataclasses import dataclass, fields
+import typing as t
+from enum import Enum
+
+from mypy_boto3_dynamodb.service_resource import Table
+
+from hmalib.common.config import HMAConfig
+from hmalib.common.configs import tx_collab_config
+from hmalib.common.mappings import import_class
+from hmalib.common.mappings import HMASignalTypeMapping
+from hmalib.common.models.bank import Bank, BanksTable
+
+from hmalib.lambdas.api.middleware import SubApp, jsoninator, JSONifiable
+
+from threatexchange.exchanges.collab_config import CollaborationConfigBase
+from threatexchange.utils.dataclass_json import dataclass_loads
+
+
+@dataclass
+class AllCollabsEnvelope(JSONifiable):
+    collabs: t.List[tx_collab_config.EditableCollaborationConfig]
+
+    def to_json(self) -> t.Dict:
+        return {"collabs": [collab.to_json() for collab in self.collabs]}
+
+
+def _serialize_type(f):
+    if t.get_origin(f.type) != None:
+        origin = t.get_origin(f.type)
+        return {"type": origin.__name__, "args": t.get_args(f.type)[0].__name__}
+    elif issubclass(f.type, Enum):
+        return {"type": "enum", "possible_values": [e.name for e in f.type]}
+    else:
+        return f.type.__name__
+
+
+def get_collabs_api(
+    hma_config_table: str, bank_table: Table, signal_type_mapping: HMASignalTypeMapping
+) -> bottle.Bottle:
+    collabs_api = SubApp()
+    HMAConfig.initialize(hma_config_table)
+    banks_table = BanksTable(table=bank_table, signal_type_mapping=signal_type_mapping)
+
+    @collabs_api.get("/available-schemas")
+    def get_available_schemas():
+        """
+        Get the class names as the attribute key / types for all currently added
+        collabs.
+
+        A future version could pull from a static location or scan all packages
+        for subclasses.
+
+        PS: Is schemata the correct plural?
+        """
+        configs = tx_collab_config.get_all_collab_configs()
+        return {
+            "schemas": {
+                config.collab_config_class: {
+                    f.name: _serialize_type(f)
+                    for f in fields(config.to_pytx_collab_config())
+                }
+                for config in configs
+            }
+        }
+
+    @collabs_api.get("/", apply=[jsoninator])
+    def get_collab_configs():
+        """
+        Get currently available (enabled/disabled) Collab configs.
+        """
+        configs = tx_collab_config.get_all_collab_configs()
+        return AllCollabsEnvelope(configs)
+
+    return collabs_api

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -13,6 +13,7 @@ import {
 } from './messages/BankMessages';
 import {toDate} from './utils/DateTimeUtils';
 import {ContentType, getContentTypeForString} from './utils/constants';
+import {Collab} from './messages/CollabMessages';
 
 async function getAuthorizationToken(): Promise<string> {
   const currentSession = await Auth.currentSession();
@@ -743,4 +744,16 @@ export async function fetchIndexesLastModified(): Promise<Date> {
 
 export async function rebuildAllIndexes(): Promise<undefined> {
   return apiPost('indexes/rebuild-all').then();
+}
+
+// Collab APIs
+
+type AllCollabsEnvelope = {
+  collabs: Collab[];
+};
+
+export async function fetchAllCollabs(): Promise<Array<Collab>> {
+  return apiGet<AllCollabsEnvelope>('collabs/').then(
+    response => response.collabs,
+  );
 }

--- a/hasher-matcher-actioner/webapp/src/App.tsx
+++ b/hasher-matcher-actioner/webapp/src/App.tsx
@@ -20,6 +20,7 @@ import ViewBank from './pages/bank-management/ViewBank';
 import ViewBankMember from './pages/bank-management/ViewBankMember';
 import {AppWithNotifications} from './AppWithNotifications';
 import {AppWithConfirmations} from './AppWithConfirmations';
+import ViewCollaborations from './pages/collaborations/ViewCollaborations';
 
 export default function App(): JSX.Element {
   return (
@@ -63,6 +64,9 @@ export default function App(): JSX.Element {
                   </Route>
                   <Route path="/banks/">
                     <ViewAllBanks />
+                  </Route>
+                  <Route path="/collabs/">
+                    <ViewCollaborations />
                   </Route>
                   <Route path="/dashboard/">
                     <Dashboard />

--- a/hasher-matcher-actioner/webapp/src/Sidebar.tsx
+++ b/hasher-matcher-actioner/webapp/src/Sidebar.tsx
@@ -67,6 +67,14 @@ export default function Sidebar(
             Banks
           </NavLink>
         </li>
+        <li className="nav-item">
+          <NavLink
+            activeClassName="text-white bg-secondary rounded"
+            to="/collabs/"
+            className="nav-link px-2">
+            Collaborations
+          </NavLink>
+        </li>
       </ul>
 
       <ul className="navbar-nav push-down pb-2 pt-1">

--- a/hasher-matcher-actioner/webapp/src/messages/CollabMessages.tsx
+++ b/hasher-matcher-actioner/webapp/src/messages/CollabMessages.tsx
@@ -1,0 +1,6 @@
+export type Collab = {
+  name: string;
+  import_as_bank_id: string;
+  collab_config_class: string;
+  attributes: {[key: string]: string};
+};

--- a/hasher-matcher-actioner/webapp/src/pages/collaborations/ViewCollaborations.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/collaborations/ViewCollaborations.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React, {useEffect, useState} from 'react';
+import {Row, Col, Card, Button} from 'react-bootstrap';
+import {generatePath, NavLink} from 'react-router-dom';
+import {fetchAllCollabs} from '../../Api';
+import EmptyState from '../../components/EmptyState';
+import Loader from '../../components/Loader';
+import {Collab} from '../../messages/CollabMessages';
+import FixedWidthCenterAlignedLayout from '../layouts/FixedWidthCenterAlignedLayout';
+
+const KNOWN_PYTX_TYPES: Map<string, string> = new Map();
+KNOWN_PYTX_TYPES.set(
+  'threatexchange.exchanges.impl.fb_threatexchange_api.FBThreatExchangeCollabConfig',
+  'ThreatExchange',
+);
+KNOWN_PYTX_TYPES.set(
+  'threatexchange.exchanges.impl.ncmec_api.NCMECCollabConfig',
+  'NCMEC',
+);
+
+function mapPyTXClassToShorthand(pytxClass: string): string {
+  return KNOWN_PYTX_TYPES.get(pytxClass) || pytxClass;
+}
+
+function CollabCard({
+  name,
+  import_as_bank_id,
+  collab_config_class,
+  attributes,
+}: Collab): JSX.Element {
+  return (
+    <Card className="my-4">
+      <Card.Body>
+        <h3>{name}</h3>
+        <p>
+          <NavLink
+            to={generatePath('/banks/bank/:bankId/bank-details', {
+              bankId: import_as_bank_id,
+            })}>
+            Go to bank.
+          </NavLink>
+        </p>
+        <p>Type: {mapPyTXClassToShorthand(collab_config_class)}</p>
+        <p>Attributes:</p>
+        <ul>
+          {Object.entries(attributes).map((values: [string, string]) => (
+            <li key={values[0]}>
+              {values[0]}: {values[1]}
+            </li>
+          ))}
+        </ul>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default function ViewCollaborations(): JSX.Element {
+  const [neverFetched, setNeverFetched] = useState<boolean>(true);
+  const [collabs, setCollabs] = useState<Collab[]>([]);
+
+  useEffect(() => {
+    fetchAllCollabs().then(_collabs => {
+      setCollabs(_collabs);
+      setNeverFetched(false);
+    });
+  }, []);
+
+  return (
+    <FixedWidthCenterAlignedLayout>
+      <Row className="mt-4">
+        <Col xs={{span: 8}}>
+          <h1>Collaborations</h1>
+        </Col>
+        <Col xs={{span: 4}}>
+          <div className="float-right">
+            {collabs.length === 0 ? null : <Button>Add Collab</Button>}
+          </div>
+        </Col>
+      </Row>
+      <Row>
+        {neverFetched ? (
+          <Col>
+            <Loader />
+          </Col>
+        ) : null}
+
+        {neverFetched === false && collabs.length === 0 ? (
+          <EmptyState>
+            <EmptyState.Lead>
+              You have not created a collab yet. Create your first collab!
+            </EmptyState.Lead>
+          </EmptyState>
+        ) : null}
+
+        {neverFetched === false && collabs.length !== 0 ? (
+          <Col>
+            {collabs.map(collab => (
+              <CollabCard
+                name={collab.name}
+                import_as_bank_id={collab.import_as_bank_id}
+                collab_config_class={collab.collab_config_class}
+                attributes={collab.attributes}
+              />
+            ))}
+          </Col>
+        ) : null}
+      </Row>
+    </FixedWidthCenterAlignedLayout>
+  );
+}


### PR DESCRIPTION
Summary
---------
Adding / updating collabs and managing their import-as-banks was getting too challenging. This puts a readonly UI where we'll add more as the operations become clear.

This will replace the datasets settings panel.

I find that "Collaborations" are a top-level construct and make sense to locate at the same level as banks.

Test Plan (I got screenshots)
---------

<img width="428" alt="Screen Shot 2022-11-21 at 13 29 06" src="https://user-images.githubusercontent.com/217056/203148226-295d9a47-383f-49f0-972d-2ac56f339685.png">
<img width="1599" alt="Screen Shot 2022-11-21 at 13 31 42" src="https://user-images.githubusercontent.com/217056/203148242-1c562adc-776b-4d42-a7cc-315a033b4411.png">
