### PR TITLE
[pdq] Replace POSIX dependent functions with STL equivalent

### DIFF
--- a/pdq/cpp/bin/clusterize256x.cpp
+++ b/pdq/cpp/bin/clusterize256x.cpp
@@ -6,6 +6,9 @@
 #define _GNU_SOURCE
 #endif
 
+#include <fstream>
+#include <iostream>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -47,7 +50,7 @@ const int DEFAULT_PDQ_DISTANCE_THRESHOLD = 31;
 
 // ----------------------------------------------------------------
 static void handle_fp(
-    FILE* fp,
+    std::istream& in,
     MIH256<std::string>& mih,
     std::map<Hash256, int>& centersToIndices,
     int distanceThreshold,
@@ -131,7 +134,7 @@ int main(int argc, char** argv) {
   int counter = 0;
   if (argi == argc) {
     handle_fp(
-        stdin,
+        std::cin,
         mih,
         centersToIndices,
         distanceThreshold,
@@ -143,15 +146,15 @@ int main(int argc, char** argv) {
   } else {
     for (; argi < argc; argi++) {
       char* filename = argv[argi];
-      FILE* fp = fopen(filename, "r");
-      if (fp == nullptr) {
+      std::ifstream in(filename);
+      if (!in) {
         perror("fopen");
         fprintf(stderr, "Could not open \"%s\" for read.\n", filename);
         exit(1);
       }
 
       handle_fp(
-          fp,
+          in,
           mih,
           centersToIndices,
           distanceThreshold,
@@ -161,7 +164,7 @@ int main(int argc, char** argv) {
           traceCount,
           doBruteForceQuery);
 
-      fclose(fp);
+      in.close();
     }
   }
 
@@ -170,7 +173,7 @@ int main(int argc, char** argv) {
 
 // ----------------------------------------------------------------
 static void handle_fp(
-    FILE* fp,
+    std::istream& in,
     MIH256<std::string>& mih,
     std::map<Hash256, int>& centersToIndices,
     int distanceThreshold,
@@ -183,7 +186,7 @@ static void handle_fp(
   std::string metadata;
 
   while (facebook::pdq::io::loadHashAndMetadataFromStream(
-      fp, hash, metadata, counter)) {
+      in, hash, metadata, counter)) {
     if (traceCount > 0) {
       if ((counter % traceCount) == 0) {
         fprintf(stderr, "-- %d\n", counter);

--- a/pdq/cpp/bin/hashtool256.cpp
+++ b/pdq/cpp/bin/hashtool256.cpp
@@ -11,8 +11,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
-#include <unistd.h>
 #include <pdq/cpp/common/pdqhashtypes.h>
 #include <pdq/cpp/io/hashio.h>
 
@@ -73,9 +71,7 @@ static void usage(char* argv0, int rc) {
 
 // ----------------------------------------------------------------
 int main(int argc, char** argv) {
-  srandom(time(nullptr) ^ getpid()); // seed the RNG for Hash256::fuzz
-
-  // Parse command-line flags. I'm expliclily not using gflags or other such
+  // Parse command-line flags. I'm explicitly not using gflags or other such
   // libraries, to minimize the number of external dependencies for this
   // project.
   if (argc < 2) {

--- a/pdq/cpp/bin/hashtool256.cpp
+++ b/pdq/cpp/bin/hashtool256.cpp
@@ -6,6 +6,8 @@
 #define _GNU_SOURCE
 #endif
 
+#include <iostream>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -179,7 +181,7 @@ static void do_matrix(
   std::vector<Hash256> hashes2;
 
   if (argc == 0) {
-    loadHashesFromStream(stdin, hashes1);
+    loadHashesFromStream(std::cin, hashes1);
     hashes2 = hashes1;
   } else if (argc == 1) {
     loadHashesFromFile(argv[0], hashes1);

--- a/pdq/cpp/bin/hashtool256.cpp
+++ b/pdq/cpp/bin/hashtool256.cpp
@@ -125,7 +125,7 @@ static void do_slot_norms(
   for (auto hash : hashes) {
     printf("%s", hash.format().c_str());
     for (int i = 0; i < HASH256_NUM_WORDS; i++) {
-      printf(" %2d", __builtin_popcount(hash.w[i]));
+      printf(" %2d", hammingNorm16(hash.w[i]));
     }
     printf("\n");
   }

--- a/pdq/cpp/common/pdqhamming.h
+++ b/pdq/cpp/common/pdqhamming.h
@@ -12,7 +12,7 @@
 // performance by a few percent -- worth using but OK to live without.)
 #if !defined(_MSC_VER) && !defined(WIN32) && !defined(_WIN32) &&  \
     !defined(__WIN32__) && !defined(WIN64) && !defined(_WIN64) && \
-    !defined(__WIN64__) && !defined(__linux)
+    !defined(__WIN64__)
 #define USE_BUILTIN_POPCOUNT
 #endif
 

--- a/pdq/cpp/common/pdqhamming.h
+++ b/pdq/cpp/common/pdqhamming.h
@@ -10,7 +10,11 @@
 // If your compiler doesn't support __builtin_popcount then feel free to
 // undefine this. (Experiments have shown that using builtin popcount helps
 // performance by a few percent -- worth using but OK to live without.)
+#if !defined(_MSC_VER) && !defined(WIN32) && !defined(_WIN32) &&  \
+    !defined(__WIN32__) && !defined(WIN64) && !defined(_WIN64) && \
+    !defined(__WIN64__) && !defined(__linux)
 #define USE_BUILTIN_POPCOUNT
+#endif
 
 namespace facebook {
 namespace pdq {

--- a/pdq/cpp/common/pdqhashtypes.cpp
+++ b/pdq/cpp/common/pdqhashtypes.cpp
@@ -4,6 +4,8 @@
 
 #include <pdq/cpp/common/pdqhashtypes.h>
 
+#include <random>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -17,6 +19,9 @@ namespace hashing {
 const char hash256_format[] =
     "%04hx%04hx%04hx%04hx%04hx%04hx%04hx%04hx"
     "%04hx%04hx%04hx%04hx%04hx%04hx%04hx%04hx";
+
+std::random_device rd;
+std::mt19937 gen(rd());
 
 // ================================================================
 Hash256::Hash256(const char* hex_formatted_string) {
@@ -185,11 +190,10 @@ bool Hash256::operator==(const Hash256& that) const {
 }
 
 // ----------------------------------------------------------------
-// Does not itself call srandom(); caller must.
 Hash256 Hash256::fuzz(int numErrorBits) {
   Hash256 rv = *this;
   for (int i = 0; i < numErrorBits; i++) {
-    int idx = random() % 256;
+    int idx = std::uniform_int_distribution<int>(0, 255)(gen);
     rv.flipBit(idx);
   }
   return rv;

--- a/pdq/cpp/common/pdqhashtypes.cpp
+++ b/pdq/cpp/common/pdqhashtypes.cpp
@@ -50,24 +50,24 @@ Hash256::Hash256(const char* hex_formatted_string) {
 }
 
 // ----------------------------------------------------------------
-Hash256 Hash256::fromLineOrDie(char* line, int linelen) {
-  if (line[linelen - 1] == '\n') {
-    line[linelen - 1] = 0;
+Hash256 Hash256::fromLineOrDie(std::string& line) {
+  if (!line.empty() && line.back() == '\n') {
+    line.pop_back();
   }
   return Hash256::fromStringOrDie(line);
 }
 
 // ----------------------------------------------------------------
-Hash256 Hash256::fromStringOrDie(char* string) {
+Hash256 Hash256::fromStringOrDie(const std::string& string) {
   Hash256 h;
-  if (strlen(string) != 64) {
+  if (string.size() != 64) {
     // could throw; only current use is ops-tools which
     // would exit anyway.
-    fprintf(stderr, "Scan \"%s\" failed.\n", string);
+    fprintf(stderr, "Scan \"%s\" failed.\n", string.c_str());
     exit(1);
   }
   int rv = sscanf(
-      string,
+      string.c_str(),
       hash256_format,
       &h.w[15],
       &h.w[14],
@@ -88,7 +88,7 @@ Hash256 Hash256::fromStringOrDie(char* string) {
   if (rv != 16) {
     // could throw; only current use is ops-tools which
     // would exit anyway.
-    fprintf(stderr, "Scan \"%s\" failed.\n", string);
+    fprintf(stderr, "Scan \"%s\" failed.\n", string.c_str());
     exit(1);
   }
   return h;

--- a/pdq/cpp/common/pdqhashtypes.h
+++ b/pdq/cpp/common/pdqhashtypes.h
@@ -132,8 +132,8 @@ struct Hash256 {
   bool operator>=(const Hash256& that) const;
   bool operator==(const Hash256& that) const;
 
-  static Hash256 fromLineOrDie(char* line, int linelen);
-  static Hash256 fromStringOrDie(char* string);
+  static Hash256 fromLineOrDie(std::string& line);
+  static Hash256 fromStringOrDie(const std::string& string);
 
   std::string format() const;
   void dump() { printf("%s", this->format().c_str()); }

--- a/pdq/cpp/common/pdqhashtypes.h
+++ b/pdq/cpp/common/pdqhashtypes.h
@@ -10,6 +10,7 @@
 // ================================================================
 
 #include <pdq/cpp/common/pdqbasetypes.h>
+#include <pdq/cpp/common/pdqhamming.h>
 
 #include <stdio.h>
 #include <string>
@@ -73,14 +74,14 @@ struct Hash256 {
   int hammingNorm() {
     int n = 0;
     for (int i = 0; i < HASH256_NUM_WORDS; i++) {
-      n += __builtin_popcount(this->w[i]);
+      n += hammingNorm16(this->w[i]);
     }
     return n;
   }
   int hammingDistance(const Hash256& that) const {
     int n = 0;
     for (int i = 0; i < HASH256_NUM_WORDS; i++) {
-      n += __builtin_popcount(this->w[i] ^ that.w[i]);
+      n += hammingDistance16(this->w[i], that.w[i]);
     }
     return n;
   }

--- a/pdq/cpp/io/hashio.h
+++ b/pdq/cpp/io/hashio.h
@@ -5,6 +5,8 @@
 #ifndef HASHIO_H
 #define HASHIO_H
 
+#include <istream>
+
 #include <pdq/cpp/common/pdqhashtypes.h>
 
 #include <stdio.h>
@@ -54,20 +56,20 @@ namespace io {
 // hash=a5f0...b0fa,norm=128,delta=124,quality=100,filename=file8.jpg
 
 bool loadHashAndMetadataFromStream(
-    FILE* fp,
+    std::istream& in,
     facebook::pdq::hashing::Hash256& hash,
     std::string& metadata,
     // Used in case metadata is absent. Please pass in an incremented counter:
     int counter);
 
 void loadHashesAndMetadataFromStream(
-    FILE* fp,
+    std::istream& in,
     std::vector<std::pair<facebook::pdq::hashing::Hash256, std::string>>&
         vector_of_pairs);
 
 // On file-read error, returns false.
 bool loadHashesAndMetadataFromFile(
-    char* filename,
+    const char* filename,
     std::vector<std::pair<facebook::pdq::hashing::Hash256, std::string>>&
         vector_of_pairs);
 
@@ -93,13 +95,13 @@ void loadHashesFromFilesOrDie(
     std::vector<facebook::pdq::hashing::Hash256>& hashes);
 
 void loadHashesFromFileOrDie(
-    char* filename, std::vector<facebook::pdq::hashing::Hash256>& hashes);
+    const char* filename, std::vector<facebook::pdq::hashing::Hash256>& hashes);
 
 bool loadHashesFromFile(
-    char* filename, std::vector<facebook::pdq::hashing::Hash256>& hashes);
+    const char* filename, std::vector<facebook::pdq::hashing::Hash256>& hashes);
 
 void loadHashesFromStream(
-    FILE* fp, std::vector<facebook::pdq::hashing::Hash256>& hashes);
+    std::istream& in, std::vector<facebook::pdq::hashing::Hash256>& hashes);
 
 } // namespace io
 } // namespace pdq

--- a/vpdq/cpp/CMakeLists.txt
+++ b/vpdq/cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(SOURCES
     ../../pdq/cpp/common/pdqhashtypes.cpp
     ../../pdq/cpp/hashing/pdqhashing.cpp
+    ../../pdq/cpp/common/pdqhamming.cpp
     ../../pdq/cpp/io/hashio.cpp
     ../../pdq/cpp/downscaling/downscaling.cpp
     ../../pdq/cpp/hashing/torben.cpp
@@ -30,6 +31,7 @@ set(SOURCES
 SET(HEADERS
     ../../pdq/cpp/common/pdqbasetypes.h
     ../../pdq/cpp/common/pdqhashtypes.h
+    ../../pdq/cpp/common/pdqhamming.h
     ../../pdq/cpp/hashing/pdqhashing.h
     ../../pdq/cpp/io/hashio.h
     ../../pdq/cpp/downscaling/downscaling.h

--- a/vpdq/cpp/Makefile
+++ b/vpdq/cpp/Makefile
@@ -6,6 +6,7 @@ CC=g++ -fPIC -O2 $(CYTHON) -std=c++14 -I../..
 
 LIBHDR=\
 ../../pdq/cpp/common/pdqbasetypes.h \
+../../pdq/cpp/common/pdqhamming.h \
 ../../pdq/cpp/common/pdqhashtypes.h \
 ../../pdq/cpp/hashing/pdqhashing.h \
 ../../pdq/cpp/io/hashio.h \
@@ -17,6 +18,7 @@ LIBHDR=\
 
 LIBOBJ= \
 ../../pdq/cpp/common/pdqhashtypes.o \
+../../pdq/cpp/common/pdqhamming.o \
 ../../pdq/cpp/hashing/pdqhashing.o \
 ../../pdq/cpp/io/hashio.o \
 ../../pdq/cpp/downscaling/downscaling.o \

--- a/vpdq/cpp/io/vpdqio.cpp
+++ b/vpdq/cpp/io/vpdqio.cpp
@@ -37,7 +37,7 @@ bool loadHashesFromFileOrDie(
     const string& inputHashFileName,
     vector<hashing::vpdqFeature>& pdqHashes,
     const char* programName) {
-  ifstream inputfp(inputHashFileName);
+  std::ifstream inputfp(inputHashFileName);
   string str;
   if (!inputfp.is_open()) {
     fprintf(
@@ -67,7 +67,7 @@ bool loadHashesFromFileOrDie(
       return false;
     }
     pdqHashes.push_back(
-        {pdq::hashing::Hash256::fromStringOrDie((char*)frameValues[2].c_str()),
+        {pdq::hashing::Hash256::fromStringOrDie(frameValues[2]),
          atoi(frameValues[0].c_str()),
          atoi(frameValues[1].c_str()),
          atof(frameValues[3].c_str())});


### PR DESCRIPTION
Summary
---------

While I was testing vpdq on Windows I had to make a couple changes to get it to build with pdq.

They're solid changes in general, so I thought I would upload them.

Use C++11 STL over OS dependent functions in general:

- Change file pointers to streams 
  - File pointers were used with getline() which is POSIX only. Replaced file pointers **_only wherever necessary_** with streams and use std::getline(). I tried to change as little as possible here.
- Use C++ random device instead of random() which is POSIX only 
  - This could have been done with rand() but I just used the C++11 one because it's a C++ project
- Fix __builtin_popcount where hamming*() should have been used
  - There's a define in `pdqhamming.h` which chooses either a lookup table or __builtin_popcount based on the `USE_BUILTIN_POPCOUNT`  directive but some functions were directly calling __builtin_popcount regardless.

None of these changes should affect bindings. The Python binding doesn't call any of the changed functions since they're almost all file IO.

I'm not sure why __builtin_popcount is being used at all. [std::bitset::count](https://godbolt.org/z/UpN8Qh) and [__builtin_popcount](https://godbolt.org/z/C4tY8W) generate the same assembly. I can replace __builtin_popcount with std::bitset::count if you would like.

The getline problem is a really good example of why it's not good to do `using namespace std;` since std::getline and getline are both functions.

I vaguely remember reading something about Buck for building and if you guys use that for PDQ I'm not sure how these changes would be affected by that.

Test Plan
---------

Run included PDQ tests and vPDQ tests.