### PR TITLE
[hma][ui] Support updating credentials for exchanges from HMA UI

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/configs/tests/test_tx_apis.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tests/test_tx_apis.py
@@ -7,7 +7,7 @@ from hmalib.common.config import HMAConfig
 from hmalib.common.models.tests.ddb_test_common import HMAConfigTestBase
 from hmalib.common.configs.tx_apis import (
     ToggleableSignalExchangeAPIConfig,
-    disable_signal_exchange_api,
+    set_status_signal_exchange_api,
     add_signal_exchange_api,
     AddSignalExchangeAPIResult,
 )
@@ -56,7 +56,7 @@ class TXApiConfigsTestCase(HMAConfigTestBase, unittest.TestCase):
             )
 
             self.assertTrue(ToggleableSignalExchangeAPIConfig.get_all()[0].enabled)
-            disable_signal_exchange_api(
-                "threatexchange.exchanges.impl.ncmec_api.NCMECCollabConfig"
+            set_status_signal_exchange_api(
+                "threatexchange.exchanges.impl.ncmec_api.NCMECCollabConfig", False
             )
             self.assertFalse(ToggleableSignalExchangeAPIConfig.get_all()[0].enabled)

--- a/hasher-matcher-actioner/hmalib/common/configs/tx_apis.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tx_apis.py
@@ -74,6 +74,11 @@ def add_signal_exchange_api(
     return AddSignalExchangeAPIResult.ADDED
 
 
+class SignalExchangeAPIStatus(Enum):
+    ENABLED = 1
+    DISABLED = 2
+
+
 class UpdateSignalExchangeAPIStatusResult(Enum):
     DISABLED = 1
     ENABLED = 2
@@ -81,7 +86,7 @@ class UpdateSignalExchangeAPIStatusResult(Enum):
 
 
 def set_status_signal_exchange_api(
-    klass: str, status: bool
+    klass: str, status: SignalExchangeAPIStatus
 ) -> UpdateSignalExchangeAPIStatusResult:
     """
     Convenience method. Will fail if klass does not translate to an actual
@@ -102,7 +107,7 @@ def set_status_signal_exchange_api(
         return UpdateSignalExchangeAPIStatusResult.FAILED
 
     config = t.cast(ToggleableSignalExchangeAPIConfig, config)
-    config.enabled = status
+    config.enabled = status == SignalExchangeAPIStatus.ENABLED
     update_config(config)
 
     return (

--- a/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/api_root.py
@@ -19,6 +19,7 @@ from hmalib.lambdas.api.bank import get_bank_api
 from hmalib.lambdas.api.action_rules import get_action_rules_api
 from hmalib.lambdas.api.actions import get_actions_api
 from hmalib.lambdas.api.content import get_content_api
+from hmalib.lambdas.api.exchanges import get_exchanges_api
 from hmalib.lambdas.api.datasets import get_datasets_api
 from hmalib.lambdas.api.indexes import get_indexes_api
 from hmalib.lambdas.api.matches import get_matches_api
@@ -183,6 +184,13 @@ def bottle_init_once() -> t.Tuple[
             hma_config_table=HMA_CONFIG_TABLE,
             bank_table=bank_table,
             signal_type_mapping=functionality_mapping.signal_and_content,
+        ),
+    )
+
+    app.mount(
+        "/exchanges/",
+        get_exchanges_api(
+            hma_config_table=HMA_CONFIG_TABLE, secrets_prefix=SECRETS_PREFIX
         ),
     )
 

--- a/hasher-matcher-actioner/hmalib/lambdas/api/exchanges.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/exchanges.py
@@ -16,6 +16,9 @@ from hmalib.common.configs.tx_apis import (
     add_signal_exchange_api,
     set_status_signal_exchange_api,
 )
+from hmalib.common.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def get_exchanges_api(hma_config_table: str, secrets_prefix: str) -> bottle.Bottle:
@@ -26,7 +29,7 @@ def get_exchanges_api(hma_config_table: str, secrets_prefix: str) -> bottle.Bott
     @exchanges_api.get("/")
     def get_exchanges():
         """
-        Get the currently enabled APIs.
+        Get all APIs that are currently configured (enabled and disabled).
         """
         apis = ToggleableSignalExchangeAPIConfig.get_all()
         return {
@@ -63,6 +66,9 @@ def get_exchanges_api(hma_config_table: str, secrets_prefix: str) -> bottle.Bott
         ]
 
         if not api:
+            logger.info(
+                "Tried to load credentials for non-existent exchange: %s", classname
+            )
             return {"result": "failed"}
 
         try:
@@ -70,6 +76,9 @@ def get_exchanges_api(hma_config_table: str, secrets_prefix: str) -> bottle.Bott
                 "credential_string": secrets.get_secret(api[0].get_credential_name())
             }
         except ValueError:
+            logger.info(
+                "Tried to load non-existent credential for exchange: %s", classname
+            )
             return {"result": "failed"}
 
     @exchanges_api.post("/set-credential-string")

--- a/hasher-matcher-actioner/hmalib/lambdas/api/exchanges.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/exchanges.py
@@ -1,0 +1,92 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+APIs to power viewing and editing of exchanges.
+"""
+
+import bottle
+
+from threatexchange.exchanges import auth
+
+from hmalib.lambdas.api.middleware import SubApp
+from hmalib.aws_secrets import AWSSecrets
+from hmalib.common.config import HMAConfig
+from hmalib.common.configs.tx_apis import (
+    ToggleableSignalExchangeAPIConfig,
+    add_signal_exchange_api,
+    set_status_signal_exchange_api,
+)
+
+
+def get_exchanges_api(hma_config_table: str, secrets_prefix: str) -> bottle.Bottle:
+    exchanges_api = SubApp()
+    HMAConfig.initialize(hma_config_table)
+    secrets = AWSSecrets(secrets_prefix)
+
+    @exchanges_api.get("/")
+    def get_exchanges():
+        """
+        Get the currently enabled APIs.
+        """
+        apis = ToggleableSignalExchangeAPIConfig.get_all()
+        return {
+            "exchanges": {
+                api.signal_exchange_api_class: {
+                    "enabled": api.enabled,
+                    "supports_credentials": issubclass(
+                        api.to_concrete_class(), auth.SignalExchangeWithAuth
+                    ),
+                }
+                for api in apis
+            }
+        }
+
+    @exchanges_api.post("/update-enabled")
+    def update_enabled():
+        classname = bottle.request.query.get("class")
+        target_status = bottle.request.query.get("enabled") == "true"
+
+        return {"result": set_status_signal_exchange_api(classname, target_status).name}
+
+    @exchanges_api.post("/add-new-exchange")
+    def add_new_exchange():
+        classname = bottle.request.query.get("class")
+        return {"result": add_signal_exchange_api(classname).name}
+
+    @exchanges_api.get("/get-credential-string")
+    def get_credential_string():
+        classname = bottle.request.query.get("class")
+        api = [
+            x
+            for x in ToggleableSignalExchangeAPIConfig.get_all()
+            if x.signal_exchange_api_class == classname
+        ]
+
+        if not api:
+            return {"result": "failed"}
+
+        try:
+            return {
+                "credential_string": secrets.get_secret(api[0].get_credential_name())
+            }
+        except ValueError:
+            return {"result": "failed"}
+
+    @exchanges_api.post("/set-credential-string")
+    def set_credential_string():
+        classname = bottle.request.json.get("class")
+        credential_string = bottle.request.json.get("credential_string")
+
+        api = [
+            x
+            for x in ToggleableSignalExchangeAPIConfig.get_all()
+            if x.signal_exchange_api_class == classname
+        ]
+
+        if not api:
+            return {"result": "failed"}
+
+        secrets.put_secret(api[0].get_credential_name(), credential_string)
+        return {"result": "success"}
+
+    return exchanges_api

--- a/hasher-matcher-actioner/terraform/api/main.tf
+++ b/hasher-matcher-actioner/terraform/api/main.tf
@@ -151,12 +151,15 @@ data "aws_iam_policy_document" "api_root" {
     resources = ["*"]
   }
 
-  statement {
-    effect    = "Allow"
-    actions   = ["secretsmanager:GetSecretValue", "secretsmanager:UpdateSecret"]
-    resources = [var.te_api_token_secret.arn]
-  }
 
+  statement {
+    effect  = "Allow"
+    actions = ["secretsmanager:GetSecretValue", "secretsmanager:CreateSecret", "secretsmanager:PutSecretValue"]
+    resources = [
+      var.te_api_token_secret.arn,
+      "arn:aws:secretsmanager:${data.aws_region.current.name}:${local.account_id}:secret:${var.secrets_prefix}*"
+    ]
+  }
   statement {
     effect    = "Allow"
     actions   = ["sqs:SendMessage"]

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -772,6 +772,14 @@ export async function fetchAllExchanges(): Promise<{
   );
 }
 
+export async function addNewExchange(className: string): Promise<void> {
+  return apiPost<{result: string}>(
+    'exchanges/add-new-exchange',
+    {},
+    {class: className},
+  ).then();
+}
+
 export async function updateExchangeStatus(
   className: string,
   enabled: boolean,

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -14,6 +14,7 @@ import {
 import {toDate} from './utils/DateTimeUtils';
 import {ContentType, getContentTypeForString} from './utils/constants';
 import {Collab} from './messages/CollabMessages';
+import {Exchange} from './messages/ExchangeMessages';
 
 async function getAuthorizationToken(): Promise<string> {
   const currentSession = await Auth.currentSession();
@@ -756,4 +757,51 @@ export async function fetchAllCollabs(): Promise<Array<Collab>> {
   return apiGet<AllCollabsEnvelope>('collabs/').then(
     response => response.collabs,
   );
+}
+
+// Exchange APIs
+type AllExchangesEnvelope = {
+  exchanges: {[key: string]: Exchange};
+};
+
+export async function fetchAllExchanges(): Promise<{
+  [key: string]: Exchange;
+}> {
+  return apiGet<AllExchangesEnvelope>('exchanges/').then(
+    response => response.exchanges,
+  );
+}
+
+export async function updateExchangeStatus(
+  className: string,
+  enabled: boolean,
+): Promise<string> {
+  return apiPost<{result: string}>(
+    'exchanges/update-enabled',
+    {},
+    {class: className, enabled},
+  ).then(res => res.result);
+}
+
+export async function getExchangeCredentialString(
+  className: string,
+): Promise<string> {
+  return apiGet<{credential_string: string}>(
+    'exchanges/get-credential-string',
+    {class: className},
+  ).then(res => res.credential_string);
+}
+
+export async function setExchangeCredentialString(
+  className: string,
+  credentialString: string,
+): Promise<void> {
+  return apiPost<{result: string}>('exchanges/set-credential-string', {
+    class: className,
+    credential_string: credentialString,
+  }).then(res => {
+    if (res.result !== 'success') {
+      throw Error('Could not update credential string');
+    }
+  });
 }

--- a/hasher-matcher-actioner/webapp/src/messages/ExchangeMessages.tsx
+++ b/hasher-matcher-actioner/webapp/src/messages/ExchangeMessages.tsx
@@ -1,0 +1,4 @@
+export type Exchange = {
+  enabled: boolean;
+  supports_credentials: boolean;
+};

--- a/hasher-matcher-actioner/webapp/src/pages/Settings.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/Settings.tsx
@@ -15,10 +15,11 @@ import ActionPerformerSettingsTab, {
 } from './settings/ActionPerformerSettingsTab';
 import ThreatExchangeSettingsTab from './settings/ThreatExchangeSettingsTab';
 import IndexSettingsTab from './settings/IndexSettingsTab';
+import ExchangesTab from './settings/ExchangesTab';
 
 // This array must include the eventKey attribute value of any Tab in Tabs as
 // a part of the implementation to give each tab its own route.
-const tabEventKeys = ['threatexchange', 'actions', 'action-rules'];
+const tabEventKeys = ['exchanges', 'actions', 'action-rules', 'threatexchange'];
 
 export default function Settings(): JSX.Element {
   const {tab = tabEventKeys[0]} = useParams<{tab: string}>();
@@ -47,8 +48,8 @@ export default function Settings(): JSX.Element {
         onSelect={key => {
           history.push(`/settings/${key}`);
         }}>
-        <Tab eventKey="threatexchange" title="ThreatExchange">
-          <ThreatExchangeSettingsTab />
+        <Tab eventKey="exchanges" title="Exchanges">
+          <ExchangesTab />
         </Tab>
         <Tab eventKey="actions" title="Actions">
           <ActionPerformerSettingsTab
@@ -66,6 +67,9 @@ export default function Settings(): JSX.Element {
         </Tab>
         <Tab eventKey="index" title="Indexes">
           <IndexSettingsTab />
+        </Tab>
+        <Tab eventKey="threatexchange" title="ThreatExchange">
+          <ThreatExchangeSettingsTab />
         </Tab>
       </Tabs>
     </div>

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ExchangesTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ExchangesTab.tsx
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+
+import React, {useContext, useEffect, useState} from 'react';
+import {
+  Button,
+  Card,
+  Col,
+  Container,
+  Form,
+  InputGroup,
+  Modal,
+  Row,
+  Spinner,
+} from 'react-bootstrap';
+import {IonIcon} from '@ionic/react';
+import {eyeOutline, eyeOffOutline} from 'ionicons/icons';
+import {
+  fetchAllExchanges,
+  getExchangeCredentialString,
+  setExchangeCredentialString,
+  updateExchangeStatus,
+} from '../../Api';
+import {NotificationsContext} from '../../AppWithNotifications';
+import {Exchange} from '../../messages/ExchangeMessages';
+import SettingsTabPane from './SettingsTabPane';
+
+function humanizeClassName(className: string) {
+  const parts = className.split('.');
+  return parts[parts.length - 1];
+}
+
+type CredentialControlProps = {
+  cls: string;
+};
+
+function CredentialControl({cls}: CredentialControlProps): JSX.Element {
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const [showCurrentCreds, setShowCurrentCreds] = useState<boolean>(false);
+  const [currentCreds, setCurrentCreds] = useState<string>();
+  const [newCredentialString, setNewCredentialString] = useState<string>();
+  const [refetchCounter, setRefetchCounter] = useState<number>(1);
+
+  const notifications = useContext(NotificationsContext);
+
+  const humanized = humanizeClassName(cls);
+
+  useEffect(() => {
+    getExchangeCredentialString(cls).then(setCurrentCreds);
+  }, [refetchCounter]);
+
+  const handleUpdateCredentialString = () => {
+    if (newCredentialString) {
+      setExchangeCredentialString(cls, newCredentialString)
+        .then(() => {
+          notifications.info({message: 'Updated credentials.'});
+          setShowModal(false);
+          setNewCredentialString(undefined);
+          setRefetchCounter(refetchCounter + 1);
+        })
+        .catch(() => {
+          notifications.error({message: 'Could not update credentials.'});
+        });
+    }
+  };
+
+  return (
+    <p>
+      <Modal show={showModal} onHide={() => setShowModal(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Change credential string for {humanized}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {currentCreds === null ? (
+            <Spinner animation="border" role="status" />
+          ) : (
+            <Container>
+              <Row className="mb-4">
+                <Col>
+                  <Form.Label htmlFor="current-creds">
+                    Current Credential String
+                  </Form.Label>
+                  <InputGroup>
+                    <Form.Control
+                      disabled
+                      type={showCurrentCreds ? 'text' : 'password'}
+                      value={currentCreds}
+                      id="current-creds"
+                    />
+                    <InputGroup.Text
+                      onClick={() => setShowCurrentCreds(!showCurrentCreds)}>
+                      <IonIcon
+                        icon={showCurrentCreds ? eyeOffOutline : eyeOutline}
+                      />
+                    </InputGroup.Text>
+                  </InputGroup>
+                </Col>
+              </Row>
+              <Row className="mb-4">
+                <Col>
+                  <Form.Label htmlFor="current-creds">
+                    Set Credential String
+                  </Form.Label>
+                  <Form.Control
+                    type="password"
+                    value={newCredentialString}
+                    id="current-creds"
+                    onChange={e => setNewCredentialString(e.target.value)}
+                  />
+                </Col>
+              </Row>
+              <Row className="mb-4">
+                <Col>
+                  <Button
+                    onClick={handleUpdateCredentialString}
+                    disabled={
+                      newCredentialString === '' ||
+                      newCredentialString === undefined
+                    }>
+                    Update
+                  </Button>
+                </Col>
+              </Row>
+            </Container>
+          )}
+        </Modal.Body>
+      </Modal>
+      <Button variant="secondary" onClick={() => setShowModal(true)}>
+        Change Credential String
+      </Button>
+    </p>
+  );
+}
+
+export default function ExchangesTab(): JSX.Element {
+  const [exchanges, setExchanges] = useState<{[key: string]: Exchange}>({});
+  const notifications = useContext(NotificationsContext);
+
+  useEffect(() => {
+    fetchAllExchanges().then(setExchanges);
+  }, []);
+
+  const setUpdateStatus = (className: string, status: boolean) => {
+    const message = status
+      ? `Enabled ${humanizeClassName(className)}`
+      : `Disabled ${humanizeClassName(className)}`;
+
+    updateExchangeStatus(className, status).then(() => {
+      notifications.success({
+        message,
+      });
+    });
+
+    const newExchanges: {[key: string]: Exchange} = {};
+    Object.keys(exchanges).forEach(key => {
+      if (key === className) {
+        newExchanges[key] = {...exchanges[key], enabled: status};
+      } else {
+        newExchanges[key] = exchanges[key];
+      }
+    });
+
+    setExchanges(newExchanges);
+  };
+
+  const exchangeRows = Object.keys(exchanges).map(cxClass => {
+    const humanName = humanizeClassName(cxClass);
+
+    return (
+      <Row key={cxClass} className="mt-2">
+        <Col>
+          <Card>
+            <Card.Header>
+              <div className="float-left">
+                <code>{humanName}</code>
+              </div>
+              <div className="float-right">
+                <Form>
+                  <Form.Check
+                    id={`enabled-${humanName}`}
+                    type="switch"
+                    label="Enabled"
+                    checked={exchanges[cxClass].enabled}
+                    onChange={() =>
+                      setUpdateStatus(cxClass, !exchanges[cxClass].enabled)
+                    }
+                  />
+                </Form>
+              </div>
+            </Card.Header>
+            <Card.Body>
+              <p>
+                <b>Full Class Name:&nbsp;</b>
+                <code>{cxClass}</code>
+              </p>
+              {exchanges[cxClass].supports_credentials ? (
+                <CredentialControl cls={cxClass} />
+              ) : null}
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
+    );
+  });
+
+  return (
+    <SettingsTabPane>
+      <Row>
+        <Col>
+          <SettingsTabPane.Title>Exchanges</SettingsTabPane.Title>
+        </Col>
+      </Row>
+      <Row className="mb-3">
+        <Col>
+          Exchanges are how you connect to other Signal sharing locations like
+          Meta&apos;s ThreatExchange.
+        </Col>
+      </Row>
+      <>{exchangeRows}</>
+    </SettingsTabPane>
+  );
+}

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ThreatExchangeSettingsTab.tsx
@@ -11,8 +11,10 @@ import {
   OverlayTrigger,
   Card,
   Col,
+  Alert,
 } from 'react-bootstrap';
 import classNames from 'classnames';
+import {Link} from 'react-router-dom';
 import ThreatExchangePrivacyGroupCard from '../../components/settings/ThreatExchangePrivacyGroupCard';
 import {
   HolidaysDatasetInformationBlock,
@@ -125,6 +127,18 @@ export default function ThreatExchangeSettingsTab(): JSX.Element {
   }, []);
   return (
     <SettingsTabPane>
+      <Row>
+        <Col>
+          <Alert variant="warning">
+            <Alert.Heading>Warning</Alert.Heading>
+            <p>
+              We are now recommending you use the{' '}
+              <Link to="/collabs/">Collaborations</Link> feature to manage your
+              ThreatExchange Privacy Groups.
+            </p>
+          </Alert>
+        </Col>
+      </Row>
       <Row className="mt-3">
         <Col xs={{span: 8}}>
           <h3>ThreatExchange Datasets </h3>


### PR DESCRIPTION
Summary
---
When I tried to get into the prod instance, there were no exchanges configured with the appropriate credentials.

This adds the ability for users to update the credentials for APIs that are already available in HMA.

Test Plan
---
terraform apply, webapp run

https://user-images.githubusercontent.com/217056/206073736-aae02149-6a6f-4d5d-88ea-21dfea5f1d4b.mp4

Fig 1: Test changing credentials for APIs.


https://user-images.githubusercontent.com/217056/206076591-c5004d45-df83-4747-810a-ac41b4a042af.mp4

Fig 2: Add a new exchange API
