### PR TITLE
[smol] Get docker build to work and miscellaneous changes

### DIFF
--- a/hasher-matcher-actioner/.devcontainer/Dockerfile
+++ b/hasher-matcher-actioner/.devcontainer/Dockerfile
@@ -105,7 +105,7 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - \
   && apt-get update && apt-get install terraform
 
 # [Install GitHub CLI]
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0 \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key 23F3D4EA75716059 \
   && apt-add-repository https://cli.github.com/packages \
   && apt update \
   && apt install gh

--- a/hasher-matcher-actioner/Dockerfile
+++ b/hasher-matcher-actioner/Dockerfile
@@ -10,7 +10,8 @@ RUN pip install -e .
 
 # Copy local-threatexchange if it exists and install threatexchange from it in
 # editable mode. This will override a copy of threatexchange fetched from pypi.
-COPY local-threatexchang[e] ./
+# Must copy .gitignore because COPY needs atleast one file to succeed.
+COPY .gitignore local-threatexchang[e] ./
 RUN if [ -d "local-threatexchange" ]; then pip install -e ./local-threatexchange; fi
 
 # LAMBDA_TASK_ROOT is recommended in the image [1]. I'm hoping this will prevent

--- a/hasher-matcher-actioner/terraform/migrations/main.tf
+++ b/hasher-matcher-actioner/terraform/migrations/main.tf
@@ -7,12 +7,14 @@
 # AFTER v0.1.2 https://github.com/facebook/ThreatExchange/releases/tag/HMA-v0.1.2
 resource "null_resource" "default_signal_content_type_configs" {
   provisioner "local-exec" {
-    command = "python -m hmalib.scripts.cli.main migrate 2022_04_02_default_content_signal_type_configs --config-table ${var.config_table.name}"
+    working_dir = "../../"
+    command     = "python -m hmalib.scripts.cli.main migrate 2022_04_02_default_content_signal_type_configs --config-table ${var.config_table.name}"
   }
 }
 
 resource "null_resource" "default_signal_exchange_apis" {
   provisioner "local-exec" {
-    command = "python -m hmalib.scripts.cli.main migrate 2022_07_24_default_signal_exchange_apis --config-table ${var.config_table.name}"
+    working_dir = "../../"
+    command     = "python -m hmalib.scripts.cli.main migrate 2022_07_24_default_signal_exchange_apis --config-table ${var.config_table.name}"
   }
 }

--- a/hasher-matcher-actioner/workspace.code-workspace
+++ b/hasher-matcher-actioner/workspace.code-workspace
@@ -1,0 +1,14 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../.github"
+		},
+		{
+			"path": "../python-threatexchange"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
Summary
---
- Docker copy does not succeed without atleast one file
- add python-threatexchange to our regular devcontainer workspaces so we've got python-threatexchange to work with
- add working directory to migrations; it was failing on our CI deploy
- update keyserver key in devcontainer dockerfile - the current one stopped working and stackoverflow gave this answer

Test Plan
---
Will know after CI. Locally making these changes on our ec2 host allowed CI to work.