### PR TITLE
[vpdq] Cleanup matchTwoHash

### DIFF
--- a/vpdq/cpp/hashing/matchTwoHash.cpp
+++ b/vpdq/cpp/hashing/matchTwoHash.cpp
@@ -8,24 +8,19 @@
 #include <vpdq/cpp/hashing/vpdqHashType.h>
 #include <vpdq/cpp/io/vpdqio.h>
 
-using namespace std;
-
 namespace facebook {
 namespace vpdq {
 namespace hashing {
 bool matchTwoHashBrute(
-    vector<vpdq::hashing::vpdqFeature> qHashes,
-    vector<vpdq::hashing::vpdqFeature> tHashes,
+    std::vector<vpdq::hashing::vpdqFeature> qHashes,
+    std::vector<vpdq::hashing::vpdqFeature> tHashes,
     int distanceTolerance,
     int qualityTolerance,
     double& qMatch,
     double& tMatch,
-    bool verbose) {
-  vector<vpdq::hashing::vpdqFeature> queryFiltered, targetFiltered;
-  int qMatchCnt = 0;
-  int tMatchCnt = 0;
-
+    const bool verbose) {
   // Filter low quality hashes for query
+  std::vector<vpdq::hashing::vpdqFeature> queryFiltered;
   for (const auto& qHash : qHashes) {
     if (qHash.quality >= qualityTolerance) {
       queryFiltered.push_back(qHash);
@@ -39,6 +34,7 @@ bool matchTwoHashBrute(
   }
 
   // Filter low quality hashes for target
+  std::vector<vpdq::hashing::vpdqFeature> targetFiltered;
   for (const auto& tHash : tHashes) {
     if (tHash.quality >= qualityTolerance) {
       targetFiltered.push_back(tHash);
@@ -52,6 +48,7 @@ bool matchTwoHashBrute(
   }
 
   // Get matches for query in target
+  unsigned int qMatchCnt = 0;
   for (const auto& qHash : queryFiltered) {
     for (const auto& tHash : targetFiltered) {
       if (qHash.pdqHash.hammingDistance(tHash.pdqHash) < distanceTolerance) {
@@ -67,6 +64,7 @@ bool matchTwoHashBrute(
   }
 
   // Get matches for target in query
+  unsigned int tMatchCnt = 0;
   for (const auto& tHash : targetFiltered) {
     for (const auto& qHash : queryFiltered) {
       if (tHash.pdqHash.hammingDistance(qHash.pdqHash) < distanceTolerance) {
@@ -81,8 +79,8 @@ bool matchTwoHashBrute(
     }
   }
 
-  qMatch = (float)qMatchCnt * 100 / queryFiltered.size();
-  tMatch = (float)tMatchCnt * 100 / targetFiltered.size();
+  qMatch = (qMatchCnt * 100.0) / queryFiltered.size();
+  tMatch = (tMatchCnt * 100.0) / targetFiltered.size();
   return true;
 }
 } // namespace hashing

--- a/vpdq/cpp/hashing/matchTwoHash.cpp
+++ b/vpdq/cpp/hashing/matchTwoHash.cpp
@@ -52,7 +52,7 @@ static std::vector<vpdq::hashing::vpdqFeature> filterFeatures(
  *
  * @return Number of matches
  */
-static unsigned int findMatches(
+static std::vector<vpdq::hashing::vpdqFeature>::size_type findMatches(
     const std::vector<vpdq::hashing::vpdqFeature>& features1,
     const std::vector<vpdq::hashing::vpdqFeature>& features2,
     const int distanceTolerance,

--- a/vpdq/cpp/hashing/matchTwoHash.h
+++ b/vpdq/cpp/hashing/matchTwoHash.h
@@ -29,8 +29,8 @@ namespace hashing {
 bool matchTwoHashBrute(
     std::vector<vpdq::hashing::vpdqFeature> qHashes,
     std::vector<vpdq::hashing::vpdqFeature> tHashes,
-    int distanceTolerance,
-    int qualityTolerance,
+    const int distanceTolerance,
+    const int qualityTolerance,
     double& qMatch,
     double& tMatch,
     const bool verbose);

--- a/vpdq/cpp/hashing/matchTwoHash.h
+++ b/vpdq/cpp/hashing/matchTwoHash.h
@@ -7,14 +7,12 @@
 #ifndef MATCHTWOHASH_H
 #define MATCHTWOHASH_H
 
-using namespace std;
-
 namespace facebook {
 namespace vpdq {
 namespace hashing {
 /**
  * Compare two vpdq hash vectors in brute-force.
- * Result in two float percentage number qMatch, tMatch
+ * Result in two double percentages: qMatch, tMatch
  *
  * @param qHashes Query video's hash
  * @param tHashes Target video's hash
@@ -29,13 +27,13 @@ namespace hashing {
  * @return If successfully hash the video
  */
 bool matchTwoHashBrute(
-    vector<vpdq::hashing::vpdqFeature> qHashes,
-    vector<vpdq::hashing::vpdqFeature> tHashes,
+    std::vector<vpdq::hashing::vpdqFeature> qHashes,
+    std::vector<vpdq::hashing::vpdqFeature> tHashes,
     int distanceTolerance,
     int qualityTolerance,
     double& qMatch,
     double& tMatch,
-    bool verbose);
+    const bool verbose);
 } // namespace hashing
 } // namespace vpdq
 } // namespace facebook


### PR DESCRIPTION
Summary
---------

Use idiomatic C++ in general:
 - Iterate over vectors with range based for loops
 - Use std::cout instead of printf for verbose output. 

Reduce repeated code by moving them into two functions: filterFeatures and findMatches.

I also fixed casting to the wrong type for the result. It should be a double but it was cast to a float. C++ doesn't need the dividend to be cast at all.
If you use 100.0 it's guaranteed to be a double since C++11, otherwise you have to use the suffix "f".

I made the parameters const because that's what `filehasher.h` does, even if they're passed by value.

Test Plan
---------

Compare old output to new output and see that they're the same.

regtest.py is not very useful with these changes because it will be using this function to test. There should probably be some false-positive tests added because right now it only shows 100.0% for all. There should be some test videos that should not be matches.

Timed with [hyperfine](https://github.com/sharkdp/hyperfine) and performance is the same as before the changes.
