### PR TITLE
[omm] Allow digits in bank names except as first character

### DIFF
--- a/open-media-match/src/OpenMediaMatch/database.py
+++ b/open-media-match/src/OpenMediaMatch/database.py
@@ -64,7 +64,7 @@ class Bank(db.Model):  # type: ignore[name-defined]
 
     @validates("name")
     def validate_name(self, _key: str, name: str) -> str:
-        if not re.fullmatch("[A-Z_]+", name):
+        if not re.fullmatch("[A-Z_][A-Z0-9_]*+", name):
             raise ValueError("Bank names must be UPPER_WITH_UNDERSCORE")
         return name
 
@@ -78,10 +78,12 @@ class BankContent(db.Model):  # type: ignore[name-defined]
 
     # Should we store the content type as well?
 
-    disable_until_ts: Mapped[int] = mapped_column(default=BankContentConfig.ENABLED)
+    disable_until_ts: Mapped[int] = mapped_column(
+        default=BankContentConfig.ENABLED)
     original_content_uri: Mapped[t.Optional[str]]
 
-    signals: Mapped[t.List["ContentSignal"]] = relationship(cascade="all, delete")
+    signals: Mapped[t.List["ContentSignal"]
+                    ] = relationship(cascade="all, delete")
 
     def as_storage_iface_cls(self) -> BankContentConfig:
         return BankContentConfig(
@@ -155,7 +157,8 @@ class CollaborationConfig(db.Model):  # type: ignore[name-defined]
     @validates("name")
     def validate_name(self, _key: str, name: str) -> str:
         if not re.fullmatch("[A-Z_]+", name):
-            raise ValueError("Collaboration names must be UPPER_WITH_UNDERSCORE")
+            raise ValueError(
+                "Collaboration names must be UPPER_WITH_UNDERSCORE")
         return name
 
 

--- a/open-media-match/src/OpenMediaMatch/database.py
+++ b/open-media-match/src/OpenMediaMatch/database.py
@@ -78,12 +78,10 @@ class BankContent(db.Model):  # type: ignore[name-defined]
 
     # Should we store the content type as well?
 
-    disable_until_ts: Mapped[int] = mapped_column(
-        default=BankContentConfig.ENABLED)
+    disable_until_ts: Mapped[int] = mapped_column(default=BankContentConfig.ENABLED)
     original_content_uri: Mapped[t.Optional[str]]
 
-    signals: Mapped[t.List["ContentSignal"]
-                    ] = relationship(cascade="all, delete")
+    signals: Mapped[t.List["ContentSignal"]] = relationship(cascade="all, delete")
 
     def as_storage_iface_cls(self) -> BankContentConfig:
         return BankContentConfig(
@@ -157,8 +155,7 @@ class CollaborationConfig(db.Model):  # type: ignore[name-defined]
     @validates("name")
     def validate_name(self, _key: str, name: str) -> str:
         if not re.fullmatch("[A-Z_]+", name):
-            raise ValueError(
-                "Collaboration names must be UPPER_WITH_UNDERSCORE")
+            raise ValueError("Collaboration names must be UPPER_WITH_UNDERSCORE")
         return name
 
 

--- a/open-media-match/src/OpenMediaMatch/database.py
+++ b/open-media-match/src/OpenMediaMatch/database.py
@@ -64,7 +64,7 @@ class Bank(db.Model):  # type: ignore[name-defined]
 
     @validates("name")
     def validate_name(self, _key: str, name: str) -> str:
-        if not re.fullmatch("[A-Z_][A-Z0-9_]*+", name):
+        if not re.fullmatch("[A-Z_][A-Z0-9_]*", name):
             raise ValueError("Bank names must be UPPER_WITH_UNDERSCORE")
         return name
 

--- a/open-media-match/src/OpenMediaMatch/tests/test_api.py
+++ b/open-media-match/src/OpenMediaMatch/tests/test_api.py
@@ -15,12 +15,27 @@ def test_banks_empty_index(client: FlaskClient):
 
 
 def test_banks_create(client: FlaskClient):
+    # Must not start with number
     post_response = client.post(
         "/c/banks",
-        json={"name": "MY_TEST_BANK"},
+        json={"name": "01_TEST_BANK"},
+    )
+    assert post_response.status_code == 500
+
+    # Cannot contain lowercase letters
+    post_response = client.post(
+        "/c/banks",
+        json={"name": "my_test_bank"},
+    )
+    assert post_response.status_code == 500
+
+    post_response = client.post(
+        "/c/banks",
+        json={"name": "MY_TEST_BANK_01"},
     )
     assert post_response.status_code == 201
-    assert post_response.json == {"matching_enabled_ratio": 1.0, "name": "MY_TEST_BANK"}
+    assert post_response.json == {
+        "matching_enabled_ratio": 1.0, "name": "MY_TEST_BANK_01"}
 
     # Should now be visible on index
     response = client.get("/c/banks")

--- a/open-media-match/src/OpenMediaMatch/tests/test_api.py
+++ b/open-media-match/src/OpenMediaMatch/tests/test_api.py
@@ -35,7 +35,9 @@ def test_banks_create(client: FlaskClient):
     )
     assert post_response.status_code == 201
     assert post_response.json == {
-        "matching_enabled_ratio": 1.0, "name": "MY_TEST_BANK_01"}
+        "matching_enabled_ratio": 1.0,
+        "name": "MY_TEST_BANK_01",
+    }
 
     # Should now be visible on index
     response = client.get("/c/banks")


### PR DESCRIPTION
Summary
---------

Bank names should allow digits, except in first char

Test Plan
---------

Added tests to test_api.py to validate that invalid names result in HTTP 500 response codes