### PR TITLE
HMA FetchStore implementation backed by row-based calling of SignalExchangeAPI classmethods

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/models/bank.py
+++ b/hasher-matcher-actioner/hmalib/common/models/bank.py
@@ -547,14 +547,14 @@ class BanksTable:
             result = self._table.query(
                 ScanIndexForward=False,
                 KeyConditionExpression=Key("PK").eq(expected_pk),
-                # FilterExpression=Key("IsRemoved").eq(False),
+                FilterExpression=Key("IsRemoved").eq(False),
                 Limit=PAGE_SIZE,
             )
         else:
             result = self._table.query(
                 ScanIndexForward=False,
                 KeyConditionExpression=Key("PK").eq(expected_pk),
-                # FilterExpression=Key("IsRemoved").eq(False),
+                FilterExpression=Key("IsRemoved").eq(False),
                 ExclusiveStartKey=exclusive_start_key,
                 Limit=PAGE_SIZE,
             )

--- a/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_member_with_key.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_member_with_key.py
@@ -16,11 +16,12 @@ from hmalib.common.models.tests.test_signal_uniqueness import BanksTableTestBase
 
 
 class BankMemberWithKeyTestCase(BanksTableTestBase, unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._id_count = 0
+
     def _create_bank(self) -> str:
         """Create a bank with a unique id."""
-        if not hasattr(self, "_id_count"):
-            self._id_count = 0
-
         self._id_count = self._id_count + 1
 
         table_manager = BanksTable(
@@ -112,5 +113,5 @@ class BankMemberWithKeyTestCase(BanksTableTestBase, unittest.TestCase):
             )
             self.assertSetEqual(
                 {PDQ_1, PDQ_2, MD5},
-                set([x.signal_value for x in all_signals]),
+                {x.signal_value for x in all_signals},
             )

--- a/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_member_with_key.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_member_with_key.py
@@ -112,5 +112,5 @@ class BankMemberWithKeyTestCase(BanksTableTestBase, unittest.TestCase):
             )
             self.assertSetEqual(
                 {PDQ_1, PDQ_2, MD5},
-                set(map(lambda x: x.signal_value, all_signals)),
+                set([x.signal_value for x in all_signals]),
             )

--- a/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_member_with_key.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/test_bank_member_with_key.py
@@ -1,10 +1,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from contextlib import contextmanager
 import typing as t
 from dataclasses import dataclass
 import unittest
 
 from threatexchange.content_type.photo import PhotoContent
+from threatexchange.signal_type.pdq import PdqSignal
+from threatexchange.signal_type.md5 import VideoMD5Signal
 
 from hmalib.common.tests.mapping_common import get_default_signal_type_mapping
 
@@ -14,41 +17,100 @@ from hmalib.common.models.tests.test_signal_uniqueness import BanksTableTestBase
 
 class BankMemberWithKeyTestCase(BanksTableTestBase, unittest.TestCase):
     def _create_bank(self) -> str:
+        """Create a bank with a unique id."""
+        if not hasattr(self, "_id_count"):
+            self._id_count = 0
+
+        self._id_count = self._id_count + 1
+
         table_manager = BanksTable(
             self.get_table(), signal_type_mapping=get_default_signal_type_mapping()
         )
 
-        bank = table_manager.create_bank("TEST_Bank", "Test bank description")
+        bank = table_manager.create_bank(
+            f"TEST_Bank_{self._id_count}", "Test bank description"
+        )
         return bank.bank_id
 
+    def _add_photo_bank_member_with_key(
+        self, table_manager: BanksTable, bank_id: str, member_key: str
+    ):
+        return table_manager.add_keyed_bank_member(
+            bank_id=bank_id,
+            member_key=member_key,
+            content_type=PhotoContent,
+            storage_bucket=None,
+            storage_key=None,
+            raw_content="does not matter",
+            notes="",
+            is_media_unavailable=True,
+        )
+
     def test_add_bank_member_with_key(self):
-        with self.fresh_dynamodb():
-            table_manager = BanksTable(
-                self.get_table(), get_default_signal_type_mapping()
-            )
-
+        with self.fresh_table_manager() as table_manager:
             bank_id = self._create_bank()
-            bank_member_id = "fooofofofofoof"
+            member_key = "fooofofofofoof"
 
-            table_manager.add_bank_member_with_key(
-                bank_id=bank_id,
-                bank_member_id=bank_member_id,
-                content_type=PhotoContent,
-                storage_bucket=None,
-                storage_key=None,
-                raw_content=None,
-                notes="",
-                is_media_unavailable=True,
-            )
+            self._add_photo_bank_member_with_key(table_manager, bank_id, member_key)
 
             with self.assertRaises(KeyError):
-                table_manager.add_bank_member_with_key(
-                    bank_id=bank_id,
-                    bank_member_id=bank_member_id,
-                    content_type=PhotoContent,
-                    storage_bucket=None,
-                    storage_key=None,
-                    raw_content=None,
-                    notes="",
-                    is_media_unavailable=True,
-                )
+                self._add_photo_bank_member_with_key(table_manager, bank_id, member_key)
+
+    def test_add_keyed_bank_member_in_multiple_banks(self):
+        with self.fresh_table_manager() as table_manager:
+            bank_id = self._create_bank()
+            bank_id_2 = self._create_bank()
+
+            member_key = "a-very-unique-id-as-you-can-see"
+
+            bank_member = self._add_photo_bank_member_with_key(
+                table_manager, bank_id, member_key
+            )
+
+            bank_member_2 = self._add_photo_bank_member_with_key(
+                table_manager, bank_id_2, member_key
+            )
+
+            self.assertNotEqual(bank_member.bank_member_id, bank_member_2)
+
+    def test_add_multiple_signals_for_keyed_bank_member(self):
+        """Prove that multiple signals of the same type can be stored for the
+        same bank member. eg. MD5s from slightly altered copies of a video."""
+        with self.fresh_table_manager() as table_manager:
+            bank_id = self._create_bank()
+            member_key = "a-very-unique-id-as-you-can-see"
+
+            PDQ_1 = "f13de9de2e5d46ea51749338e45ea9891a068e17c455bca745ab17de0e7241c4"
+            PDQ_2 = "7c455bca745ab17de0e7241c4f13de9de2e5d46ea51749338e45ea9891a068e1"
+            MD5 = "7c455bca745ab17de0e7241c4e7241c4"
+
+            bank_member = self._add_photo_bank_member_with_key(
+                table_manager, bank_id, member_key
+            )
+
+            table_manager.add_bank_member_signal(
+                bank_id=bank_id,
+                bank_member_id=bank_member.bank_member_id,
+                signal_type=PdqSignal,
+                signal_value=PDQ_1,
+            )
+            table_manager.add_bank_member_signal(
+                bank_id=bank_id,
+                bank_member_id=bank_member.bank_member_id,
+                signal_type=PdqSignal,
+                signal_value=PDQ_2,
+            )
+            table_manager.add_bank_member_signal(
+                bank_id=bank_id,
+                bank_member_id=bank_member.bank_member_id,
+                signal_type=VideoMD5Signal,
+                signal_value=MD5,
+            )
+
+            all_signals = table_manager.get_signals_for_bank_member(
+                bank_member.bank_member_id
+            )
+            self.assertSetEqual(
+                {PDQ_1, PDQ_2, MD5},
+                set(map(lambda x: x.signal_value, all_signals)),
+            )

--- a/hasher-matcher-actioner/hmalib/common/models/tests/test_signal_uniqueness.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/test_signal_uniqueness.py
@@ -1,17 +1,30 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from contextlib import contextmanager
 import unittest
 import typing as t
 from concurrent import futures
 
 from threatexchange.signal_type.md5 import VideoMD5Signal
 
-from hmalib.common.models.bank import BankedSignalEntry
+from hmalib.common.models.bank import BankedSignalEntry, BanksTable
+from hmalib.common.tests.mapping_common import get_default_signal_type_mapping
 
 from .ddb_test_common import DynamoDBTableTestBase
 
 
 class BanksTableTestBase(DynamoDBTableTestBase):
+    @contextmanager
+    def fresh_table_manager(self):
+        with self.fresh_dynamodb():
+            try:
+                yield BanksTable(
+                    self.get_table(),
+                    signal_type_mapping=get_default_signal_type_mapping(),
+                )
+            finally:
+                pass
+
     @classmethod
     def get_table_definition(cls) -> t.Any:
         table_name = "test-banks-table"

--- a/hasher-matcher-actioner/hmalib/common/models/tests/test_signal_uniqueness.py
+++ b/hasher-matcher-actioner/hmalib/common/models/tests/test_signal_uniqueness.py
@@ -17,13 +17,10 @@ class BanksTableTestBase(DynamoDBTableTestBase):
     @contextmanager
     def fresh_table_manager(self):
         with self.fresh_dynamodb():
-            try:
-                yield BanksTable(
-                    self.get_table(),
-                    signal_type_mapping=get_default_signal_type_mapping(),
-                )
-            finally:
-                pass
+            yield BanksTable(
+                self.get_table(),
+                signal_type_mapping=get_default_signal_type_mapping(),
+            )
 
     @classmethod
     def get_table_definition(cls) -> t.Any:

--- a/hasher-matcher-actioner/hmalib/fetching/bank_store.py
+++ b/hasher-matcher-actioner/hmalib/fetching/bank_store.py
@@ -1,0 +1,289 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from functools import reduce
+import typing as t
+
+from threatexchange.signal_type.signal_base import SignalType
+from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
+from threatexchange.exchanges.fetch_state import (
+    FetchCheckpointBase,
+    FetchDelta,
+    SignalOpinion,
+    TUpdateRecordKey,
+    TUpdateRecordValue,
+    FetchedSignalMetadata,
+)
+
+from hmalib.common.configs.tx_collab_config import EditableCollaborationConfig
+from hmalib.common.configs.tx_apis import ToggleableSignalExchangeAPIConfig
+from hmalib.common.models.bank import BanksTable
+from hmalib.common.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class NoImportAsBankDefined(Exception):
+    def __init__(self, collab_config: EditableCollaborationConfig):
+        self.collab_config = collab_config
+        super().__init__(
+            f"CollabConfig {collab_config.name} is not connected to an importable bank. Create a bank, and save again using tx_collab_config apis."
+        )
+
+
+class MultipleContentTypesInFetchDeltaRow(Exception):
+    pass
+
+
+class BankCollabFetchStore:
+    """
+    Translates fetch operations into bank operations. Ideally, should not need
+    to store anything outside of banks.
+
+    Use with a single collab passed when creating an instance. Create multiple
+    instances when working with more than one collab.
+    """
+
+    def __init__(
+        self,
+        signal_types: t.Sequence[t.Type[SignalType]],
+        banks_table: BanksTable,
+        collab: EditableCollaborationConfig,
+    ) -> None:
+        self.banks_table = banks_table
+        self.collab = collab
+        self._signal_types = signal_types
+
+        try:
+            self._import_bank = banks_table.get_bank(collab.import_as_bank_id)
+        except Exception:
+            logger.error(f"No bank configured for exporting collab: {collab.name}")
+            raise NoImportAsBankDefined(collab_config=collab)
+
+        pytx_collab = self.collab.to_pytx_collab_config()
+        self._api_cls: t.Type[SignalExchangeAPI] = {
+            f.get_name(): f
+            for f in [
+                api.to_concrete_class()
+                for api in ToggleableSignalExchangeAPIConfig.get_all()
+                if api.enabled
+            ]
+        }[pytx_collab.api]
+
+        self._unflushed_deletes: t.Set[TUpdateRecordKey] = set()
+
+        # Updates on the same key must get overriden.
+        # SignalExchangeAPI.fetch_iter should be returning the entire object.
+        # That way we need not keep track of what has changed. Eg.
+        # /threat_updates will return all descriptors for an indicator whenever
+        # any of those descriptors change.
+        self._unflushed_updates: t.MutableMapping[
+            TUpdateRecordKey, TUpdateRecordValue
+        ] = {}
+
+    def _coerce_key(self, key: TUpdateRecordKey) -> str:
+        """
+        Convert a FetchDelta update key to a string. This string will be used as
+        a bank-member key.
+
+        If for a SignalExchange, the key type is neither str, nor tuple[str,
+        str], this function will need updating.
+        """
+        if type(key) == str:
+            return key
+        elif (
+            type(key) == tuple and len(key) == 2 and type(key[0]) == type(key[1]) == str
+        ):
+            return f"{key[0]}:{key[1]}"
+        else:
+            raise ValueError(
+                "Only str and tuple[str, str] key types supported in BankCollabFetchStore."
+            )
+
+    @property
+    def _dirty(self) -> bool:
+        # Are there unflushed updates?
+        return len(self._unflushed_updates) != 0 or len(self._unflushed_deletes) != 0
+
+    def get_checkpoint(self) -> t.Optional[FetchCheckpointBase]:
+        return self.banks_table.get_bank_info(self._import_bank.bank_id)
+
+    def set_checkpoint(self, checkpoint: FetchCheckpointBase):
+        return self.banks_table.update_bank_info(self._import_bank.bank_id, checkpoint)
+
+    def merge(self, delta: FetchDelta) -> None:
+        """
+        David's suggestion was:
+        1. try to merge updates one at a time to determine what get's added,
+        what gets deleted.
+        2. SignalExchangeAPI.naive_fetch_merge is considered demonstration only
+        and should not be used here.
+
+        NCMEC FetchDelta.updates key
+        - entry.member_id-entry.id -> multiple hashes...
+        StopNCII, FBThreatExchange FetchDelta.updates key
+        - hash-type, hash-value
+        """
+
+        if len(delta.updates) == 0:
+            logger.warning("merge() called with no updates")
+            return
+
+        delta_updates = t.cast(
+            t.Dict[TUpdateRecordKey, t.Optional[TUpdateRecordValue]], delta.updates
+        )
+
+        for update_key, update_value in delta_updates.items():
+            # NCMECSignalExchangeAPI.fetch_iter() does not clear metadata,
+            # need to call fetch_value_merge to clear metadata.
+            update_value = self._api_cls.fetch_value_merge(None, update_value)
+
+            if update_value is None:  # This is a delete.
+                self._unflushed_deletes.add(update_key)
+                # Why update something if it will end up getting deleted?
+                self._unflushed_updates.pop(update_key, None)
+            else:  # This update is an add / update
+                self._unflushed_updates[update_key] = update_value
+                self._unflushed_deletes.discard(update_key)
+
+    def flush(self, checkpoint: FetchCheckpointBase) -> None:
+        if self._dirty:
+            # self._delta check is avoidable as it is covered by self._dirty,
+            # but python type checker gets annoyed.
+
+            del_count = 0
+            while len(self._unflushed_deletes) > 0:
+                delete = self._unflushed_deletes.pop()
+                self._handle_delete(delete)
+                del_count = del_count + 1
+            logger.info(
+                "BankCollabFetchStore flushed %d deletes for collab: %s",
+                del_count,
+                self.collab.name,
+            )
+
+            upsert_count = 0
+            for update_key in list(self._unflushed_updates.keys()):
+                update_value = self._unflushed_updates.pop(update_key)
+                self._handle_upsert(update_key, update_value)
+                upsert_count = upsert_count + 1
+            logger.info(
+                "BankCollabFetchStore flushed %d upserts for collab: %s",
+                upsert_count,
+                self.collab.name,
+            )
+        else:
+            logger.info("FetchStore is clean!")
+
+        logger.info("Setting checkpoint for collab: %s", self.collab.name)
+        self.set_checkpoint(checkpoint)
+
+    def clear(self) -> None:
+        """
+        This one might be a time-consuming operation.
+
+        The ideal way would be to get a list of all bank members and then remove
+        them and their signals. However, that would have to rely on paginated
+        queries and batch operations which are both slow in dynamodb.
+
+        An easier way out would be to iterate over all collab configs, unlink
+        their banks and then
+        """
+        raise NotImplementedError
+
+    def _handle_upsert(self, key: TUpdateRecordKey, value: TUpdateRecordValue):
+        """
+        Respond to an update event from a signal exchange API. This can happen
+        at most once per key per flush.
+
+        A single update can translate into multiple signals, but all will be
+        stored as part of the same bank-member.
+        """
+        str_key = self._coerce_key(key)
+
+        # Call naive_convert_to_signal_type one update at a time, to get the
+        # full expected state of a bank-member.
+        signal_type_view = self._api_cls.naive_convert_to_signal_type(
+            self._signal_types, self.collab.to_pytx_collab_config(), {key: value}
+        )
+
+        if len(signal_type_view) == 0:
+            # Cases where none of the signal types in the update can be
+            # processed. eg. NCMEC returning pdna
+            return
+
+        # Ascertain that all signal_types map from the same content type.
+        # HMA at present can't store multiple content types in one bank
+        # member.
+        unique_content_types = set(
+            # Is there a signal type that may have multiple content_types?
+            list(map(lambda st: st.get_content_types()[0], signal_type_view.keys()))
+        )
+        if len(unique_content_types) > 1:
+            raise MultipleContentTypesInFetchDeltaRow()
+
+        content_type = unique_content_types.pop()
+
+        opinion_lists = [
+            metadata.get_as_opinions()
+            for val in signal_type_view.values()
+            for metadata in val.values()
+        ]
+        unique_opinion_tags = set()
+        for opinion_list in opinion_lists:
+            unique_opinion_tags.update(self.convert_opinions_to_label(opinion_list))
+
+        try:
+            member = self.banks_table.add_keyed_bank_member(
+                self._import_bank.bank_id,
+                str_key,
+                content_type,
+                None,
+                None,
+                None,
+                "",
+                True,
+                unique_opinion_tags,
+            )
+        except KeyError:
+            # member already exists, update labels just to be sure.
+            member = self.banks_table.update_bank_member(
+                self.banks_table._key_for_bank(self._import_bank.bank_id, str_key),
+                notes="",
+                bank_member_tags=unique_opinion_tags,
+            )
+
+        for signal_type in signal_type_view:
+            for hash_value in signal_type_view[signal_type].keys():
+                self.banks_table.add_bank_member_signal(
+                    bank_id=self._import_bank.bank_id,
+                    bank_member_id=member.bank_member_id,
+                    signal_type=signal_type,
+                    signal_value=hash_value,
+                )
+
+                # TODO: We don't verify that all existing bank-member signals should continue existing.
+
+    def _handle_delete(self, key: TUpdateRecordKey):
+        """
+        Respond to a delete from a signal exchange API. Typically, this would
+        happen at most once per key per flush.
+        """
+        str_key = self._coerce_key(key)
+        member = self.banks_table.get_keyed_bank_member(
+            self._import_bank.bank_id, str_key
+        )
+        if member:
+            self.banks_table.remove_bank_member(member.bank_member_id)
+
+    def convert_opinions_to_label(self, opinions: t.Sequence[SignalOpinion]):
+        """
+        Simplistic 1:1 translation of opinion tag to label of same name. This
+        could be made more configurable on an API / Collab basis via the UI.
+
+        This should be an instance method even though it does not use self. This
+        is to ensure that future modifications (that require loading stuff from
+        ddb using self.banks_table) can be written.
+        """
+        return reduce(
+            lambda tags, acc: acc.union(tags), map(lambda x: x.tags, opinions)
+        )

--- a/hasher-matcher-actioner/hmalib/fetching/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/fetching/fetcher.py
@@ -1,0 +1,153 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from functools import lru_cache
+import typing as t
+import time
+
+from threatexchange.exchanges.collab_config import CollaborationConfigBase
+from threatexchange.exchanges.signal_exchange_api import TSignalExchangeAPICls
+from threatexchange.exchanges.fetch_state import FetchCheckpointBase, FetchDeltaTyped
+
+from hmalib.common.logging import get_logger
+from hmalib.common.mappings import HMASignalTypeMapping
+from hmalib.common.models.bank import BanksTable
+
+from hmalib.common.configs import tx_collab_config
+from hmalib.common.configs.tx_apis import ToggleableSignalExchangeAPIConfig
+from hmalib.fetching.bank_store import BankCollabFetchStore
+
+logger = get_logger(__name__)
+
+
+class Fetcher:
+    """
+
+    In python-threatexchange, SignalExchangeAPI -> CollaborationConfig is
+    one-to-many. Which makes sense. An exchange like ThreatExchange can power
+    multiple collaborations.
+
+    Even in-house, a single exchange can power multiple collab-like groupings of
+    signals.
+    """
+
+    def __init__(
+        self, signal_type_mapping: HMASignalTypeMapping, banks_table: BanksTable
+    ):
+        self.signal_type_mapping = signal_type_mapping
+        self.banks_table = banks_table
+
+    def _get_api_classes_from_config(self):
+        return [
+            api.to_concrete_class()
+            for api in ToggleableSignalExchangeAPIConfig.get_all()
+            if api.enabled
+        ]
+
+    def has_hit_limits(self) -> bool:
+        return False
+
+    def should_checkpoint(self) -> bool:
+        # TBD
+        return True
+        # if not hasattr(self, "_should_checkpoint_counter"):
+        #     self._should_checkpoint_counter = 0
+
+        # self._should_checkpoint_counter = self._should_checkpoint_counter + 1
+        # return self._should_checkpoint_counter % 5 == 0
+
+    @lru_cache(maxsize=None)
+    def get_api_classes(self) -> t.Dict[str, TSignalExchangeAPICls]:
+        """
+        Mapping from name to class for all enabled APIs on this HMA instance.
+        """
+        return {f.get_name(): f for f in self._get_api_classes_from_config()}
+
+    def run(self):
+        """
+        Lambda will only fire-and-forget into this.
+
+        Any state-management, rate-limiting, time-outing, checkpointing needs to
+        happen here.
+        """
+        all_active_collabs = self._get_all_active_collabs()
+        logger.info("Found %d active collaborations.", len(all_active_collabs))
+        logger.info(
+            "Active signal types are %s",
+            [st.get_name() for st in self.signal_type_mapping.signal_types],
+        )
+
+        for collab in all_active_collabs:
+            self._execute_for_collab(collab)
+
+    def _get_all_active_collabs(
+        self,
+    ) -> t.List[tx_collab_config.EditableCollaborationConfig]:
+        """
+        Return all collabs that require fetching in this run.
+        """
+        return [
+            c
+            for c in tx_collab_config.get_all_collab_configs()
+            if c.to_pytx_collab_config().enabled
+        ]
+
+    def _execute_for_collab(
+        self, collab: tx_collab_config.EditableCollaborationConfig
+    ) -> bool:
+        logger.info("Fetching for collab: %s", collab.name)
+        api_instance = self.get_api_classes()[
+            collab.to_pytx_collab_config().api
+        ].for_collab(collab=collab.to_pytx_collab_config())
+
+        store = BankCollabFetchStore(
+            self.signal_type_mapping.signal_types, self.banks_table, collab
+        )
+
+        checkpoint = store.get_checkpoint()
+        if checkpoint:
+            logger.info("Found checkpoint: %s", checkpoint)
+        else:
+            logger.info("No checkpoint found. Will start from scratch.")
+
+        try:
+            it = api_instance.fetch_iter(
+                self.signal_type_mapping.signal_types, checkpoint=checkpoint
+            )
+            delta: FetchDeltaTyped
+            for delta in it:
+                assert delta.checkpoint is not None  # Inifinite loop protection
+                logger.info("fetch() with %d new records.", len(delta.updates))
+                next_checkpiont = delta.checkpoint
+
+                if checkpoint is not None:
+                    prev_time = checkpoint.get_progress_timestamp()
+                    progress_time = delta.checkpoint.get_progress_timestamp()
+
+                    if prev_time is not None and progress_time is not None:
+                        # A subsequent checkpoint is _before_ a previous checkpoint?
+                        assert prev_time <= progress_time, (
+                            "checkpoint time rewound? ",
+                            "This can indicate a serious ",
+                            "problem with the API and checkpointing",
+                        )
+
+                checkpoint = next_checkpiont
+                store.merge(delta)
+                if self.has_hit_limits():
+                    # Hit limits. Must checkpoint
+                    break
+                if self.should_checkpoint():
+                    store.flush(checkpoint)
+                    self.last_checkpoint_time = time.time()
+
+            # Flush the last delta.
+            store.flush(checkpoint)
+            completed = True
+        except Exception as exc:
+            logger.error("Failure during fetch()")
+            logger.exception(exc)
+            return False
+        finally:
+            store.flush(checkpoint)
+
+        return True

--- a/hasher-matcher-actioner/hmalib/indexers/s3_indexers.py
+++ b/hasher-matcher-actioner/hmalib/indexers/s3_indexers.py
@@ -15,7 +15,7 @@ import functools
 from mypy_boto3_s3.service_resource import Bucket
 from mypy_boto3_s3.type_defs import MetricsAndOperatorTypeDef
 from threatexchange.signal_type.signal_base import TrivialSignalTypeIndex
-from threatexchange.signal_type.pdq_index import PDQIndex, PDQFlatIndex
+from threatexchange.signal_type.pdq.pdq_index import PDQIndex, PDQFlatIndex
 
 from hmalib.common.logging import get_logger
 from hmalib import metrics

--- a/hasher-matcher-actioner/hmalib/lambdas/api/bank.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/bank.py
@@ -305,7 +305,7 @@ def get_bank_api(
         )
 
     @bank_api.post("/update-bank-member/<bank_member_id>", apply=[jsoninator])
-    def update_bank_member(bank_member_id=None) -> Bank:
+    def update_bank_member(bank_member_id=None) -> BankMember:
         """
         Update notes and tags for a bank_member_id.
         """

--- a/hasher-matcher-actioner/hmalib/scripts/cli/run_lambda.py
+++ b/hasher-matcher-actioner/hmalib/scripts/cli/run_lambda.py
@@ -64,7 +64,7 @@ class RunLambdaCommand(base.Command, base.NeedsTerraformOutputs):
         fn = getattr(module, fn_name)
 
         try:
-            from lambda_local import get_event
+            from lambda_local import get_event  # type: ignore
 
             fn(get_event(self.lambda_name), None)
         except ModuleNotFoundError:

--- a/hasher-matcher-actioner/hmalib/scripts/cli/run_lambda.py
+++ b/hasher-matcher-actioner/hmalib/scripts/cli/run_lambda.py
@@ -64,9 +64,9 @@ class RunLambdaCommand(base.Command, base.NeedsTerraformOutputs):
         fn = getattr(module, fn_name)
 
         try:
-            from lambda_local import event as event_value  # type: ignore
+            from lambda_local import get_event
 
-            fn(event_value, None)
+            fn(get_event(self.lambda_name), None)
         except ModuleNotFoundError:
             print(
                 "Please define variable `event` in hasher-matcher-actioner/lambda_local.py"

--- a/hasher-matcher-actioner/setup.py
+++ b/hasher-matcher-actioner/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 extras_require = {
     "cli": [
         "pandas==1.3.5",
-        "numpy==1.22.1",
+        "numpy>=1.23.2",
     ]
 }
 

--- a/hasher-matcher-actioner/setup.py
+++ b/hasher-matcher-actioner/setup.py
@@ -24,7 +24,7 @@ setup(
     install_requires=[
         "boto3==1.20.37",
         "boto3-stubs[essential,sns,dynamodbstreams]==1.17.14.0",
-        "threatexchange[faiss,pdq_hasher]==0.0.29",
+        "threatexchange[faiss,pdq_hasher]==1.0.3",
         "bottle==0.12.20",
         "apig-wsgi==2.13.0",
         "pyjwt[crypto]==2.1.0",

--- a/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBank.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/bank-management/ViewBank.tsx
@@ -55,9 +55,15 @@ function BankDetails({bankId}: BankTabProps): JSX.Element {
 
 export default function ViewBank(): JSX.Element {
   const {bankId, tab} = useParams<{bankId: string; tab: string}>();
+  const [bank, setBank] = useState<Bank>();
   const history = useHistory();
 
-  const pageTitle = 'Edit Bank';
+  useEffect(() => {
+    fetchBank(bankId).then(setBank);
+  }, []);
+
+  const pageTitle =
+    bank && bank.bank_name ? `Edit Bank: ${bank.bank_name}` : 'Edit Bank';
   const returnURL = '/banks/';
 
   return (


### PR DESCRIPTION
Summary
---------
Interesting files:
- bank_store.py
- fetcher.py

fetcher.py has a Fetcher class which will be invoked in a lambda. This will cause it to get all current collabs and run `Fetcher._execute_for_collab` to be called for each collab.

`_execute_for_collab` ends up calling fetch_iter for SignalExchangeAPI. Each row of the output of fetch_iter is then processed via `SignalExchangeAPI.fetch_value_merge` to determine whether it is an add/update or a delete.

Each add/update is then processed via `SignalExchangeAPI.naive_convert_to_signal_type` to identify signals to be added or updated.

While the deletes result in bank-member deletes, the adds / updates result in bank-member + bank-member-signal writes.


Test Plan
---------
```python
    import boto3
    import logging

    from hmalib.common.config import HMAConfig

    from hmalib.common.mappings import get_pytx_functionality_mapping
    from hmalib.common.models.bank import BanksTable

    logging.basicConfig(level=logging.INFO)

    HMAConfig.initialize("...-HMAConfig")
    st_mapping = get_pytx_functionality_mapping().signal_and_content
    dynamodb = boto3.resource("dynamodb")
    banks_table = BanksTable(dynamodb.Table("...-HMABanks"), st_mapping)

    # TODO: Create fetcher per
    fetcher = Fetcher(st_mapping, banks_table)
    logger.info("Will be running fetcher now.")
    fetcher.run()
```

All three banks had been manually cleared before the run.

Resulted in 3 collab configs (two threatexchange) and 1 NCMEC getting filled up.
<img width="1269" alt="Screen Shot 2022-11-21 at 16 23 24" src="https://user-images.githubusercontent.com/217056/203162359-0a3e7904-8cc5-4a47-ac96-d87c00481f88.png">

<img width="1226" alt="Screen Shot 2022-11-21 at 16 23 19" src="https://user-images.githubusercontent.com/217056/203162367-0d685cf4-bb06-4692-959a-8028a5effd9a.png">

<img width="1168" alt="Screen Shot 2022-11-21 at 16 23 15" src="https://user-images.githubusercontent.com/217056/203162382-66f551b4-5de7-41f8-9331-a3bd3cee950d.png">


While the NCMEC fetcher never terminated, subsequent calling of the threatexchange fetchers led to no new updates proving that the checkpointing (via bank_info) works.