### PR TITLE
[OMM] Add Command to Seed large amounts of data for testing

### DIFF
--- a/open-media-match/src/OpenMediaMatch/app.py
+++ b/open-media-match/src/OpenMediaMatch/app.py
@@ -20,9 +20,12 @@ import flask_migrate
 
 from OpenMediaMatch import database
 from OpenMediaMatch.background_tasks import build_index, fetcher
-from OpenMediaMatch.persistence import get_storage
 from OpenMediaMatch.blueprints import development, hashing, matching, curation
+from OpenMediaMatch.persistence import get_storage
+from OpenMediaMatch.storage.interface import BankConfig
 
+from threatexchange.signal_type.pdq.signal import PdqSignal
+from threatexchange.signal_type.md5 import VideoMD5Signal
 
 def create_app() -> flask.Flask:
     """
@@ -163,10 +166,6 @@ def create_app() -> flask.Flask:
         or OMM_SEED_BANKS=100 OMM_SEED_HASHES=10000 flask seed_enourmous
         It will generate n banks and put n/m hashes on each bank
         """
-        from threatexchange.signal_type.pdq.signal import PdqSignal
-        from threatexchange.signal_type.md5 import VideoMD5Signal
-        from OpenMediaMatch.storage.interface import BankConfig
-
         # read from env for how many hashes to add\
         banks_to_add = int(os.environ.get("OMM_SEED_BANKS", 100))
         hashes_to_add = int(os.environ.get("OMM_SEED_HASHES", 10000))
@@ -185,7 +184,7 @@ def create_app() -> flask.Flask:
 
                 storage.bank_add_content(bank.name, {signal_type: random_hash})
 
-            print("Finished adding hashes to {}".format(bank.name))
+            print("Finished adding hashes to", bank.name)
 
     @app.cli.command("fetch")
     def fetch():

--- a/open-media-match/src/OpenMediaMatch/app.py
+++ b/open-media-match/src/OpenMediaMatch/app.py
@@ -27,6 +27,7 @@ from OpenMediaMatch.storage.interface import BankConfig
 from threatexchange.signal_type.pdq.signal import PdqSignal
 from threatexchange.signal_type.md5 import VideoMD5Signal
 
+
 def create_app() -> flask.Flask:
     """
     Create and configure the Flask app

--- a/open-media-match/src/OpenMediaMatch/app.py
+++ b/open-media-match/src/OpenMediaMatch/app.py
@@ -166,9 +166,10 @@ def create_app() -> flask.Flask:
         from threatexchange.signal_type.pdq.signal import PdqSignal
         from threatexchange.signal_type.md5 import VideoMD5Signal
         from OpenMediaMatch.storage.interface import BankConfig
+
         # read from env for how many hashes to add\
         banks_to_add = int(os.environ.get("OMM_SEED_BANKS", 100))
-        hashes_to_add = int(os.environ.get("OMM_SEED_HASHES", 100000))
+        hashes_to_add = int(os.environ.get("OMM_SEED_HASHES", 10000))
         storage = get_storage()
 
         for i in range(banks_to_add):
@@ -177,17 +178,12 @@ def create_app() -> flask.Flask:
             storage.bank_update(bank, create=True)
 
             # Add hashes
-            for _ in range(hashes_to_add//banks_to_add):
+            for _ in range(hashes_to_add // banks_to_add):
                 # grab randomly either PDQ or MD5 signal
                 signal_type = random.choice([PdqSignal, VideoMD5Signal])
                 random_hash = signal_type.generate_random_hash()
 
-                storage.bank_add_content(
-                    bank.name,
-                    {
-                        signal_type: random_hash
-                    }
-                )
+                storage.bank_add_content(bank.name, {signal_type: random_hash})
 
             print("Finished adding hashes to {}".format(bank.name))
 

--- a/open-media-match/src/OpenMediaMatch/blueprints/curation.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/curation.py
@@ -5,8 +5,6 @@ from flask import request, jsonify, abort
 
 from sqlalchemy.exc import IntegrityError
 
-from threatexchange.signal_type.pdq.signal import PdqSignal
-
 from OpenMediaMatch import database, persistence, utils
 from OpenMediaMatch.storage.interface import BankConfig
 from OpenMediaMatch.blueprints.hashing import hash_media

--- a/open-media-match/src/OpenMediaMatch/blueprints/curation.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/curation.py
@@ -5,6 +5,8 @@ from flask import request, jsonify, abort
 
 from sqlalchemy.exc import IntegrityError
 
+from threatexchange.signal_type.pdq.signal import PdqSignal
+
 from OpenMediaMatch import database, persistence, utils
 from OpenMediaMatch.storage.interface import BankConfig
 from OpenMediaMatch.blueprints.hashing import hash_media


### PR DESCRIPTION
Summary
---------

Create command to allow seeding a lot of data based on bank and hash variables.

Test Plan
---------

```
$ flask seed_enourmous
```

Will seed 100 banks and 100k hashes between all banks.
