### PR TITLE
[omm][temporarily breaking] Bank relationships and some storage iface

### DIFF
--- a/open-media-match/src/OpenMediaMatch/blueprints/curation.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/curation.py
@@ -9,20 +9,13 @@ bp = Blueprint("curation", __name__)
 
 @bp.route("/banks", methods=["GET"])
 def banks_index():
-    banks = (
-        database.db.session.execute(current_app.db.select(database.Bank))
+    banks = [
+        b.as_storage_iface_cls()
+        for b in database.db.session.execute(database.db.select(database.Bank))
         .scalars()
         .all()
-    )
+    ]
     return jsonify(banks)
-
-
-@bp.route("/bank/<int:bank_id>", methods=["GET"])
-def bank_show_by_id(bank_id: int):
-    bank = database.Bank.query.get(bank_id)
-    if not bank:
-        return jsonify({"message": "bank not found"}), 404
-    return jsonify(bank)
 
 
 @bp.route("/bank/<bank_name>", methods=["GET"])

--- a/open-media-match/src/OpenMediaMatch/database.py
+++ b/open-media-match/src/OpenMediaMatch/database.py
@@ -9,27 +9,63 @@ slower than just slinging sql on the tables, so you may see direct
 references which are meant to be reaped at some future time.
 """
 
+import typing as t
+
 from dataclasses import dataclass
+from OpenMediaMatch.storage.interface import BankConfig, BankContentConfig
 
 import flask_sqlalchemy
+from sqlalchemy import String, Text, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, DeclarativeBase, relationship
+
+
+class Base(DeclarativeBase):
+    pass
+
 
 # Initializing this at import time seems to be the only correct
 # way to do this
-db = flask_sqlalchemy.SQLAlchemy()
+db = flask_sqlalchemy.SQLAlchemy(model_class=Base)
 
 
-@dataclass
 class Bank(db.Model):  # type: ignore[name-defined]
-    __tablename__ = "banks"
-    id: int = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    name: str = db.Column(db.String(255), nullable=False)
-    enabled: bool = db.Column(db.Boolean, nullable=False)
+    __tablename__ = "bank"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(255), unique=True)
+    enabled_ratio: Mapped[float] = mapped_column(default=1.0)
+
+    content: Mapped[t.List["BankContent"]] = relationship(
+        back_populates="bank", cascade="all, delete"
+    )
+
+    def as_storage_iface_cls(self) -> BankConfig:
+        return BankConfig(self.name, self.enabled_ratio)
 
 
-@dataclass
-class Hash(db.Model):  # type: ignore[name-defined]  # Should this be Signal?
-    __tablename__ = "hashes"
-    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    enabled = db.Column(db.Boolean, nullable=False)
-    value = db.Column(db.LargeBinary, nullable=False)
-    # We may need a pointer back to the 3rd party ID to do SEEN writebacks
+class BankContent(db.Model):  # type: ignore[name-defined]
+    __tablename__ = "bank_content"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    bank_id: Mapped[int] = mapped_column(ForeignKey("bank.id"))
+    bank: Mapped[Bank] = relationship(back_populates="content")
+
+    disable_until_ts: Mapped[int] = mapped_column(default=BankContentConfig.ENABLED)
+    original_content_uri: Mapped[t.Optional[str]]
+
+    signals: Mapped[t.List["ContentSignal"]] = relationship(cascade="all, delete")
+
+    def as_storage_iface_cls(self) -> BankContentConfig:
+        return BankContentConfig(
+            self.id,
+            disable_until_ts=self.disable_until_ts,
+            collab_metadata={},
+            original_media_uri=None,
+        )
+
+
+class ContentSignal(db.Model):  # type: ignore[name-defined]
+    id: Mapped[int] = mapped_column(primary_key=True)
+    content_id: Mapped[int] = mapped_column(ForeignKey("bank_content.id"))
+    signal_type: Mapped[str]
+    signal_val: Mapped[str] = mapped_column(Text)

--- a/open-media-match/src/OpenMediaMatch/storage/default.py
+++ b/open-media-match/src/OpenMediaMatch/storage/default.py
@@ -14,10 +14,16 @@ from threatexchange.exchanges.fetch_state import (
     CollaborationConfigBase,
 )
 
+from sqlalchemy import select
+from OpenMediaMatch import database
 
 from OpenMediaMatch.storage import interface
 from OpenMediaMatch.storage.mocked import MockedUnifiedStore
-from OpenMediaMatch.storage.interface import SignalTypeConfig
+from OpenMediaMatch.storage.interface import (
+    SignalTypeConfig,
+    BankConfig,
+    BankContentConfig,
+)
 
 
 class DefaultOMMStore(interface.IUnifiedStore):
@@ -81,3 +87,52 @@ class DefaultOMMStore(interface.IUnifiedStore):
         checkpoint: FetchCheckpointBase,
     ) -> t.Any:
         return MockedUnifiedStore().get_collab_data(collab_name, key, checkpoint)
+
+    def get_banks(self) -> t.Mapping[str, BankConfig]:
+        return {
+            b.name: b.as_storage_iface_cls()
+            for b in database.db.session.execute(select(database.Bank)).scalars().all()
+        }
+
+    def get_bank(self, name: str) -> t.Optional[BankConfig]:
+        """Override for more efficient lookup"""
+        bank = database.db.session.execute(
+            select(database.Bank).where(database.Bank.name == name)
+        ).scalar_one_or_none()
+
+        return None if bank is None else bank.as_storage_iface_cls()
+
+    def bank_update(self, bank: BankConfig, create: bool = False) -> None:
+        # TODO
+        raise Exception("Not implemented")
+
+    def bank_delete(self, name: str) -> None:
+        # TODO
+        raise Exception("Not implemented")
+
+    def bank_content_get(self, id: int) -> BankContentConfig:
+        # TODO
+        raise Exception("Not implemented")
+
+    def bank_content_update(self, val: BankContentConfig) -> None:
+        # TODO
+        raise Exception("Not implemented")
+
+    def bank_add_content(
+        self,
+        bank_name: str,
+        content_signals: t.Dict[t.Type[SignalType], str],
+        config: t.Optional[BankContentConfig] = None,
+    ) -> int:
+        # TODO
+        raise Exception("Not implemented")
+
+    def bank_remove_content(self, bank_name: str, content_id: int) -> None:
+        # TODO
+        raise Exception("Not implemented")
+
+    def bank_yield_content(
+        self, signal_type: t.Optional[t.Type[SignalType]] = None
+    ) -> t.Iterator[t.Sequence[t.Tuple[t.Optional[str], int]]]:
+        # TODO
+        raise Exception("Not implemented")

--- a/open-media-match/src/OpenMediaMatch/storage/interface.py
+++ b/open-media-match/src/OpenMediaMatch/storage/interface.py
@@ -196,6 +196,9 @@ class BankContentConfig:
     has been lost
     """
 
+    ENABLED: t.ClassVar[int] = 1
+    DISABLED: t.ClassVar[int] = 0
+
     # This is what is indexed in the indice and directly returned by
     # lookup
     id: int
@@ -295,10 +298,6 @@ class IBankStore(metaclass=abc.ABCMeta):
         """Remove content from bank by id"""
 
     @abc.abstractmethod
-    def bank_content_get_banks(self) -> t.Set[str]:
-        """Return the bank names this content is in"""
-
-    @abc.abstractmethod
     def bank_yield_content(
         self, signal_type: t.Optional[t.Type[SignalType]] = None
     ) -> t.Iterator[t.Sequence[t.Tuple[t.Optional[str], int]]]:
@@ -316,6 +315,7 @@ class IUnifiedStore(
     ISignalExchangeConfigStore,
     ISignalTypeIndexStore,
     ICollaborationStore,
+    IBankStore,
     metaclass=abc.ABCMeta,
 ):
     """

--- a/open-media-match/src/OpenMediaMatch/storage/mocked.py
+++ b/open-media-match/src/OpenMediaMatch/storage/mocked.py
@@ -24,6 +24,14 @@ class MockedUnifiedStore(interface.IUnifiedStore):
     Provides plausible default values for all store interfaces.
     """
 
+    banks: t.Dict[str, interface.BankConfig]
+
+    def __init__(self) -> None:
+        self.banks = {
+            b.name: b
+            for b in (interface.BankConfig("TEST_BANK", matching_enabled_ratio=1.0),)
+        }
+
     def get_content_type_configs(self) -> t.Mapping[str, interface.ContentTypeConfig]:
         return {
             c.get_name(): interface.ContentTypeConfig(True, c)
@@ -81,3 +89,39 @@ class MockedUnifiedStore(interface.IUnifiedStore):
         checkpoint: FetchCheckpointBase,
     ) -> t.Any:
         return None
+
+    def get_banks(self) -> t.Mapping[str, interface.BankConfig]:
+        return dict(self.banks)
+
+    def bank_update(self, bank: interface.BankConfig, create: bool = False) -> None:
+        self.banks[bank.name] = bank
+
+    def bank_delete(self, name: str) -> None:
+        self.banks.pop(name, None)
+
+    def bank_content_get(self, id: int) -> interface.BankContentConfig:
+        # TODO
+        raise Exception("Not implemented")
+
+    def bank_content_update(self, val: interface.BankContentConfig) -> None:
+        # TODO
+        raise Exception("Not implemented")
+
+    def bank_add_content(
+        self,
+        bank_name: str,
+        content_signals: t.Dict[t.Type[SignalType], str],
+        config: t.Optional[interface.BankContentConfig] = None,
+    ) -> int:
+        # TODO
+        raise Exception("Not implemented")
+
+    def bank_remove_content(self, bank_name: str, content_id: int) -> None:
+        # TODO
+        raise Exception("Not implemented")
+
+    def bank_yield_content(
+        self, signal_type: t.Optional[t.Type[SignalType]] = None
+    ) -> t.Iterator[t.Sequence[t.Tuple[t.Optional[str], int]]]:
+        # TODO
+        raise Exception("Not implemented")


### PR DESCRIPTION
Summary
---------

This PR:
1. Does some more work on the bank data model, which should flex it out to allow bank -> content -> hashes
2. Rewrites some of the sqlalchemy in whatever the heck the mainline docs use: https://flask-sqlalchemy.palletsprojects.com/en/3.1.x/quickstart/ and https://docs.sqlalchemy.org/en/20/orm/basic_relationships.html#one-to-many
3. Breaks the existing curation API while I continue tooling on it

As part of this, I couldn't figure out a way to make both sqlalchemy and dataclasses happy at the same time, so we're doing something immensely stupid and just translating between them.

Test Plan
---------

mypy
