### PR TITLE
Dockerize python-threatexchange

### DIFF
--- a/python-threatexchange/Dockerfile
+++ b/python-threatexchange/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-bullseye
+
+WORKDIR /usr/src/threatexchange
+COPY . .
+RUN pip install .
+RUN rm -rf /usr/src/threatexchange
+
+ENV TX_STATEDIR=/var/lib/threatexchange
+
+VOLUME ["/var/lib/threatexchange"]
+CMD ["threatexchange"]
+ENTRYPOINT ["/usr/local/bin/threatexchange"]

--- a/python-threatexchange/README.md
+++ b/python-threatexchange/README.md
@@ -8,6 +8,27 @@ To get similar functionality in a deployable service, check out hasher-matcher-a
 
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/facebook/ThreatExchange/python-threatexchange-ci.yaml?branch=main) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/threatexchange) ![PyPI - Downloads](https://img.shields.io/pypi/dm/threatexchange) ![PyPI](https://img.shields.io/pypi/v/threatexchange) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) 
 
+## Run the CLI in Docker container
+
+A Dockerfile is provided which allows you to run the CLI with minimal dependencies.
+
+First build the container:
+```
+$ docker build --tag threatexchange .
+```
+
+Then run:
+```
+$ docker run threatexchange
+```
+
+To persist the configuration and data between invocations, mount the `/var/lib/threatexchange` volume:
+
+```
+$ docker run --volume $HOME/.threatexchange:/var/lib/threatexchange
+```
+
+
 ## Installation
 
 If you don't have `pip`, learn how to install it [here](https://pip.pypa.io/en/stable/installation/).

--- a/python-threatexchange/threatexchange/cli/main.py
+++ b/python-threatexchange/threatexchange/cli/main.py
@@ -273,7 +273,9 @@ def _setup_logging(level_str: str, *, initial: bool = False) -> None:
 
 def inner_main(
     args: t.Optional[t.Sequence[t.Text]] = None,
-    state_dir: pathlib.Path = pathlib.Path("~/.threatexchange"),
+    state_dir: pathlib.Path = pathlib.Path(
+        os.getenv("TX_STATEDIR", "~/.threatexchange")
+    ),
 ) -> None:
     """The main called by tests"""
     config = CliState(


### PR DESCRIPTION
Summary
---------

Reduce user friction by providing a Docker container for the CLI. This eliminates the need for the user to have to care about Python.

To make for a clean Docker image layout, the persistent state directory is now configurable. While the default remains `~/.threatexchange`, it can now be overridden by setting a `TX_STATEDIR` environment variable.

Test Plan
---------

```
$ docker build --tag threatexchange .
$ docker run threatexchange --help
usage: threatexchange [-h] [--factory-reset] [--version] [--verbose]
                      {config,fetch,match,label,dataset,hash} ...

Wrapper for the `threatexchange` library, can serve as a simple e2e solution.
...
```
