### PR TITLE
[RFC][HMA-in-a-bottle] Possible example of creating a modular matcher

### DIFF
--- a/hasher-matcher-actioner/webapp/package-lock.json
+++ b/hasher-matcher-actioner/webapp/package-lock.json
@@ -26398,9 +26398,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.1.tgz",
+      "integrity": "sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -47607,9 +47607,9 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.1.tgz",
+      "integrity": "sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",

--- a/python-threatexchange/threatexchange/cli/match_cmd.py
+++ b/python-threatexchange/threatexchange/cli/match_cmd.py
@@ -16,7 +16,7 @@ from threatexchange.cli.fetch_cmd import FetchCommand
 from threatexchange.cli.helpers import FlexFilesInputAction
 from threatexchange.exchanges.fetch_state import FetchedSignalMetadata
 
-from threatexchange.signal_type.index import IndexMatch, SignalTypeIndex
+from threatexchange.signal_type.index import IndexMatch
 from threatexchange.cli.exceptions import CommandError
 from threatexchange.signal_type.signal_base import BytesHasher, SignalType
 from threatexchange.cli.cli_config import CLISettings
@@ -24,6 +24,7 @@ from threatexchange.content_type.content_base import ContentType
 
 from threatexchange.signal_type.signal_base import MatchesStr, TextHasher, FileHasher
 from threatexchange.cli import command_base
+from threatexchange.matcher import matcher, file_matcher, hash_matcher
 
 
 TMatcher = t.Callable[[pathlib.Path], t.List[IndexMatch]]
@@ -145,104 +146,41 @@ class MatchCommand(command_base.Command):
         self.files = files
         self.all = all
 
-        if only_signal and content_type not in only_signal.get_content_types():
-            raise CommandError(
-                f"{only_signal.get_name()} does not "
-                f"apply to {content_type.get_name()}",
-                2,
-            )
-
     def execute(self, settings: CLISettings) -> None:
+        if self.as_hashes:
+            self.matcher: matcher.Matcher = hash_matcher.HashMatcher(
+                settings,
+                self.content_type,
+                self.only_signal,
+                (BytesHasher, TextHasher, FileHasher),
+            )
+        else:
+            self.matcher = file_matcher.FileMatcher(
+                settings, self.content_type, self.only_signal, (FileHasher, MatchesStr)
+            )
         if not settings.index.list():
             if not settings.in_demo_mode:
                 raise CommandError("No indices available. Do you need to fetch?")
             self.stderr("You haven't built any indices, so we'll call `fetch` for you!")
             FetchCommand().execute(settings)
 
-        signal_types = settings.get_signal_types_for_content(self.content_type)
-
-        if self.only_signal:
-            signal_types = [self.only_signal]
-        types: t.Tuple[type, ...] = (FileHasher, MatchesStr)
-        if self.as_hashes:
-            types = (BytesHasher, TextHasher, FileHasher)
-        signal_types = [s for s in signal_types if issubclass(s, types)]
-        if self.as_hashes and len(signal_types) > 1:
-            raise CommandError(
-                f"Error: '{self.content_type.get_name()}' supports more than one SignalType."
-                " for '--hashes' also use '--only-signal' to specify one of "
-                f"{[s.get_name() for s in signal_types]}",
-                2,
-            )
-
-        logging.info(
-            "Signal types that apply: %s",
-            ", ".join(s.get_name() for s in signal_types) or "None!",
-        )
-
-        indices: t.List[t.Tuple[t.Type[SignalType], SignalTypeIndex]] = []
-        for s_type in signal_types:
-            index = settings.index.load(s_type)
-            if index is None:
-                logging.info("No index for %s, skipping", s_type.get_name())
-                continue
-            indices.append((s_type, index))
-
-        if not indices:
-            self.stderr("No data to match against")
-            return
-
         for path in self.files:
-            for s_type, index in indices:
-                seen = set()  # TODO - maybe take the highest certainty?
-                if self.as_hashes:
-                    results = _match_hashes(path, s_type, index)
-                else:
-                    results = _match_file(path, s_type, index)
-
-                for r in results:
-                    metadatas: t.List[t.Tuple[str, FetchedSignalMetadata]] = r.metadata
-                    for collab, fetched_data in metadatas:
-                        if not self.all and collab in seen:
-                            continue
-                        seen.add(collab)
-                        # Supposed to be without whitespace, but let's make sure
-                        distance_str = "".join(r.similarity_info.pretty_str().split())
-                        print(
-                            s_type.get_name(),
-                            distance_str,
-                            f"({collab})",
-                            fetched_data,
-                        )
-
-
-def _match_file(
-    path: pathlib.Path, s_type: t.Type[SignalType], index: SignalTypeIndex
-) -> t.Sequence[IndexMatch]:
-    if issubclass(s_type, MatchesStr):
-        return index.query(path.read_text())
-    assert issubclass(s_type, FileHasher)
-    return index.query(s_type.hash_from_file(path))
-
-
-def _match_hashes(
-    path: pathlib.Path, s_type: t.Type[SignalType], index: SignalTypeIndex
-) -> t.Sequence[IndexMatch]:
-    ret: t.List[IndexMatch] = []
-    for hash in path.read_text().splitlines():
-        hash = hash.strip()
-        if not hash:
-            continue
-        try:
-            hash = s_type.validate_signal_str(hash)
-        except Exception:
-            logging.exception("%s failed verification on %s", s_type.get_name(), hash)
-            hash_repr = repr(hash)
-            if len(hash_repr) > 50:
-                hash_repr = hash_repr[:47] + "..."
-            raise CommandError(
-                f"{hash_repr} from {path} is not a valid hash for {s_type.get_name()}",
-                2,
-            )
-        ret.extend(index.query(hash))
-    return ret
+            seen = set()
+            if self.as_hashes:
+                results = self.matcher.match(*path.read_text().splitlines())
+            else:
+                results = self.matcher.match(path)
+            for r in results:
+                metadatas: t.List[t.Tuple[str, FetchedSignalMetadata]] = r.metadata
+                for collab, fetched_data in metadatas:
+                    if not self.all and collab in seen:
+                        continue
+                    seen.add(collab)
+                    # Supposed to be without whitespace, but let's make sure
+                    distance_str = "".join(r.similarity_info.pretty_str().split())
+                    print(
+                        # s_type.get_name(),
+                        distance_str,
+                        f"({collab})",
+                        fetched_data,
+                    )

--- a/python-threatexchange/threatexchange/matcher/file_matcher.py
+++ b/python-threatexchange/threatexchange/matcher/file_matcher.py
@@ -1,0 +1,15 @@
+import pathlib
+import typing as t
+from threatexchange.matcher import matcher
+from threatexchange.signal_type.index import IndexMatch, SignalTypeIndex
+from threatexchange.signal_type.signal_base import FileHasher, MatchesStr, SignalType
+
+
+class FileMatcher(matcher.Matcher[pathlib.Path]):
+    def _match_impl(
+        self, input: pathlib.Path, s_type: t.Type[SignalType], index: SignalTypeIndex
+    ) -> t.Sequence[IndexMatch]:
+        if issubclass(s_type, MatchesStr):
+            return index.query(input.read_text())
+        assert issubclass(s_type, FileHasher)
+        return index.query(s_type.hash_from_file(input))

--- a/python-threatexchange/threatexchange/matcher/hash_matcher.py
+++ b/python-threatexchange/threatexchange/matcher/hash_matcher.py
@@ -1,0 +1,20 @@
+import typing as t
+from threatexchange.matcher import matcher
+from threatexchange.signal_type.index import IndexMatch, SignalTypeIndex
+from threatexchange.signal_type.signal_base import SignalType
+
+
+class HashMatcher(matcher.Matcher[str]):
+    def _match_impl(
+        self, hash: str, s_type: t.Type[SignalType], index: SignalTypeIndex
+    ) -> t.Sequence[IndexMatch]:
+        hash = hash.strip()
+        if not hash:
+            return []
+        try:
+            hash = s_type.validate_signal_str(hash)
+        except:
+            # TODO Log exception
+            # For now, return empty as we might have a mixed input
+            return []
+        return index.query(hash)

--- a/python-threatexchange/threatexchange/matcher/matcher.py
+++ b/python-threatexchange/threatexchange/matcher/matcher.py
@@ -1,0 +1,54 @@
+import typing as t
+
+from threatexchange.cli.cli_config import CLISettings
+from threatexchange.content_type.content_base import ContentType
+from threatexchange.signal_type.index import IndexMatch, SignalTypeIndex
+from threatexchange.signal_type.signal_base import SignalType
+
+T = t.TypeVar("T")
+
+
+class Matcher(t.Generic[T]):
+    # question (sa) -- how do we want to handle the settings? In the CLI it's considered
+    # a god object -- do we want to pass it to the init of the class?
+    def __init__(
+        self,
+        settings: CLISettings,
+        content_type: t.Type[ContentType],
+        only_signal: t.Optional[t.Type[SignalType]],
+        valid_types: t.Tuple[type, ...],
+    ) -> None:
+        self.settings = settings
+        _signal_types = (
+            settings.get_signal_types_for_content(content_type)
+            if not only_signal
+            else [only_signal]
+        )
+        self.signal_types = [s for s in _signal_types if issubclass(s, valid_types)]
+
+    def match(self, *input: T) -> t.List[IndexMatch]:
+        # TODO -- this is where the fetch command should exist
+        indicies = self._get_indicies()
+        if not indicies:
+            # TODO Logging
+            return []
+        results: t.List[IndexMatch] = []
+        for s_type, index in indicies:
+            for i in input:
+                results.extend(self._match_impl(i, s_type, index))
+        return results
+
+    def _match_impl(
+        self, i: T, s_type: t.Type[SignalType], index: SignalTypeIndex
+    ) -> t.Sequence[IndexMatch]:
+        raise NotImplementedError
+
+    def _get_indicies(self) -> t.List[t.Tuple[t.Type[SignalType], SignalTypeIndex]]:
+        indices: t.List[t.Tuple[t.Type[SignalType], SignalTypeIndex]] = []
+        for s_type in self.signal_types:
+            index = self.settings.index.load(s_type)
+            if index is None:
+                # TODO logging
+                continue
+            indices.append((s_type, index))
+        return indices


### PR DESCRIPTION
Summary
---------

An example of decoupling the matcher logic from the CLI into its own module and generic base class which allows for creation of specific matcher 'types' -- this was the simplest way to separate the logic for file matching and raw hash matching. 

Test Plan
---------

This is an RFC, but ran it locally and it all works.
