### PR TITLE
[py-tx] Black 23.1.0

### DIFF
--- a/python-threatexchange/threatexchange/cli/cli_state.py
+++ b/python-threatexchange/threatexchange/cli/cli_state.py
@@ -133,7 +133,6 @@ class CliSimpleState(helpers.SimpleFetchedStateStore):
         self,
         collab_name: str,
     ) -> t.Optional[FetchDeltaTyped]:
-
         file = self.collab_file(collab_name)
         if not file.is_file():
             return None

--- a/python-threatexchange/threatexchange/cli/dataset/simple_serialization.py
+++ b/python-threatexchange/threatexchange/cli/dataset/simple_serialization.py
@@ -14,6 +14,7 @@ from threatexchange.exchanges.clients.fb_threatexchange.descriptor import (
 
 _EXTENSION = ".te"
 
+
 # TODO - merge SimpleDescriptorRollup here
 class CliIndicatorSerialization(threat_updates.ThreatUpdateSerialization):
     """A short compact serialization optimized for the CLI"""

--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -42,7 +42,6 @@ class HashCommand(command_base.Command):
 
     @classmethod
     def init_argparse(cls, settings: CLISettings, ap: argparse.ArgumentParser) -> None:
-
         signal_types = [
             s for s in settings.get_all_signal_types() if issubclass(s, FileHasher)
         ]

--- a/python-threatexchange/threatexchange/cli/match_cmd.py
+++ b/python-threatexchange/threatexchange/cli/match_cmd.py
@@ -76,7 +76,6 @@ class MatchCommand(command_base.Command):
 
     @classmethod
     def init_argparse(cls, settings: CLISettings, ap: argparse.ArgumentParser) -> None:
-
         ap.add_argument(
             "content_type",
             **common.argparse_choices_pre_type_kwargs(

--- a/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
+++ b/python-threatexchange/threatexchange/cli/tests/e2e_test_helper.py
@@ -22,7 +22,6 @@ class E2ETestSystemExit(Exception):
 
 
 class ThreatExchangeCLIE2eHelper:
-
     # A keystroke saver, prefix these args to the beginning
     # of every call.
     # You can bypass by making the first arg "tx" or

--- a/python-threatexchange/threatexchange/cli/tests/match_cmd_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/match_cmd_test.py
@@ -6,7 +6,6 @@ from threatexchange.signal_type.md5 import VideoMD5Signal
 
 
 class MatchCommandTest(ThreatExchangeCLIE2eTest):
-
     COMMON_CALL_ARGS = ("match",)
 
     def test_file_noexst(self):

--- a/python-threatexchange/threatexchange/exchanges/fetch_state.py
+++ b/python-threatexchange/threatexchange/exchanges/fetch_state.py
@@ -176,7 +176,6 @@ class AggregateSignalOpinionCategory(IntEnum):
 
 @dataclass
 class AggregateSignalOpinion:
-
     category: AggregateSignalOpinionCategory
     tags: t.Set[str]
 

--- a/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
@@ -87,7 +87,6 @@ class FBThreatExchangeCheckpoint(state.FetchCheckpointBase):
 
 @dataclass
 class FBThreatExchangeOpinion(state.SignalOpinion):
-
     REACTION_DESCRIPTOR_ID: t.ClassVar[int] = -1
 
     owner_app_id: int
@@ -104,7 +103,6 @@ class FBThreatExchangeOpinion(state.SignalOpinion):
 
 @dataclass
 class FBThreatExchangeIndicatorRecord(state.FetchedSignalMetadata):
-
     opinions: t.List[FBThreatExchangeOpinion]
 
     def get_as_opinions(

--- a/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
@@ -179,7 +179,6 @@ class StopNCIISignalExchangeAPI(
 def _get_delta_mapping(
     record: api.StopNCIIHashRecord,
 ) -> t.Tuple[t.Tuple[str, str], t.Optional[StopNCIISignalMetadata]]:
-
     type_str = _type_mapping().get(record.signalType)
     if not type_str:
         return ("", ""), None

--- a/python-threatexchange/threatexchange/exchanges/tests/test_state_compatibility.py
+++ b/python-threatexchange/threatexchange/exchanges/tests/test_state_compatibility.py
@@ -70,9 +70,9 @@ def get_SignalOpinion() -> t.Tuple[SignalOpinion, t.Sequence[object]]:
     return (current, [owner_removed])
 
 
-def get_FBThreatExchangeOpinion() -> t.Tuple[
-    FBThreatExchangeOpinion, t.Sequence[object]
-]:
+def get_FBThreatExchangeOpinion() -> (
+    t.Tuple[FBThreatExchangeOpinion, t.Sequence[object]]
+):
     ## Current
     is_mine = False
     category = SignalOpinionCategory.POSITIVE_CLASS

--- a/python-threatexchange/threatexchange/signal_type/tests/test_raw_text.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/test_raw_text.py
@@ -6,7 +6,6 @@ from threatexchange.signal_type.raw_text import RawTextSignal
 
 
 class TestRawTextSignal(MatchesStrAutoTest):
-
     TYPE = RawTextSignal
 
     def get_validate_hash_cases(self):

--- a/python-threatexchange/threatexchange/tests/hashing/test_pdq_faiss_matcher.py
+++ b/python-threatexchange/threatexchange/tests/hashing/test_pdq_faiss_matcher.py
@@ -29,7 +29,7 @@ class MixinTests:
             self.assertEqual(
                 len(result), len(expected), "search results not of expected length"
             )
-            for (r, e) in zip(result, expected):
+            for r, e in zip(result, expected):
                 self.assertCountEqual(r, e)
 
         def test_search_index_for_exact_matches(self):
@@ -117,7 +117,6 @@ class TestPDQFlatHashIndex(MixinTests.PDQHashIndexCommonTests, unittest.TestCase
 class TestPDQFlatHashIndexWithCustomIds(
     MixinTests.PDQHashIndexCommonTests, unittest.TestCase
 ):
-
     custom_ids = [MAX_UNSIGNED_INT64 - i for i in range(len(test_hashes))]
 
     def setUp(self):


### PR DESCRIPTION
Summary
---------

A new version of black is out, which adds some new rules! Surprisingly, doing `pip install --upgrade -e .[all]` didn't upgrade the version, I had to do it manually. 

It may be getting close to where we want to try and set a py env

Test Plan
---------

`black` in the root directory, see no changes.
