### PR TITLE
[hma][deploy] add code check on ClientError in set up scripts

### DIFF
--- a/hasher-matcher-actioner/hmalib/common/configs/tx_apis.py
+++ b/hasher-matcher-actioner/hmalib/common/configs/tx_apis.py
@@ -77,12 +77,15 @@ def add_signal_exchange_api(
                 enabled=True,
             )
         )
-    except ClientError:
-        logger.warning(
-            "Attempted to add SignalExchangeAPI with class: %s, but it already exists.",
-            klass,
-        )
-        return AddSignalExchangeAPIResult.ALREADY_EXISTS
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            logger.warning(
+                "Attempted to add SignalExchangeAPI with class: %s, but it already exists.",
+                klass,
+            )
+            return AddSignalExchangeAPIResult.ALREADY_EXISTS
+        else:
+            raise e
 
     return AddSignalExchangeAPIResult.ADDED
 

--- a/hasher-matcher-actioner/hmalib/scripts/migrations/2022_04_02_default_content_signal_type_configs.py
+++ b/hasher-matcher-actioner/hmalib/scripts/migrations/2022_04_02_default_content_signal_type_configs.py
@@ -35,10 +35,13 @@ class _Migration(MigrationBase):
                     enabled=True,
                 )
             )
-        except ClientError:
-            logger.warning(
-                "Attempted to add ToggleableContentTypeConfig for VideoContent, but it already exists."
-            )
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                logger.warning(
+                    "Attempted to add ToggleableContentTypeConfig for VideoContent, but it already exists."
+                )
+            else:
+                raise e
         try:
             create_config(
                 ToggleableContentTypeConfig(
@@ -47,10 +50,13 @@ class _Migration(MigrationBase):
                     enabled=True,
                 )
             )
-        except ClientError:
-            logger.warning(
-                "Attempted to add ToggleableContentTypeConfig for PhotoContent, but it already exists."
-            )
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                logger.warning(
+                    "Attempted to add ToggleableContentTypeConfig for PhotoContent, but it already exists."
+                )
+            else:
+                raise e
         try:
             create_config(
                 ToggleableSignalTypeConfig(
@@ -59,10 +65,13 @@ class _Migration(MigrationBase):
                     enabled=True,
                 )
             )
-        except ClientError:
-            logger.warning(
-                "Attempted to add ToggleableSignalTypeConfig for VideoMD5Signal, but it already exists."
-            )
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                logger.warning(
+                    "Attempted to add ToggleableSignalTypeConfig for VideoMD5Signal, but it already exists."
+                )
+            else:
+                raise e
         try:
             create_config(
                 ToggleableSignalTypeConfig(
@@ -71,7 +80,10 @@ class _Migration(MigrationBase):
                     enabled=True,
                 )
             )
-        except ClientError:
-            logger.warning(
-                "Attempted to add ToggleableSignalTypeConfig for PdqSignal, but it already exists."
-            )
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                logger.warning(
+                    "Attempted to add ToggleableSignalTypeConfig for PdqSignal, but it already exists."
+                )
+            else:
+                raise e


### PR DESCRIPTION
Summary
---------

See title. @Dcallies was right to ask for this in #1281 but I didn't add them before merge.

Test Plan
---------

Tested 3 cases
1. Made sure the command still ran if the configs didn't exist
2. Made sure the command gave the expected warning if they did exist
3. Used an expired token and made sure the command threw the error instead of just displaying the incorrect/misleading warning message. 
