### PR TITLE
[omm] implement lookup and mock index

### DIFF
--- a/open-media-match/src/OpenMediaMatch/app_resources.py
+++ b/open-media-match/src/OpenMediaMatch/app_resources.py
@@ -7,10 +7,16 @@ I can't tell if these should just be in app.py, so I'm sticking it here for now,
 since one advantage of putting these in functions is we can type the output.
 """
 
-from flask import g
+import functools
+import typing as t
+
+from flask import g, abort, request
+from werkzeug.exceptions import HTTPException
 
 from OpenMediaMatch.storage.interface import IUnifiedStore
 from OpenMediaMatch.storage.default import DefaultOMMStore
+
+T = t.TypeVar("T", bound=t.Callable[..., t.Any])
 
 
 def get_storage() -> IUnifiedStore:
@@ -23,3 +29,44 @@ def get_storage() -> IUnifiedStore:
         # hiding flask bits from pytx bits
         g.storage = DefaultOMMStore()
     return g.storage
+
+
+def abort_to_json(fn: T) -> T:
+    """
+    Wrap json endpoints to turn abort("message", code) to json
+
+    @bp.route("/function")
+
+    def function():
+      if thing:
+        abort(400, "thing missin")
+
+    will return
+        HTTP/1.1 400 BAD_REQUEST
+        Content-Type: application/json
+
+        {
+            "message": "thing missin"
+        }
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwds):
+        try:
+            return fn(*args, **kwds)
+        except HTTPException as e:
+            return {"message": e.description}, e.code
+
+    return t.cast(T, wrapper)
+
+
+def require_request_param(name: str) -> str:
+    """
+    Wrapper around a required request parameter.
+
+    aborts with 400 if it's missing.
+    """
+    ret = request.args.get(name)
+    if ret is None:
+        abort(400, f"{name} is required")
+    return ret

--- a/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
@@ -29,7 +29,7 @@ def hash_media():
     """
     media_url = request.args.get("url", None)
     if media_url is None:
-        abort(400, "url is required")
+        return {"message": "url is required"}, 400
 
     download_resp = requests.get(media_url, allow_redirects=True, timeout=30 * 1000)
     download_resp.raise_for_status()
@@ -74,10 +74,10 @@ def _parse_request_content_type(url_content_type: str) -> ContentType:
     storage = app_resources.get_storage()
     content_type_config = storage.get_content_type_configs().get(arg)
     if content_type_config is None:
-        abort(400, f"no such content_type: '{arg}'")
+        return {"message": f"no such content_type: '{arg}'"}, 400
 
     if not content_type_config.enabled:
-        abort(400, f"content_type {arg} is disabled")
+        return {"message": f"content_type {arg} is disabled"}, 400
 
     return content_type_config.content_type
 

--- a/open-media-match/src/OpenMediaMatch/blueprints/matching.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/matching.py
@@ -1,12 +1,23 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Endpoints for matching content and hashes.
+"""
+
 from flask import Blueprint
-from flask import abort, request
+from flask import abort
+
+from OpenMediaMatch.app_resources import (
+    abort_to_json,
+    require_request_param,
+    get_storage,
+)
 
 bp = Blueprint("matching", __name__)
 
-# TODO: everything :D
-
 
 @bp.route("/lookup")
+@abort_to_json
 def lookup():
     """
     Look up a hash in the similarity index
@@ -17,7 +28,25 @@ def lookup():
     Output:
      * List of matching content items
     """
-    abort(501)  # Unimplemented
+    signal = require_request_param("signal")
+    signal_type_name = require_request_param("signal_type")
+    storage = get_storage()
+    signal_type_config = storage.get_signal_type_configs().get(signal_type_name)
+    if signal_type_config is None:
+        abort(f"No such SignalType '{signal_type_name}'", 400)
+    if not signal_type_config.enabled:
+        return {}  # Should this be an error?
+    signal_type = signal_type_config.signal_type
+
+    try:
+        signal = signal_type.validate_signal_str(signal)
+    except Exception as e:
+        abort(400, f"invalid signal type: {e}")
+
+    index = storage.get_signal_type_index(signal_type)
+    if not index:
+        abort(503, "index not yet ready")
+    return {"matches": [m.metadata for m in index.query(signal)]}
 
 
 @bp.route("/index/status")

--- a/open-media-match/src/OpenMediaMatch/models.py
+++ b/open-media-match/src/OpenMediaMatch/models.py
@@ -13,8 +13,9 @@ class Bank(db.Model):
 
 
 @dataclass
-class Hash(db.Model):
+class Hash(db.Model):  # Should this be Signal?
     __tablename__ = "hashes"
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     enabled = db.Column(db.Boolean, nullable=False)
     value = db.Column(db.LargeBinary, nullable=False)
+    # We may need a pointer back to the 3rd party ID to do SEEN writebacks

--- a/open-media-match/src/OpenMediaMatch/storage/mocked.py
+++ b/open-media-match/src/OpenMediaMatch/storage/mocked.py
@@ -6,8 +6,10 @@ from threatexchange.content_type.photo import PhotoContent
 from threatexchange.content_type.video import VideoContent
 from threatexchange.exchanges.signal_exchange_api import TSignalExchangeAPICls
 from threatexchange.exchanges.impl.static_sample import StaticSampleSignalExchangeAPI
+from threatexchange.signal_type.index import SignalTypeIndex
 from threatexchange.signal_type.pdq.signal import PdqSignal
 from threatexchange.signal_type.md5 import VideoMD5Signal
+from threatexchange.signal_type.signal_base import SignalType
 
 from OpenMediaMatch.storage import interface
 from OpenMediaMatch.storage.interface import SignalTypeConfig
@@ -32,3 +34,13 @@ class MockedUnifiedStore(interface.IUnifiedStore):
             s.get_name(): interface.SignalTypeConfig(True, s)
             for s in (PdqSignal, VideoMD5Signal)
         }
+
+    def get_signal_type_index(
+        self, signal_type: type[SignalType]
+    ) -> t.Optional[SignalTypeIndex[int]]:
+        return signal_type.get_index_cls().build(
+            (example_signal, fake_id)
+            for fake_id, example_signal in enumerate(
+                set(signal_type.get_examples()), start=1
+            )
+        )


### PR DESCRIPTION
Summary
---------

1. Implement `lookup` API
2. Put in a placeholder for how one fetches the index (this is probably the only callsite)
3. Made a helper for json-ifying errors (though running into weird problems with the lints getting confused about whether the file exists or not - suspect this is interference with `__init__.py`

Test Plan
---------

```
$ curl -i 'localhost:5000/m/lookup?signal_type=pdq&signal=f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22'
HTTP/1.1 200 OK
Content-Type: application/json

{
  "matches": [
    10,
    13,
    12,
    4,
    8,
    6,
    16,
    3,
    15,
    2,
    14,
    1
  ]
}

```

Errors:
```
$ curl -i 'localhost:5000/m/lookup?signal_type=pdq&signal=1234'
HTTP/1.1 400 BAD REQUEST
Content-Type: application/json

{
  "message": "invalid signal type: invalid PDQ hash"
}
```
```
$ curl -i localhost:5000/m/lookup?signal=1234
HTTP/1.1 400 BAD REQUEST
Content-Type: application/json

{
  "message": "signal_type is required"
}
```