### PR TITLE
fix #1222: Add unit test for fetcher; fix bugs found as a result

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/models/bank.py
+++ b/hasher-matcher-actioner/hmalib/common/models/bank.py
@@ -678,10 +678,12 @@ class BanksTable:
 
     def remove_bank_member(self, bank_member_id: str):
         """
-        Removes the bank member and associated signals from the bank. Merely
-        marks as removed, does not physically delete from the store. DOES NOT
-        stop matching until index is updated. DOES NOT undo any actions already
-        taken.
+        Removes the bank member from the bank. Merely marks as removed, does not
+        physically delete from the store.
+
+        DOES NOT stop matching until index is updated.
+        DOES NOT undo any actions already taken.
+        DOES NOT delete associated signals. Consider bank_operations.remove_bank_member.
         """
         bank_member_keys = self._table.query(
             IndexName=BankMember.BANK_MEMBER_ID_INDEX,

--- a/hasher-matcher-actioner/hmalib/fetching/bank_store.py
+++ b/hasher-matcher-actioner/hmalib/fetching/bank_store.py
@@ -17,6 +17,7 @@ from threatexchange.exchanges.fetch_state import (
 from hmalib.common.configs.tx_collab_config import EditableCollaborationConfig
 from hmalib.common.configs.tx_apis import ToggleableSignalExchangeAPIConfig
 from hmalib.common.models.bank import BanksTable
+from hmalib.banks import bank_operations as bank_ops
 from hmalib.common.logging import get_logger
 
 logger = get_logger(__name__)
@@ -303,7 +304,7 @@ class BankCollabFetchStore:
             self._import_bank.bank_id, str_key
         )
         if member:
-            self.banks_table.remove_bank_member(member.bank_member_id)
+            bank_ops.remove_bank_member(self.banks_table, member.bank_member_id)
 
     def convert_opinions_to_label(self, opinions: t.Sequence[SignalOpinion]):
         """
@@ -315,5 +316,5 @@ class BankCollabFetchStore:
         ddb using self.banks_table) can be written.
         """
         return reduce(
-            lambda tags, acc: acc.union(tags), map(lambda x: x.tags, opinions)
+            lambda tags, acc: acc.union(tags), map(lambda x: x.tags, opinions), []
         )

--- a/hasher-matcher-actioner/hmalib/fetching/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/fetching/fetcher.py
@@ -91,6 +91,13 @@ class Fetcher:
             if c.to_pytx_collab_config().enabled
         ]
 
+    def get_store(
+        self, collab: tx_collab_config.EditableCollaborationConfig
+    ) -> BankCollabFetchStore:
+        return BankCollabFetchStore(
+            self.signal_type_mapping.signal_types, self.banks_table, collab
+        )
+
     def _execute_for_collab(
         self, collab: tx_collab_config.EditableCollaborationConfig
     ) -> bool:
@@ -99,9 +106,7 @@ class Fetcher:
             collab.to_pytx_collab_config().api
         ].for_collab(collab=collab.to_pytx_collab_config())
 
-        store = BankCollabFetchStore(
-            self.signal_type_mapping.signal_types, self.banks_table, collab
-        )
+        store = self.get_store(collab)
 
         checkpoint = store.get_checkpoint()
         if checkpoint:

--- a/hasher-matcher-actioner/hmalib/fetching/tests/__init__.py
+++ b/hasher-matcher-actioner/hmalib/fetching/tests/__init__.py
@@ -1,0 +1,2 @@
+# Not part of the hmalib public interface, however, because of how
+# SignalExchangeAPI classes are handled, we need this to be reachable by python

--- a/hasher-matcher-actioner/hmalib/fetching/tests/test_fetcher_and_bank_store.py
+++ b/hasher-matcher-actioner/hmalib/fetching/tests/test_fetcher_and_bank_store.py
@@ -1,0 +1,310 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Most classes unapologetically stolen from
+threatexchange.exchanges.tests.test_state
+
+Verifies (using a mock bank) that the operations issued on a bank when fetching
+a collab are what we'd expect.
+"""
+
+import typing as t
+import contextlib
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+import pytest
+import boto3
+from moto import mock_dynamodb2
+
+from threatexchange.signal_type.signal_base import SignalType
+from threatexchange.exchanges.signal_exchange_api import TSignalExchangeAPICls
+from threatexchange.exchanges.collab_config import (
+    CollaborationConfigBase,
+    CollaborationConfigWithDefaults,
+)
+from threatexchange.utils.dataclass_json import dataclass_dumps
+from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
+from threatexchange.exchanges.fetch_state import (
+    FetchCheckpointBase,
+    TUpdateRecordKey,
+    TUpdateRecordValue,
+    SignalOpinion,
+    SignalOpinionCategory,
+    FetchedSignalMetadata,
+    FetchDelta,
+)
+from threatexchange.signal_type.md5 import VideoMD5Signal
+from threatexchange.signal_type.pdq.signal import PdqSignal
+from threatexchange.content_type.text import TextContent
+from threatexchange.content_type.content_base import ContentType
+
+from hmalib.fetching.fetcher import Fetcher
+from hmalib.fetching.bank_store import BankCollabFetchStore
+from hmalib.common.mappings import HMASignalTypeMapping
+from hmalib.common.models.bank import (
+    BanksTable,
+    Bank,
+    BankMember,
+    BankMemberSignal,
+    PaginatedResponse,
+)
+from hmalib.common.config import HMAConfig, create_config
+from hmalib.common.configs.tx_collab_config import EditableCollaborationConfig
+from hmalib.common.configs.tx_apis import ToggleableSignalExchangeAPIConfig
+
+from hmalib.common.tests.mapping_common import get_default_signal_type_mapping
+from hmalib.common.models.tests.ddb_test_common import (
+    DynamoDBTableTestBase,
+    HMAConfigTestBase,
+)
+from hmalib.common.models.tests.test_signal_uniqueness import BanksTableTestBase
+
+
+@dataclass
+class FakeCheckpoint(FetchCheckpointBase):
+    update_time: int
+
+
+@dataclass
+class FakeUpdateRecord:
+    # Interpret all values None as delete
+    signal_type: t.Optional[t.Type[SignalType]]
+    signal_value: t.Optional[str]
+    tag: t.Optional[str]
+
+
+@dataclass
+class FakeSignalMetadata(FetchedSignalMetadata):
+    tags: t.Set[str]
+
+    def get_as_opinions(self) -> t.Sequence[SignalOpinion]:
+        return [
+            SignalOpinion(True, SignalOpinionCategory.INVESTIGATION_SEED, self.tags)
+        ]
+
+
+# terrible-design, but it is a test. module level state to be overriden before
+# creating a fetcher instance. Since FakeAPI is instantiated via a classmethod
+# and FakeAPI needs to be discoverable as hmalib.foo.bar.tests.FakeAPI, I can't
+# use any kind of dynamic class gen.
+FETCH_RESPONSES: t.Sequence[
+    t.Dict[TUpdateRecordKey, t.Optional[TUpdateRecordValue]]
+] = []
+
+
+class ImaginarySignalType(SignalType):
+    @classmethod
+    def get_content_types(cls) -> t.List[t.Type[ContentType]]:
+        return [TextContent]
+
+
+class FakeAPI(
+    SignalExchangeAPI[
+        CollaborationConfigBase,
+        FakeCheckpoint,
+        FakeSignalMetadata,
+        str,
+        FakeUpdateRecord,
+    ]
+):
+    @classmethod
+    def for_collab(cls, collab: CollaborationConfigBase) -> SignalExchangeAPI:
+        return FakeAPI()
+
+    def fetch_iter(
+        self,
+        supported_signal_types: t.Sequence[t.Type[SignalType]],
+        checkpoint: t.Optional[FakeCheckpoint],
+    ) -> t.Iterator[FetchDelta[str, FakeUpdateRecord, FakeCheckpoint]]:
+        for i, update in enumerate(FETCH_RESPONSES):
+            yield FetchDelta(update, FakeCheckpoint((i + 1) * 100))
+
+    @staticmethod
+    def get_config_cls() -> t.Type[CollaborationConfigBase]:
+        return CollaborationConfigBase
+
+    @staticmethod
+    def get_checkpoint_cls() -> t.Type[FakeCheckpoint]:
+        return FakeCheckpoint
+
+    @staticmethod
+    def get_record_cls() -> t.Type[FakeSignalMetadata]:
+        return FakeSignalMetadata
+
+    @classmethod
+    def naive_convert_to_signal_type(
+        cls,
+        signal_types: t.Sequence[t.Type[SignalType]],
+        collab: CollaborationConfigBase,
+        fetched: t.Mapping[int, t.Optional[FakeUpdateRecord]],
+    ) -> t.Dict[t.Type[SignalType], t.Dict[str, FakeSignalMetadata]]:
+        result: t.Dict[t.Type[SignalType], t.Dict[str, t.Set[str]]] = defaultdict(
+            lambda: defaultdict(set)
+        )
+        for update in fetched.values():
+            if (
+                update is not None
+                and update.signal_type is not None
+                and update.signal_value is not None
+                and update.tag is not None
+            ):
+                if update.signal_type in signal_types:
+                    result[update.signal_type][update.signal_value].add(update.tag)
+
+        return {
+            k: {ik: FakeSignalMetadata(iv) for ik, iv in v.items()}
+            for k, v in result.items()
+        }
+
+
+class FakeFetcher(Fetcher):
+    # Allows overriding store. Since the real fetcher must instantiate a store
+    # per collab, we need this override.
+    def __init__(
+        self,
+        signal_type_mapping: HMASignalTypeMapping,
+        banks_table: BanksTable,
+        store: BankCollabFetchStore,
+    ):
+        super().__init__(signal_type_mapping, banks_table)
+        self._fake_store = store
+
+    def get_store(self, collab: EditableCollaborationConfig) -> BankCollabFetchStore:
+        return self._fake_store
+
+
+@pytest.fixture
+def banks_table():
+    DynamoDBTableTestBase.mock_aws_credentials()
+    mddb = mock_dynamodb2()
+    mddb.start()
+    dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+
+    # Create the config table too, just in case a table needs it. Would be best
+    # if we could somehow make config_table a fixture too, but using mocked
+    # dynamodb would have become unwieldy.
+    dynamodb.create_table(**HMAConfigTestBase.get_table_definition())
+    HMAConfig.initialize(HMAConfigTestBase.TABLE_NAME)
+
+    table = dynamodb.create_table(**BanksTableTestBase.get_table_definition())
+    yield BanksTable(table, get_default_signal_type_mapping())
+    mddb.stop()
+
+
+@pytest.fixture
+def mock_enabled_signal_exchange_apis(monkeypatch):
+    def mock_get(*args, **kwargs):
+        return [
+            ToggleableSignalExchangeAPIConfig(
+                "fake",
+                "hmalib.fetching.tests.test_fetcher_and_bank_store.FakeAPI",
+                True,
+            )
+        ]
+
+    monkeypatch.setattr(ToggleableSignalExchangeAPIConfig, "get_all", mock_get)
+
+
+def get_fake_collab_config(import_as_bank_id: str) -> CollaborationConfigBase:
+    pytx_config = CollaborationConfigWithDefaults("Test State", "fake")  # type: ignore
+
+    return EditableCollaborationConfig(
+        name="does not matter",
+        collab_config_class="threatexchange.exchanges.collab_config.CollaborationConfigWithDefaults",
+        attributes_json_serialized=dataclass_dumps(pytx_config),
+        import_as_bank_id=import_as_bank_id,
+    )
+
+
+# For brevity when describing test cases.
+K1 = "key-one"
+K2 = "key-two"
+K3 = "key-three"
+
+
+def md5(n: int) -> str:
+    return f"{n:032x}"
+
+
+def pdq(n: int) -> str:
+    return f"{n:064x}"
+
+
+# Each test case is a 3 value tuple. For each case n,
+# tuple[0] is a human readable test name. We'll print this if tests fail.
+# tuple[1] is the update to be emitted by fetch_iter()
+# tuple[2] is the expected end state after all n tuple[1]s have been emitted.
+# tuple[3] if NotImplemented, indicates unsupported behavior.
+#
+# Note: the test cases are cumulative. Each test case will behave as if all the
+# previous tests have been performed on this store.
+TEST_CASES = [
+    (
+        "Must have no indexable content when naive_convert_to_signal_type returns None",
+        {K1: FakeUpdateRecord(ImaginarySignalType, md5(1), "tag-one")},
+        {},
+    ),
+    (
+        "Must have one indexable signal for one known signal type.",
+        {K1: FakeUpdateRecord(VideoMD5Signal, md5(1), "tag-one")},
+        {VideoMD5Signal: {md5(1)}},
+    ),
+    (
+        "Must be able to replace signals of same key..",
+        {
+            K1: FakeUpdateRecord(VideoMD5Signal, md5(2), "tag-two"),
+            K2: FakeUpdateRecord(VideoMD5Signal, md5(3), "tag-three"),
+        },
+        {VideoMD5Signal: {md5(3)}},
+        NotImplemented,
+    ),
+    (
+        "Must be able to handle a delete for a known key.",
+        {K1: None},
+        {VideoMD5Signal: {md5(3)}},
+    ),
+]
+
+
+def unwrap_bank_signals_response(response: PaginatedResponse) -> t.Set[str]:
+    # Helper to convert bank member signals response to something that can be
+    # compared with TEST_CASE data
+    return {item.signal_value for item in response.items}
+
+
+@pytest.mark.usefixtures(
+    "mock_enabled_signal_exchange_apis",
+)
+@pytest.mark.parametrize("i", range(len(TEST_CASES)))
+def test_for_case_until(i, banks_table):
+    signal_type_mapping = get_default_signal_type_mapping()
+    bank = banks_table.create_bank("TEST_IMPORT_COLLAB", "Description")
+
+    fake_config = get_fake_collab_config(bank.bank_id)
+    create_config(fake_config)
+
+    global FETCH_RESPONSES
+    FETCH_RESPONSES = [tc[1] for tc in TEST_CASES[: i + 1]]
+
+    # fake_table = FakeBanksTable()
+    fetch_store = BankCollabFetchStore(
+        signal_type_mapping.signal_types, banks_table, fake_config
+    )
+    fetcher = FakeFetcher(signal_type_mapping, banks_table, fetch_store)
+    fetcher.run()
+
+    for signal_type, signal_values in TEST_CASES[i][2].items():
+        context = (
+            pytest.raises(AssertionError)
+            if NotImplemented in TEST_CASES[i]
+            else contextlib.nullcontext()
+        )
+
+        with context:
+            assert (
+                unwrap_bank_signals_response(
+                    banks_table.get_bank_member_signals_to_process_page(signal_type)
+                )
+                == signal_values
+            ), TEST_CASES[i][0]


### PR DESCRIPTION
Summary
---
Most of the new code sets up a Fake exchange that can return whatever data we command. This is stolen from test_state in python-threatexchange.

Expresses 4 of the behaviors in the issue. I'm a little confused about what the others are so will add them after discussing with the team.

Test Plan
---
New unit test, py.test, black, mypy yada yada.