### PR TITLE
[pytx] devcontainer: install pip "extras" for development

### DIFF
--- a/python-threatexchange/.devcontainer/devcontainer.json
+++ b/python-threatexchange/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
     }
   },
   "remoteUser": "vscode",
-  "postCreateCommand": "pip install --editable .",
+  "postCreateCommand": "pip install --editable .[dev]",
   "mounts": [
     "source=python-threatexchange-cmdhistory,target=/commandhistory,type=volume"
   ]


### PR DESCRIPTION
Summary
---------

Install the dev dependencies as defined in the `setup.py` - `pytest`, `black`, and so on.

Test Plan
---------

Rebuild devcontainer and check for presence of `pytest` command.
