### PR TITLE
[py-tx] No stack for pipe fail on read only dataset commands

### DIFF
--- a/python-threatexchange/threatexchange/cli/dataset_cmd.py
+++ b/python-threatexchange/threatexchange/cli/dataset_cmd.py
@@ -177,11 +177,15 @@ class DatasetCommand(command_base.Command):
             self.execute_clear_indices(settings)
         elif self.rebuild_indices:
             self.execute_generate_indices(settings)
-        elif self.print_signals:
-            self.execute_print_signals(settings)
         else:
-            assert self.signal_summary
-            self.execute_print_summary(settings)
+            try:
+                if self.print_signals:
+                    self.execute_print_signals(settings)
+                else:
+                    assert self.signal_summary
+                    self.execute_print_summary(settings)
+            except BrokenPipeError:
+                pass  # No stack for pipe terminate, since these are read only
 
     def get_signal_types(self, settings: CLISettings) -> t.Set[t.Type[SignalType]]:
         signal_types = self.only_signals or settings.get_all_signal_types()


### PR DESCRIPTION
Summary
---------

This is probably generalizable for all read only commands, but if you use something like 

```
tx dataset -P | head -n 5
```
It generates a messy stack trace from python realizing its output pipe has closed. There are a bunch of ways to handle this, but the program gracefully exiting is probably the right way for these commands, which are also the most likely to be pipe terminated. 

Test Plan
---------
```
tx dataset -P | head -n 10
```
It doesn't asplode