### PR TITLE
[vpdq] Fix regression Python binding compile error and OpenCV type error

### DIFF
--- a/vpdq/MANIFEST.in
+++ b/vpdq/MANIFEST.in
@@ -1,10 +1,12 @@
 include pdq/cpp/common/pdqhashtypes.cpp
+include pdq/cpp/common/pdqhamming.cpp
 include pdq/cpp/hashing/pdqhashing.cpp
 include pdq/cpp/io/hashio.cpp
 include pdq/cpp/downscaling/downscaling.cpp
 include pdq/cpp/hashing/torben.cpp
 include pdq/cpp/common/pdqhashtypes.h
 include pdq/cpp/common/pdqbasetypes.h
+include pdq/cpp/common/pdqhamming.h
 include pdq/cpp/hashing/pdqhashing.h
 include pdq/cpp/io/hashio.h
 include pdq/cpp/downscaling/downscaling.h

--- a/vpdq/cpp/Makefile
+++ b/vpdq/cpp/Makefile
@@ -37,6 +37,9 @@ libvpdq.a: $(LIBOBJ)
 ../../pdq/cpp/common/pdqhashtypes.o: ../../pdq/cpp/common/pdqhashtypes.cpp $(LIBHDR)
 	$(CC) -c ../../pdq/cpp/common/pdqhashtypes.cpp -o ../../pdq/cpp/common/pdqhashtypes.o
 
+../../pdq/cpp/common/pdqhamming.o: ../../pdq/cpp/common/pdqhamming.cpp $(LIBHDR)
+	$(CC) -c ../../pdq/cpp/common/pdqhamming.cpp -o ../../pdq/cpp/common/pdqhamming.o
+
 ../../pdq/cpp/io/hashio.o: ../../pdq/cpp/io/hashio.cpp $(LIBHDR)
 	$(CC) -c ../../pdq/cpp/io/hashio.cpp -o ../../pdq/cpp/io/hashio.o
 

--- a/vpdq/python/vpdq.pyx
+++ b/vpdq/python/vpdq.pyx
@@ -140,10 +140,10 @@ def computeHash(
     vid = cv2.VideoCapture(str_path)
     frames_per_sec = vid.get(cv2.CAP_PROP_FPS)
     if downsample_width == 0:
-        downsample_width = vid.get(cv2.CAP_PROP_FRAME_WIDTH)
+        downsample_width = int(vid.get(cv2.CAP_PROP_FRAME_WIDTH))
 
     if downsample_height == 0:
-        downsample_height = vid.get(cv2.CAP_PROP_FRAME_HEIGHT)
+        downsample_height = int(vid.get(cv2.CAP_PROP_FRAME_HEIGHT))
     
     vid.release()
 


### PR DESCRIPTION


Summary
---------

Fix Python binding compile error and cv2 type error


This fixes issues caused by the POSIX functions being replaced with STL in c0cc68f. `pdqhamming.cpp` was included but never compiled by Python. I never detected the issue because the CI didn't run and when I ran `vpdq-release` locally it must have said it installed even though it failed installing, because it does that. And the Python CI tests don't run when the Python Makefile is modified, even though it is required to build. Disaster.

Also fix a strange bug with cv2 returning a float for width and height. This is completely unrelated to the fix above, but it occurred during a CI test. height and width must be int before being passed to hashVideoFileFFMpeg, but they are returned by cv2 as a float so they must be cast to int. I don't know how this didn't occur until now. I hope putting it in this PR is okay.

I think the Python CI should probably run whenever vpdq or pdq source files are changed since they are direct dependencies. Otherwise stuff like this can happen.

This fix is rendered useless when [this](https://github.com/facebook/ThreatExchange/pull/1331) is merged because the Makefile is being deleted, but this should be applied before it's merged to get Python building.

Test Plan
---------

Run the CI and see that the Python CI now runs successfully.