### PR TITLE
[pytx] Add py.typed marker to threatexchange

### DIFF
--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -72,5 +72,5 @@ setup(
             "tx = threatexchange.cli.main:main",
         ],
     },
-    package_data={'threatexchange': ['py.typed']}
+    package_data={"threatexchange": ["py.typed"]},
 )

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -72,4 +72,5 @@ setup(
             "tx = threatexchange.cli.main:main",
         ],
     },
+    package_data={'threatexchange': ['py.typed']}
 )


### PR DESCRIPTION
Some percentage of this library is typed, and I think this is the correct way to mark it.

In a following PR I'll bump the version number.