### PR TITLE
[hma][api] Fix /for-hash/ endpoint by passing signal_type_mapping to jsoninator decorator

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -540,7 +540,7 @@ def get_matches_api(
         return match_objects
 
     @matches_api.get(
-        "/for-hash/", apply=[jsoninator(MatchesForHashRequest, from_query=True)]
+        "/for-hash/", apply=[jsoninator(MatchesForHashRequest, from_query=True, signal_type_mapping=signal_type_mapping)]
     )
     def for_hash(request: MatchesForHashRequest) -> MatchesForHashResponse:
         """


### PR DESCRIPTION
Summary
---------

#1277 flagged that the `/for-hash/` endpoint was failing to parse well formed requests.

Looks like the migrations to using a signal_type_mapping that is dynamically loaded this endpoint was missing a passthrough to the middleware. (apologies for all the buzzwords, the part of the stack is unfortunately opaque).

Test Plan
---------

I saw in `cloudwatch` for `<prefix>_api_root` that we had an assert error where `signal_type_mapping` is None.

updating the decorator for the two endpoints that use `DictParseableWithSignalTypeMapping` in `api/matches.py` seemed to remove this error.  fixes #1277 (though I think it is possible there are other endpoints there could have been missed)