### PR TITLE
[omm] Collaboration Config table

### DIFF
--- a/open-media-match/src/OpenMediaMatch/database.py
+++ b/open-media-match/src/OpenMediaMatch/database.py
@@ -11,11 +11,18 @@ references which are meant to be reaped at some future time.
 
 import typing as t
 
-from dataclasses import dataclass
 from OpenMediaMatch.storage.interface import BankConfig, BankContentConfig
 
+from threatexchange.exchanges.collab_config import CollaborationConfigBase
+from threatexchange.exchanges.signal_exchange_api import (
+    TSignalExchangeAPICls,
+    SignalExchangeAPI,
+    TCollabConfig,
+)
+from threatexchange.utils import dataclass_json
+
 import flask_sqlalchemy
-from sqlalchemy import String, Text, ForeignKey
+from sqlalchemy import String, Text, ForeignKey, JSON
 from sqlalchemy.orm import Mapped, mapped_column, DeclarativeBase, relationship
 
 
@@ -69,3 +76,56 @@ class ContentSignal(db.Model):  # type: ignore[name-defined]
     content_id: Mapped[int] = mapped_column(ForeignKey("bank_content.id"))
     signal_type: Mapped[str]
     signal_val: Mapped[str] = mapped_column(Text)
+
+
+class CollaborationConfig(db.Model):  # type: ignore[name-defined]
+    id: Mapped[int] = mapped_column(primary_key=True)
+    # These three fields are also in typed_config, but exposing them
+    # allows for selecting them from the database layer
+    name: Mapped[str] = mapped_column(String(255), unique=True)
+    api_cls: Mapped[str] = mapped_column(String(255))
+    fetching_enabled: Mapped[bool] = mapped_column(default=True)
+    # Someday, we want writeback columns
+    # report_seen: Mapped[bool] = mapped_column(default=True)
+    # report_true_positive = mapped_column(default=True)
+    # report_false_positive = mapped_column(default=True)
+
+    # This is the dacite-serialized version of the typed
+    # CollaborationConfig.
+    typed_config: Mapped[t.Dict[str, t.Any]] = mapped_column(JSON)
+
+    def set_typed_config(self, cfg: CollaborationConfigBase) -> t.Self:
+        self.name = cfg.name
+        self.fetching_enabled = cfg.enabled
+        self.api_cls = cfg.api
+        self.typed_config = dataclass_json.dataclass_dump_dict(cfg)
+        return self
+
+    def as_storage_iface_cls(
+        self, exchange_types: t.Dict[str, TSignalExchangeAPICls]
+    ) -> CollaborationConfigBase:
+        exchange_cls = exchange_types.get(self.api_cls, None)
+        if exchange_cls is None:
+            # If this is None, it means we either serialized it wrong, or
+            # we changed which exchanges were valid between storing and
+            # fetching.
+            # We could throw an exception here, but maybe instead we just
+            # return it stripped and let the application figure out what to do
+            # with an invalid API cls.
+            return CollaborationConfigBase(
+                name=self.name, api=self.api_cls, enabled=self.fetching_enabled
+            )
+        return self.as_storage_iface_cls_typed(exchange_cls)
+
+    def as_storage_iface_cls_typed(
+        self,
+        exchange_cls: t.Type[
+            SignalExchangeAPI[TCollabConfig, t.Any, t.Any, t.Any, t.Any]
+        ],
+    ) -> TCollabConfig:
+        cls = exchange_cls.get_config_cls()
+        # This looks like it should be typed correctly, but too complicated
+        # mypy
+        return dataclass_json.dataclass_load_dict(
+            self.typed_config, cls
+        )  # type: ignore[return-value]

--- a/open-media-match/src/OpenMediaMatch/database.py
+++ b/open-media-match/src/OpenMediaMatch/database.py
@@ -104,7 +104,7 @@ class CollaborationConfig(db.Model):  # type: ignore[name-defined]
     def as_storage_iface_cls(
         self, exchange_types: t.Dict[str, TSignalExchangeAPICls]
     ) -> CollaborationConfigBase:
-        exchange_cls = exchange_types.get(self.api_cls, None)
+        exchange_cls = exchange_types.get(self.api_cls)
         if exchange_cls is None:
             # If this is None, it means we either serialized it wrong, or
             # we changed which exchanges were valid between storing and

--- a/open-media-match/src/OpenMediaMatch/tests/test_api.py
+++ b/open-media-match/src/OpenMediaMatch/tests/test_api.py
@@ -1,21 +1,7 @@
 import os
 import pytest
-import json
 
-from OpenMediaMatch.app import create_app
-
-
-@pytest.fixture()
-def app():
-    os.environ.setdefault("OMM_CONFIG", "tests/omm_config.py")
-    app = create_app()
-
-    yield app
-
-
-@pytest.fixture()
-def client(app):
-    return app.test_client()
+from OpenMediaMatch.tests.utils import app, client
 
 
 def test_status_response(client):

--- a/open-media-match/src/OpenMediaMatch/tests/test_database.py
+++ b/open-media-match/src/OpenMediaMatch/tests/test_database.py
@@ -1,0 +1,61 @@
+import typing as t
+from flask import Flask
+from sqlalchemy import select
+from OpenMediaMatch.tests.utils import app
+
+from threatexchange.exchanges.signal_exchange_api import TSignalExchangeAPICls
+from threatexchange.exchanges.impl.static_sample import StaticSampleSignalExchangeAPI
+from threatexchange.exchanges.impl.fb_threatexchange_api import (
+    FBThreatExchangeSignalExchangeAPI,
+)
+from threatexchange.exchanges.collab_config import CollaborationConfigBase
+
+from OpenMediaMatch import database
+
+
+def test_store_collab_config(app: Flask):
+    with app.app_context():
+        existing = (
+            database.db.session.execute(select(database.CollaborationConfig))
+            .scalars()
+            .all()
+        )
+        assert existing == []
+
+        all_exchange_apis: t.List[TSignalExchangeAPICls] = [
+            StaticSampleSignalExchangeAPI,
+            FBThreatExchangeSignalExchangeAPI,  # type: ignore[list-item]  # another mypy corner case
+        ]
+        exchange_apis = {ex.get_name(): ex for ex in all_exchange_apis}
+
+        typed_config_default = CollaborationConfigBase(
+            name="Basic",
+            api=StaticSampleSignalExchangeAPI.get_name(),
+            enabled=True,
+        )
+        extended_cls = FBThreatExchangeSignalExchangeAPI.get_config_cls()
+        typed_config_extended = extended_cls(
+            name="Extended",
+            privacy_group=1234567,
+            enabled=True,
+        )
+
+        database.db.session.add(
+            database.CollaborationConfig().set_typed_config(typed_config_default)
+        )
+        database.db.session.add(
+            database.CollaborationConfig().set_typed_config(typed_config_extended)
+        )
+        database.db.session.commit()
+
+        from_db = (
+            database.db.session.execute(select(database.CollaborationConfig))
+            .scalars()
+            .all()
+        )
+
+        assert len(from_db) == 2
+        by_name = {c.name: c.as_storage_iface_cls(exchange_apis) for c in from_db}
+
+        for config in (typed_config_default, typed_config_extended):
+            assert config == by_name.get(config.name)

--- a/open-media-match/src/OpenMediaMatch/tests/utils.py
+++ b/open-media-match/src/OpenMediaMatch/tests/utils.py
@@ -1,0 +1,24 @@
+import os
+import pytest
+
+from OpenMediaMatch.app import create_app
+from OpenMediaMatch import database
+
+
+@pytest.fixture()
+def app():
+    os.environ.setdefault("OMM_CONFIG", "tests/omm_config.py")
+    app = create_app()
+
+    with app.app_context():
+        # I'm sorry future person, I don't know how to keep the
+        # test database clean without affecting the the prod instance
+        database.db.drop_all()
+        database.db.create_all()
+
+    yield app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()


### PR DESCRIPTION
Summary
---------

Adds a CollaborationConfig table that allows configuring the connection between external APIs and banks.

It doesn't attempt to actually use this table.

Test Plan
---------

Added a simple test to exercise serialization (though I didn't deeply verify it). 

As part of this diff, the fixture for app WILL NOW CLEAR YOUR TABLES in order to make it possible to test inserting data. 
