### PR TITLE
[omm] Matching by banks

### DIFF
--- a/open-media-match/src/OpenMediaMatch/app.py
+++ b/open-media-match/src/OpenMediaMatch/app.py
@@ -1,20 +1,21 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+# NO IMPORTS ABOVE ME
+# Import pdq first with its hash order warning squelched, it's before our time
+import warnings
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from threatexchange.signal_type.pdq import signal as _
+## Resume regularly scheduled imports
+
 import logging
 import os
 import sys
-import warnings
-from OpenMediaMatch.blueprints.curation import banks_index, get_all_signal_types
-from OpenMediaMatch.blueprints.curation import get_all_content_types
 
 import flask
 from flask.logging import default_handler
 import flask_migrate
-
-# Import pdq first with its hash order warning squelched, it's before our time
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    from threatexchange.signal_type.pdq import signal as _
 
 from OpenMediaMatch import database
 from OpenMediaMatch.background_tasks import build_index, fetcher
@@ -52,9 +53,10 @@ def create_app() -> flask.Flask:
         Sanity check endpoint showing a basic status page
         TODO: in development mode, this could show some useful additional info
         """
-        signaltypes = get_all_signal_types()
-        contenttypes = get_all_content_types()
-        banks = banks_index()
+        signaltypes = curation.get_all_signal_types()
+        contenttypes = curation.get_all_content_types()
+        banks = curation.banks_index()
+
         return flask.render_template(
             "index.html.j2",
             production=app.config.get("PRODUCTION"),

--- a/open-media-match/src/OpenMediaMatch/database.py
+++ b/open-media-match/src/OpenMediaMatch/database.py
@@ -92,6 +92,7 @@ class BankContent(db.Model):  # type: ignore[name-defined]
             disable_until_ts=self.disable_until_ts,
             collab_metadata={},
             original_media_uri=None,
+            bank=self.bank.as_storage_iface_cls(),
         )
 
 

--- a/open-media-match/src/OpenMediaMatch/storage/default.py
+++ b/open-media-match/src/OpenMediaMatch/storage/default.py
@@ -165,9 +165,13 @@ class DefaultOMMStore(interface.IUnifiedStore):
         # TODO
         raise Exception("Not implemented")
 
-    def bank_content_get(self, id: int) -> BankContentConfig:
-        # TODO
-        raise Exception("Not implemented")
+    def bank_content_get(self, ids: t.Iterable[int]) -> t.Sequence[BankContentConfig]:
+        return [
+            b.as_storage_iface_cls()
+            for b in database.db.session.query(database.BankContent)
+            .filter(database.BankContent.id.in_(ids))
+            .all()
+        ]
 
     def bank_content_update(self, val: BankContentConfig) -> None:
         # TODO

--- a/open-media-match/src/OpenMediaMatch/storage/interface.py
+++ b/open-media-match/src/OpenMediaMatch/storage/interface.py
@@ -225,6 +225,8 @@ class BankContentConfig:
     collab_metadata: t.Mapping[str, t.Sequence[str]]
     original_media_uri: t.Optional[str]
 
+    bank: BankConfig
+
     @property
     def enabled(self) -> bool:
         if self.disable_until_ts == 0:
@@ -285,7 +287,7 @@ class IBankStore(metaclass=abc.ABCMeta):
 
     # Bank content
     @abc.abstractmethod
-    def bank_content_get(self, id: int) -> BankContentConfig:
+    def bank_content_get(self, id: t.Iterable[int]) -> t.Sequence[BankContentConfig]:
         """Get the content config for a bank"""
 
     @abc.abstractmethod

--- a/open-media-match/src/OpenMediaMatch/storage/mocked.py
+++ b/open-media-match/src/OpenMediaMatch/storage/mocked.py
@@ -104,7 +104,9 @@ class MockedUnifiedStore(interface.IUnifiedStore):
     def bank_delete(self, name: str) -> None:
         self.banks.pop(name, None)
 
-    def bank_content_get(self, id: int) -> interface.BankContentConfig:
+    def bank_content_get(
+        self, id: t.Iterable[int]
+    ) -> t.Sequence[interface.BankContentConfig]:
         # TODO
         raise Exception("Not implemented")
 

--- a/open-media-match/src/OpenMediaMatch/tests/test_api.py
+++ b/open-media-match/src/OpenMediaMatch/tests/test_api.py
@@ -1,9 +1,8 @@
 from flask.testing import FlaskClient
 from flask import Flask
-from sqlalchemy import select, and_
-import typing as t
-from threatexchange.signal_type.pdq.signal import PdqSignal
+
 from sqlalchemy import select
+
 from OpenMediaMatch.tests.utils import (
     app,
     client,
@@ -145,14 +144,14 @@ def test_banks_add_hash_index(app: Flask, client: FlaskClient):
 
     # Test against first image
     post_response = client.get(
-        "/m/lookup?signal_type=pdq&signal={}".format(IMAGE_URL_TO_PDQ[image_url])
+        "/m/raw_lookup?signal_type=pdq&signal={}".format(IMAGE_URL_TO_PDQ[image_url])
     )
     assert post_response.status_code == 200
     assert post_response.json == {"matches": [1]}
 
     # Test against second image
     post_response = client.get(
-        "/m/lookup?signal_type=pdq&signal={}".format(IMAGE_URL_TO_PDQ[image_url_2])
+        "/m/raw_lookup?signal_type=pdq&signal={}".format(IMAGE_URL_TO_PDQ[image_url_2])
     )
     assert post_response.status_code == 200
     assert post_response.json == {"matches": [2]}


### PR DESCRIPTION
Summary
---------

Create a new matching interface that exercises all the enabled/disable logic and returns a list of banks. 

Test Plan
---------

```
$ curl -i 'localhost:5000/m/lookup?signal=f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22&signal_type=pdq'
HTTP/1.1 200 OK
Server: Werkzeug/3.0.0 Python/3.11.4
Date: Wed, 04 Oct 2023 17:33:35 GMT
Content-Type: application/json
Content-Length: 18
Connection: close

[
  "TEST_BANK"
]
```
