### PR TITLE
UI to add new collab configs

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/configs/tx_apis.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tx_apis.py
@@ -10,6 +10,7 @@ from enum import Enum
 
 from botocore.exceptions import ClientError
 from threatexchange.exchanges.signal_exchange_api import SignalExchangeAPI
+from threatexchange.exchanges.impl.file_api import LocalFileSignalExchangeAPI
 
 from hmalib.common.config import HMAConfig, create_config, update_config
 from hmalib.common.logging import get_logger
@@ -31,6 +32,18 @@ class ToggleableSignalExchangeAPIConfig(HMAConfig):
 
     def to_concrete_class(self) -> t.Type[SignalExchangeAPI]:
         return import_class(self.signal_exchange_api_class)
+
+    @classmethod
+    def get_all(
+        cls: t.Type["ToggleableSignalExchangeAPIConfig"],
+    ) -> t.List["ToggleableSignalExchangeAPIConfig"]:
+        return [
+            api
+            for api in super(ToggleableSignalExchangeAPIConfig, cls).get_all()
+            # Do not want to handle local files without supporting s3 uploads
+            # for those files..
+            if api.to_concrete_class() is not LocalFileSignalExchangeAPI
+        ]
 
     def get_credential_name(self):
         """

--- a/hasher-matcher-actioner/hmalib/lambdas/api/collabs.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/collabs.py
@@ -5,6 +5,7 @@ APIs to power viewing and editing of collaborations.
 """
 
 import bottle
+import json
 from dataclasses import dataclass, fields
 import typing as t
 from enum import Enum
@@ -12,8 +13,8 @@ from enum import Enum
 from mypy_boto3_dynamodb.service_resource import Table
 
 from hmalib.common.config import HMAConfig
-from hmalib.common.configs import tx_collab_config
-from hmalib.common.mappings import import_class
+from hmalib.common.configs import tx_collab_config, tx_apis
+from hmalib.common.mappings import import_class, full_class_name
 from hmalib.common.mappings import HMASignalTypeMapping
 from hmalib.common.models.bank import Bank, BanksTable
 
@@ -21,6 +22,7 @@ from hmalib.lambdas.api.middleware import SubApp, jsoninator, JSONifiable
 
 from threatexchange.exchanges.collab_config import CollaborationConfigBase
 from threatexchange.utils.dataclass_json import dataclass_loads
+from threatexchange.exchanges.impl.file_api import LocalFileSignalExchangeAPI
 
 
 @dataclass
@@ -41,6 +43,10 @@ def _serialize_type(f):
         return f.type.__name__
 
 
+def _to_schema(config_class: t.Type[CollaborationConfigBase]):
+    return {f.name: _serialize_type(f) for f in fields(config_class)}
+
+
 def get_collabs_api(
     hma_config_table: str, bank_table: Table, signal_type_mapping: HMASignalTypeMapping
 ) -> bottle.Bottle:
@@ -56,17 +62,19 @@ def get_collabs_api(
 
         A future version could pull from a static location or scan all packages
         for subclasses.
-
-        PS: Is schemata the correct plural?
         """
-        configs = tx_collab_config.get_all_collab_configs()
+        apis = tx_apis.ToggleableSignalExchangeAPIConfig.get_all()
+        config_classes = [
+            api.to_concrete_class().get_config_cls()
+            for api in apis
+            # Do not want to handle local files without supporting s3 uploads
+            # for those files..
+            if api.to_concrete_class() is not LocalFileSignalExchangeAPI
+        ]
         return {
             "schemas": {
-                config.collab_config_class: {
-                    f.name: _serialize_type(f)
-                    for f in fields(config.to_pytx_collab_config())
-                }
-                for config in configs
+                full_class_name(config_cls): _to_schema(config_cls)
+                for config_cls in config_classes
             }
         }
 
@@ -77,5 +85,54 @@ def get_collabs_api(
         """
         configs = tx_collab_config.get_all_collab_configs()
         return AllCollabsEnvelope(configs)
+
+    @collabs_api.get("/get-schema-for-class")
+    def get_schema_for_class():
+        """
+        Get the schem for a specific class. This could be a new class or one
+        that we already have a config for. Used on the UI to provide a form to
+        create a new config.
+        """
+        try:
+            pytx_collab_config_class = import_class(bottle.request.query["class"])
+        except ModuleNotFoundError:
+            bottle.abort(404)
+
+        return {
+            "class": full_class_name(pytx_collab_config_class),
+            "schema": _to_schema(pytx_collab_config_class),
+        }
+
+    @collabs_api.post("/add-collab-config")
+    def add_collab_config():
+        """
+        Add a collaboration.
+        """
+        pytx_collab_config_class = import_class(bottle.request.json["class"])
+
+        attributes = json.loads(bottle.request.json["attributes"])
+        mapped_attributes = {}
+        for f in fields(pytx_collab_config_class):
+            if t.get_origin(f.type) != None:
+                if t.get_args(f.type)[0].__name__ == "int":
+                    # Convert to list of int..
+                    mapped_attributes[f.name] = [int(x) for x in attributes[f.name]]
+            elif issubclass(f.type, Enum):
+                found = [e for e in f.type if e.name == attributes[f.name]][0]
+                mapped_attributes[f.name] = found.value
+            else:
+                mapped_attributes[f.name] = attributes[f.name]
+
+        pytx_collab_config: CollaborationConfigBase = dataclass_loads(
+            json.dumps(mapped_attributes), pytx_collab_config_class
+        )
+
+        bank = banks_table.create_bank(
+            f"Import Collab: {pytx_collab_config.name}",
+            f"Auto-created bank for importing collaboration: {pytx_collab_config.name} on API: {pytx_collab_config.api}",
+        )
+
+        tx_collab_config.create_collab_config(pytx_collab_config, bank.bank_id)
+        return {"result": "success"}
 
     return collabs_api

--- a/hasher-matcher-actioner/hmalib/lambdas/api/collabs.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/collabs.py
@@ -22,7 +22,6 @@ from hmalib.lambdas.api.middleware import SubApp, jsoninator, JSONifiable
 
 from threatexchange.exchanges.collab_config import CollaborationConfigBase
 from threatexchange.utils.dataclass_json import dataclass_loads
-from threatexchange.exchanges.impl.file_api import LocalFileSignalExchangeAPI
 
 
 @dataclass
@@ -64,13 +63,7 @@ def get_collabs_api(
         for subclasses.
         """
         apis = tx_apis.ToggleableSignalExchangeAPIConfig.get_all()
-        config_classes = [
-            api.to_concrete_class().get_config_cls()
-            for api in apis
-            # Do not want to handle local files without supporting s3 uploads
-            # for those files..
-            if api.to_concrete_class() is not LocalFileSignalExchangeAPI
-        ]
+        config_classes = [api.to_concrete_class().get_config_cls() for api in apis]
         return {
             "schemas": {
                 full_class_name(config_cls): _to_schema(config_cls)
@@ -89,7 +82,7 @@ def get_collabs_api(
     @collabs_api.get("/get-schema-for-class")
     def get_schema_for_class():
         """
-        Get the schem for a specific class. This could be a new class or one
+        Get the schema for a specific class. This could be a new class or one
         that we already have a config for. Used on the UI to provide a form to
         create a new config.
         """

--- a/hasher-matcher-actioner/webapp/src/Api.tsx
+++ b/hasher-matcher-actioner/webapp/src/Api.tsx
@@ -13,7 +13,7 @@ import {
 } from './messages/BankMessages';
 import {toDate} from './utils/DateTimeUtils';
 import {ContentType, getContentTypeForString} from './utils/constants';
-import {Collab} from './messages/CollabMessages';
+import {Collab, CollabSchema} from './messages/CollabMessages';
 import {Exchange} from './messages/ExchangeMessages';
 
 async function getAuthorizationToken(): Promise<string> {
@@ -757,6 +757,28 @@ export async function fetchAllCollabs(): Promise<Array<Collab>> {
   return apiGet<AllCollabsEnvelope>('collabs/').then(
     response => response.collabs,
   );
+}
+
+type AllCollabSchemasEnvelope = {
+  schemas: Record<string, CollabSchema>;
+};
+
+export async function fetchAllCollabSchemas(): Promise<
+  Record<string, CollabSchema>
+> {
+  return apiGet<AllCollabSchemasEnvelope>('collabs/available-schemas').then(
+    response => response.schemas,
+  );
+}
+
+export async function addNewCollab(
+  className: string,
+  attributes: any,
+): Promise<void> {
+  return apiPost('collabs/add-collab-config', {
+    class: className,
+    attributes: JSON.stringify(attributes),
+  });
 }
 
 // Exchange APIs

--- a/hasher-matcher-actioner/webapp/src/components/PillBox.tsx
+++ b/hasher-matcher-actioner/webapp/src/components/PillBox.tsx
@@ -15,6 +15,7 @@ type PillBoxProps = {
   handleNewTagAdd: (tag: string) => void;
   handleTagDelete: (tag: string) => void;
   readOnly?: boolean;
+  placeholder?: string;
 };
 
 type PillProps = {
@@ -52,6 +53,7 @@ export default function PillBox({
   handleNewTagAdd,
   handleTagDelete,
   readOnly,
+  placeholder,
 }: PillBoxProps) {
   const [newTagValue, setNewTagValue] = useState<string>('');
 
@@ -87,7 +89,7 @@ export default function PillBox({
                 handleNewTagAddInner();
               }
             }}
-            placeholder="Add new tag"
+            placeholder={placeholder}
           />
           <InputGroup.Append>
             <Button onClick={handleNewTagAddInner} variant="secondary">
@@ -102,4 +104,5 @@ export default function PillBox({
 
 PillBox.defaultProps = {
   readOnly: false,
+  placeholder: 'Add new tag',
 };

--- a/hasher-matcher-actioner/webapp/src/messages/CollabMessages.tsx
+++ b/hasher-matcher-actioner/webapp/src/messages/CollabMessages.tsx
@@ -4,3 +4,16 @@ export type Collab = {
   collab_config_class: string;
   attributes: {[key: string]: string};
 };
+
+export type CollabSchemaComplexType = {
+  type: 'enum' | 'set';
+  possible_values?: Array<string>;
+  args?: string;
+};
+
+export type CollabSchemaFieldType =
+  | 'int'
+  | 'str'
+  | 'bool'
+  | CollabSchemaComplexType;
+export type CollabSchema = Record<string, CollabSchemaFieldType>;

--- a/hasher-matcher-actioner/webapp/src/pages/collaborations/AddCollaborationModal.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/collaborations/AddCollaborationModal.tsx
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  */
-import {getValue} from '@testing-library/user-event/dist/utils';
 import React, {useContext, useEffect, useState} from 'react';
 import {
   Modal,
@@ -11,6 +10,7 @@ import {
   Col,
   InputGroup,
   Button,
+  Alert,
 } from 'react-bootstrap';
 import {Link} from 'react-router-dom';
 import {addNewCollab, fetchAllCollabSchemas} from '../../Api';
@@ -71,8 +71,7 @@ function Field({type, name, value, onChange}: FieldProps) {
           ))}
         </Form.Control>
       );
-    } else {
-      // Must be set..
+    } else if (type.type === 'set') {
       control = (
         <PillBox
           handleNewTagAdd={tag => {
@@ -90,6 +89,23 @@ function Field({type, name, value, onChange}: FieldProps) {
           pills={value || []}
           placeholder="Add values..."
         />
+      );
+    } else {
+      control = (
+        <Alert variant="warning">
+          <Alert.Heading>Warning</Alert.Heading>
+          <p>
+            We do not currently support variables of type{' '}
+            <code>{type.type}</code>. Please file an{' '}
+            <a
+              target="_blank"
+              href="https://github.com/facebook/ThreatExchange/issues/new"
+              rel="noreferrer">
+              issue on github
+            </a>
+            .
+          </p>
+        </Alert>
       );
     }
   }
@@ -153,20 +169,20 @@ export default function AddCollaborationModal({
                     <Link to="/settings/exchanges">Settings</Link> and add one.
                   </p>
                 ) : (
-                  Object.entries(existingSchemas).map(
-                    ([className, thisSchema]) => (
-                      <Button
-                        key={className}
-                        variant="link"
-                        onClick={() => {
-                          setFieldValues({});
-                          setCollabClassName(className);
-                          setSchema(thisSchema);
-                        }}>
-                        {humanizeClassName(className)},
-                      </Button>
-                    ),
-                  )
+                  <Form.Control
+                    as="select"
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      setFieldValues({});
+                      setCollabClassName(e.target.value);
+                      setSchema(existingSchemas[e.target.value]);
+                    }}>
+                    <option>Select...</option>
+                    {Object.keys(existingSchemas).map(className => (
+                      <option value={className} key={className}>
+                        {humanizeClassName(className)}
+                      </option>
+                    ))}
+                  </Form.Control>
                 )}
               </p>
             </Col>

--- a/hasher-matcher-actioner/webapp/src/pages/collaborations/AddCollaborationModal.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/collaborations/AddCollaborationModal.tsx
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ */
+import {getValue} from '@testing-library/user-event/dist/utils';
+import React, {useContext, useEffect, useState} from 'react';
+import {
+  Modal,
+  Container,
+  Row,
+  Form,
+  Col,
+  InputGroup,
+  Button,
+} from 'react-bootstrap';
+import {Link} from 'react-router-dom';
+import {addNewCollab, fetchAllCollabSchemas} from '../../Api';
+import {NotificationsContext} from '../../AppWithNotifications';
+import PillBox from '../../components/PillBox';
+import {
+  CollabSchema,
+  CollabSchemaFieldType,
+} from '../../messages/CollabMessages';
+import {humanizeClassName} from '../settings/ExchangesTab';
+
+type AddCollaborationModalProps = {
+  show: boolean;
+  onHide: () => void;
+  didAdd: () => void;
+};
+
+type FieldProps = {
+  type: CollabSchemaFieldType;
+  name: string;
+  value: any;
+  onChange: (value: any) => void;
+};
+function Field({type, name, value, onChange}: FieldProps) {
+  let control = (
+    <Form.Control
+      type="text"
+      value={value}
+      onChange={e => onChange(e.target.value)}
+    />
+  );
+  if (type === 'int') {
+    control = (
+      <Form.Control
+        onChange={e => onChange(parseInt(e.target.value, 10))}
+        value={value}
+        type="text"
+      />
+    );
+  } else if (type === 'bool') {
+    control = (
+      <Form.Check checked={!!value} onChange={() => onChange(!value)} />
+    );
+  } else if (type !== 'str') {
+    // Must be complex type...
+    if (type.type === 'enum') {
+      control = (
+        <Form.Control
+          as="select"
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            onChange(e.target.value)
+          }>
+          <option>Open this select menu</option>
+          {type.possible_values?.map(possible_value => (
+            <option key={possible_value} value={possible_value}>
+              {possible_value}
+            </option>
+          ))}
+        </Form.Control>
+      );
+    } else {
+      // Must be set..
+      control = (
+        <PillBox
+          handleNewTagAdd={tag => {
+            if (!value) {
+              onChange([tag]);
+            } else if (value.indexOf(tag) === -1) {
+              onChange(value.concat([tag]));
+            }
+          }}
+          handleTagDelete={tag => {
+            if (value.indexOf(tag) !== -1) {
+              onChange(value.filter((x: string) => x !== tag));
+            }
+          }}
+          pills={value || []}
+          placeholder="Add values..."
+        />
+      );
+    }
+  }
+
+  return (
+    <Form.Group className="mb-3" controlId="">
+      <Form.Label>{name}</Form.Label>
+      {control}
+    </Form.Group>
+  );
+}
+
+export default function AddCollaborationModal({
+  show,
+  onHide,
+  didAdd,
+}: AddCollaborationModalProps): JSX.Element {
+  const [existingSchemas, setExistingSchemas] = useState<
+    Record<string, CollabSchema>
+  >({});
+  const [collabClassName, setCollabClassName] = useState<string>();
+  const [schema, setSchema] = useState<CollabSchema>();
+  const [fieldValues, setFieldValues] = useState<Record<string, any>>({});
+
+  const notifications = useContext(NotificationsContext);
+
+  // Load all existing schemas.
+  useEffect(() => {
+    fetchAllCollabSchemas().then(setExistingSchemas);
+  }, []);
+
+  const handleAdd = () => {
+    if (collabClassName === undefined) {
+      notifications.error({message: 'Must select a collab type.'});
+      return;
+    }
+
+    addNewCollab(collabClassName, fieldValues).then(() => {
+      setCollabClassName(undefined);
+      setSchema({});
+      setFieldValues({});
+      notifications.success({message: 'Added config'});
+      didAdd();
+    });
+  };
+
+  return (
+    <Modal show={show} onHide={onHide} size="lg">
+      <Modal.Header closeButton>
+        <Modal.Title>Add a new Collaboration Config</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Container>
+          <Row>
+            <Col>
+              <p>Select from the following collab class types.</p>
+              <p>
+                {Object.keys(existingSchemas).length === 0 ? (
+                  <p>
+                    No Signal Exchange APIs enabled. Go to{' '}
+                    <Link to="/settings/exchanges">Settings</Link> and add one.
+                  </p>
+                ) : (
+                  Object.entries(existingSchemas).map(
+                    ([className, thisSchema]) => (
+                      <Button
+                        key={className}
+                        variant="link"
+                        onClick={() => {
+                          setFieldValues({});
+                          setCollabClassName(className);
+                          setSchema(thisSchema);
+                        }}>
+                        {humanizeClassName(className)},
+                      </Button>
+                    ),
+                  )
+                )}
+              </p>
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              {collabClassName === undefined ? null : (
+                <h2>{humanizeClassName(collabClassName)}</h2>
+              )}
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              {schema === undefined
+                ? null
+                : Object.entries(schema).map(([fieldName, fieldType]) => (
+                    <Field
+                      key={fieldName}
+                      type={fieldType}
+                      name={fieldName}
+                      value={fieldValues[fieldName]}
+                      onChange={newValue => {
+                        const newFieldValues = {...fieldValues};
+                        newFieldValues[fieldName] = newValue;
+                        setFieldValues(newFieldValues);
+                      }}
+                    />
+                  ))}
+            </Col>
+          </Row>
+        </Container>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button size="lg" onClick={handleAdd}>
+          Add
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/hasher-matcher-actioner/webapp/src/pages/collaborations/ViewCollaborations.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/collaborations/ViewCollaborations.tsx
@@ -10,6 +10,7 @@ import EmptyState from '../../components/EmptyState';
 import Loader from '../../components/Loader';
 import {Collab} from '../../messages/CollabMessages';
 import FixedWidthCenterAlignedLayout from '../layouts/FixedWidthCenterAlignedLayout';
+import AddCollaborationModal from './AddCollaborationModal';
 
 const KNOWN_PYTX_TYPES: Map<string, string> = new Map();
 KNOWN_PYTX_TYPES.set(
@@ -60,13 +61,15 @@ function CollabCard({
 export default function ViewCollaborations(): JSX.Element {
   const [neverFetched, setNeverFetched] = useState<boolean>(true);
   const [collabs, setCollabs] = useState<Collab[]>([]);
+  const [showAddModal, setShowAddModal] = useState<boolean>(false);
+  const [refetchCounter, setRefetchCounter] = useState<number>(1);
 
   useEffect(() => {
     fetchAllCollabs().then(_collabs => {
       setCollabs(_collabs);
       setNeverFetched(false);
     });
-  }, []);
+  }, [refetchCounter]);
 
   return (
     <FixedWidthCenterAlignedLayout>
@@ -76,7 +79,7 @@ export default function ViewCollaborations(): JSX.Element {
         </Col>
         <Col xs={{span: 4}}>
           <div className="float-right">
-            {collabs.length === 0 ? null : <Button>Add Collab</Button>}
+            <Button onClick={() => setShowAddModal(true)}>Add Collab</Button>
           </div>
         </Col>
       </Row>
@@ -99,6 +102,7 @@ export default function ViewCollaborations(): JSX.Element {
           <Col>
             {collabs.map(collab => (
               <CollabCard
+                key={collab.name}
                 name={collab.name}
                 import_as_bank_id={collab.import_as_bank_id}
                 collab_config_class={collab.collab_config_class}
@@ -108,6 +112,14 @@ export default function ViewCollaborations(): JSX.Element {
           </Col>
         ) : null}
       </Row>
+      <AddCollaborationModal
+        show={showAddModal}
+        onHide={() => setShowAddModal(false)}
+        didAdd={() => {
+          setShowAddModal(false);
+          setRefetchCounter(refetchCounter + 1);
+        }}
+      />
     </FixedWidthCenterAlignedLayout>
   );
 }

--- a/hasher-matcher-actioner/webapp/src/pages/settings/ExchangesTab.tsx
+++ b/hasher-matcher-actioner/webapp/src/pages/settings/ExchangesTab.tsx
@@ -27,7 +27,7 @@ import {NotificationsContext} from '../../AppWithNotifications';
 import {Exchange} from '../../messages/ExchangeMessages';
 import SettingsTabPane from './SettingsTabPane';
 
-function humanizeClassName(className: string) {
+export function humanizeClassName(className: string) {
   const parts = className.split('.');
   return parts[parts.length - 1];
 }


### PR DESCRIPTION
Summary
---
Adds a new modal that allows the user to add a new collab config. Some of this modal can be hidden. Eg why should the user have to type out the api name again? Why not enable by default.

Test Plan
---
Tested for NCMEC and FB ThreatExchange.


# Empty Collabs page
<img width="1156" alt="Screen Shot 2022-12-10 at 14 27 05" src="https://user-images.githubusercontent.com/217056/206873188-b03cf6c1-735a-4600-bc80-aeeb41e5b056.png">

# Add Collabs Modal with no type selected
<img width="859" alt="Screen Shot 2022-12-10 at 14 27 14" src="https://user-images.githubusercontent.com/217056/206873201-d2942f59-16c8-481c-a7e9-e2eda88e93e1.png">

# NCMEC Collab selected
<img width="844" alt="Screen Shot 2022-12-10 at 14 58 01" src="https://user-images.githubusercontent.com/217056/206873207-e3b235e5-32ba-4a84-8e31-e2be022d6fd4.png">

# Adding a FB ThreatExchange PG
https://user-images.githubusercontent.com/217056/206873136-bab7fedb-5ef6-4c19-96a1-2dcb43c7e196.mp4
