### PR TITLE
[omm][devcontainer] Add home mount for ease of access to local files

### DIFF
--- a/open-media-match/.devcontainer/devcontainer.json
+++ b/open-media-match/.devcontainer/devcontainer.json
@@ -3,7 +3,10 @@
   "dockerComposeFile": "docker-compose.yaml",
   "service": "app",
   "workspaceFolder": "/workspace",
-  "forwardPorts": [8080, 5432],
+  "forwardPorts": [
+    8080,
+    5432
+  ],
   "customizations": {
     "vscode": {
       "extensions": [
@@ -15,17 +18,17 @@
       ],
       "settings": {
         "python.defaultInterpreterPath": "/usr/local/bin/python",
-				"python.linting.enabled": true,
-				"python.linting.pylintEnabled": true,
-				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-				"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-				"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+        "python.linting.enabled": true,
+        "python.linting.pylintEnabled": true,
+        "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+        "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+        "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+        "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+        "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+        "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+        "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+        "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+        "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
         "sqltools.connections": [
           {
             "name": "Container database",
@@ -48,7 +51,8 @@
   "remoteUser": "vscode",
   "postCreateCommand": "pip install --editable .[all]",
   "mounts": [
-    "source=python-threatexchange-cmdhistory,target=/commandhistory,type=volume"
+    "source=python-threatexchange-cmdhistory,target=/commandhistory,type=volume",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE},target=/host-home-folder,type=bind,consistency=cached"
   ],
   "postAttachCommand": "/workspace/.devcontainer/startup.sh"
 }


### PR DESCRIPTION
Summary
---------

I keep wanting to touch a local install of python-threatexchange in my devcontainer, but it's not in the folder. I have my local checkout in my home, for this works for me, and this lets others do either something similar or add symlinks for workarounds.

Test Plan
---------

Rebuild devcontainer, navigate to /host-home-mount
