### PR TITLE
Add a query endpoint to combine hashing and matching

### DIFF
--- a/open-media-match/src/OpenMediaMatch/app.py
+++ b/open-media-match/src/OpenMediaMatch/app.py
@@ -19,7 +19,7 @@ with warnings.catch_warnings():
 from OpenMediaMatch import database
 from OpenMediaMatch.background_tasks import build_index, fetcher
 from OpenMediaMatch.persistence import get_storage
-from OpenMediaMatch.blueprints import hashing, matching, curation
+from OpenMediaMatch.blueprints import development, hashing, matching, curation
 
 
 def create_app() -> flask.Flask:
@@ -72,6 +72,9 @@ def create_app() -> flask.Flask:
     # URL prefixing facilitates easy Layer 7 routing :)
     # Linters complain about imports off the top level, but this is needed
     # to prevent circular imports
+
+    if not os.environ.get("PRODUCTION", False) and app.config.get("ROLE_HASHER", False) and app.config.get("ROLE_MATCHER", False):
+        app.register_blueprint(development.bp)
 
     if app.config.get("ROLE_HASHER", False):
         app.register_blueprint(hashing.bp, url_prefix="/h")

--- a/open-media-match/src/OpenMediaMatch/app.py
+++ b/open-media-match/src/OpenMediaMatch/app.py
@@ -73,8 +73,12 @@ def create_app() -> flask.Flask:
     # Linters complain about imports off the top level, but this is needed
     # to prevent circular imports
 
-    if not os.environ.get("PRODUCTION", False) and app.config.get("ROLE_HASHER", False) and app.config.get("ROLE_MATCHER", False):
-        app.register_blueprint(development.bp)
+    if (
+        not os.environ.get("PRODUCTION", False)
+        and app.config.get("ROLE_HASHER", False)
+        and app.config.get("ROLE_MATCHER", False)
+    ):
+        app.register_blueprint(development.bp, url_prefix="/dev")
 
     if app.config.get("ROLE_HASHER", False):
         app.register_blueprint(hashing.bp, url_prefix="/h")

--- a/open-media-match/src/OpenMediaMatch/blueprints/development.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/development.py
@@ -13,6 +13,7 @@ from OpenMediaMatch.utils import abort_to_json, require_request_param
 
 bp = Blueprint("development", __name__)
 
+
 @bp.route("/query")
 @abort_to_json
 def query_media():
@@ -29,15 +30,17 @@ def query_media():
     """
     signal_type_to_signal_map = hash_media()
     if not isinstance(signal_type_to_signal_map, dict):
-        # We really should not get here, since if something went wrong, it should 
+        # We really should not get here, since if something went wrong, it should
         if isinstance(signal_type_to_signal_map, tuple):
             return signal_type_to_signal_map
         abort(500, "Something went wrong while hashing the provided media.")
 
-
     # Check if signal_type is an option in the map of hashes
     signal_type_name = require_request_param("signal_type")
     if signal_type_name not in signal_type_to_signal_map:
-        abort(400, f"Requested signal type '{signal_type_name}' is not supported for the provided media.")
-    
+        abort(
+            400,
+            f"Requested signal type '{signal_type_name}' is not supported for the provided media.",
+        )
+
     return lookup_signal(signal_type_to_signal_map[signal_type_name], signal_type_name)

--- a/open-media-match/src/OpenMediaMatch/blueprints/development.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/development.py
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Development only routes for easily testing functionality end-to-end, all running on a single host.
+"""
+
+from flask import Blueprint, abort, redirect, request, url_for
+
+from OpenMediaMatch.blueprints.hashing import hash_media
+from OpenMediaMatch.blueprints.matching import lookup, lookup_signal
+from OpenMediaMatch.utils import abort_to_json, require_request_param
+
+
+bp = Blueprint("development", __name__)
+
+@bp.route("/query")
+@abort_to_json
+def query_media():
+    """
+    Hash the input media and then match against all banked content.
+    This is simply a wrapper around the hasing and matching APIs.
+
+     Input:
+     * url - path to the media to hash. Supports image or video.
+     * signal_type - Signal type (hash type)
+
+     Output:
+        * List of matching content items
+    """
+    signal_type_to_signal_map = hash_media()
+    if not isinstance(signal_type_to_signal_map, dict):
+        # We really should not get here, since if something went wrong, it should 
+        if isinstance(signal_type_to_signal_map, tuple):
+            return signal_type_to_signal_map
+        abort(500, "Something went wrong while hashing the provided media.")
+
+
+    # Check if signal_type is an option in the map of hashes
+    signal_type_name = require_request_param("signal_type")
+    if signal_type_name not in signal_type_to_signal_map:
+        abort(400, f"Requested signal type '{signal_type_name}' is not supported for the provided media.")
+    
+    return lookup_signal(signal_type_to_signal_map[signal_type_name], signal_type_name)

--- a/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
@@ -31,7 +31,7 @@ def hash_media():
 
     Input:
         * url - path to the media to hash. Supports image or video.
-        
+
     Output:
         * Mapping of signal types to hash values. Signal types are derived from the content type of the provided URL
     """

--- a/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
@@ -28,10 +28,16 @@ bp = Blueprint("hashing", __name__)
 def hash_media():
     """
     Fetch content and return its hash.
+
+    Input:
+        * url - path to the media to hash. Supports image or video.
+        
+    Output:
+        * Mapping of signal types to hash values. Signal types are derived from the content type of the provided URL
     """
     media_url = request.args.get("url", None)
     if media_url is None:
-        return {"message": "url is required"}, 400
+        abort(400, "url is required")
 
     download_resp = requests.get(media_url, allow_redirects=True, timeout=30 * 1000)
     download_resp.raise_for_status()

--- a/open-media-match/src/OpenMediaMatch/blueprints/matching.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/matching.py
@@ -6,6 +6,8 @@ Endpoints for matching content and hashes.
 
 from flask import Blueprint
 from flask import abort
+from threatexchange.signal_type.signal_base import SignalType
+from OpenMediaMatch.storage.interface import IUnifiedStore
 
 from OpenMediaMatch.utils import (
     abort_to_json,
@@ -30,13 +32,11 @@ def lookup():
     """
     signal = require_request_param("signal")
     signal_type_name = require_request_param("signal_type")
+    return lookup_signal(signal, signal_type_name)
+
+def lookup_signal(signal: str, signal_type_name: str) -> dict[str, list[int]]:
     storage = get_storage()
-    signal_type_config = storage.get_signal_type_configs().get(signal_type_name)
-    if signal_type_config is None:
-        abort(f"No such SignalType '{signal_type_name}'", 400)
-    if not signal_type_config.enabled:
-        return {}  # Should this be an error?
-    signal_type = signal_type_config.signal_type
+    signal_type = validate_and_transform_signal_type(signal_type_name, storage)
 
     try:
         signal = signal_type.validate_signal_str(signal)
@@ -48,6 +48,17 @@ def lookup():
         abort(503, "index not yet ready")
     return {"matches": [m.metadata for m in index.query(signal)]}
 
+def validate_and_transform_signal_type(signal_type_name: str, storage: IUnifiedStore) -> type[SignalType]:
+    """
+    Accepts a signal type name and returns the corresponding signal type class,
+    validating that the signal type exists and is enabled for the provided storage.
+    """
+    signal_type_config = storage.get_signal_type_configs().get(signal_type_name)
+    if signal_type_config is None:
+        abort(400, f"No such SignalType '{signal_type_name}'")
+    if not signal_type_config.enabled:
+        abort(400, f"SignalType '{signal_type_name}' is not enabled")
+    return signal_type_config.signal_type
 
 @bp.route("/index/status")
 def index_status():

--- a/open-media-match/src/OpenMediaMatch/blueprints/matching.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/matching.py
@@ -37,7 +37,7 @@ def lookup():
 
 def lookup_signal(signal: str, signal_type_name: str) -> dict[str, list[int]]:
     storage = get_storage()
-    signal_type = validate_and_transform_signal_type(signal_type_name, storage)
+    signal_type = _validate_and_transform_signal_type(signal_type_name, storage)
 
     try:
         signal = signal_type.validate_signal_str(signal)
@@ -50,7 +50,7 @@ def lookup_signal(signal: str, signal_type_name: str) -> dict[str, list[int]]:
     return {"matches": [m.metadata for m in index.query(signal)]}
 
 
-def validate_and_transform_signal_type(
+def _validate_and_transform_signal_type(
     signal_type_name: str, storage: IUnifiedStore
 ) -> type[SignalType]:
     """

--- a/open-media-match/src/OpenMediaMatch/blueprints/matching.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/matching.py
@@ -34,6 +34,7 @@ def lookup():
     signal_type_name = require_request_param("signal_type")
     return lookup_signal(signal, signal_type_name)
 
+
 def lookup_signal(signal: str, signal_type_name: str) -> dict[str, list[int]]:
     storage = get_storage()
     signal_type = validate_and_transform_signal_type(signal_type_name, storage)
@@ -48,7 +49,10 @@ def lookup_signal(signal: str, signal_type_name: str) -> dict[str, list[int]]:
         abort(503, "index not yet ready")
     return {"matches": [m.metadata for m in index.query(signal)]}
 
-def validate_and_transform_signal_type(signal_type_name: str, storage: IUnifiedStore) -> type[SignalType]:
+
+def validate_and_transform_signal_type(
+    signal_type_name: str, storage: IUnifiedStore
+) -> type[SignalType]:
     """
     Accepts a signal type name and returns the corresponding signal type class,
     validating that the signal type exists and is enabled for the provided storage.
@@ -59,6 +63,7 @@ def validate_and_transform_signal_type(signal_type_name: str, storage: IUnifiedS
     if not signal_type_config.enabled:
         abort(400, f"SignalType '{signal_type_name}' is not enabled")
     return signal_type_config.signal_type
+
 
 @bp.route("/index/status")
 def index_status():


### PR DESCRIPTION
- fix: change __init__.py to app.py in hello world instructions
- feat: add a query endpoint to combine hashing and matching

Summary
---------

Adds a /query endpoint which allows you to specify an image and signal type and it will return matches for that image 
and signal type with the DB.

Test Plan
---------

Test manually
```
vscode ➜ /workspace $ curl 
'localhost:5000/query?signal_type=pdq&url=https://github.com/facebook/ThreatExchange/blob/main/pdq/data/misc-images/b.jpg?raw=true'
{
  "matches": [
    1,
    13,
    11,
    8,
    5,
    15,
    12,
    10,
    7,
    6,
    4,
    3
  ]
}```
