### PR TITLE
[vpdq] Fix resource leak while computing perceptual hash

### DIFF
--- a/vpdq/cpp/hashing/filehasher.cpp
+++ b/vpdq/cpp/hashing/filehasher.cpp
@@ -60,6 +60,7 @@ bool hashVideoFile(
       vpdq::hashing::FrameBufferHasherFactory::createFrameHasher(height, width);
   if (phasher == nullptr) {
     fprintf(stderr, "Error: Phasher is null");
+    pclose(inputFp);
     return false;
   }
 
@@ -96,6 +97,7 @@ bool hashVideoFile(
             "%s: failed to hash frame buffer. Frame width or height smaller than minimum hashable dimension. %d.\n",
             argv0,
             fno);
+        pclose(inputFp);
         return false;
       }
       // Push to pdqHashes vector
@@ -114,6 +116,7 @@ bool hashVideoFile(
           (int)fread_rc);
     }
   }
+  pclose(inputFp);
   return true;
 }
 

--- a/vpdq/cpp/io/vpdqio.cpp
+++ b/vpdq/cpp/io/vpdqio.cpp
@@ -129,6 +129,7 @@ bool readVideoStreamInfo(
         "%s: could not open video \"%s\".\n",
         programName,
         inputVideoFileName.c_str());
+    avformat_free_context(pFormatCtx);
     return false;
   }
   AVCodecContext* pCodecCtx;
@@ -140,6 +141,7 @@ bool readVideoStreamInfo(
         "%s: could not find video stream info \"%s\".\n",
         programName,
         inputVideoFileName.c_str());
+    avformat_close_input(&pFormatCtx);
     return false;
   }
   for (int i = 0; i < pFormatCtx->nb_streams; i++) {
@@ -154,6 +156,7 @@ bool readVideoStreamInfo(
         "%s: could not find video stream \"%s\".\n",
         programName,
         inputVideoFileName.c_str());
+    avformat_close_input(&pFormatCtx);
     return false;
   }
   AVCodecParameters* videoParameter =
@@ -162,6 +165,7 @@ bool readVideoStreamInfo(
   width = videoParameter->width;
   AVRational fr = pFormatCtx->streams[videoStream]->avg_frame_rate;
   framesPerSec = (double)fr.num / (double)fr.den;
+  avformat_close_input(&pFormatCtx);
   return true;
 }
 // readVideoDuration is not used in calculating VPDQ for now
@@ -178,9 +182,11 @@ bool readVideoDuration(
         "%s: could not open video \"%s\".\n",
         programName,
         inputVideoFileName.c_str());
+    avformat_free_context(pFormatCtx);
     return false;
   }
   durationInSec = (double)pFormatCtx->duration / MILLISEC_IN_SEC;
+  avformat_close_input(&pFormatCtx);
   return true;
 }
 } // namespace io

--- a/vpdq/python/vpdq.pyx
+++ b/vpdq/python/vpdq.pyx
@@ -145,6 +145,8 @@ def computeHash(
     if downsample_height == 0:
         downsample_height = vid.get(cv2.CAP_PROP_FRAME_HEIGHT)
 
+    vid.release()
+
     rt = hashVideoFile(
         str_path.encode("utf-8"),
         vpdq_hash,


### PR DESCRIPTION
Summary
---------

## Files are leaked because they're never closed


The video files are being read using `popen()`, but they are not closed before going out of scope. Unlike fstream, which automatically releases resources, `popen()` requires the use of `pclose()`.

`popen()` does not automatically release resources like fstream does. It requires `pclose()`.

I fixed this by calling `pclose()` before the opened file goes out of scope in order to release the files.

---

Additionally, `avformat_open_input()` and `avformat_alloc_context()` require releasing after allocation.

`avformat_open_input()` is released by `avformat_close_input()`, which will also call `avformat_free_context()`. If `avformat_open_input()` fails, the context still needs to be freed.

I fixed this by calling `avformat_close_input()` before returning from functions that opened input. But, if `avformat_close_input()` fails, I called `avformat_free_context()` to release the context.

---

Finally, in the Python binding, video files are read using OpenCV, but they are not immediately released after reading.

I fixed this by calling `vid.release()` after the video is read and the attributes are extracted.

This does not appear to directly affect the file leaks above because they are released by the VideoCapture destructor, but it would allow other processes access to file during `hashVideoFile` which could take some time to run.

Test Plan
---------

Get number of files open:

```sh
lsof | wc -l
```

You can see that if you run computeHash multiple times it will never clean up the files and the number of files open will continually increase.