### PR TITLE
[py-tx] Align `tx match --hash` format with the output of `tx hash` 

### DIFF
--- a/hasher-matcher-actioner/webapp/package-lock.json
+++ b/hasher-matcher-actioner/webapp/package-lock.json
@@ -26398,9 +26398,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.1.tgz",
+      "integrity": "sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -47607,9 +47607,9 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.1.tgz",
+      "integrity": "sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",

--- a/python-threatexchange/threatexchange/cli/tests/match_cmd_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/match_cmd_test.py
@@ -3,6 +3,7 @@
 import tempfile
 from threatexchange.cli.tests.e2e_test_helper import ThreatExchangeCLIE2eTest
 from threatexchange.signal_type.md5 import VideoMD5Signal
+from threatexchange.signal_type.pdq import PdqSignal
 
 
 class MatchCommandTest(ThreatExchangeCLIE2eTest):
@@ -29,5 +30,61 @@ class MatchCommandTest(ThreatExchangeCLIE2eTest):
         not_hash = "this is not an md5"
         self.assert_cli_usage_error(
             ("-H", "video", "--", not_hash),
-            f"{not_hash!r} from .* is not a valid hash for video_md5",
+            f"Error attempting to infer Signal Type: '{not_hash.split()[0]}' is not a valid Signal Type.",
         )
+
+    def test_valid_hash_with_prefix(self):
+        hash = "pdq " + PdqSignal.get_examples()[0]
+        self.assert_cli_output(
+            ("-H", "photo", "--", hash), "pdq 16 (Sample Signals) INVESTIGATION_SEED"
+        )
+
+    def test_no_prefix_specific_signal_type(self):
+        hash = PdqSignal.get_examples()[0]
+        self.assert_cli_output(
+            ("-H", "-S", "pdq", "photo", "--", hash),
+            "pdq 16 (Sample Signals) INVESTIGATION_SEED",
+        )
+
+    def test_multiple_prefixes(self):
+        hash1 = "pdq " + PdqSignal.get_examples()[0]
+        hash2 = "pdq " + PdqSignal.get_examples()[1]
+        with tempfile.NamedTemporaryFile("a+") as fp:
+            fp.write(hash1 + "\n")
+            fp.write(hash2)
+            fp.seek(0)
+            # CLI is currently showing only one match for multiple hashes
+            # TODO Improve the handling of multiple hashes in one match query
+            self.assert_cli_output(
+                ("-H", "photo", fp.name), "pdq 16 (Sample Signals) INVESTIGATION_SEED"
+            )
+
+    def test_incorrect_valid_and_no_prefixes(self):
+        fakeprefix = "fakesignal"
+        hash1 = "pdq " + PdqSignal.get_examples()[0]
+        hash2 = fakeprefix + " " + PdqSignal.get_examples()[1]
+        hash3 = fakeprefix + " " + PdqSignal.get_examples()[2]
+        with tempfile.NamedTemporaryFile("a+") as fp:
+            fp.write(hash1 + "\n")
+            fp.write(hash2 + "\n")
+            fp.write(hash3)
+            fp.seek(0)
+            self.assert_cli_usage_error(
+                ("-H", "photo", fp.name),
+                f"Error attempting to infer Signal Type: '{fakeprefix}' is not a valid Signal Type.",
+            )
+
+    def test_prefix_and_no_prefixes(self):
+        hash1 = "pdq " + PdqSignal.get_examples()[0]
+        hash2 = "pdq " + PdqSignal.get_examples()[1]
+        hash3 = PdqSignal.get_examples()[1]
+        with tempfile.NamedTemporaryFile("a+") as fp:
+            fp.write(hash1 + "\n")
+            fp.write(hash2 + "\n")
+            fp.write(hash3)
+            fp.seek(0)
+            # CLI is currently showing only one match for multiple hashes
+            # TODO Improve the handling of multiple hashes in one match query
+            self.assert_cli_output(
+                ("-H", "photo", fp.name), "pdq 16 (Sample Signals) INVESTIGATION_SEED"
+            )

--- a/python-threatexchange/threatexchange/cli/tests/match_cmd_test.py
+++ b/python-threatexchange/threatexchange/cli/tests/match_cmd_test.py
@@ -30,7 +30,7 @@ class MatchCommandTest(ThreatExchangeCLIE2eTest):
         not_hash = "this is not an md5"
         self.assert_cli_usage_error(
             ("-H", "video", "--", not_hash),
-            f"Error attempting to infer Signal Type: '{not_hash.split()[0]}' is not a valid Signal Type.",
+            f"'{not_hash.split()[0]}' is not a valid hash for video_md5",
         )
 
     def test_valid_hash_with_prefix(self):
@@ -71,7 +71,7 @@ class MatchCommandTest(ThreatExchangeCLIE2eTest):
             fp.seek(0)
             self.assert_cli_usage_error(
                 ("-H", "photo", fp.name),
-                f"Error attempting to infer Signal Type: '{fakeprefix}' is not a valid Signal Type.",
+                f"Error: '{fakeprefix}' is not a valid Signal Type.*",
             )
 
     def test_prefix_and_no_prefixes(self):


### PR DESCRIPTION
Summary
---------
Fixes #1188 
This pr allows for the usage of the hash format produced by the hash command to be used in the match command (i.e. prefixed with 'pdq'). In addition, allows for multiple hashes in a single file of varying signal types. 

Will throw exceptions when:
- You specify (-S) a signal type, and provide hashes of another type
- When there are multiple signal type prefixes with a mixture of no prefixes -- i.e. we are unable to 'infer' the signal type from the hash
- Provide an invalid signal type 
- Provide an invalid hash for the signal type

Test Plan
---------
Wrote unit tests and they all pass. Also ran a few manual tests, and piped the command from hash to match which works.
`tx hash photo <photo location> | tx match --hashes -S pdq photo -`