### PR TITLE
[pdq] Replace __builtin_popcount with std::bitset<N>::count

### DIFF
--- a/pdq/cpp/common/pdqhamming.h
+++ b/pdq/cpp/common/pdqhamming.h
@@ -5,16 +5,20 @@
 #ifndef PDQHAMMING_H
 #define PDQHAMMING_H
 
+#include <bitset>
+
 #include <pdq/cpp/common/pdqbasetypes.h>
 
+// OLD NOTICE:
 // If your compiler doesn't support __builtin_popcount then feel free to
 // undefine this. (Experiments have shown that using builtin popcount helps
 // performance by a few percent -- worth using but OK to live without.)
-#if !defined(_MSC_VER) && !defined(WIN32) && !defined(_WIN32) &&  \
-    !defined(__WIN32__) && !defined(WIN64) && !defined(_WIN64) && \
-    !defined(__WIN64__)
+//
+// NOTICE:
+// __builin_popcount was replaced by std::bitset<>::count()
+// The define is left here for backwards compatibility
+// if you want to use the lookup table.
 #define USE_BUILTIN_POPCOUNT
-#endif
 
 namespace facebook {
 namespace pdq {
@@ -23,16 +27,16 @@ namespace hashing {
 #ifdef USE_BUILTIN_POPCOUNT
 // Inlined right here
 inline int hammingNorm8(Hash8 h) {
-  return __builtin_popcount((unsigned)h);
+  return std::bitset<8>(h).count();
 }
 inline int hammingNorm16(Hash16 h) {
-  return __builtin_popcount((unsigned)h);
+  return std::bitset<16>(h).count();
 }
 inline int hammingDistance8(Hash8 a, Hash8 b) {
-  return __builtin_popcount((unsigned)(a ^ b));
+  return std::bitset<8>(a ^ b).count();
 }
 inline int hammingDistance16(Hash16 a, Hash16 b) {
-  return __builtin_popcount((unsigned)(a ^ b));
+  return std::bitset<16>(a ^ b).count();
 }
 #else
 // Implemented in pdqhamming.cpp with lookup tables.


### PR DESCRIPTION
Summary
---------

Replace `__builtin_popcount()` which is a GCC extension with `std::bitset<N>::count`.

Depending on your compiler the resulting assembly will be nearly identical.

I removed the preprocessor check that I previously added for Windows to use the lookup table since it's not needed anymore.

Fun fact, [std::popcount](https://en.cppreference.com/w/cpp/numeric/popcount) is it's own function that works with any unsigned integer type in C++20.

Test Plan
---------

Run the regression test and see that the output is the same.

You can put them both in godbolt to see that the asm the same as well. Even if it's not, `std::bitset<N>::count` is better than it not compiling at all.