### PR TITLE
Implementation of hash POST with file upload

### DIFF
--- a/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
@@ -58,13 +58,15 @@ def hash_media():
                 ret[st.get_name()] = st.hash_from_file(path)
     return ret
 
+
 @bp.route("/hash", methods=["POST"])
 @abort_to_json
 def hash_media_post():
     """
     Calculate the hash for the provided image file.
     """
-    abort(501, 'Not yet implemented.')
+    abort(501, "Not yet implemented.")
+
 
 def _parse_request_content_type(url_content_type: str) -> t.Type[ContentType]:
     arg = request.args.get("content_type", "")

--- a/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
@@ -23,7 +23,7 @@ from OpenMediaMatch.utils import abort_to_json
 bp = Blueprint("hashing", __name__)
 
 
-@bp.route("/hash")
+@bp.route("/hash", methods=["GET"])
 @abort_to_json
 def hash_media():
     """
@@ -58,6 +58,13 @@ def hash_media():
                 ret[st.get_name()] = st.hash_from_file(path)
     return ret
 
+@bp.route("/hash", methods=["POST"])
+@abort_to_json
+def hash_media_post():
+    """
+    Calculate the hash for the provided image file.
+    """
+    abort(501, 'Not yet implemented.')
 
 def _parse_request_content_type(url_content_type: str) -> t.Type[ContentType]:
     arg = request.args.get("content_type", "")

--- a/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
@@ -63,7 +63,7 @@ def hash_media():
 @abort_to_json
 def hash_media_post():
     """
-    Calculate the hash for the provided file(s).
+    Calculate the hash for the provided file.
     """
     if not request.files:
         return {"message": "Missing multipart/form-data file upload"}, 400

--- a/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
@@ -15,7 +15,7 @@ import requests
 from threatexchange.content_type.content_base import ContentType
 from threatexchange.content_type.photo import PhotoContent
 from threatexchange.content_type.video import VideoContent
-from threatexchange.signal_type.signal_base import FileHasher, SignalType
+from threatexchange.signal_type.signal_base import FileHasher, BytesHasher, SignalType
 
 from OpenMediaMatch.persistence import get_storage
 from OpenMediaMatch.utils import abort_to_json
@@ -63,9 +63,40 @@ def hash_media():
 @abort_to_json
 def hash_media_post():
     """
-    Calculate the hash for the provided image file.
+    Calculate the hash for the provided file(s).
     """
-    abort(501, "Not yet implemented.")
+    if not request.files:
+        return {"message": "Missing multipart/form-data file upload"}, 400
+
+    # Let's just accept a single file per request.
+    if len(request.files) > 1:
+        return {"message": "Only one file allowed per request"}, 400
+
+    ret = {}
+
+    # Each file in a multipart/form-data body has a name as well as a filename:
+    # Content-Disposition: form-data; name="field1"; filename="example.txt"
+    # We will require that the field name is one of the supported content types.
+    for field_name in request.files.keys():
+        # The file key must be one of the supported content types.
+        content_type = _lookup_content_type(field_name)
+        signal_types = _parse_request_signal_type(content_type)
+
+        if len(request.files.getlist(field_name)) > 1:
+            return {"message": "Only one file allowed per request"}, 400
+
+        for file in request.files.getlist(field_name):
+            current_app.logger.debug(
+                "Processing upload of type %s, filename=%s, mimetype=%s",
+                field_name,
+                file.filename,
+                file.mimetype,
+            )
+            for st in signal_types.values():
+                if issubclass(st, BytesHasher):
+                    ret[st.get_name()] = st.hash_from_bytes(file.stream.read())
+
+    return ret
 
 
 def _parse_request_content_type(url_content_type: str) -> t.Type[ContentType]:
@@ -79,9 +110,13 @@ def _parse_request_content_type(url_content_type: str) -> t.Type[ContentType]:
             abort(
                 400,
                 f"unsupported url ContentType: '{url_content_type}', "
-                "if you know the expected type, provide it with content_type",
+                "if you know the expected type, provide it with the content_type query param",
             )
 
+    return _lookup_content_type(arg)
+
+
+def _lookup_content_type(arg: str) -> t.Type[ContentType]:
     content_type_config = get_storage().get_content_type_configs().get(arg)
     if content_type_config is None:
         abort(400, f"no such content_type: '{arg}'")


### PR DESCRIPTION
Summary
---------

Fleshed out the hash_media_post function. Validates input, and submits the (single) file upload to the corresponding signal_types.

Test Plan
---------

Basic positive & negative testing:

```
vscode ➜ /workspace $ curl localhost:5000/h/hash -F photo=@screenshot-1.jpg
{
  "pdq": "d6530e83f9e9346da58ccb3616c6f0f3690e07c9f431d9660bc33e0e95a4c1f1"
}
vscode ➜ /workspace $ curl localhost:5000/h/hash -F video=@ScreenRecording.mov
{
  "video_md5": "52210dccb6893e61592808f9bd52f4a1"
}
vscode ➜ /workspace $ curl localhost:5000/h/hash -F video=@ScreenRecording.mov -F photo=@screenshot-1.jpg
{
  "message": "Only one file allowed per request"
}
vscode ➜ /workspace $ curl localhost:5000/h/hash -F photo=@screenshot-1.jpg -F photo=@screenshot-2.jpg
{
  "message": "Only one file allowed per request"
}
vscode ➜ /workspace $ curl localhost:5000/h/hash -F bad_content_type=@ScreenRecording.mov
{
  "message": "no such content_type: 'bad_content_type'"
}
```
