### PR TITLE
[omm] Add development background tasks with apscheduler

### DIFF
--- a/open-media-match/.devcontainer/omm_config.py
+++ b/open-media-match/.devcontainer/omm_config.py
@@ -9,8 +9,14 @@ DBHOST = "localhost"
 DBNAME = "media_match"
 DATABASE_URI = f"postgresql+psycopg2://{DBUSER}:{DBPASS}@{DBHOST}/{DBNAME}"
 
+# Role configuration
 ROLE_HASHER = True
 ROLE_MATCHER = True
 ROLE_CURATOR = True
 
+# Installed signal types
 SIGNAL_TYPES = [PdqSignal, VideoMD5Signal]
+
+
+# APScheduler (background threads for development)
+SCHEDULER_API_ENABLED = True

--- a/open-media-match/pyproject.toml
+++ b/open-media-match/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "psycopg2",
     "requests",
     "threatexchange",
+    "flask_apscheduler",
 ]
 
 [project.optional-dependencies]
@@ -31,7 +32,8 @@ all = [
     "pytest",
     "types-Flask-Migrate",
     "types-requests",
-    "gunicorn"
+    "gunicorn",
+    "flask_apscheduler"
 ]
 
 test = [ "pytest" ]

--- a/open-media-match/pyproject.toml
+++ b/open-media-match/pyproject.toml
@@ -46,6 +46,10 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 strict_optional = true
 
+[[tool.mypy.overrides]]
+module = "flask_apscheduler.*,importlib_metadata.*"
+ignore_missing_imports = true
+
 [project.urls]
 "Homepage" = "https://github.com/facebook/ThreatExchange/"
 "Bug Tracker" = "https://github.com/facebook/ThreatExchange/issues"

--- a/open-media-match/src/OpenMediaMatch/background_tasks/build_index.py
+++ b/open-media-match/src/OpenMediaMatch/background_tasks/build_index.py
@@ -3,8 +3,12 @@
 import logging
 import typing as t
 
+from flask import Flask
+
 from threatexchange.signal_type.signal_base import SignalType
 
+from OpenMediaMatch.background_tasks.development import get_apscheduler
+from OpenMediaMatch.persistence import get_storage
 from OpenMediaMatch.storage.interface import (
     ISignalTypeIndexStore,
     ISignalTypeConfigStore,
@@ -12,6 +16,12 @@ from OpenMediaMatch.storage.interface import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def apscheduler_build_all_indices() -> None:
+    with get_apscheduler().app.app_context():
+        storage = get_storage()
+        build_all_indices(storage, storage, storage)
 
 
 def build_all_indices(
@@ -29,6 +39,7 @@ def build_all_indices(
     for st in enabled.values():
         build_index(st, bank_store, index_store)
 
+    logger.info("Completed %s background task", build_all_indices.__name__)
     # TODO cleanup disabled / deleted signal types
 
 
@@ -42,10 +53,13 @@ def build_index(
     """
     logger.info("Building index for %s", for_signal_type.get_name())
     index_cls = for_signal_type.get_index_cls()
-    list = []
+    signal_list = []
     for batch in bank_store.bank_yield_content(for_signal_type):
         for signal, bc_id in batch:
             if signal:
                 tuple = (signal, bc_id)
-                list.append(tuple)
-    index_store.store_signal_type_index(for_signal_type, index_cls.build(list))
+                signal_list.append(tuple)
+    logger.info(
+        "Indexed %d signals for %s", len(signal_list), for_signal_type.get_name()
+    )
+    index_store.store_signal_type_index(for_signal_type, index_cls.build(signal_list))

--- a/open-media-match/src/OpenMediaMatch/background_tasks/development.py
+++ b/open-media-match/src/OpenMediaMatch/background_tasks/development.py
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Why do all the flask authors love module state so much?
+
+Tasks need to refer to their scheduler instance, but only
+json-serializable data can be passed as args. So provide
+this as a way to get a static instance.
+"""
+
+from flask_apscheduler import APScheduler
+
+_SCHEDULER = None
+
+
+def get_apscheduler() -> APScheduler:
+    global _SCHEDULER
+    if _SCHEDULER is None:
+        _SCHEDULER = APScheduler()
+    return _SCHEDULER


### PR DESCRIPTION
Summary
---------

This is NOT the answer for #1367, this is just something to hold us over while we continue iterating on the background task design.

I can already see issues with just running on an interval:
1. Interval delay between hash added and when hash will match
2. Need to record somewhere that it is in progress and the result - this is probably duplicate with what every persistent task scheduler does
3. For at least build index, most of the time you don't need to do anything, so we need to detect that.

Test Plan
---------

Look at de logs:

```
[2023-10-10 14:48:36,464] CRITICAL in app: DEVELOPMENT: Started background tasks with apscheduler.
 * Debugger is active!
 * Debugger PIN: 649-591-200
[2023-10-10 14:48:51,465] INFO in build_index: Running the build_all_indices background task
[2023-10-10 14:48:51,479] INFO in build_index: Building index for pdq
[2023-10-10 14:48:51,482] INFO in build_index: Indexed 16 signals for pdq
[2023-10-10 14:48:51,486] INFO in build_index: Building index for video_md5
[2023-10-10 14:48:51,487] INFO in build_index: Indexed 0 signals for video_md5
[2023-10-10 14:48:51,489] INFO in build_index: Completed build_all_indices background task
[2023-10-10 14:49:06,465] INFO in fetcher: Running the fetch_all background task
[2023-10-10 14:49:06,466] INFO in fetcher: Completed fetch_all background task
```
