### PR TITLE
Add-to-bank now accepts file upload as well.

### DIFF
--- a/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/hashing.py
@@ -74,7 +74,7 @@ def hash_media_post():
     if not request.files:
         return {"message": "Missing multipart/form-data file upload"}, 400
 
-    # Let's just accept a single file per request.
+    # Let's just accept a single file per request. This keeps it consistent with the GET method.
     if len(request.files) > 1:
         return {"message": "Only one file allowed per request"}, 400
 


### PR DESCRIPTION
Summary
---------

Add-to-bank now accepts file upload as well.

Test Plan
---------

Manual testing so far:
```
vscode ➜ /workspace $ curl localhost:5000/c/bank/TEST_BANK/content -F photo=@src/OpenMediaMatch/tests/b.jpg
{
  "id": 17,
  "signals": {
    "pdq": "f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22"
  }
}
vscode ➜ /workspace $ curl 'localhost:5000/m/lookup?signal_type=pdq&signal=f8f8f0cee0f4a84f06370a22038f63f0b36e2ed596621e1d33e6b39c4e9c9b22'
{
  "matches": [
    6,
    13,
    10,
    7,
    4,
    11,
    9,
    8,
    5,
    15,
    2,
    1
  ]
}
```