### PR TITLE
[pdq] Avoid function call by loading pixels before iteration

### DIFF
--- a/pdq/python/pdqhashing/hasher/pdq_hasher.py
+++ b/pdq/python/pdqhashing/hasher/pdq_hasher.py
@@ -131,10 +131,11 @@ class PDQHasher:
     def fillFloatLumaFromBufferImage(self, img, luma):
         numCols, numRows = img.size
         rgb_image = img.convert("RGB")
-        numCols, numRows = img.size
+        pixels = rgb_image.load()
+
         for i in range(numRows):
             for j in range(numCols):
-                r, g, b = rgb_image.getpixel((j, i))
+                r, g, b = pixels[j, i]
                 luma[i * numCols + j] = (
                     self.LUMA_FROM_R_COEFF * r
                     + self.LUMA_FROM_G_COEFF * g


### PR DESCRIPTION
Summary
---------


Accessing individual pixels with Image.getpixel() is extremely slow, so by loading all the pixels before iterating there will be a huge performance gain.

This speeds up hashing by around 10% every image!

Also, there is a redundant `numCols, numRows = img.size()` for some reason that I also removed. This does not affect noticeably affect speed, and it does not affect functionality at all.

Test Plan
---------
Tested with a variety of image types. All of them passed.

No further tests will needed to be added because this just loads the image's pixels before iteration.
