### PR TITLE
[pdq] Apply missing DCT scaling factor

### DIFF
--- a/pdq/python/pdqhashing/hasher/pdq_hasher.py
+++ b/pdq/python/pdqhashing/hasher/pdq_hasher.py
@@ -51,12 +51,11 @@ class PDQHasher:
     DCT_matrix: List[List[float]] = []
 
     def compute_dct_matrix(self):
-        matrix_scale_factor = math.sqrt(2.0 / 64.0)
         d = [0] * 16
         for i in range(0, 16):
             di = [0] * 64
             for j in range(0, 64):
-                di[j] = math.cos((math.pi / 2 / 64.0) * (i + 1) * (2 * j + 1))
+                di[j] = self.DCT_MATRIX_SCALE_FACTOR * math.cos((math.pi / 2 / 64.0) * (i + 1) * (2 * j + 1))
             d[i] = di
         return d
 


### PR DESCRIPTION
Summary
---------

Apply missing matrix scaling factor during discrete cosine transform calculation.

This is in the CPP implementation, but the scaling factor is not applied in the Python implementation. It produces the exact same hash, but the DCT matrix will be different internally.

CPP version (from pdqhashing.cpp):

```cpp
static float* fill_dct_matrix_64_cached() {
  static bool initialized = false;
  static float buffer[16 * 64];
  if (!initialized) {
    const float matrix_scale_factor = std::sqrt(2.0 / 64.0);
    for (int i = 0; i < 16; i++) {
      for (int j = 0; j < 64; j++) {
        buffer[i * 64 + j] = matrix_scale_factor *
            cos((M_PI / 2 / 64.0) * (i + 1) * (2 * j + 1));
      }
    }
    initialized = false;
  }
  return &buffer[0];
}
```


Test Plan
---------

Run the Python tests and see they all pass. You can change hamming_tolerance to 0 to see that they're identical.