### PR TITLE
Add force_rgb option for pdq_hasher

### DIFF
--- a/python-threatexchange/threatexchange/signal_type/pdq/pdq_hasher.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq/pdq_hasher.py
@@ -13,22 +13,23 @@ PDQOutput = t.Tuple[
 ]  # hexadecimal representation of the Hash vector and a numerical quality value
 
 
-def pdq_from_file(path: pathlib.Path) -> PDQOutput:
+def pdq_from_file(path: pathlib.Path, force_rgb=False) -> PDQOutput:
     """
     Given a path to a file return the PDQ Hash string in hex.
     Current tested against: jpg
     """
-    np_array = _convert_image_to_correct_array_dimension(Image.open(path))
-    return _pdq_from_numpy_array(np_array)
+    return _pdq_from_image(Image.open(path), force_rgb)
 
 
-def pdq_from_bytes(file_bytes: bytes) -> PDQOutput:
+def pdq_from_bytes(file_bytes: bytes, force_rgb=False) -> PDQOutput:
     """
     For the bytestream from an image file, compute PDQ Hash and quality.
     """
-    np_array = _convert_image_to_correct_array_dimension(
-        Image.open(io.BytesIO(file_bytes))
-    )
+    return _pdq_from_image(Image.open(io.BytesIO(file_bytes)), force_rgb)
+
+
+def _pdq_from_image(image: Image, force_rgb) -> PDQOutput:
+    np_array = _convert_image_to_correct_array_dimension(image, force_rgb)
     return _pdq_from_numpy_array(np_array)
 
 
@@ -46,11 +47,11 @@ def _pdq_from_numpy_array(array: np.ndarray) -> PDQOutput:
     return hex_str, quality
 
 
-def _convert_image_to_correct_array_dimension(image: Image) -> np.ndarray:
+def _convert_image_to_correct_array_dimension(image: Image, force_rgb) -> np.ndarray:
     """
     Handle possible image format conversion or
     """
-    if image.mode == "LA":
+    if force_rgb or image.mode == "LA":
         # LA images (luminance with alpha) return 3 dimensional ndarray
         # which is incompatible with pdqhash
         image = image.convert("RGB")

--- a/python-threatexchange/threatexchange/signal_type/pdq/pdq_hasher.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq/pdq_hasher.py
@@ -13,7 +13,7 @@ PDQOutput = t.Tuple[
 ]  # hexadecimal representation of the Hash vector and a numerical quality value
 
 
-def pdq_from_file(path: pathlib.Path, force_rgb=False) -> PDQOutput:
+def pdq_from_file(path: pathlib.Path, force_rgb: bool = False) -> PDQOutput:
     """
     Given a path to a file return the PDQ Hash string in hex.
     Current tested against: jpg
@@ -21,14 +21,14 @@ def pdq_from_file(path: pathlib.Path, force_rgb=False) -> PDQOutput:
     return _pdq_from_image(Image.open(path), force_rgb)
 
 
-def pdq_from_bytes(file_bytes: bytes, force_rgb=False) -> PDQOutput:
+def pdq_from_bytes(file_bytes: bytes, force_rgb: bool = False) -> PDQOutput:
     """
     For the bytestream from an image file, compute PDQ Hash and quality.
     """
     return _pdq_from_image(Image.open(io.BytesIO(file_bytes)), force_rgb)
 
 
-def _pdq_from_image(image: Image, force_rgb) -> PDQOutput:
+def _pdq_from_image(image: Image, force_rgb: bool) -> PDQOutput:
     np_array = _convert_image_to_correct_array_dimension(image, force_rgb)
     return _pdq_from_numpy_array(np_array)
 
@@ -47,7 +47,9 @@ def _pdq_from_numpy_array(array: np.ndarray) -> PDQOutput:
     return hex_str, quality
 
 
-def _convert_image_to_correct_array_dimension(image: Image, force_rgb) -> np.ndarray:
+def _convert_image_to_correct_array_dimension(
+    image: Image, force_rgb: bool
+) -> np.ndarray:
     """
     Handle possible image format conversion or
     """

--- a/python-threatexchange/threatexchange/tests/hashing/test_pdq_hasher.py
+++ b/python-threatexchange/threatexchange/tests/hashing/test_pdq_hasher.py
@@ -71,3 +71,13 @@ class PDQHasherModuleUnitTest(unittest.TestCase):
             100,
         )
         assert pdq_hasher.pdq_from_file(file_path) == expected_pdq_output
+
+    def test_pdq_from_file_i_png(self):
+        file_path = pathlib.Path("threatexchange/tests/hashing/resources/I.png")
+        expected_pdq_output = (
+            "e57435b3ca5f03c8fc1ba1e4de1743e0bc1b4593987e7a8184783f83c0fc1f03",
+            11,
+        )
+        assert (
+            pdq_hasher.pdq_from_file(file_path, force_rgb=True) == expected_pdq_output
+        )


### PR DESCRIPTION
Summary
---------
Found a new image type which fails to get hashed by existing pdq_hasher logic

```
% threatexchange hash --signal-type pdq photo https://i.redd.it/vum5cw55ryga1.png
Traceback (most recent call last):
  File "/Users/daniel.sun/.pyenv/versions/threatexchange/bin/threatexchange", line 33, in <module>
    sys.exit(load_entry_point('threatexchange', 'console_scripts', 'threatexchange')())
  File "/Users/daniel.sun/src/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 319, in main
    inner_main()
  File "/Users/daniel.sun/src/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 312, in inner_main
    execute_command(settings, namespace)
  File "/Users/daniel.sun/src/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 157, in execute_command
    command.execute(settings)
  File "/Users/daniel.sun/src/ThreatExchange/python-threatexchange/threatexchange/cli/hash_cmd.py", line 106, in execute
    hash_str = hasher.hash_from_file(file)
  File "/Users/daniel.sun/src/ThreatExchange/python-threatexchange/threatexchange/signal_type/signal_base.py", line 195, in hash_from_file
    return cls.hash_from_bytes(file.read_bytes())
  File "/Users/daniel.sun/src/ThreatExchange/python-threatexchange/threatexchange/signal_type/pdq/signal.py", line 77, in hash_from_bytes
    pdq_hash, quality = pdq_from_bytes(bytes_)
  File "/Users/daniel.sun/src/ThreatExchange/python-threatexchange/threatexchange/signal_type/pdq/pdq_hasher.py", line 28, in pdq_from_bytes
    return _pdq_from_image(Image.open(io.BytesIO(file_bytes)), force_rgb)
  File "/Users/daniel.sun/src/ThreatExchange/python-threatexchange/threatexchange/signal_type/pdq/pdq_hasher.py", line 33, in _pdq_from_image
    return _pdq_from_numpy_array(np_array)
  File "/Users/daniel.sun/src/ThreatExchange/python-threatexchange/threatexchange/signal_type/pdq/pdq_hasher.py", line 37, in _pdq_from_numpy_array
    hash_vector, quality = pdqhash.compute(array)
  File "pdqhash/bindings.pyx", line 71, in pdqhash.bindings.compute
ValueError: Buffer dtype mismatch, expected 'char' but got 'int'
```

```
>>> from PIL import Image
>>> f = open("/Users/daniel.sun/Downloads/vum5cw55ryga1.png", "rb")
>>> image = Image.open(f)
>>> image.mode
'I'
```
`I` image mode is 32-bit pixels which makes sense why error message says `expected 'char' but got 'int'`

This PR adds an option to force RGB conversion of input image for PDQ hashing
According to #465 this caused a perf regression, so making this feature an option for those who can trade-off latency for stability.

Test Plan
---------

<!--Replace with a description of how you tested this change, did you add test, run something locally...-->

Added this image as `I.png` in resources and add unit test which demonstrates calling `pdq_from_file` with `force_rgb` returns a PDQ hash instead of throwing above error