### PR TITLE
Hook in secrets and the new fetcher to the fetching lambda

### DIFF
--- a/hasher-matcher-actioner/hmalib/fetching/bank_store.py
+++ b/hasher-matcher-actioner/hmalib/fetching/bank_store.py
@@ -205,8 +205,14 @@ class BankCollabFetchStore:
         else:
             logger.info("FetchStore is clean!")
 
-        logger.info("Setting checkpoint for collab: %s", self.collab.name)
-        self.set_checkpoint(checkpoint)
+        if checkpoint:
+            logger.info("Setting checkpoint for collab: %s", self.collab.name)
+            self.set_checkpoint(checkpoint)
+        else:
+            logger.warn(
+                "No checkpoint found for collab: %s. Next fetch will start at the beginnging of time.",
+                self.collab.name,
+            )
 
     def _handle_upsert(self, key: TUpdateRecordKey, value: TUpdateRecordValue):
         """

--- a/hasher-matcher-actioner/hmalib/fetching/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/fetching/fetcher.py
@@ -4,14 +4,15 @@ from functools import lru_cache
 import typing as t
 import time
 
+from threatexchange.exchanges import auth
 from threatexchange.exchanges.collab_config import CollaborationConfigBase
 from threatexchange.exchanges.signal_exchange_api import TSignalExchangeAPICls
 from threatexchange.exchanges.fetch_state import FetchCheckpointBase, FetchDeltaTyped
 
 from hmalib.common.logging import get_logger
-from hmalib.common.mappings import HMASignalTypeMapping
+from hmalib.common.mappings import HMASignalTypeMapping, full_class_name
 from hmalib.common.models.bank import BanksTable
-
+from hmalib.aws_secrets import AWSSecrets
 from hmalib.common.configs import tx_collab_config
 from hmalib.common.configs.tx_apis import ToggleableSignalExchangeAPIConfig
 from hmalib.fetching.bank_store import BankCollabFetchStore
@@ -31,10 +32,14 @@ class Fetcher:
     """
 
     def __init__(
-        self, signal_type_mapping: HMASignalTypeMapping, banks_table: BanksTable
+        self,
+        signal_type_mapping: HMASignalTypeMapping,
+        banks_table: BanksTable,
+        secrets: AWSSecrets,
     ):
         self.signal_type_mapping = signal_type_mapping
         self.banks_table = banks_table
+        self.secrets = secrets
 
     def _get_api_classes_from_config(self):
         return [
@@ -91,13 +96,36 @@ class Fetcher:
             if c.to_pytx_collab_config().enabled
         ]
 
+    def _get_credential_string(self, signal_exchange_api_cls: str) -> str:
+        api_classes_with_this_exchange = [
+            api
+            for api in ToggleableSignalExchangeAPIConfig.get_all()
+            if api.signal_exchange_api_class == signal_exchange_api_cls
+        ]
+        assert (
+            api_classes_with_this_exchange
+        ), f"No SignalExhchange configured for {signal_exchange_api_cls}, but collab config was found."
+
+        return self.secrets.get_secret(
+            api_classes_with_this_exchange[0].get_credential_name()
+        )
+
     def _execute_for_collab(
         self, collab: tx_collab_config.EditableCollaborationConfig
     ) -> bool:
         logger.info("Fetching for collab: %s", collab.name)
-        api_instance = self.get_api_classes()[
-            collab.to_pytx_collab_config().api
-        ].for_collab(collab=collab.to_pytx_collab_config())
+        api_cls = self.get_api_classes()[collab.to_pytx_collab_config().api]
+
+        if issubclass(api_cls, auth.SignalExchangeWithAuth):
+            creds_class = api_cls.get_credential_cls()
+            creds = creds_class._from_str(
+                self._get_credential_string(full_class_name(api_cls))
+            )
+            api_instance = api_cls.for_collab(
+                collab=collab.to_pytx_collab_config(), credentials=creds
+            )
+        else:
+            api_instance = api_cls.for_collab(collab=collab.to_pytx_collab_config())
 
         store = BankCollabFetchStore(
             self.signal_type_mapping.signal_types, self.banks_table, collab

--- a/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/fetcher.py
@@ -1,215 +1,39 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 """
-Implementation of the "fetcher" module of HMA.
-
-Fetching involves connecting to the ThreatExchange API and downloading
-signals to synchronize a local copy of the database, which will then
-be fed into various indices.
+Connect to SignalExchange APIs and download signals, store in banks.
 """
-
-import logging
-import time
 import os
-from collections import defaultdict
-from dataclasses import dataclass
-from datetime import datetime
-from functools import lru_cache
-from typing import DefaultDict
 import boto3
-
-from threatexchange.api import ThreatExchangeAPI
-from threatexchange.signal_type.pdq import PdqSignal
-from threatexchange.signal_type.md5 import VideoMD5Signal
-from threatexchange.threat_updates import ThreatUpdateJSON
+from functools import lru_cache
 
 from hmalib.aws_secrets import AWSSecrets
-from hmalib.common.config import HMAConfig
+from hmalib.fetching.fetcher import Fetcher
 from hmalib.common.logging import get_logger
-from hmalib.common.configs.fetcher import ThreatExchangeConfig
-from hmalib.common.s3_adapters import ThreatUpdateS3Store
-
+from hmalib.common.config import HMAConfig
+from hmalib.common.models.bank import BanksTable
+from hmalib.lambdas.common import get_signal_type_mapping, HMASignalTypeMapping
 
 logger = get_logger(__name__)
-dynamodb = boto3.resource("dynamodb")
 
-# In one fetcher run, how many descriptor updates to fetch per privacy group
-# using /threat_updates
-MAX_DESCRIPTORS_UPDATED = 20000
-
-# Print progress when polling threat_updates once every...<> seconds
-PROGRESS_PRINT_INTERVAL_SEC = 20
-
+BANKS_TABLE = os.environ["BANKS_TABLE"]
+CONFIG_TABLE_NAME = os.environ["CONFIG_TABLE_NAME"]
 SECRETS_PREFIX = os.environ["SECRETS_PREFIX"]
 
 
 @lru_cache(maxsize=None)
-def get_s3_client():
-    return boto3.client("s3")
-
-
-# Lambda init tricks
-@lru_cache(maxsize=1)
-def lambda_init_once():
-    """
-    Do some late initialization for required lambda components.
-
-    Lambda initialization is weird - despite the existence of perfectly
-    good constructions like __name__ == __main__, there don't appear
-    to be easy ways to split your lambda-specific logic from your
-    module logic except by splitting up the files and making your
-    lambda entry as small as possible.
-
-    TODO: Just refactor this file to separate the lambda and functional
-          components
-    """
-    cfg = FetcherConfig.get()
-    HMAConfig.initialize(cfg.config_table_name)
-
-
-@dataclass
-class FetcherConfig:
-    """
-    Simple holder for getting typed environment variables
-    """
-
-    s3_bucket: str
-    s3_te_data_folder: str
-    config_table_name: str
-    data_store_table: str
-
-    @classmethod
-    @lru_cache(maxsize=None)  # probably overkill, but at least it's consistent
-    def get(cls):
-        # These defaults are naive but can be updated for testing purposes.
-        return cls(
-            s3_bucket=os.environ["THREAT_EXCHANGE_DATA_BUCKET_NAME"],
-            s3_te_data_folder=os.environ["THREAT_EXCHANGE_DATA_FOLDER"],
-            config_table_name=os.environ["CONFIG_TABLE_NAME"],
-            data_store_table=os.environ["DYNAMODB_DATASTORE_TABLE"],
-        )
-
-
-def is_int(int_string: str):
-    """
-    Checks if string is convertible to int.
-    """
-    try:
-        int(int_string)
-        return True
-    except ValueError:
-        return False
-
-
-class ProgressLogger:
-    """
-    Use this to get a progress logger which counts up the number of items
-    processed via /threat_updates.
-
-    Returns a callable class.
-    """
-
-    def __init__(self):
-        self.processed = 0
-        self.last_update_time = None
-        self.counts = defaultdict(lambda: 0)
-        self.last_update_printed = 0
-
-    def __call__(self, update: ThreatUpdateJSON):
-        self.processed += 1
-        self.counts[update.threat_type] += -1 if update.should_delete else 1
-        self.last_update_time = update.time
-
-        now = time.time()
-        if now - self.last_update_printed >= PROGRESS_PRINT_INTERVAL_SEC:
-            self.last_update_printed = now
-            logger.info("threat_updates/: processed %d descriptors.", self.processed)
+def get_banks_table(signal_type_mapping: HMASignalTypeMapping):
+    dynamodb = boto3.resource("dynamodb")
+    table = dynamodb.Table(BANKS_TABLE)
+    return BanksTable(table, signal_type_mapping)
 
 
 def lambda_handler(_event, _context):
-    """
-    Run through threatexchange privacy groups and fetch updates to them. If this
-    is the first time for a privacy group, will fetch from the start, else only
-    updates since the last time.
+    HMAConfig.initialize(CONFIG_TABLE_NAME)
 
-    Note: since this is a scheduled job, we swallow all exceptions. We only log
-    exceptions and move on.
-    """
-
-    lambda_init_once()
-    config = FetcherConfig.get()
-    collabs = ThreatExchangeConfig.get_all()
-
-    now = datetime.now()
-    current_time = now.strftime("%H:%M:%S")
-
-    names = [collab.privacy_group_name for collab in collabs[:5]]
-    if len(names) < len(collabs):
-        names[-1] = "..."
-
-    data = f"Triggered at time {current_time}, found {len(collabs)} collabs: {', '.join(names)}"
-    logger.info(data)
-
-    api_token = AWSSecrets(SECRETS_PREFIX).te_api_token()
-    api = ThreatExchangeAPI(api_token)
-
-    for collab in collabs:
-        logger.info(
-            "Processing updates for collaboration %s", collab.privacy_group_name
-        )
-
-        if not is_int(collab.privacy_group_id):
-            logger.info(
-                f"Fetch skipped because privacy_group_id({collab.privacy_group_id}) is not an int"
-            )
-            continue
-
-        if not collab.fetcher_active:
-            logger.info(
-                f"Fetch skipped because configs has `fetcher_active` set to false for privacy_group_id({collab.privacy_group_id})"
-            )
-            continue
-
-        indicator_store = ThreatUpdateS3Store(
-            int(collab.privacy_group_id),
-            api.app_id,
-            s3_client=get_s3_client(),
-            s3_bucket_name=config.s3_bucket,
-            s3_te_data_folder=config.s3_te_data_folder,
-            data_store_table=config.data_store_table,
-            supported_signal_types=[VideoMD5Signal, PdqSignal],
-        )
-
-        try:
-            indicator_store.load_checkpoint()
-
-            if indicator_store.stale:
-                logger.warning(
-                    "Store for %s - %d stale! Resetting.",
-                    collab.privacy_group_name,
-                    int(collab.privacy_group_id),
-                )
-                indicator_store.reset()
-
-            if indicator_store.fetch_checkpoint >= now.timestamp():
-                continue
-
-            delta = indicator_store.next_delta
-
-            delta.incremental_sync_from_threatexchange(
-                api, limit=MAX_DESCRIPTORS_UPDATED, progress_fn=ProgressLogger()
-            )
-        except Exception:  # pylint: disable=broad-except
-            logger.exception(
-                "Encountered exception while getting updates. Will attempt saving.."
-            )
-            # Force delta to show finished
-            delta.end = delta.current
-        finally:
-            if delta:
-                logging.info("Fetch complete, applying %d updates", len(delta.updates))
-                indicator_store.apply_updates(
-                    delta, post_apply_fn=indicator_store.post_apply
-                )
-            else:
-                logging.error("Failed before fetching any records")
+    signal_type_mapping = get_signal_type_mapping()
+    secrets = AWSSecrets(SECRETS_PREFIX)
+    fetcher = Fetcher(
+        signal_type_mapping, get_banks_table(signal_type_mapping), secrets
+    )
+    fetcher.run()

--- a/hasher-matcher-actioner/terraform/fetcher/variables.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/variables.tf
@@ -19,24 +19,6 @@ variable "lambda_docker_info" {
     })
   })
 }
-
-
-variable "datastore" {
-  description = "DynamoDB Table to store hash and match information into"
-  type = object({
-    name = string
-    arn  = string
-  })
-}
-
-variable "threat_exchange_data" {
-  description = "Configuration information for the S3 Bucket that will hold ThreatExchange Data. data_folder is actually just a key prefix to search for but this is displyed as a folder in AWS UI"
-  type = object({
-    bucket_name = string
-    data_folder = string
-  })
-}
-
 variable "additional_tags" {
   description = "Additional resource tags"
   type        = map(string)
@@ -52,18 +34,18 @@ variable "fetch_frequency" {
   type        = string
 }
 
-variable "te_api_token_secret" {
-  description = "The aws secret where the ThreatExchange API token is stored"
-  type = object({
-    name = string
-    arn  = string
-  })
-}
-
 variable "config_table" {
   description = "The name and arn of the DynamoDB table used for persisting configs."
   type = object({
     arn  = string
     name = string
+  })
+}
+
+variable "banks_datastore" {
+  description = "DynamoDB Table to store bank information into"
+  type = object({
+    name = string
+    arn  = string
   })
 }

--- a/hasher-matcher-actioner/terraform/main.tf
+++ b/hasher-matcher-actioner/terraform/main.tf
@@ -161,19 +161,11 @@ module "fetcher" {
     }
   }
 
-  datastore = module.datastore.primary_datastore
-
-  threat_exchange_data = {
-    bucket_name = module.hashing_data.threat_exchange_data_folder_info.bucket_name
-    data_folder = local.te_data_folder
-  }
-
   log_retention_in_days = var.log_retention_in_days
   additional_tags       = merge(var.additional_tags, local.common_tags)
   fetch_frequency       = var.fetch_frequency
-
-  te_api_token_secret = aws_secretsmanager_secret.te_api_token
-  config_table        = local.config_table
+  banks_datastore       = module.datastore.banks_datastore
+  config_table          = local.config_table
 }
 
 resource "aws_sns_topic" "matches" {


### PR DESCRIPTION
Summary
---
Use AWSSecrets to store signal exchange credentials and use them during fetching. Also, hook up the new hmalib.fetching.fetcher modules into the lambda and cleanup the older threatexchange focussed fetching code.

Test Plan
---
Ran against a threatexchange privacy group and verified that banks are getting populated.
