### PR TITLE
[pytx] CLI separation: move config and state classes out of cli module

### DIFF
--- a/python-threatexchange/threatexchange/cli/command_base.py
+++ b/python-threatexchange/threatexchange/cli/command_base.py
@@ -13,7 +13,8 @@ import typing as t
 import sys
 
 from threatexchange import common
-from threatexchange.cli.cli_config import CLISettings
+from threatexchange.config import TXSettings
+
 from threatexchange.cli.exceptions import CommandError
 
 
@@ -24,7 +25,7 @@ class Command:
 
     @classmethod
     def add_command_to_subparser(
-        cls, settings: CLISettings, subparsers
+        cls, settings: TXSettings, subparsers
     ) -> argparse.ArgumentParser:
         """
         Shortcut for adding the command to the parser.
@@ -43,7 +44,7 @@ class Command:
 
     @classmethod
     def init_argparse(
-        cls, settings: CLISettings, argparse: argparse.ArgumentParser
+        cls, settings: TXSettings, argparse: argparse.ArgumentParser
     ) -> None:
         """
         Program the command subparser for __init__
@@ -83,7 +84,7 @@ class Command:
         """Convenience accessor to stderr"""
         print(*args, file=sys.stderr, **kwargs)
 
-    def execute(self, settings: CLISettings) -> None:
+    def execute(self, settings: TXSettings) -> None:
         raise NotImplementedError
 
 
@@ -92,7 +93,7 @@ class CommandWithSubcommands(Command):
 
     @classmethod
     def add_command_to_subparser(
-        cls, settings: CLISettings, subparsers
+        cls, settings: TXSettings, subparsers
     ) -> argparse.ArgumentParser:
         command_ap = super().add_command_to_subparser(settings, subparsers)
         sub_subparsers = command_ap.add_subparsers()
@@ -102,5 +103,5 @@ class CommandWithSubcommands(Command):
 
         return command_ap
 
-    def execute(self, settings: CLISettings) -> None:
+    def execute(self, settings: TXSettings) -> None:
         raise CommandError("subcommand is required", 2)

--- a/python-threatexchange/threatexchange/cli/fetch_cmd.py
+++ b/python-threatexchange/threatexchange/cli/fetch_cmd.py
@@ -7,12 +7,11 @@ import logging
 import time
 import typing as t
 
-from threatexchange.cli.cli_config import CLISettings
+from threatexchange.config import TXSettings
+
 from threatexchange.cli.dataset_cmd import DatasetCommand
 from threatexchange.exchanges.collab_config import CollaborationConfigBase
-from threatexchange.exchanges.impl.ncmec_api import NCMECCheckpoint
 from threatexchange.exchanges.signal_exchange_api import (
-    SignalExchangeAPI,
     TSignalExchangeAPICls,
 )
 from threatexchange.exchanges.fetch_state import (
@@ -42,7 +41,7 @@ class FetchCommand(command_base.Command):
     PROGRESS_PRINT_INTERVAL_SEC = 30
 
     @classmethod
-    def init_argparse(cls, settings: CLISettings, ap) -> None:
+    def init_argparse(cls, settings: TXSettings, ap) -> None:
         ap.add_argument(
             "--clear",
             action="store_true",
@@ -124,7 +123,7 @@ class FetchCommand(command_base.Command):
             return False
         return time.time() > self.checkpoint_every + self.last_checkpoint_time
 
-    def execute(self, settings: CLISettings) -> None:
+    def execute(self, settings: TXSettings) -> None:
         # Verify collab arguments
         self.collabs = settings.get_all_collabs()
         if self.only_collab:
@@ -165,9 +164,7 @@ class FetchCommand(command_base.Command):
         if not all_succeeded:
             raise command_base.CommandError("Some collabs had errors!", 3)
 
-    def execute_for_api(
-        self, settings: CLISettings, api: TSignalExchangeAPICls
-    ) -> bool:
+    def execute_for_api(self, settings: TXSettings, api: TSignalExchangeAPICls) -> bool:
         success = True
         for collab in self.collabs:
             if collab.api != api.get_name():
@@ -183,7 +180,7 @@ class FetchCommand(command_base.Command):
 
     def execute_for_collab(
         self,
-        settings: CLISettings,
+        settings: TXSettings,
         collab: CollaborationConfigBase,
     ) -> bool:
         api = settings.apis.get_instance_for_collab(collab)

--- a/python-threatexchange/threatexchange/cli/hash_cmd.py
+++ b/python-threatexchange/threatexchange/cli/hash_cmd.py
@@ -9,7 +9,8 @@ import argparse
 import pathlib
 import typing as t
 from threatexchange import common
-from threatexchange.cli.cli_config import CLISettings
+from threatexchange.config import TXSettings
+
 from threatexchange.cli.exceptions import CommandError
 from threatexchange.content_type.content_base import ContentType
 
@@ -41,7 +42,7 @@ class HashCommand(command_base.Command):
     """
 
     @classmethod
-    def init_argparse(cls, settings: CLISettings, ap: argparse.ArgumentParser) -> None:
+    def init_argparse(cls, settings: TXSettings, ap: argparse.ArgumentParser) -> None:
         signal_types = [
             s for s in settings.get_all_signal_types() if issubclass(s, FileHasher)
         ]
@@ -87,7 +88,7 @@ class HashCommand(command_base.Command):
 
         self.files = files
 
-    def execute(self, settings: CLISettings) -> None:
+    def execute(self, settings: TXSettings) -> None:
         hashers = [
             s
             for s in settings.get_signal_types_for_content(self.content_type)

--- a/python-threatexchange/threatexchange/cli/label_cmd.py
+++ b/python-threatexchange/threatexchange/cli/label_cmd.py
@@ -8,10 +8,11 @@ from threatexchange.cli.helpers import FlexFilesInputAction
 from threatexchange.exchanges.fetch_state import SignalOpinion, SignalOpinionCategory
 
 
-from threatexchange.signal_type.signal_base import MatchesStr, SignalType, TextHasher
+from threatexchange.signal_type.signal_base import SignalType
 
 from threatexchange import common
-from threatexchange.cli.cli_config import CLISettings
+from threatexchange.config import TXSettings
+
 from threatexchange.content_type.content_base import ContentType
 from threatexchange.exchanges.collab_config import CollaborationConfigBase
 from threatexchange.cli import command_base
@@ -46,7 +47,7 @@ class LabelCommand(command_base.Command):
     """
 
     @classmethod
-    def init_argparse(cls, settings: CLISettings, ap: ArgumentParser) -> None:
+    def init_argparse(cls, settings: TXSettings, ap: ArgumentParser) -> None:
         ap.add_argument(
             "--labels",
             "-l",
@@ -122,7 +123,7 @@ class LabelCommand(command_base.Command):
         if self.collab is None:
             raise ArgumentTypeError("No such collaboration!")
 
-    def execute(self, settings: CLISettings) -> None:
+    def execute(self, settings: TXSettings) -> None:
         self.stderr("This command is not implemented yet, and most actions won't work")
 
         api = settings.apis.get_instance_for_collab(self.collab)
@@ -145,7 +146,7 @@ class LabelCommand(command_base.Command):
         raise NotImplementedError
 
 
-def _collab_type(name: str, settings: CLISettings) -> CollaborationConfigBase:
+def _collab_type(name: str, settings: TXSettings) -> CollaborationConfigBase:
     ret = settings.get_collab(name)
     if ret is None:
         raise ArgumentTypeError(f"No such collab '{name}'!")

--- a/python-threatexchange/threatexchange/cli/match_cmd.py
+++ b/python-threatexchange/threatexchange/cli/match_cmd.py
@@ -12,6 +12,8 @@ import typing as t
 
 
 from threatexchange import common
+from threatexchange.config import TXSettings
+
 from threatexchange.cli.fetch_cmd import FetchCommand
 from threatexchange.cli.helpers import FlexFilesInputAction
 from threatexchange.exchanges.fetch_state import FetchedSignalMetadata
@@ -19,7 +21,6 @@ from threatexchange.exchanges.fetch_state import FetchedSignalMetadata
 from threatexchange.signal_type.index import IndexMatch, SignalTypeIndex
 from threatexchange.cli.exceptions import CommandError
 from threatexchange.signal_type.signal_base import BytesHasher, SignalType
-from threatexchange.cli.cli_config import CLISettings
 from threatexchange.content_type.content_base import ContentType
 
 from threatexchange.signal_type.signal_base import MatchesStr, TextHasher, FileHasher
@@ -75,7 +76,7 @@ class MatchCommand(command_base.Command):
     """
 
     @classmethod
-    def init_argparse(cls, settings: CLISettings, ap: argparse.ArgumentParser) -> None:
+    def init_argparse(cls, settings: TXSettings, ap: argparse.ArgumentParser) -> None:
         ap.add_argument(
             "content_type",
             **common.argparse_choices_pre_type_kwargs(
@@ -152,7 +153,7 @@ class MatchCommand(command_base.Command):
                 2,
             )
 
-    def execute(self, settings: CLISettings) -> None:
+    def execute(self, settings: TXSettings) -> None:
         if not settings.index.list():
             if not settings.in_demo_mode:
                 raise CommandError("No indices available. Do you need to fetch?")


### PR DESCRIPTION
Summary
---------

The library's core functionality and the CLI are separate concerns, so code which doesn't concern the CLI, shouldn't have the appearance of doing so. Move and rename the config and state management classes to reflect this. This will be fundamental to making the API parts make sense.

Test Plan
---------

See what GH CI says...
