### PR TITLE
Fall back to r_frame_rate if avg_frame_rate is 0

### DIFF
--- a/vpdq/cpp/io/vpdqio.cpp
+++ b/vpdq/cpp/io/vpdqio.cpp
@@ -161,9 +161,17 @@ bool readVideoStreamInfo(
   height = videoParameter->height;
   width = videoParameter->width;
   AVRational fr = pFormatCtx->streams[videoStream]->avg_frame_rate;
+
+  // if avg_frame_rate is 0, fall back to r_frame_rate which is the
+  // lowest framerate with which all timestamps can be represented accurately
+  if (fr.num == 0 || fr.den == 0) {
+    fr = pFormatCtx->streams[videoStream]->r_frame_rate;
+  }
+
   framesPerSec = (double)fr.num / (double)fr.den;
   return true;
 }
+
 // readVideoDuration is not used in calculating VPDQ for now
 bool readVideoDuration(
     const string& inputVideoFileName,


### PR DESCRIPTION
Summary
---------

avg_frame_rate will return 0 for some videos like extremely short GIFs. It's also not a guaranteed property for a given video stream.

r_frame_rate is an approximation for the framerate, see [this](https://stackoverflow.com/questions/14124321/when-could-fps-be-a-guess-and-not-exact-value) and [avformat.h](https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/avformat.h) from FFmpeg below.

```c
    /**
     * Real base framerate of the stream.
     * This is the lowest framerate with which all timestamps can be
     * represented accurately (it is the least common multiple of all
     * framerates in the stream). Note, this value is just a guess!
     * For example, if the time base is 1/90000 and all frames have either
     * approximately 3600 or 1800 timer ticks, then r_frame_rate will be 50/1.
     */
    AVRational r_frame_rate;
```

```c
    /**
     * Average framerate
     *
     * - demuxing: May be set by libavformat when creating the stream or in
     *             avformat_find_stream_info().
     * - muxing: May be set by the caller before avformat_write_header().
     */
    AVRational avg_frame_rate;
```

This is used for calculating the timestamp in a vpdqFeature.

```c
pdqHashes.push_back({pdqHash, fno, quality, (double)fno / framesPerSec});
```

The timestamp isn't used at all for matching videos in the included match brute force implementation. For extremely short videos I can't imagine that the timestamp for video a couple frames long would matter anyway for whatever heuristic you're using to compare videos.

Additionally, calculating timestamp via average frame rate is not accurate for variable frame rate videos. The actual value this is trying to estimate for a frame is the [presentation timestamp](https://en.wikipedia.org/wiki/Presentation_timestamp) (PTS).

I see [here](https://github.com/facebook/ThreatExchange/pull/1068) that the duration was replaced with timestamp, but duration is a property that makes sense for all videos while average frame rate is not if you're trying to calculate a timestamp.

I'm not sure why a feature even includes a timestamp. It already includes a frame number which can be used (sometimes inaccurately) with the frame rate to estimate the PTS. If it's not used and not even a potential use is mentioned in the reference implementation, then why is it included in every single feature?

Test Plan
---------

Test hashing extremely short GIFs (like 2 frames short) and see that avg_frame_rate will equal -nan. This is not a bug that only affects broken/corrupted videos.

I tested with the attached 2 frame long GIF and avg_frame_rate = -nan while r_frame_rate = 25.000000

The GIF can be added to the tests. It's tmk/sample-videos/chair-19-sd-bar.mp4 but converted it to a GIF and cut to only 2 frames.

![chair-19-sd-bar-2frame](https://github.com/facebook/ThreatExchange/assets/52143079/9d0204d6-1529-4cd2-b947-95d850e695e7)