### PR TITLE
Fix for file-based matching.

### DIFF
--- a/open-media-match/src/OpenMediaMatch/blueprints/matching.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/matching.py
@@ -76,24 +76,31 @@ def lookup_get():
     `signal_type` and `signal` query params, or a file url can be provided in the
     `url` query param.
     Input:
+     Either:
+     * File URL (`url`)
+     * Optional content type (`content_type`)
+     Or:
      * Signal type (hash type)
      * Signal value (the hash)
+
+     Also (applies to both cases):
      * Optional seed (content id) for consistent coinflip
     Output:
      * List of matching banks
     """
     # Url was passed as a query param?
     if request.args.get("url", None):
-        hash = hashing.hash_media()
-        # The hash_media function returns an object with a single key
-        # (the signal_type) and value (the signal)
-        signal_type = list(hash.keys())[0]
-        signal = hash[signal_type]
+        hashes = hashing.hash_media()
+        resp = {}
+        for signal_type in hashes.keys():
+            signal = hashes[signal_type]
+            resp[signal_type] = lookup(signal, signal_type)
     else:
         signal = require_request_param("signal")
         signal_type = require_request_param("signal_type")
+        resp = lookup(signal, signal_type)
 
-    return lookup(signal, signal_type)
+    return resp
 
 
 @bp.route("/lookup", methods=["POST"])
@@ -109,13 +116,14 @@ def lookup_post():
     Output:
      * List of matching banks
     """
-    hash = hashing.hash_media_post()
+    hashes = hashing.hash_media_post()
 
-    # The hash function returns an object with a single key (the signal_type) and value (the signal)
-    signal_type = list(hash.keys())[0]
-    signal = hash[signal_type]
+    resp = {}
+    for signal_type in hashes.keys():
+        signal = hashes[signal_type]
+        resp[signal_type] = lookup(signal, signal_type)
 
-    return lookup(signal, signal_type)
+    return resp
 
 
 def lookup(signal, signal_type_name):
@@ -137,7 +145,7 @@ def lookup(signal, signal_type_name):
         b.name for b in banks.values() if b.matching_enabled_ratio >= coinflip
     ]
     current_app.logger.debug(
-        "lookup matches %d banks (%d enabked)", len(banks), len(enabled_banks)
+        "lookup matches %d banks (%d enabled)", len(banks), len(enabled_banks)
     )
     return enabled_banks
 


### PR DESCRIPTION
Summary
---------

Fixed file-based matching to support multiple signal types.

Test Plan
---------

```
vscode ➜ /workspace/src/OpenMediaMatch $ !128
curl localhost:5000/m/lookup -F photo=@b.jpg
{
  "pdq": [
    "TEST_BANK"
  ]
}
vscode ➜ /workspace/src/OpenMediaMatch $ !129
curl localhost:5000/m/lookup -F video=@screen.mov
{
  "video_md5": []
}
```
