### PR TITLE
[vpdq] Regression test improvements for local development

### DIFF
--- a/.github/workflows/vpdq-ci-cpp.yml
+++ b/.github/workflows/vpdq-ci-cpp.yml
@@ -17,7 +17,7 @@ on:
 
 defaults:
   run:
-    working-directory: vpdq/cpp
+    working-directory: vpdq
 
 jobs:
   build-and-test:
@@ -31,11 +31,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y make cmake ffmpeg libavdevice-dev libavfilter-dev libavformat-dev libavcodec-dev libswresample-dev libswscale-dev libavutil-dev
-          mkdir -p build
-          cd build
+          mkdir -p cpp/build
+          cd cpp/build
           cmake ..
           make
       - name: regression test
         run: |
-          mkdir -p output-hashes
-          python regtest.py -d ${GITHUB_WORKSPACE}/vpdq/cpp/output-hashes -i ${GITHUB_WORKSPACE}/tmk/sample-videos
+          mkdir -p cpp/output-hashes
+          python cpp/regtest.py -d ${GITHUB_WORKSPACE}/vpdq/cpp/output-hashes -i ${GITHUB_WORKSPACE}/tmk/sample-videos

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -11,6 +11,7 @@ VPDQ_DIR = DIR.parent
 SAMPLE_HASHES_DIR = VPDQ_DIR / "sample-hashes"
 EXEC_DIR = VPDQ_DIR / "cpp/build"
 
+
 def get_argparse() -> argparse.ArgumentParser:
     DEFAULT_OUTPUT_HASHES_DIR = VPDQ_DIR / "output-hashes"
     DEFAULT_SAMPLE_VIDEOS_DIR = VPDQ_DIR.parent / "tmk/sample-videos"
@@ -108,6 +109,11 @@ def main():
     distanceTolerance = str(args.matchDistanceTolerance)
     qualityTolerance = str(args.qualityTolerance)
     verbose = args.verbose
+
+    if not inputVideoFolder.exists():
+        raise argparse.ArgumentTypeError(
+            f"inputVideoFolder: {inputVideoFolder} does not exist."
+        )
 
     outputHashFolder.mkdir(parents=True, exist_ok=True)
 

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -148,7 +148,11 @@ def main():
             if verbose:
                 command.insert(1, "-v")
 
-            subprocess.call(command)
+            try:
+                subprocess.check_call(command)
+            except subprocess.CalledProcessError as e:
+                print(e)
+                sys.exit(1)
 
             if outputHashFolder is not None:
                 copyfile(file, outputHashFolder / outputHashFileName)
@@ -170,7 +174,11 @@ def main():
             if verbose:
                 command.insert(1, "-v")
 
-            subprocess.call(command)
+            try:
+                subprocess.check_call(command)
+            except subprocess.CalledProcessError as e:
+                print(e)
+                sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -8,13 +8,13 @@ import glob
 
 DIR = Path(__file__).parent
 VPDQ_DIR = DIR.parent
-SAMPLE_VIDEOS_DIR = VPDQ_DIR.parent / "tmk/sample-videos"
 SAMPLE_HASHES_DIR = VPDQ_DIR / "sample-hashes"
-OUTPUT_HASHES_DIR = VPDQ_DIR / "output-hashes"
 EXEC_DIR = VPDQ_DIR / "cpp/build"
 
-
 def get_argparse() -> argparse.ArgumentParser:
+    DEFAULT_OUTPUT_HASHES_DIR = VPDQ_DIR / "output-hashes"
+    DEFAULT_SAMPLE_VIDEOS_DIR = VPDQ_DIR.parent / "tmk/sample-videos"
+
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
         "-f",
@@ -36,7 +36,7 @@ def get_argparse() -> argparse.ArgumentParser:
         "--outputHashFolder",
         metavar="OUTPUT_HASH_Folder_PATH",
         help="Output Hash Folder's Name",
-        default=OUTPUT_HASHES_DIR,
+        default=DEFAULT_OUTPUT_HASHES_DIR,
         type=dir_path,
     )
     ap.add_argument(
@@ -44,7 +44,7 @@ def get_argparse() -> argparse.ArgumentParser:
         "--inputVideoFolder",
         metavar="INPUTPUT_VIDEO_FOLDER_PATH",
         help="Input Video Folder",
-        default=SAMPLE_VIDEOS_DIR,
+        default=DEFAULT_SAMPLE_VIDEOS_DIR,
         type=dir_path,
     )
     ap.add_argument(
@@ -149,14 +149,13 @@ def main():
 
         subprocess.call(command)
 
-    for fileStr in glob.iglob(f"{outputHashFolder}/**/*.txt", recursive=True):
-        file = Path(fileStr)
-        print(f"\nMatching File {file.name}")
-        outputFile = outputHashFolder / file.name
-
+    for outputFileStr in glob.iglob(f"{outputHashFolder}/**/*.txt", recursive=True):
+        outputFile = Path(outputFileStr)
+        sampleFile = SAMPLE_HASHES_DIR / outputFile.name
+        print(f"\nMatching File {sampleFile.name}")
         command = [
             matchHashesExecutable,
-            file,
+            sampleFile,
             outputFile,
             distanceTolerance,
             qualityTolerance,

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -18,13 +18,6 @@ def get_argparse() -> argparse.ArgumentParser:
 
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
-        "-f",
-        "--ffmpegPath",
-        metavar="FFMPEG_PATH",
-        help="Specific path to ffmpeg you want to use",
-        default="ffmpeg",
-    )
-    ap.add_argument(
         "-r",
         "--secondsPerHash",
         metavar="NON_NEGATIVE_FLOAT",
@@ -103,7 +96,6 @@ def main():
     args = ap.parse_args()
     inputVideoFolder = Path(args.inputVideoFolder)
     outputHashFolder = Path(args.outputHashFolder)
-    ffmpegPath = args.ffmpegPath
     secondsPerHash = str(args.secondsPerHash)
     downsampleFrameDimension = str(args.downsampleFrameDimension)
     distanceTolerance = str(args.matchDistanceTolerance)
@@ -138,8 +130,6 @@ def main():
 
         command = [
             hashVideoExecutable,
-            "-f",
-            ffmpegPath,
             "-r",
             secondsPerHash,
             "-d",

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from shutil import copyfile
 import glob
+import platform
 
 DIR = Path(__file__).parent
 VPDQ_DIR = DIR.parent
@@ -77,6 +78,10 @@ def get_argparse() -> argparse.ArgumentParser:
 def main():
     hashVideoExecutable = EXEC_DIR / "vpdq-hash-video"
     matchHashesExecutable = EXEC_DIR / "match-hashes-byline"
+
+    if platform.system() == "Windows":
+        hashVideoExecutable = Path(f"{hashVideoExecutable}.exe")
+        matchHashesExecutable = Path(f"{matchHashesExecutable}.exe")
 
     if not hashVideoExecutable.exists() or not matchHashesExecutable.exists():
         print(

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -144,8 +144,7 @@ def main():
 
             # Create output hash file in a tempdir
             outputHashFile = tempOutputHashFolder / f"{file.stem}.txt"
-            with open(outputHashFile, "x+t"):
-                pass
+            outputHashFile.touch(exist_ok=False)
 
             print(f"\nHashing file {file.name}")
             command = [

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -111,7 +111,9 @@ def main():
             if not outputHashFolder.exists():
                 print(f"Creating output directory at {outputHashFolder}")
                 outputHashFolder.mkdir(parents=True, exist_ok=True)
-
+            print(f"Writing output to directory: {outputHashFolder}")
+        else:
+            print(f"Writing output to temp directory: {tempOutputHashFolder}")
         # TODO: Add more general options for other video extensions.
         for fileStr in glob.iglob(f"{inputVideoFolder}/**/*.mp4", recursive=True):
             file = Path(fileStr)
@@ -129,10 +131,10 @@ def main():
             b = stripExtension(b, ".");
             outputHashFileName = outputDirectory + "/" + b + ".txt";
             """
-            outputHashFileName = tempOutputHashFolder / f"{file.stem}.txt"
-            with open(outputHashFileName, "w"):
+            outputHashFile = tempOutputHashFolder / f"{file.stem}.txt"
+            with open(outputHashFile, "x+t"):
                 pass
-
+            print(f"\nHashing file {file.name}")
             command = [
                 hashVideoExecutable,
                 "-r",
@@ -155,13 +157,12 @@ def main():
                 sys.exit(1)
 
             if outputHashFolder is not None:
-                copyfile(file, outputHashFolder / outputHashFileName)
-
+                copyfile(outputHashFile, Path(outputHashFolder / outputHashFile.name))
         for outputFileStr in glob.iglob(
             f"{tempOutputHashFolder}/**/*.txt", recursive=True
         ):
             outputFile = Path(outputFileStr)
-            sampleFile = SAMPLE_HASHES_DIR / outputFile.name
+            sampleFile = Path(SAMPLE_HASHES_DIR / outputFile.name)
             print(f"\nMatching File {sampleFile.name}")
             command = [
                 matchHashesExecutable,

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -89,10 +89,15 @@ def dir_path(string):
 
 
 def main():
-    if not EXEC_DIR.exists():
-        print(f"Error: {EXEC_DIR} does not exist.")
-        print(f"Build vpdq before running regtest.")
+    hashVideoExecutable = EXEC_DIR / "vpdq-hash-video"
+    matchHashesExecutable = EXEC_DIR / "match-hashes-byline"
+
+    if not hashVideoExecutable.exists() or not matchHashesExecutable.exists():
+        print(
+            "Error: Hashing executable/s not found. Build vpdq before running regtest."
+        )
         sys.exit(1)
+
     ap = get_argparse()
     args = ap.parse_args()
     inputVideoFolder = Path(args.inputVideoFolder)
@@ -103,9 +108,6 @@ def main():
     distanceTolerance = str(args.matchDistanceTolerance)
     qualityTolerance = str(args.qualityTolerance)
     verbose = args.verbose
-
-    hashVideoExecutable = EXEC_DIR / "vpdq-hash-video"
-    matchHashesExecutable = EXEC_DIR / "match-hashes-byline"
 
     outputHashFolder.mkdir(parents=True, exist_ok=True)
 

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -122,9 +122,9 @@ def main():
             Create output hash file or overwrite existing file
             This is hardcoded in cpp, and it
             does not create the file if it does not exist:
-            
+
             vpdq-hash-video.cpp:
-            
+
             // Strip containing directory:
             std::string b = basename(inputVideoFileName, "/");
             // Strip file extension:
@@ -163,7 +163,9 @@ def main():
         ):
             outputFile = Path(outputFileStr)
             sampleFile = Path(SAMPLE_HASHES_DIR / outputFile.name)
-            print(f"\nMatching File {sampleFile.name}")
+            print(
+                f"\nMatching Video {sampleFile.name} from hash file {outputFile.name}"
+            )
             command = [
                 matchHashesExecutable,
                 sampleFile,

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -24,7 +24,8 @@ def get_os() -> str:
     elif platform.system() == "Linux":
         return "Linux"
     else:
-        raise Exception("Unsupported OS")
+        print("Unknown OS. Unexpected results may occur.")
+        return "Unknown"
 
 
 def get_argparse() -> argparse.ArgumentParser:
@@ -134,7 +135,7 @@ def main():
             if not outputHashFolder.exists():
                 print(f"Creating output directory at {outputHashFolder}")
                 outputHashFolder.mkdir(parents=True)
-            print(f"Writing output to directory: {outputHashFolder}")
+            print(f"Writing output hash files to directory: {outputHashFolder}")
         else:
             print(f"Writing output to temp directory: {tempOutputHashFolder}")
         # TODO: Add more general options for other video extensions.
@@ -160,6 +161,9 @@ def main():
             ]
 
             if verbose:
+                # Print all PDQHashes e.g.
+                # PDQHash: ebcc8b06b0666ea34cf9b85972a983a4f94668af05fc9d52aa9662f975499514
+                # selectframe 563
                 command.insert(1, "-v")
 
             try:
@@ -169,17 +173,13 @@ def main():
                     capture_output=True,
                     shell=(OS == "Windows"),
                 )
-                if verbose:
-                    # Print all PDQHashes e.g.
-                    # PDQHash: ebcc8b06b0666ea34cf9b85972a983a4f94668af05fc9d52aa9662f975499514
-                    # selectframe 563
-                    print(str(hash_proc.stdout, "utf-8"))
+                print(str(hash_proc.stdout, "utf-8"))
             except subprocess.CalledProcessError as e:
-                print(e.cmd)
+                print(" ".join([str(i) for i in e.cmd]))
                 print(str(e.stderr, "utf-8"))
                 sys.exit(1)
 
-            # Copy hash files to output directory if it is specified.
+            # Copy hash files to output directory if it is specified
             # This will overwrite existing files with the same
             # name as outputHashFile in the directory
             if outputHashFolder is not None:
@@ -201,6 +201,9 @@ def main():
             ]
 
             if verbose:
+                # Print all PDQHashes and if they match e.g.
+                # Line 201 Hash1: da4b380330b725b4a5f08ff03d0f6949da4fd2d3e7c8e4930fa7b80662a17c4e
+                # Hash2: da4b380330b725b4a5f08ff03d0f6949da4fd2d3e7c8e4930fa7b80662a17c4e match
                 command.insert(1, "-v")
 
             try:
@@ -210,11 +213,7 @@ def main():
                     capture_output=True,
                     shell=(OS == "Windows"),
                 )
-                if verbose:
-                    # Print all PDQHashes and if they match e.g.
-                    # Line 201 Hash1: da4b380330b725b4a5f08ff03d0f6949da4fd2d3e7c8e4930fa7b80662a17c4e
-                    # Hash2: da4b380330b725b4a5f08ff03d0f6949da4fd2d3e7c8e4930fa7b80662a17c4e match
-                    print(str(match_proc.stdout, "utf-8"))
+                print(str(match_proc.stdout, "utf-8"))
             except subprocess.CalledProcessError as e:
                 print(e.cmd)
                 print(str(e.stderr, "utf-8"))

--- a/vpdq/cpp/regtest.py
+++ b/vpdq/cpp/regtest.py
@@ -95,8 +95,8 @@ def main():
         sys.exit(1)
     ap = get_argparse()
     args = ap.parse_args()
-    inputVideoFolder = args.inputVideoFolder
-    outputHashFolder = args.outputHashFolder
+    inputVideoFolder = Path(args.inputVideoFolder)
+    outputHashFolder = Path(args.outputHashFolder)
     ffmpegPath = args.ffmpegPath
     secondsPerHash = str(args.secondsPerHash)
     downsampleFrameDimension = str(args.downsampleFrameDimension)
@@ -107,7 +107,7 @@ def main():
     hashVideoExecutable = EXEC_DIR / "vpdq-hash-video"
     matchHashesExecutable = EXEC_DIR / "match-hashes-byline"
 
-    Path(outputHashFolder).mkdir(parents=True, exist_ok=True)
+    outputHashFolder.mkdir(parents=True, exist_ok=True)
 
     # TODO: Add more general options for other video extensions.
     for fileStr in glob.iglob(f"{inputVideoFolder}/**/*.mp4", recursive=True):


### PR DESCRIPTION
Summary
---------

Improvements to the regression test for local runs:

- Create output dir if it doesn't exist

- Create output files if they do not exist

- Changed default directories so that they work locally

- Remove duplicate code just for verbosity option

With these changes you can just run regtest.py and it will run locally with the defaults.

Before, the defaults were set to stuff like "/ThreatExchange/vpdq/output-hashes". I don't know why.

You can also run `regtest.py` from anywhere, you don't have to be in cpp/build.

I also changed all of the os.path stuff to Path. It's much nicer to work with.

I don't see a reason why the cpp CI test working directory shouldn't be set to the whole directory, especially since it accesses it anyway to get the sample hashes.

Test Plan
---------

Run the CI test and regtest.py locally. See that it outputs correctly.

Perhaps take a close look at the things I changed since it's a regression test. But, the test "passes" anyway even if it fails as long as it compiles and executes so the changes can't do too much harm...

<details>
<summary>Example regtest.py run</summary>

```sh

Writing output to temp directory: /tmp/tmpshrfc681

Hashing file chair-19-sd-bar.mp4


Hashing file chair-20-sd-bar.mp4


Hashing file chair-22-sd-grey-bar.mp4


Hashing file chair-22-sd-sepia-bar.mp4


Hashing file chair-22-with-large-logo-bar.mp4


Hashing file chair-22-with-small-logo-bar.mp4


Hashing file chair-orig-22-fhd-no-bar.mp4


Hashing file chair-orig-22-hd-no-bar.mp4


Hashing file chair-orig-22-sd-bar.mp4


Hashing file doorknob-hd-no-bar.mp4


Hashing file pattern-hd-no-bar.mp4


Hashing file pattern-longer-no-bar.mp4


Hashing file pattern-sd-grey-bar.mp4


Hashing file pattern-sd-with-large-logo-bar.mp4


Hashing file pattern-sd-with-small-logo-bar.mp4


Matching Video chair-19-sd-bar.txt from hash file chair-19-sd-bar.txt
100.000000 Percentage  matches


Matching Video chair-20-sd-bar.txt from hash file chair-20-sd-bar.txt
100.000000 Percentage  matches


Matching Video chair-22-sd-grey-bar.txt from hash file chair-22-sd-grey-bar.txt
100.000000 Percentage  matches


Matching Video chair-22-sd-sepia-bar.txt from hash file chair-22-sd-sepia-bar.txt
100.000000 Percentage  matches


Matching Video chair-22-with-large-logo-bar.txt from hash file chair-22-with-large-logo-bar.txt
100.000000 Percentage  matches


Matching Video chair-22-with-small-logo-bar.txt from hash file chair-22-with-small-logo-bar.txt
100.000000 Percentage  matches


Matching Video chair-orig-22-fhd-no-bar.txt from hash file chair-orig-22-fhd-no-bar.txt
100.000000 Percentage  matches


Matching Video chair-orig-22-hd-no-bar.txt from hash file chair-orig-22-hd-no-bar.txt
100.000000 Percentage  matches


Matching Video chair-orig-22-sd-bar.txt from hash file chair-orig-22-sd-bar.txt
100.000000 Percentage  matches


Matching Video doorknob-hd-no-bar.txt from hash file doorknob-hd-no-bar.txt
100.000000 Percentage  matches


Matching Video pattern-hd-no-bar.txt from hash file pattern-hd-no-bar.txt
100.000000 Percentage  matches


Matching Video pattern-longer-no-bar.txt from hash file pattern-longer-no-bar.txt
100.000000 Percentage  matches


Matching Video pattern-sd-grey-bar.txt from hash file pattern-sd-grey-bar.txt
100.000000 Percentage  matches


Matching Video pattern-sd-with-large-logo-bar.txt from hash file pattern-sd-with-large-logo-bar.txt
100.000000 Percentage  matches


Matching Video pattern-sd-with-small-logo-bar.txt from hash file pattern-sd-with-small-logo-bar.txt
100.000000 Percentage  matches

```
</details>
