### PR TITLE
Support user managed secrets using AWS Secrets Manager

### DIFF
--- a/hasher-matcher-actioner/hmalib/aws_secrets.py
+++ b/hasher-matcher-actioner/hmalib/aws_secrets.py
@@ -55,8 +55,6 @@ class AWSSecrets:
         Update a secret or create it if does not exist
         """
         try:
-            print(self._get_full_secret_id(secret_id))
-
             self.secrets_client.put_secret_value(
                 SecretId=self._get_full_secret_id(secret_id), SecretString=secret_value
             )

--- a/hasher-matcher-actioner/hmalib/aws_secrets.py
+++ b/hasher-matcher-actioner/hmalib/aws_secrets.py
@@ -25,8 +25,8 @@ class AWSSecrets:
 
     Except for the older te_api_token and hma_api_tokens secrets, which get
     their SecretIds from environment variables, all other secrets are stored
-    with a prefix in their ID. This is to prevent with existing AWS Secrets and
-    other instances of HMA (like test, or a new version).
+    with a prefix in their ID. This is to prevent collisions with existing AWS
+    Secrets and other instances of HMA (like test, or a new version).
     """
 
     secrets_client: t.Any
@@ -41,7 +41,7 @@ class AWSSecrets:
 
     def get_secret(self, secret_id: str) -> str:
         """
-        Get a secret if it exist. Raises ValueError if it does not.
+        Get a secret if it exists. Raises ValueError if it does not.
         """
         try:
             return self._get_str_secret(self._get_full_secret_id(secret_id))

--- a/hasher-matcher-actioner/hmalib/aws_secrets.py
+++ b/hasher-matcher-actioner/hmalib/aws_secrets.py
@@ -8,6 +8,7 @@ import os
 import functools
 import json
 import typing as t
+from botocore.errorfactory import ClientError
 
 from hmalib.common.logging import get_logger
 
@@ -19,14 +20,54 @@ THREAT_EXCHANGE_API_TOKEN_SECRET_NAME = "THREAT_EXCHANGE_API_TOKEN_SECRET_NAME"
 
 class AWSSecrets:
     """
-    A class for reading secrets stored in aws
+    A class for reading secrets stored in aws. We will be storing everything as
+    string, so unless specified, assume everything is a string.
+
+    Except for the older te_api_token and hma_api_tokens secrets, which get
+    their SecretIds from environment variables, all other secrets are stored
+    with a prefix in their ID. This is to prevent with existing AWS Secrets and
+    other instances of HMA (like test, or a new version).
     """
 
     secrets_client: t.Any
 
-    def __init__(self):
+    def __init__(self, prefix: str):
         session = boto3.session.Session()
         self.secrets_client = session.client(service_name="secretsmanager")
+        self.prefix = prefix
+
+    def _get_full_secret_id(self, secret_id: str) -> str:
+        return f"{self.prefix}{secret_id}"
+
+    def get_secret(self, secret_id: str) -> str:
+        """
+        Get a secret if it exist. Raises ValueError if it does not.
+        """
+        try:
+            return self._get_str_secret(self._get_full_secret_id(secret_id))
+        except ClientError as error:
+            if error.response["Error"]["Code"] == "ResourceNotFoundException":
+                raise ValueError(f"No secret with secret id: {secret_id}")
+            raise error
+
+    def put_secret(self, secret_id: str, secret_value: str):
+        """
+        Update a secret or create it if does not exist
+        """
+        try:
+            print(self._get_full_secret_id(secret_id))
+
+            self.secrets_client.put_secret_value(
+                SecretId=self._get_full_secret_id(secret_id), SecretString=secret_value
+            )
+        except ClientError as error:
+            if error.response["Error"]["Code"] == "ResourceNotFoundException":
+                self.secrets_client.create_secret(
+                    Name=self._get_full_secret_id(secret_id), SecretString=secret_value
+                )
+            else:
+                # Can't handle anything else.
+                raise error
 
     def update_te_api_token(self, token: str):
         f"""
@@ -69,6 +110,7 @@ class AWSSecrets:
 
     def _get_bin_secret(self, secret_name: str) -> bytes:
         """
+        Deprecated: Do not see any usage. Maybe safe to delete.
         For secerts stored in AWS Secrets Manager as binary
         """
         response = self._get_secret_value_response(secret_name)

--- a/hasher-matcher-actioner/hmalib/common/threatexchange_config.py
+++ b/hasher-matcher-actioner/hmalib/common/threatexchange_config.py
@@ -56,8 +56,8 @@ def create_privacy_group_if_not_exists(
             raise
 
 
-def sync_privacy_groups():
-    api_token = AWSSecrets().te_api_token()
+def sync_privacy_groups(secrets_prefix: str):
+    api_token = AWSSecrets(prefix=secrets_prefix).te_api_token()
     api = ThreatExchangeAPI(api_token)
     privacy_group_member_list = api.get_threat_privacy_groups_member()
     privacy_group_owner_list = api.get_threat_privacy_groups_owner()

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_auth.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_auth.py
@@ -14,6 +14,7 @@ from hmalib.common.logging import get_logger
 
 USER_POOL_URL = os.environ["USER_POOL_URL"]
 CLIENT_ID = os.environ["CLIENT_ID"]
+SECRETS_PREFIX = os.environ["SECRETS_PREFIX"]
 
 # https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-verifying-a-jwt.html
 KEYS_URL = f"{USER_POOL_URL}/.well-known/jwks.json"
@@ -101,7 +102,7 @@ def validate_jwt(token: str):
 @functools.lru_cache(maxsize=10)
 def validate_access_token(token: str) -> bool:
 
-    access_tokens = AWSSecrets().hma_api_tokens()
+    access_tokens = AWSSecrets(prefix=SECRETS_PREFIX).hma_api_tokens()
     if not access_tokens or not token:
         logger.debug("No access tokens found")
         return False

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -53,6 +53,7 @@ LCC_DURABLE_FS_PATH = os.environ["LCC_DURABLE_FS_PATH"]
 INDEXES_BUCKET_NAME = os.environ["INDEXES_BUCKET_NAME"]
 INDEXER_FUNCTION_NAME = os.environ["INDEXER_FUNCTION_NAME"]
 WRITEBACK_QUEUE_URL = os.environ["WRITEBACKS_QUEUE_URL"]
+SECRETS_PREFIX = os.environ["SECRETS_PREFIX"]
 
 
 @lru_cache(maxsize=1)
@@ -137,6 +138,7 @@ def bottle_init_once() -> t.Tuple[
             datastore_table=dynamodb.Table(DYNAMODB_TABLE),
             threat_exchange_data_bucket_name=THREAT_EXCHANGE_DATA_BUCKET_NAME,
             threat_exchange_data_folder=THREAT_EXCHANGE_DATA_FOLDER,
+            secrets_prefix=SECRETS_PREFIX,
         ),
     )
 

--- a/hasher-matcher-actioner/hmalib/lambdas/api/datasets.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/datasets.py
@@ -284,6 +284,7 @@ def get_datasets_api(
     datastore_table: Table,
     threat_exchange_data_bucket_name: str,
     threat_exchange_data_folder: str,
+    secrets_prefix: str,
 ) -> bottle.Bottle:
     """
     ToDo / FixMe: this file is probably more about privacy groups than datasets...
@@ -362,7 +363,7 @@ def get_datasets_api(
         """
         Fetch new collaborations from ThreatExchange and sync with the configs stored in DynamoDB.
         """
-        sync_privacy_groups()
+        sync_privacy_groups(secrets_prefix)
         return SyncDatasetResponse(response="Privacy groups are up to date")
 
     @datasets_api.post("/delete/<key>", apply=[jsoninator])
@@ -452,7 +453,7 @@ def get_datasets_api(
         token = bottle.request.json["token"]
         is_valid_token = try_api_token(token)
         if is_valid_token:
-            AWSSecrets().update_te_api_token(token)
+            AWSSecrets(secrets_prefix).update_te_api_token(token)
             return {}
 
         bottle.response.status_code = 400

--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -40,6 +40,8 @@ MAX_DESCRIPTORS_UPDATED = 20000
 # Print progress when polling threat_updates once every...<> seconds
 PROGRESS_PRINT_INTERVAL_SEC = 20
 
+SECRETS_PREFIX = os.environ["SECRETS_PREFIX"]
+
 
 @lru_cache(maxsize=None)
 def get_s3_client():
@@ -148,7 +150,7 @@ def lambda_handler(_event, _context):
     data = f"Triggered at time {current_time}, found {len(collabs)} collabs: {', '.join(names)}"
     logger.info(data)
 
-    api_token = AWSSecrets().te_api_token()
+    api_token = AWSSecrets(SECRETS_PREFIX).te_api_token()
     api = ThreatExchangeAPI(api_token)
 
     for collab in collabs:

--- a/hasher-matcher-actioner/hmalib/writebacker/writebacker_base.py
+++ b/hasher-matcher-actioner/hmalib/writebacker/writebacker_base.py
@@ -157,7 +157,7 @@ class ThreatExchangeWritebacker(Writebacker):
         mock_te_api = os.environ.get("MOCK_TE_API")
         if mock_te_api == "True":
             return MockedThreatExchangeAPI()
-        api_token = AWSSecrets().te_api_token()
+        api_token = AWSSecrets("").te_api_token()
         return ThreatExchangeAPI(api_token)
 
     def my_descriptor_from_all_descriptors(

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -33,6 +33,7 @@ resource "aws_lambda_function" "api_root" {
   memory_size = 512
   environment {
     variables = {
+      SECRETS_PREFIX                        = var.secrets_prefix
       DYNAMODB_TABLE                        = var.datastore.name
       HMA_CONFIG_TABLE                      = var.config_table.name
       BANKS_TABLE                           = var.banks_datastore.name
@@ -204,6 +205,7 @@ resource "aws_lambda_function" "api_auth" {
   memory_size = 128
   environment {
     variables = {
+      SECRETS_PREFIX               = var.secrets_prefix
       HMA_ACCESS_TOKEN_SECRET_NAME = var.hma_api_access_tokens_secret.name
       USER_POOL_URL                = local.user_pool_url
       CLIENT_ID                    = var.api_authorizer_audience

--- a/hasher-matcher-actioner/terraform/api/variables.tf
+++ b/hasher-matcher-actioner/terraform/api/variables.tf
@@ -5,6 +5,11 @@ variable "prefix" {
   type        = string
 }
 
+variable "secrets_prefix" {
+  description = "Prefix for all AWS Secrets created by the enduser."
+  type        = string
+}
+
 variable "api_and_webapp_user_pool_id" {
   description = "user pool id that can be used to create a URL to the JWT issuer (used by the api gateway authorizer)"
   type        = string

--- a/hasher-matcher-actioner/terraform/fetcher/main.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/main.tf
@@ -31,6 +31,7 @@ resource "aws_lambda_function" "fetcher" {
   memory_size = 512
   environment {
     variables = {
+      SECRETS_PREFIX                        = var.secrets_prefix
       THREAT_EXCHANGE_DATA_BUCKET_NAME      = var.threat_exchange_data.bucket_name
       CONFIG_TABLE_NAME                     = var.config_table.name
       THREAT_EXCHANGE_DATA_FOLDER           = var.threat_exchange_data.data_folder

--- a/hasher-matcher-actioner/terraform/fetcher/variables.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/variables.tf
@@ -5,6 +5,11 @@ variable "prefix" {
   type        = string
 }
 
+variable "secrets_prefix" {
+  description = "Prefix for all AWS Secrets created by the enduser."
+  type        = string
+}
+
 variable "lambda_docker_info" {
   description = "Docker container information for lambda functions"
   type = object({

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -150,8 +150,9 @@ module "counters" {
 }
 
 module "fetcher" {
-  source = "./fetcher"
-  prefix = var.prefix
+  source         = "./fetcher"
+  prefix         = var.prefix
+  secrets_prefix = local.secrets_prefix
 
   lambda_docker_info = {
     uri = var.hma_lambda_docker_uri

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -24,6 +24,9 @@ locals {
   hma_api_tokens_secret_name = "hma/${var.prefix}_api_tokens"
 
   durable_storage_path = "/mnt/durable-storage"
+
+  secrets_prefix = "${var.prefix}_hma_secret/"
+
 }
 
 ### Config storage ###
@@ -467,6 +470,8 @@ module "api" {
   prefix                      = var.prefix
   api_and_webapp_user_pool_id = module.authentication.webapp_and_api_user_pool_id
   api_authorizer_audience     = module.authentication.webapp_and_api_user_pool_client_id
+  secrets_prefix              = local.secrets_prefix
+
   lambda_docker_info = {
     uri = var.hma_lambda_docker_uri
     commands = {


### PR DESCRIPTION
Summary
---
So far, we were using terraform to manage secrets because the number of secrets (credentials) was controlled by terraform.

With the new extensions model, we need to manage an arbitrary number of secrets. Think NCMEC, StopNCII etc. It would be best to be able to manage them from HMA UI itself. That way, updating your keys if they change or adding a new collab for a never before used signal exchange becomes possible without developer support.

Test Plan
---
```
$ terraform plan / apply.
```

Use the python REPL to test out `get_secret`, `put_secret` methods in AWS Secrets. 
1. Verify that put_secret creates OR updates secrets 
2. Verify that get_secret works for existing secrets and throws ValueError for non-existing ones.

