### PR TITLE
[omm] Very early poking of gunicorn

### DIFF
--- a/open-media-match/.devcontainer/gunicorn_omm_config.py
+++ b/open-media-match/.devcontainer/gunicorn_omm_config.py
@@ -1,0 +1,24 @@
+"""
+A 
+
+This is meant to demonstrate the differences between the development
+"""
+
+from threatexchange.signal_type.pdq.signal import PdqSignal
+from threatexchange.signal_type.md5 import VideoMD5Signal
+
+# Database configuration
+PRODUCTION = False
+DBUSER = "media_match"
+DBPASS = "hunter2"
+DBHOST = "localhost"
+DBNAME = "media_match"
+DATABASE_URI = f"postgresql+psycopg2://{DBUSER}:{DBPASS}@{DBHOST}/{DBNAME}"
+
+# Role configuration
+ROLE_HASHER = False
+ROLE_MATCHER = False
+ROLE_CURATOR = True
+
+# Installed SignalTypes
+SIGNAL_TYPES = [PdqSignal, VideoMD5Signal]

--- a/open-media-match/Dockerfile
+++ b/open-media-match/Dockerfile
@@ -2,7 +2,9 @@ FROM python:3.11-bullseye
 
 WORKDIR /usr/src/open-media-match
 COPY . .
-RUN pip install .[prod]
+# Because this Dockerfile is used by some github CI, you have to install
+# the test and development dependencies too...
+RUN pip install .[all] 
 #RUN rm -rf /usr/src/open-media-match
 
 # Here is where you need to install your config and role settings

--- a/open-media-match/Dockerfile
+++ b/open-media-match/Dockerfile
@@ -2,9 +2,7 @@ FROM python:3.11-bullseye
 
 WORKDIR /usr/src/open-media-match
 COPY . .
-RUN pip install .
+RUN pip install .[prod]
 #RUN rm -rf /usr/src/open-media-match
 
-#ENTRYPOINT ["python"]
-
-#CMD ["flask", "run"]
+ENTRYPOINT ["gunicorn", "app:create_app()"]

--- a/open-media-match/Dockerfile
+++ b/open-media-match/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /usr/src/open-media-match
 COPY . .
 # Because this Dockerfile is used by some github CI, you have to install
 # the test and development dependencies too...
-RUN pip install .[all] 
+RUN pip install .
 #RUN rm -rf /usr/src/open-media-match
 
 # Here is where you need to install your config and role settings
 
-ENTRYPOINT ["gunicorn", "app:create_app()"]
+#ENTRYPOINT ["gunicorn", "app:create_app()"]

--- a/open-media-match/Dockerfile
+++ b/open-media-match/Dockerfile
@@ -5,4 +5,6 @@ COPY . .
 RUN pip install .[prod]
 #RUN rm -rf /usr/src/open-media-match
 
+# Here is where you need to install your config and role settings
+
 ENTRYPOINT ["gunicorn", "app:create_app()"]

--- a/open-media-match/pyproject.toml
+++ b/open-media-match/pyproject.toml
@@ -35,6 +35,8 @@ all = [
 
 test = [ "pytest" ]
 
+prod = [ "gunicorn" ]
+
 [tool.mypy]
 warn_unused_configs = true
 warn_redundant_casts = true

--- a/open-media-match/pyproject.toml
+++ b/open-media-match/pyproject.toml
@@ -31,6 +31,7 @@ all = [
     "pytest",
     "types-Flask-Migrate",
     "types-requests",
+    "gunicorn"
 ]
 
 test = [ "pytest" ]


### PR DESCRIPTION
Summary
---------

Choosing a production environment is key to how we do background tasks, so let's go with gunicorn.

Just testing enough to make sure it boots.

Test Plan
---------

```
OMM_CONFIG=/workspace/.devcontainer/gunicorn_omm_config.py gunicorn 'app:create_app()'
```
