### PR TITLE
[omm] bank methods to storage iface

### DIFF
--- a/open-media-match/src/OpenMediaMatch/tests/test_api.py
+++ b/open-media-match/src/OpenMediaMatch/tests/test_api.py
@@ -1,6 +1,3 @@
-import os
-import pytest
-
 from OpenMediaMatch.tests.utils import app, client
 
 


### PR DESCRIPTION
Summary
---------

Convert some calls over to storage interface. 

Test Plan
---------


```
$ flask reset_all_tables
$ flask seed

$ curl -i 'localhost:5000/c/banks'
HTTP/1.1 200 OK
Server: Werkzeug/2.3.7 Python/3.11.4
Date: Fri, 29 Sep 2023 21:34:06 GMT
Content-Type: application/json
Content-Length: 71
Connection: close

[
  {
    "matching_enabled_ratio": 1.0,
    "name": "TEST_BANK"
  }
]

$ curl -i 'localhost:5000/c/bank/TEST_BANK'
HTTP/1.1 200 OK
Server: Werkzeug/2.3.7 Python/3.11.4
Date: Fri, 29 Sep 2023 21:37:39 GMT
Content-Type: application/json
Content-Length: 59
Connection: close

{
  "matching_enabled_ratio": 1.0,
  "name": "TEST_BANK"
}

$ curl -i 'localhost:5000/c/bank/TEST_BANK2'
HTTP/1.1 404 NOT FOUND
Server: Werkzeug/2.3.7 Python/3.11.4
Date: Fri, 29 Sep 2023 21:37:48 GMT
Content-Type: application/json
Content-Length: 47
Connection: close

{
  "message": "bank 'TEST_BANK2' not found"
}
```
