### PR TITLE
[pytx] Improved record printing, starting with StopNCII

### DIFF
--- a/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
@@ -64,7 +64,10 @@ class StopNCIISignalMetadata(state.FetchedSignalMetadata):
 
     def __str__(self) -> str:
         """
-        A human-readable version of the opinion suitable for the terminal
+        Specialized override for StopNCII.
+
+        For StopNCII, we "unowned" signals submitted by users, as well as well-formed
+        owner names.
         """
         confidence = 0
         owner_strs = []

--- a/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
@@ -62,6 +62,25 @@ class StopNCIISignalMetadata(state.FetchedSignalMetadata):
         )
         return opinions
 
+    def __str__(self) -> str:
+        """
+        A human-readable version of the opinion suitable for the terminal
+        """
+        confidence = 0
+        owner_strs = []
+
+        for feedback in sorted(self.feedbacks, key=lambda f: f.source):
+            if feedback.feedbackValue == api.StopNCIICSPFeedbackValue.Blocked:
+                confidence += 1
+                owner_strs.append(f"+{feedback.source}")
+            elif feedback.feedbackValue == api.StopNCIICSPFeedbackValue.NotBlocked:
+                confidence -= 1
+                owner_strs.append(f"-{feedback.source}")
+
+        confidence_str = f"{confidence:+d}" if owner_strs else str(confidence)
+
+        return f"{self.get_as_aggregate_opinion().category.name} {confidence_str} {','.join(owner_strs)}"
+
 
 @dataclass
 class StopNCIICredentials(auth.CredentialHelper):


### PR DESCRIPTION
Summary
---------

I needed to run stats for the program today, and realized I wanted this general capability. Doing this here makes the output of dataset backwards incompatible/inconsistent for -P, but we might want to standardize on everything after the collab name being unspecified. 

I originally started this as a stats thing, but it's actually easier to use grep/uniq -c to generate fast numbers.

Test Plan
---------
```
$ tx config collab stop_ncii stop_ncii -C 
$ tx fetch
$ tx dataset -P | awk '{$2 = "..."; print $0}' | sort | uniq
```
### Before
Some of this data is faked for demonstration
```
pdq ... 'stop_ncii' DISPUTED
pdq ... 'stop_ncii' INVESTIGATION_SEED
pdq ... 'stop_ncii' POSITIVE_CLASS
video_md5 ... 'stop_ncii' DISPUTED
video_md5 ... 'stop_ncii' INVESTIGATION_SEED
video_md5 ... 'stop_ncii' POSITIVE_CLASS
```

### After
Some of this data is faked for demonstration
```
pdq ... 'stop_ncii' DISPUTED -1 -Member1
pdq ... 'stop_ncii' INVESTIGATION_SEED 0
pdq ... 'stop_ncii' DISPUTED +0 +Member1,-Member2
pdq ... 'stop_ncii' POSITIVE_CLASS +1 +Member1
pdq ... 'stop_ncii' POSITIVE_CLASS +2 +Member1,+Member2
video_md5 ... 'stop_ncii' DISPUTED -1 -Member1
...
```
