### PR TITLE
[hma] Fix indexing, matching and hashing

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/models/bank.py
+++ b/hasher-matcher-actioner/hmalib/common/models/bank.py
@@ -794,8 +794,9 @@ class BanksTable:
         self,
         signal_type: t.Type[SignalType],
         exclusive_start_key: t.Optional[DynamoDBCursorKey] = None,
-        limit: int = 100,
+        limit: t.Optional[int] = None,
     ) -> PaginatedResponse[BankMemberSignal]:
+        # TODO: Respect limit.
         if not exclusive_start_key:
             result = self._table.query(
                 IndexName=BankMemberSignal.BANK_MEMBER_SIGNAL_CURSOR_INDEX,
@@ -803,7 +804,6 @@ class BanksTable:
                 KeyConditionExpression=Key(
                     BankMemberSignal.BANK_MEMBER_SIGNAL_CURSOR_INDEX_SIGNAL_TYPE
                 ).eq(signal_type.get_name()),
-                Limit=limit,
             )
         else:
             result = self._table.query(
@@ -813,7 +813,6 @@ class BanksTable:
                     BankMemberSignal.BANK_MEMBER_SIGNAL_CURSOR_INDEX_SIGNAL_TYPE
                 ).eq(signal_type.get_name()),
                 ExclusiveStartKey=exclusive_start_key,
-                Limit=limit,
             )
         return PaginatedResponse(
             t.cast(DynamoDBCursorKey, result.get("LastEvaluatedKey", None)),

--- a/hasher-matcher-actioner/hmalib/lambdas/api/indexes.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/indexes.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 
 from mypy_boto3_lambda.client import LambdaClient
 
-from hmalib.indexers.s3_indexers import S3BackedInstrumentedIndexMixin
+from hmalib.indexers.index_store import S3PickledIndexStore
 from hmalib.lambdas.api.middleware import SubApp, jsoninator
 
 
@@ -39,11 +39,8 @@ def get_indexes_api(
         Returns the max of last_modified time of all indexes. Read as: when was
         the latest index rebuilt.
         """
-        return IndexesLastModifiedResponse(
-            S3BackedInstrumentedIndexMixin.get_latest_last_modified(
-                bucket_name=indexes_bucket_name
-            )
-        )
+        index_store = S3PickledIndexStore(indexes_bucket_name)
+        return IndexesLastModifiedResponse(index_store.get_latest_last_modified())
 
     @indexes_api.post("/rebuild-all")
     def rebuild_all_indexes():

--- a/hasher-matcher-actioner/hmalib/lambdas/common.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/common.py
@@ -1,0 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import functools
+
+from hmalib.common.mappings import (
+    HMASignalTypeMapping,
+    get_pytx_functionality_mapping,
+)
+
+
+@functools.lru_cache(maxsize=None)
+def get_signal_type_mapping() -> HMASignalTypeMapping:
+    """
+    Cache-get signalTypeMapping. Call only if HMAConfig has been initialized.
+    """
+    return get_pytx_functionality_mapping().signal_and_content

--- a/hasher-matcher-actioner/hmalib/lambdas/unified_indexer.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/unified_indexer.py
@@ -8,23 +8,19 @@ import boto3
 from threatexchange.signal_type.md5 import VideoMD5Signal
 from threatexchange.signal_type.pdq import PdqSignal
 from threatexchange.signal_type.signal_base import SignalType
+from threatexchange.signal_type.index import SignalTypeIndex
 
 from hmalib.common.config import HMAConfig
-from hmalib.common.mappings import get_pytx_functionality_mapping
 from hmalib.common.models.bank import BanksTable
 from hmalib.common.s3_adapters import (
     HashRowT,
-    ThreatExchangeS3Adapter,
-    ThreatExchangeS3PDQAdapter,
-    ThreatExchangeS3VideoMD5Adapter,
     S3ThreatDataConfig,
 )
 from hmalib.common.logging import get_logger
 from hmalib import metrics
 from hmalib.indexers.metadata import BankedSignalIndexMetadata
-from hmalib.indexers.s3_indexers import (
-    S3BackedInstrumentedIndexMixin,
-)
+from hmalib.indexers.index_store import S3PickledIndexStore
+from hmalib.lambdas.common import get_signal_type_mapping
 
 logger = get_logger(__name__)
 dynamodb = boto3.resource("dynamodb")
@@ -95,15 +91,6 @@ def merge_hash_rows_on_hash_value(
     return accumulator
 
 
-# Maps from signal type to the subclass of ThreatExchangeS3Adapter.
-# ThreatExchangeS3Adapter is used to fetch all the data corresponding to a
-# signal_type. At some point, we must allow _updates_ to indexes rather than
-# rebuilding them all the time.
-_ADAPTER_MAPPING: t.Dict[t.Type[SignalType], t.Type[ThreatExchangeS3Adapter]] = {
-    PdqSignal: ThreatExchangeS3PDQAdapter,
-    VideoMD5Signal: ThreatExchangeS3VideoMD5Adapter,
-}
-
 # Which signal types must be processed into an index?
 ALL_INDEXABLE_SIGNAL_TYPES = [PdqSignal, VideoMD5Signal]
 
@@ -121,55 +108,30 @@ def lambda_handler(event, context):
     - the key name must return a signal_type in
       ThreatUpdateS3Store.get_signal_type_from_object_key
     """
-    # Note: even though we know which files were updated, threatexchange indexes
-    # do not yet allow adding new entries. So, we must do a full rebuild. So, we
-    # only end up using the signal types that were updated, not the actual files
-    # that changed.
-
-    s3_config = S3ThreatDataConfig(
-        threat_exchange_data_bucket_name=THREAT_EXCHANGE_DATA_BUCKET_NAME,
-        threat_exchange_data_folder=THREAT_EXCHANGE_DATA_FOLDER,
-    )
-
-    banks_table = BanksTable(dynamodb.Table(BANKS_TABLE))
 
     HMAConfig.initialize(HMA_CONFIG_TABLE)
-    signal_content_mapping = get_pytx_functionality_mapping()
+    signal_content_mapping = get_signal_type_mapping()
+
+    index_store = S3PickledIndexStore(INDEXES_BUCKET_NAME)
+    banks_table = BanksTable(dynamodb.Table(BANKS_TABLE), signal_content_mapping)
 
     for signal_type in ALL_INDEXABLE_SIGNAL_TYPES:
-        adapter_class = _ADAPTER_MAPPING[signal_type]
-        data_files = adapter_class(
-            config=s3_config, metrics_logger=metrics.names.indexer
-        ).load_data()
-
         with metrics.timer(metrics.names.indexer.get_bank_data):
             bank_data = get_all_bank_hash_rows(signal_type, banks_table)
 
         with metrics.timer(metrics.names.indexer.merge_datafiles):
             logger.info(f"Merging {signal_type} Hash files")
 
-            # go from dict[filename, list<hash rows>] → list<hash rows>
-            flattened_data = [
-                hash_row for file_ in data_files.values() for hash_row in file_
-            ]
-
             merged_data = functools.reduce(
-                merge_hash_rows_on_hash_value, flattened_data + bank_data, {}
+                merge_hash_rows_on_hash_value, bank_data, {}
             ).values()
 
         with metrics.timer(metrics.names.indexer.build_index):
             logger.info(f"Rebuilding {signal_type} Index")
 
-            for index_class in [
-                signal_type.get_index_cls()
-                for signal_type in signal_content_mapping.signal_and_content.signal_type_by_name.values()
-            ]:
-                index: S3BackedInstrumentedIndexMixin = index_class.build(merged_data)
-
-                logger.info(
-                    f"Putting {signal_type} index in S3 for index {index.get_index_class_name()}"
-                )
-                index.save(bucket_name=INDEXES_BUCKET_NAME)
+            index: SignalTypeIndex = signal_type.get_index_cls().build(merged_data)
+            logger.info(f"Putting {signal_type} index in S3.")
+            index_store.save(index)
             metrics.flush()
 
     logger.info("Index updates complete")

--- a/hasher-matcher-actioner/terraform/.terraform.lock.hcl
+++ b/hasher-matcher-actioner/terraform/.terraform.lock.hcl
@@ -2,63 +2,62 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.74.3"
-  constraints = "~> 3.0, >= 3.63.0"
+  version     = "4.45.0"
+  constraints = ">= 3.73.0, ~> 4.0"
   hashes = [
-    "h1:SpYaB/QoM6MBiAV8k25LRVvdSEHoCoUVanXwECLEWok=",
-    "h1:h4TYqgRKTuuWfZtxJnEGcs/NxGCaxZ4jr0IwTfgZDRM=",
-    "zh:25401cd4667d0496caf7e92e74ecef7c98cf74465570705cda2207770c27ff6c",
-    "zh:2d154527a9b2585f72fc5eceac635257e3f50f68de8a519e71c795d5166a0a22",
-    "zh:499fa5201804a5a33a90d683147fb2f81da91bfcd8ed20293f88f6f39cedbf97",
-    "zh:730284250fd949a59afb6935b3a68a33709d5a78b686fa98f351ad32c919cfc3",
-    "zh:7461ebd6fb35900d620cfa3f42126d988ea1e604ee3828d1c64d5727f908bd26",
-    "zh:7c85743b31c7459f8e74aaa98471ba82c54517eb908603411808a12982d89b1c",
-    "zh:8ed977b7fb97de624f5414b08cab36fd973a624072e0e9082c0c822e0864c7b9",
-    "zh:94ae7313bb0b425d4007a0b70601a337972c4f0f7a323487acf69215e74b4425",
-    "zh:b5a1589672d709da725a72c46d28bf5b2dea71325f6e0b44a0049f644cd09eba",
-    "zh:c7e8e7ce59e4578416557fc2f138137af3c8365ac3e34f0ff5166323c7d641a1",
-    "zh:ccf2e286b207e749fff76bb4075deddb9e7e237936d8654f34828c54e7035455",
+    "h1:J/XjRsEJIpxi+mczXQfnH3nvfACv3LRDtrthQJCIibY=",
+    "zh:22da03786f25658a000d1bcc28c780816a97e7e8a1f59fff6eee7d452830e95e",
+    "zh:2543be56eee0491eb0c79ca1c901dcbf71da26625961fe719f088263fef062f4",
+    "zh:31a1da1e3beedfd88c3c152ab505bdcf330427f26b75835885526f7bb75c4857",
+    "zh:4409afe50f225659d5f378fe9303a45052953a1219f7f1acc82b69d07528b7ba",
+    "zh:4dadec3b783f10d2f8eef3dab5e817baae9c932a7967d45fe3d77fcbcbdaa438",
+    "zh:55be80d6e24828dcb0db7a0226fb275415c1c0ad63dd2f33b76f3ac0cd64e6a6",
+    "zh:560bba29efb7dbe0bfcc937369d88817aa31a8d18aa25395b1afe2576cb04495",
+    "zh:6caacc202e83438ff63d5d96733e283f44e349668d96c6b1c5c7df463ebf85cc",
+    "zh:6cabab83a61d5b4ac801c5a5d57556a0e76ec8dc879d28cf777509db5f6a657e",
+    "zh:96c4528bf9c16edb8841b68479ec51c499ed7fa680462fa28caeab3fc168bb43",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:cdc0b47ff840d708fbf75abfe86d23dc7f1dffdd233a771822a17b5c637f4769",
+    "zh:d9a9583e82776d1ebb6cf6c3d47acc2b302f8778f470ceffe7579dc794eb1feb",
+    "zh:e9367ca9f6f6418a23cdf8d01f29dd0c4f614e78499f52a767a422e4c334b915",
+    "zh:f6d355a2fb3bcebb597f68bbca4fa2aaa364efd29240236c582375e219d77656",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/local" {
-  version = "2.1.0"
+  version = "2.2.3"
   hashes = [
-    "h1:/OpJKWupvFd8WJX1mTt8vi01pP7dkA6e//4l4C3TExE=",
-    "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
-    "h1:KfieWtVyGWwplSoLIB5usKAUnrIkDQBkWaR5TI+4WYg=",
-    "h1:PaQTpxHMbZB9XV+c1od1eaUvndQle3ZZHx79hrI6C3k=",
-    "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
-    "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
-    "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
-    "zh:719dfd97bb9ddce99f7d741260b8ece2682b363735c764cac83303f02386075a",
-    "zh:7598bb86e0378fd97eaa04638c1a4c75f960f62f69d3662e6d80ffa5a89847fe",
-    "zh:ad0a188b52517fec9eca393f1e2c9daea362b33ae2eb38a857b6b09949a727c1",
-    "zh:c46846c8df66a13fee6eff7dc5d528a7f868ae0dcf92d79deaac73cc297ed20c",
-    "zh:dc1a20a2eec12095d04bf6da5321f535351a594a636912361db20eb2a707ccc4",
-    "zh:e57ab4771a9d999401f6badd8b018558357d3cbdf3d33cc0c4f83e818ca8e94b",
-    "zh:ebdcde208072b4b0f8d305ebf2bfdc62c926e0717599dcf8ec2fd8c5845031c3",
-    "zh:ef34c52b68933bedd0868a13ccfd59ff1c820f299760b3c02e008dc95e2ece91",
+    "h1:aWp5iSUxBGgPv1UnV5yag9Pb0N+U1I0sZb38AXBFO8A=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/null" {
-  version = "3.1.0"
+  version = "3.2.1"
   hashes = [
-    "h1:SFT7X3zY18CLWjoH2GfQyapxsRv6GDKsy9cF1aRwncc=",
-    "h1:grYDj8/Lvp1OwME+g1AsECPN1czO5ssSf+8fCluCHQY=",
-    "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
-    "h1:xhbHC6in3nQryvTQBWKxebi3inG5OCgHgc4fRxL0ymc=",
-    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
-    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
-    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
-    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
-    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
-    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
-    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
-    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
-    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
-    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
-    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
+    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
+    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
+    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
+    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
+    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
+    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
+    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
+    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
+    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
+    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
+    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
   ]
 }

--- a/hasher-matcher-actioner/terraform/authentication-shared/main.tf
+++ b/hasher-matcher-actioner/terraform/authentication-shared/main.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/hasher-matcher-actioner/terraform/indexer/main.tf
+++ b/hasher-matcher-actioner/terraform/indexer/main.tf
@@ -86,8 +86,12 @@ resource "aws_lambda_function" "indexer" {
   image_config {
     command = [var.lambda_docker_info.commands.indexer]
   }
-  timeout     = 300
-  memory_size = 512
+  timeout     = 720 # 12 minutes
+  memory_size = 5120
+
+  ephemeral_storage {
+    size = 5120
+  }
 
   environment {
     variables = {
@@ -166,6 +170,11 @@ data "aws_iam_policy_document" "indexer" {
     effect    = "Allow"
     actions   = ["dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan", "dynamodb:PutItem", "dynamodb:UpdateItem"]
     resources = ["${var.banks_datastore.arn}*"]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan", "dynamodb:PutItem", "dynamodb:DeleteItem"]
+    resources = [var.config_table.arn]
   }
   statement {
     effect = "Allow"

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/hasher-matcher-actioner/terraform/matcher/main.tf
+++ b/hasher-matcher-actioner/terraform/matcher/main.tf
@@ -14,7 +14,11 @@ resource "aws_lambda_function" "matcher_lambda" {
   }
 
   timeout     = 300
-  memory_size = 512
+  memory_size = 5120
+
+  ephemeral_storage {
+    size = 5120
+  }
 
   environment {
     variables = {


### PR DESCRIPTION
Summary
---------
This is mostly doing what mypy fails to do. Tried out some common HMA flows (submitting an image, building an index, matching against an index) and solved what the logs deemed broken.

In hasher-matcher-actioner/hmalib/lambdas/common.py, we've extracted out a function that's common across all lambdas. This new function allows you to get a config backed signal_type_mapping easily.

A new addition is an S3 backed index store. The older way was to provide a mixin, but that won't fly with the new threatexchange extensions model because we want _any_ SignalTypeIndex class to be used and dynamically generated classes do not pickle.

Test Plan
---------
Terraform build / apply.

Tested out a submission..
<img width="971" alt="Screen Shot 2022-12-05 at 19 11 11" src="https://user-images.githubusercontent.com/217056/205793001-380f3bba-db02-476c-9f29-395800aaad80.png">

tested out an index build..
- indexes are getting built regularly from a million PDQ hashes.

Both these flows were failing, but mypy never caught the errors. In its defense, some of the errors were not type errors.
