### PR TITLE
The computation of intGradientSum was found to be inaccurate.

### DIFF
--- a/pdq/php/pdqhasher.php
+++ b/pdq/php/pdqhasher.php
@@ -378,7 +378,7 @@ class PDQHasher {
       for ($j = 0; $j < 63; $j++) {
         $u = $buffer_64x64[$i][$j];
         $v = $buffer_64x64[$i][$j+1];
-        $$d = (int)((($u - $v) * 100) / 255);
+        $d = (int)((($u - $v) * 100) / 255);
         $int_gradient_sum += (int)abs($d);
       }
     }


### PR DESCRIPTION
Summary
---------

Within the second loop, it consistently referenced the last $d value from the first loop, potentially causing adverse effects on images with a small intGradientSum, particularly when the final $d value from the first loop was substantial.
