### PR TITLE
OMM: bank CRUD functions

### DIFF
--- a/open-media-match/.devcontainer/devcontainer.json
+++ b/open-media-match/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
         "ms-python.mypy-type-checker",
         "mtxr.sqltools",
         "mtxr.sqltools-driver-pg",
-        "tamasfe.even-better-toml"
+        "tamasfe.even-better-toml",
+        "humao.rest-client"
       ],
       "settings": {
         "python.defaultInterpreterPath": "/usr/local/bin/python",

--- a/open-media-match/src/OpenMediaMatch/blueprints/curation.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/curation.py
@@ -1,6 +1,75 @@
 from flask import Blueprint
-from flask import abort, request
+from flask import abort, request, current_app, jsonify
+
+from OpenMediaMatch import models
+
+import json
 
 bp = Blueprint("curation", __name__)
 
-# TODO: everything :D
+
+@bp.route("/banks", methods=["GET"])
+def banks_index():
+    banks = (
+        current_app.db.session.execute(current_app.db.select(models.Bank))
+        .scalars()
+        .all()
+    )
+    return jsonify(banks)
+
+
+@bp.route("/bank/<int:bank_id>", methods=["GET"])
+def bank_show_by_id(bank_id: int):
+    bank = models.Bank.query.get(bank_id)
+    if not bank:
+        return jsonify({"message": "bank not found"}), 404
+    return jsonify(bank)
+
+
+@bp.route("/bank/<bank_name>", methods=["GET"])
+def bank_show_by_name(bank_name: str):
+    bank = (
+        current_app.db.session.execute(
+            current_app.db.select(models.Bank).where(models.Bank.name == bank_name)
+        )
+        .scalars()
+        .all()
+    )
+    return jsonify(bank)
+
+
+@bp.route("/banks", methods=["POST"])
+def bank_create():
+    data = request.get_json()
+    if not "name" in data:
+        return jsonify({"message": "Field `name` is required"}), 400
+    bank = models.Bank(name=data["name"], enabled=bool(data.get("enabled", True)))
+    current_app.db.session.add(bank)
+    current_app.db.session.commit()
+    return jsonify({"message": "Created successfully"}), 201
+
+
+@bp.route("/bank/<int:bank_id>", methods=["PUT"])
+def bank_update(bank_id: int):
+    data = request.get_json()
+    bank = models.Bank.query.get(bank_id)
+    if not bank:
+        return jsonify({"message": "bank not found"}), 404
+
+    if "name" in data:
+        bank.name = data["name"]
+    if "enabled" in data:
+        bank.enabled = bool(data["enabled"])
+
+    current_app.db.session.commit()
+    return jsonify(bank)
+
+
+@bp.route("/bank/<int:bank_id>", methods=["DELETE"])
+def bank_delete(bank_id: int):
+    bank = models.Bank.query.get(bank_id)
+    if not bank:
+        return jsonify({"message": "bank not found"}), 404
+    current_app.db.session.delete(bank)
+    current_app.db.session.commit()
+    return jsonify({"message": f"Bank {bank.name} ({bank.id}) deleted"})

--- a/open-media-match/src/OpenMediaMatch/models.py
+++ b/open-media-match/src/OpenMediaMatch/models.py
@@ -1,16 +1,19 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-from OpenMediaMatch import database as db
+from dataclasses import dataclass
+from OpenMediaMatch import db
 
 
-class Bank(db.Model):  # type: ignore[name-defined]  # mypy not smart enough
+@dataclass
+class Bank(db.Model):
     __tablename__ = "banks"
-    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    name = db.Column(db.String(255), nullable=False)
-    enabled = db.Column(db.Boolean, nullable=False)
+    id: int = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    name: str = db.Column(db.String(255), nullable=False)
+    enabled: bool = db.Column(db.Boolean, nullable=False)
 
 
-class Hash(db.Model):  # type: ignore[name-defined]  # mypy not smart enough
+@dataclass
+class Hash(db.Model):
     __tablename__ = "hashes"
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     enabled = db.Column(db.Boolean, nullable=False)


### PR DESCRIPTION
Summary
---------

With this commit, OMM is now a legit REST API.
Banks can be indexed, created, updated and deleted through the API.
When implementing CRUD functions for other data entities, we now have some reference code.

Test Plan
---------

I used the `humao.rest-client` VSCode extension to compose HTTP JSON requests in the editor and fire them off to the API. I recommend it.

```
POST http://localhost:5000/c/banks
content-type: application/json

{
    "name": "terrorism"
}

###

GET http://localhost:5000/c/banks

###

GET http://localhost:5000/c/bank/2

###

GET http://localhost:5000/c/bank/lloyds

###

PUT http://localhost:5000/c/bank/2
content-type: application/json

{
    "enabled": false
}

###

DELETE http://localhost:5000/c/bank/3
```
