### PR TITLE
[hma][setup] Move migrations that are actually core setup steps to root main.tf

### DIFF
--- a/hasher-matcher-actioner/README.md
+++ b/hasher-matcher-actioner/README.md
@@ -22,12 +22,16 @@ You'll need an AWS account set up. Additionally, you'll need the following tools
 2. [jq cli](https://stedolan.github.io/jq/)
 3. [terraform cli](https://www.terraform.io/)
 4. [Docker](https://www.docker.com/)
+5. [python3](https://www.python.org/) (including `pip` and `venv`)
 
 ## Spinning Up an Instance
 In a horrifying misuse of Make, there is a makefile to help you get started and create some configs with default naming. More details on customization be found in [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ```bash
 $ cd hasher-matcher-actioner
+# Recommended: setup a virtual environment as make/terraform steps include pip install as part of initial deployment.
+$ python3 -m venv ~/.venv/hma
+$ source ~/.venv/hma/bin/activate 
 # Before doing this step, make sure to configure the aws cli with `aws configure`
 $ make dev_create_configs  # Will populate a terraform.tfvars backend.tf with default names
 # Optional: edit terraform.tfvars backend.tf to your preference for names of services

--- a/hasher-matcher-actioner/hmalib/scripts/migrations/2022_04_02_default_content_signal_type_configs.py
+++ b/hasher-matcher-actioner/hmalib/scripts/migrations/2022_04_02_default_content_signal_type_configs.py
@@ -2,6 +2,7 @@
 
 import typing as t
 
+from botocore.exceptions import ClientError
 from threatexchange.content_type.photo import PhotoContent
 from threatexchange.content_type.video import VideoContent
 from threatexchange.signal_type.md5 import VideoMD5Signal
@@ -13,40 +14,62 @@ from hmalib.common.mappings import (
     ToggleableSignalTypeConfig,
     full_class_name,
 )
-
+from hmalib.common.logging import get_logger
 from hmalib.scripts.migrations.migrations_base import MigrationBase
+
+logger = get_logger(__name__)
 
 
 class _Migration(MigrationBase):
     def do_migrate(self):
-        create_config(
-            ToggleableContentTypeConfig(
-                name=ToggleableContentTypeConfig.get_name_from_type(VideoContent),
-                content_type_class=full_class_name(VideoContent),
-                enabled=True,
+        """
+        if any of the 4 default mappings do not exist, create them
+        """
+        try:
+            create_config(
+                ToggleableContentTypeConfig(
+                    name=ToggleableContentTypeConfig.get_name_from_type(VideoContent),
+                    content_type_class=full_class_name(VideoContent),
+                    enabled=True,
+                )
             )
-        )
-
-        create_config(
-            ToggleableContentTypeConfig(
-                name=ToggleableContentTypeConfig.get_name_from_type(PhotoContent),
-                content_type_class=full_class_name(PhotoContent),
-                enabled=True,
+        except ClientError:
+            logger.warning(
+                "Attempted to add ToggleableContentTypeConfig for VideoContent, but it already exists."
             )
-        )
-
-        create_config(
-            ToggleableSignalTypeConfig(
-                name=ToggleableSignalTypeConfig.get_name_from_type(VideoMD5Signal),
-                signal_type_class=full_class_name(VideoMD5Signal),
-                enabled=True,
+        try:
+            create_config(
+                ToggleableContentTypeConfig(
+                    name=ToggleableContentTypeConfig.get_name_from_type(PhotoContent),
+                    content_type_class=full_class_name(PhotoContent),
+                    enabled=True,
+                )
             )
-        )
-
-        create_config(
-            ToggleableSignalTypeConfig(
-                name=ToggleableSignalTypeConfig.get_name_from_type(PdqSignal),
-                signal_type_class=full_class_name(PdqSignal),
-                enabled=True,
+        except ClientError:
+            logger.warning(
+                "Attempted to add ToggleableContentTypeConfig for PhotoContent, but it already exists."
             )
-        )
+        try:
+            create_config(
+                ToggleableSignalTypeConfig(
+                    name=ToggleableSignalTypeConfig.get_name_from_type(VideoMD5Signal),
+                    signal_type_class=full_class_name(VideoMD5Signal),
+                    enabled=True,
+                )
+            )
+        except ClientError:
+            logger.warning(
+                "Attempted to add ToggleableSignalTypeConfig for VideoMD5Signal, but it already exists."
+            )
+        try:
+            create_config(
+                ToggleableSignalTypeConfig(
+                    name=ToggleableSignalTypeConfig.get_name_from_type(PdqSignal),
+                    signal_type_class=full_class_name(PdqSignal),
+                    enabled=True,
+                )
+            )
+        except ClientError:
+            logger.warning(
+                "Attempted to add ToggleableSignalTypeConfig for PdqSignal, but it already exists."
+            )

--- a/hasher-matcher-actioner/terraform/migrations/README.md
+++ b/hasher-matcher-actioner/terraform/migrations/README.md
@@ -1,8 +1,8 @@
 # What are migrations
 
-Migrations are commands to run when installing a new version of HMA. This includes both a fresh install or an upgrade of an older version. 
+Migrations are commands to run when installing a new version of HMA. 
 
-In both cases, there may be things that can't be done from within terraform, like creating some database entries, or running an hmalib.cli command, etc.
+There may be things that can't be done from within terraform, like creating some database entries, or running an hmalib.cli command, etc.
 
 # How do I add a migration?
 
@@ -12,13 +12,9 @@ At the end of the `[migrations/main.tf](https://github.com/facebook/ThreatExchan
 resource "null_resource" "some-name that identifies what this migration does" {
   provisioner "local-exec" {
     working_dir = "../../"
-    command     = "<whatever command you want to run. eg.> python -m hmalib.scripts.cli.main migrate 2022_04_02_default_content_signal_type_configs --config-table ${var.config_table.name}"
+    command     = "<whatever command you want to run. eg.> hmalib migrate 2022_04_02_default_content_signal_type_configs --config-table ${var.config_table.name}"
   }
 }
 ```
 
 You have access to variable names defined in `[migrations/variables.tf](https://github.com/facebook/ThreatExchange/blob/main/hasher-matcher-actioner/terraform/migrations/variables.tf)`
-
-# Migrations are not working?
-
-At present, their is an annoying bug. Any `python -m hmalib._foo_` command run during migration fails because terraform is not running the command from the appropriate directory. Editing the working_directory has not led to a solution. This is something we need to address. See [#1249](https://github.com/facebook/ThreatExchange/issues/1249)

--- a/hasher-matcher-actioner/terraform/migrations/main.tf
+++ b/hasher-matcher-actioner/terraform/migrations/main.tf
@@ -4,17 +4,4 @@
 # operate. terraform is already doing the state-management of the HMA versions.
 # It will suffice as way to record migrations between versions.
 
-# AFTER v0.1.2 https://github.com/facebook/ThreatExchange/releases/tag/HMA-v0.1.2
-resource "null_resource" "default_signal_content_type_configs" {
-  provisioner "local-exec" {
-    working_dir = "../../"
-    command     = "python -m hmalib.scripts.cli.main migrate 2022_04_02_default_content_signal_type_configs --config-table ${var.config_table.name}"
-  }
-}
 
-resource "null_resource" "default_signal_exchange_apis" {
-  provisioner "local-exec" {
-    working_dir = "../../"
-    command     = "python -m hmalib.scripts.cli.main migrate 2022_07_24_default_signal_exchange_apis --config-table ${var.config_table.name}"
-  }
-}

--- a/hasher-matcher-actioner/terraform/migrations/variables.tf
+++ b/hasher-matcher-actioner/terraform/migrations/variables.tf
@@ -1,9 +1,1 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-
-variable "config_table" {
-  description = "The name and arn of the DynamoDB table used for persisting configs."
-  type = object({
-    arn  = string
-    name = string
-  })
-}


### PR DESCRIPTION
Summary
---------

#1249 Flags that migrations do not run successfully. My first thought was to disable them by default (as our most common usages is still fresh installs) however looking at the scripts themselves these "migrations" are actually a core apart of post deploy config set up. Meaning they are always required regardless.   

So instead of disabling I did the following:

1) moved the existing migration commands to the root `main.ft` as they are setup critical
2) update the command that was failing to first install `hmacli` via pip  instead of trying to run the command and hope everything is in the right place
 - This does have the added side effect of tf apply updating the python libraries installed, therefore I updated the README.md to included a recommendation for using python's `venv` (something I hope folks most were already doing).

I also went ahead anded added some error checking to one of the scripts run in the python setup command so both they can be rerun without issue.

Unfortunately I can't just delete `terraform/migrations` because then anyone already deployed will get an error. So I just emptied the .tf files and updated the local README (We will likely have a usage for this module for actual migrations eventually anyway.) 


Test Plan
---------
Made sure `make dev_apply_with_newest_docker_image` can be run without error and deploys cleanly.

Validated install and error handling on setup scripts:
```
python3 -m venv ~/.venv/hma
source ~/.venv/hma/bin/activate 
# force terraform to rerun the python scripts
terraform -chdir=terraform taint null_resource.default_system_config
make dev_apply_with_newest_docker_image
<redacted>
Apply complete! Resources: 1 added, 1 changed, 1 destroyed.

Outputs:
<redacted>

```


