### PR TITLE
Allow using config backed signal_type_mapping in all submit APIs.

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/middleware.py
@@ -84,6 +84,7 @@ def jsoninator(
         t.Type[DictParseableWithSignalTypeMapping],
     ],
     from_query=False,
+    signal_type_mapping: t.Optional[HMASignalTypeMapping] = None,
 ):
     """
     Bottle plugin which allows you to create 'typed' views.
@@ -136,9 +137,23 @@ def jsoninator(
                 try:
                     # Try to extract request
                     if from_query:
-                        request_object = request_type.from_dict(bottle.request.query)
+                        if issubclass(request_type, DictParseableWithSignalTypeMapping):
+                            assert signal_type_mapping != None
+                            request_object = request_type.from_dict(
+                                bottle.request.query, signal_type_mapping
+                            )
+                        else:
+                            request_object = request_type.from_dict(
+                                bottle.request.query
+                            )
                     else:
-                        request_object = request_type.from_dict(bottle.request.json)
+                        if issubclass(request_type, DictParseableWithSignalTypeMapping):
+                            assert signal_type_mapping != None
+                            request_object = request_type.from_dict(
+                                bottle.request.json, signal_type_mapping
+                            )
+                        else:
+                            request_object = request_type.from_dict(bottle.request.json)
                 except Exception as e:
                     logger.error(
                         "Failed to deserialize request for type: %s", str(request_type)

--- a/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/submit.py
@@ -350,7 +350,15 @@ def get_submit_api(
             force_resubmit=request.force_resubmit,
         )
 
-    @submit_api.post("/s3/", apply=[jsoninator(SubmitContents3ObjectRequestBody)])
+    @submit_api.post(
+        "/s3/",
+        apply=[
+            jsoninator(
+                SubmitContents3ObjectRequestBody,
+                signal_type_mapping=signal_type_mapping,
+            )
+        ],
+    )
     def submit_s3(
         request: SubmitContents3ObjectRequestBody,
     ) -> t.Union[SubmitResponse, SubmitError]:
@@ -372,7 +380,15 @@ def get_submit_api(
 
         return SubmitResponse(content_id=request.content_id, submit_successful=True)
 
-    @submit_api.post("/url/", apply=[jsoninator(SubmitContentViaURLRequestBody)])
+    @submit_api.post(
+        "/url/",
+        apply=[
+            jsoninator(
+                SubmitContentViaURLRequestBody,
+                signal_type_mapping=signal_type_mapping,
+            )
+        ],
+    )
     def submit_url(
         request: SubmitContentViaURLRequestBody,
     ) -> t.Union[SubmitResponse, SubmitError]:
@@ -392,7 +408,15 @@ def get_submit_api(
 
         return SubmitResponse(content_id=request.content_id, submit_successful=True)
 
-    @submit_api.post("/bytes/", apply=[jsoninator(SubmitContentBytesRequestBody)])
+    @submit_api.post(
+        "/bytes/",
+        apply=[
+            jsoninator(
+                SubmitContentBytesRequestBody,
+                signal_type_mapping=signal_type_mapping,
+            )
+        ],
+    )
     def submit_bytes(
         request: SubmitContentBytesRequestBody,
     ) -> t.Union[SubmitResponse, SubmitError]:
@@ -412,10 +436,17 @@ def get_submit_api(
         return SubmitResponse(content_id=request.content_id, submit_successful=True)
 
     @submit_api.post(
-        "/put-url/", apply=[jsoninator(SubmitContentViaPutURLUploadRequestBody)]
+        "/put-url/",
+        apply=[
+            jsoninator(
+                SubmitContentViaPutURLUploadRequestBody,
+                signal_type_mapping=signal_type_mapping,
+            )
+        ],
     )
     def submit_put_url(
         request: SubmitContentViaPutURLUploadRequestBody,
+        signal_type_mapping=signal_type_mapping,
     ) -> t.Union[SubmitViaUploadUrlResponse, SubmitError]:
         """
         Submission of content to HMA in two steps
@@ -444,7 +475,15 @@ def get_submit_api(
             message="Failed to generate upload url",
         )
 
-    @submit_api.post("/hash/", apply=[jsoninator(SubmitContentHashRequestBody)])
+    @submit_api.post(
+        "/hash/",
+        apply=[
+            jsoninator(
+                SubmitContentHashRequestBody,
+                signal_type_mapping=signal_type_mapping,
+            )
+        ],
+    )
     def submit_hash(
         request: SubmitContentHashRequestBody,
     ) -> t.Union[SubmitResponse, SubmitError]:


### PR DESCRIPTION
Summary
---
With new pytx, submit APIs need to know the supported signal types and content types. The way to do that is using the signal_type mapping in our middleware.py

hmalib.lambdas.middleware.jsoninator is an  bottle plugin that does automatic serialization and deserialization of request / response bodies.

Now, jsoninator takes additional signal_type_mapping parameters allowing it to deserialize objects that need signal_type_mapping.

Test Plan
---
Where all submission to the UI were failing, after doing these changes, they succeed.
