### PR TITLE
OMM: Roles and blueprints

### DIFF
--- a/open-media-match/.devcontainer/omm_config.py
+++ b/open-media-match/.devcontainer/omm_config.py
@@ -5,3 +5,7 @@ DBPASS = 'hunter2'
 DBHOST = 'db'
 DBNAME = 'media_match'
 DATABASE_URI = f"postgresql+psycopg2://{DBUSER}:{DBPASS}@{DBHOST}/{DBNAME}"
+
+ROLE_HASHER = True
+ROLE_MATCHER = True
+ROLE_CURATOR = True

--- a/open-media-match/.devcontainer/omm_config.py
+++ b/open-media-match/.devcontainer/omm_config.py
@@ -1,4 +1,5 @@
 # Database configuration
+PRODUCTION = False
 DBUSER = 'media_match'
 DBPASS = 'hunter2'
 DBHOST = 'db'

--- a/open-media-match/src/OpenMediaMatch/__init__.py
+++ b/open-media-match/src/OpenMediaMatch/__init__.py
@@ -11,14 +11,23 @@ def create_app():
     app = flask.Flask(__name__)
     app.config.from_envvar('OMM_CONFIG')
 
-    @app.route("/")
-    def ping():
+    @app.route('/')
+    def index():
+        """
+        Sanity check endpoint showing a basic status page
+        TODO: in development mode, this could show some useful additional info
+        """
+        app.config.get('PRODUCTION')
+        return flask.render_template('index.html.j2')
+
+    @app.route('/status')
+    def status():
         """
         Liveness/readiness check endpoint for your favourite Layer 7 load balancer
         """
-        return "I-AM-ALIVE"
+        return 'I-AM-ALIVE\n'
 
-    @app.route("/hash/image")
+    @app.route('/hash/image')
     def hash_image():
         """
         Hash an image

--- a/open-media-match/src/OpenMediaMatch/__init__.py
+++ b/open-media-match/src/OpenMediaMatch/__init__.py
@@ -3,6 +3,7 @@
 import os
 import flask
 
+from .blueprints import hashing, matching, curation
 
 def create_app():
     """
@@ -10,15 +11,14 @@ def create_app():
     """
     app = flask.Flask(__name__)
     app.config.from_envvar('OMM_CONFIG')
-
+    
     @app.route('/')
     def index():
         """
         Sanity check endpoint showing a basic status page
         TODO: in development mode, this could show some useful additional info
         """
-        app.config.get('PRODUCTION')
-        return flask.render_template('index.html.j2')
+        return flask.render_template('index.html.j2', production=app.config.get('PRODUCTION'))
 
     @app.route('/status')
     def status():
@@ -27,15 +27,16 @@ def create_app():
         """
         return 'I-AM-ALIVE\n'
 
-    @app.route('/hash/image')
-    def hash_image():
-        """
-        Hash an image
-        """
-        image_url = flask.request.args.get('url')
-        if image_url is None:
-            flask.abort(400)
+    # Register Flask blueprints for whichever server roles are enabled...
+    # URL prefixing facilitates easy Layer 7 routing :) 
+    if app.config.get('ROLE_HASHER', False):
+        app.register_blueprint(hashing.bp, url_prefix='/h')
 
-        return f"If this was implemented you'd be seeing the PDQ hash of the image at {image_url} here"
+    if app.config.get('ROLE_MATCHER', False):
+        app.register_blueprint(matching.bp, url_prefix='/m')
+
+    if app.config.get('ROLE_MATCHER', False):
+        app.register_blueprint(curation.bp, url_prefix='/c')
+
 
     return app

--- a/open-media-match/src/OpenMediaMatch/blueprints/__init__.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.

--- a/open-media-match/src/OpenMediaMatch/blueprints/curation.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/curation.py
@@ -1,0 +1,6 @@
+from flask import Blueprint
+from flask import abort, request
+
+bp = Blueprint("curation", __name__)
+
+# TODO: everything :D

--- a/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
@@ -1,0 +1,28 @@
+from flask import Blueprint
+from flask import abort, request
+
+bp = Blueprint("hashing", __name__)
+
+@bp.route('/hash')
+def hash_media():
+    """
+    Fetch content and return its hash.
+    TODO: implement
+    """
+    media_url = request.args.get('url', None)
+    if media_url is None:
+        # path is required, otherwise we don't know what we're hashing.
+        # TODO: a more helpful message
+        abort(400)
+    
+    hash_types = request.args.get('types', None)
+    if hash_types is not None:
+        # TODO: parse this into a list of hash types
+        pass
+
+
+    # TODO
+    #  - download the media
+    #  - decode it
+    #  - hash it
+    

--- a/open-media-match/src/OpenMediaMatch/blueprints/matching.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/matching.py
@@ -1,0 +1,29 @@
+from flask import Blueprint
+from flask import abort, request
+
+bp = Blueprint("matching", __name__)
+
+# TODO: everything :D
+
+@bp.route('/lookup')
+def lookup():
+    """
+    Look up a hash in the similarity index
+    Input:
+     * Signal type (hash type)
+     * Signal value (the hash)
+     * Optional list of banks to restrict search to
+    Output:
+     * List of matching content items
+    """
+    abort(501) # Unimplemented
+ 
+@bp.route('/index/status')
+def index_status():
+    """
+    Input:
+     * Signal type (hash type)
+    Output:
+     * Time of last index build
+    """
+    abort(501) # Unimplemented

--- a/open-media-match/src/OpenMediaMatch/templates/index.html.j2
+++ b/open-media-match/src/OpenMediaMatch/templates/index.html.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <title>Open Media Match</title>
+    </head>
+    <body>
+        <h1>Open Media Match</h1>
+
+        <p>Open Media Match is up and running.</p>
+        
+        {% if not production %}
+        <p>Running in development mode</p>
+        {% endif %}
+    </body>
+</html>


### PR DESCRIPTION
Summary
---------

Define the hasher, matcher and curator roles. Allow them to be enabled or disabled via config. Separate those role functions out into discrete Flask "Blueprints" with URL prefixes for easy Layer 7 routing. Add stubs for a handful of example functions from the README.


The index endpoint ('/') is distinct in function from '/status',  so separate it out. Add a basic HTML page here so that user is greeted with something human-readable to show they're up and running.


Test Plan
---------

Local `curl` commands
