### PR TITLE
[vpdq] Fix resource leak during hashing

### DIFF
--- a/vpdq/cpp/hashing/filehasher.cpp
+++ b/vpdq/cpp/hashing/filehasher.cpp
@@ -60,6 +60,7 @@ bool hashVideoFile(
       vpdq::hashing::FrameBufferHasherFactory::createFrameHasher(height, width);
   if (phasher == nullptr) {
     fprintf(stderr, "Error: Phasher is null");
+    pclose(inputFp);
     return false;
   }
 
@@ -96,6 +97,7 @@ bool hashVideoFile(
             "%s: failed to hash frame buffer. Frame width or height smaller than minimum hashable dimension. %d.\n",
             argv0,
             fno);
+        pclose(inputFp);
         return false;
       }
       // Push to pdqHashes vector
@@ -114,6 +116,7 @@ bool hashVideoFile(
           (int)fread_rc);
     }
   }
+  pclose(inputFp);
   return true;
 }
 

--- a/vpdq/cpp/hashing/filehasher.cpp
+++ b/vpdq/cpp/hashing/filehasher.cpp
@@ -100,8 +100,19 @@ bool hashVideoFile(
         pclose(inputFp);
         return false;
       }
+
+      // Avoid divide by zero when calculating timestamp
+      // The timestamp will equal the frame number of the hash
+      // if framesPerSec <= 0. This is common on very short videos.
+      double timestamp = 0;
+      if (framesPerSec > 0) {
+        timestamp = (double)fno / framesPerSec;
+      } else {
+        timestamp = fno;
+      }
+
       // Push to pdqHashes vector
-      pdqHashes.push_back({pdqHash, fno, quality, (double)fno / framesPerSec});
+      pdqHashes.push_back({pdqHash, fno, quality, timestamp});
       if (verbose) {
         printf("PDQHash: %s \n", pdqHash.format().c_str());
       }

--- a/vpdq/cpp/hashing/filehasher.cpp
+++ b/vpdq/cpp/hashing/filehasher.cpp
@@ -100,19 +100,8 @@ bool hashVideoFile(
         pclose(inputFp);
         return false;
       }
-
-      // Avoid divide by zero when calculating timestamp
-      // The timestamp will equal the frame number of the hash
-      // if framesPerSec <= 0. This is common on very short videos.
-      double timestamp = 0;
-      if (framesPerSec > 0) {
-        timestamp = (double)fno / framesPerSec;
-      } else {
-        timestamp = fno;
-      }
-
       // Push to pdqHashes vector
-      pdqHashes.push_back({pdqHash, fno, quality, timestamp});
+      pdqHashes.push_back({pdqHash, fno, quality, (double)fno / framesPerSec});
       if (verbose) {
         printf("PDQHash: %s \n", pdqHash.format().c_str());
       }

--- a/vpdq/cpp/io/vpdqio.cpp
+++ b/vpdq/cpp/io/vpdqio.cpp
@@ -140,7 +140,7 @@ bool readVideoStreamInfo(
         "%s: could not find video stream info \"%s\".\n",
         programName,
         inputVideoFileName.c_str());
-    avformat_close_input(&pFormatCtx)
+    avformat_close_input(&pFormatCtx);
     return false;
   }
   for (int i = 0; i < pFormatCtx->nb_streams; i++) {

--- a/vpdq/cpp/io/vpdqio.cpp
+++ b/vpdq/cpp/io/vpdqio.cpp
@@ -140,6 +140,7 @@ bool readVideoStreamInfo(
         "%s: could not find video stream info \"%s\".\n",
         programName,
         inputVideoFileName.c_str());
+    avformat_close_input(&pFormatCtx)
     return false;
   }
   for (int i = 0; i < pFormatCtx->nb_streams; i++) {
@@ -154,6 +155,7 @@ bool readVideoStreamInfo(
         "%s: could not find video stream \"%s\".\n",
         programName,
         inputVideoFileName.c_str());
+    avformat_close_input(&pFormatCtx);
     return false;
   }
   AVCodecParameters* videoParameter =
@@ -162,6 +164,7 @@ bool readVideoStreamInfo(
   width = videoParameter->width;
   AVRational fr = pFormatCtx->streams[videoStream]->avg_frame_rate;
   framesPerSec = (double)fr.num / (double)fr.den;
+  avformat_close_input(&pFormatCtx);
   return true;
 }
 // readVideoDuration is not used in calculating VPDQ for now
@@ -181,6 +184,7 @@ bool readVideoDuration(
     return false;
   }
   durationInSec = (double)pFormatCtx->duration / MILLISEC_IN_SEC;
+  avformat_close_input(&pFormatCtx);
   return true;
 }
 } // namespace io

--- a/vpdq/python/vpdq.pyx
+++ b/vpdq/python/vpdq.pyx
@@ -144,6 +144,8 @@ def computeHash(
 
     if downsample_height == 0:
         downsample_height = vid.get(cv2.CAP_PROP_FRAME_HEIGHT)
+    
+    vid.release()
 
     rt = hashVideoFile(
         str_path.encode("utf-8"),


### PR DESCRIPTION
## Summary

### Files are leaked because they're never closed

The video files are being read using `popen()`, but they are not closed before going out of scope. Unlike fstream, which automatically releases resources, `popen()` requires a corresponding `pclose()`.

I fixed this by calling `pclose()` before the opened file goes out of scope in order to release the files.

---

Additionally, `avformat_open_input()` and `avformat_alloc_context()` require releasing after allocation.

`avformat_open_input()` is released by `avformat_close_input()`, which will also call `avformat_free_context()`. If `avformat_open_input()` fails, the context will be automatically freed during the failure so nothing more has to be done.

I fixed the leak by calling `avformat_close_input()` before the returns of functions that opened input.

---

Finally, in the Python binding, video files are read using OpenCV, but they are not immediately released after reading.

I fixed this by calling vid.release() after the video is read and the attributes are extracted.

This does not appear to directly affect the file leaks above because they are released by the VideoCapture destructor, but it would allow other processes access to file during hashVideoFile which could take some time to run.

### Test Plan

Get number of files open:

```
lsof | wc -l
```

You can see that if you run computeHash multiple times it will never clean up the files and the number of files open will continually increase.