### PR TITLE
[hma] address missing distance field on `/for-hash/` result objects 

### DIFF
--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -15,6 +15,7 @@ from mypy_boto3_sqs.client import SQSClient
 from threatexchange.exchanges.clients.fb_threatexchange.descriptor import (
     ThreatDescriptor,
 )
+from threatexchange.signal_type.index import IndexMatch
 from threatexchange.signal_type.signal_base import SignalType
 from threatexchange.signal_type.md5 import VideoMD5Signal
 from threatexchange.signal_type.pdq import PdqSignal
@@ -513,7 +514,7 @@ def get_matches_api(
             match_objects.extend(
                 [
                     MatchesForHash(
-                        match_distance=int(match.distance),
+                        match_distance=_distance_from_match_if_exits(match),
                         matched_signal=signal_metadata,
                     )
                     for signal_metadata in Matcher.get_te_metadata_objects_from_match(
@@ -530,7 +531,7 @@ def get_matches_api(
                 metadata_obj = t.cast(BankedSignalIndexMetadata, metadata_obj)
                 match_objects.append(
                     MatchesForHash(
-                        match_distance=int(match.distance),
+                        match_distance=_distance_from_match_if_exits(match),
                         matched_signal=banks_table.get_bank_member(
                             metadata_obj.bank_member_id
                         ),
@@ -538,6 +539,13 @@ def get_matches_api(
                 )
 
         return match_objects
+
+    def _distance_from_match_if_exits(match: IndexMatch) -> int:
+        if hasattr(match.similarity_info, "distance") and isinstance(
+            match.similarity_info.distance, int
+        ):
+            return int(match.similarity_info.distance)
+        return 0
 
     @matches_api.get(
         "/for-hash/",

--- a/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
+++ b/hasher-matcher-actioner/hmalib/lambdas/api/matches.py
@@ -541,6 +541,12 @@ def get_matches_api(
         return match_objects
 
     def _distance_from_match_if_exits(match: IndexMatch) -> int:
+        """
+        Existing API expects an int, the newer SignalType interface is
+        not as specific.
+        TODO update the API to return a string for distance so support
+        various differences.
+        """
         if hasattr(match.similarity_info, "distance") and isinstance(
             match.similarity_info.distance, int
         ):

--- a/hasher-matcher-actioner/setup.py
+++ b/hasher-matcher-actioner/setup.py
@@ -24,7 +24,7 @@ setup(
     install_requires=[
         "boto3==1.20.37",
         "boto3-stubs[essential,sns,dynamodbstreams]==1.17.14.0",
-        "threatexchange[faiss,pdq_hasher]==1.0.3",
+        "threatexchange[faiss,pdq_hasher]==1.0.10",
         "bottle==0.12.20",
         "apig-wsgi==2.13.0",
         "pyjwt[crypto]==2.4.0",

--- a/hasher-matcher-actioner/terraform/fetcher/main.tf
+++ b/hasher-matcher-actioner/terraform/fetcher/main.tf
@@ -104,7 +104,7 @@ data "aws_iam_policy_document" "fetcher" {
   statement {
     effect    = "Allow"
     actions   = ["dynamodb:UpdateItem", "dynamodb:GetItem", "dynamodb:Query", "dynamodb:PutItem"]
-    resources = [var.banks_datastore.arn]
+    resources = ["${var.banks_datastore.arn}*"]
   }
 
   statement {


### PR DESCRIPTION
Summary
---------

Had to resolve a set of errors to get to the `for-hash` api issue (would normally be different PR but the first two are 1 liners)

1. update python-threatexchange version because of fetch error handling
2. fetcher IAM policy updated to enable to query of bank member to sub parts of  banks_datastore. 
3. Patch signal type check of field check on `distance` to remove error for `for-hash` API
Test Plan
---------

Confirmed that with changes fetcher can get values from API for sample set and build index and with the python code change that a valid matches data will return. 
