### PR TITLE
[omm] Create Compose file for gunicorn production deployment.

### DIFF
--- a/open-media-match/Dockerfile
+++ b/open-media-match/Dockerfile
@@ -1,12 +1,15 @@
 FROM python:3.11-bullseye
 
-WORKDIR /usr/src/open-media-match
-COPY . .
+WORKDIR /build
+COPY pyproject.toml ./
+
 # Because this Dockerfile is used by some github CI, you have to install
 # the test and development dependencies too...
-RUN pip install .
-#RUN rm -rf /usr/src/open-media-match
+RUN pip install .[prod]
+COPY ./src /build
 
 # Here is where you need to install your config and role settings
+COPY omm_config.py ./
 
-#ENTRYPOINT ["gunicorn", "app:create_app()"]
+EXPOSE 8080
+CMD ["gunicorn"  , "--bind", "0.0.0.0:8080", "OpenMediaMatch.app:create_app()"]

--- a/open-media-match/docker-compose.yaml
+++ b/open-media-match/docker-compose.yaml
@@ -1,0 +1,34 @@
+version: "3"
+
+services:
+  app:
+    build: .
+    restart: unless-stopped
+    ports:
+      - 8080:8080
+    environment:
+      OMM_CONFIG: /build/omm_config.py
+    networks:
+      - backend
+    depends_on:
+      - db
+
+  db:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+        - ./.devcontainer/pg-scripts/init-multiple-pg-dbs.sh:/docker-entrypoint-initdb.d/init-multiple-pg-dbs.sh
+        - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: media_match
+      POSTGRES_PASSWORD: hunter2
+      POSTGRES_MULTIPLE_DATABASES: media_match,media_match_test
+    networks:
+      - backend
+
+volumes:
+  postgres-data:
+
+networks:
+  backend:
+    driver: bridge

--- a/open-media-match/omm_config.py
+++ b/open-media-match/omm_config.py
@@ -1,5 +1,5 @@
 """
-A 
+A
 
 This is meant to demonstrate the differences between the development
 """
@@ -8,16 +8,16 @@ from threatexchange.signal_type.pdq.signal import PdqSignal
 from threatexchange.signal_type.md5 import VideoMD5Signal
 
 # Database configuration
-PRODUCTION = False
+PRODUCTION = True
 DBUSER = "media_match"
 DBPASS = "hunter2"
-DBHOST = "localhost"
+DBHOST = "db"
 DBNAME = "media_match"
 DATABASE_URI = f"postgresql+psycopg2://{DBUSER}:{DBPASS}@{DBHOST}/{DBNAME}"
 
 # Role configuration
-ROLE_HASHER = False
-ROLE_MATCHER = False
+ROLE_HASHER = True
+ROLE_MATCHER = True
 ROLE_CURATOR = True
 
 # Installed SignalTypes


### PR DESCRIPTION
Summary
---------

Not working yet. Loading the main page I run into:

```
open-media-match-db-1   | 2023-10-11 19:20:09.368 UTC [33] ERROR:  relation "signal_type_override" does not exist at character 101
open-media-match-db-1   | 2023-10-11 19:20:09.368 UTC [33] STATEMENT:  SELECT signal_type_override.id, signal_type_override.name, signal_typ
e_override.enabled_ratio                                                                            
open-media-match-db-1   |       FROM signal_type_override                                           
open-media-match-app-1  | [2023-10-11 19:20:09,368] ERROR in app: Exception on / [GET]
open-media-match-app-1  | Traceback (most recent call last):
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1965, in _exec_single_context
open-media-match-app-1  |     self.dialect.do_execute(                                              
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/default.py", line 921, in do_execute
open-media-match-app-1  |     cursor.execute(statement, parameters)                                 
open-media-match-app-1  | psycopg2.errors.UndefinedTable: relation "signal_type_override" does not exist
open-media-match-app-1  | LINE 2: FROM signal_type_override                                         
open-media-match-app-1  |              ^                                                            
open-media-match-app-1  |                                                                           
open-media-match-app-1  |                                                                           
open-media-match-app-1  | The above exception was the direct cause of the following exception:      
open-media-match-app-1  |                                                                           
open-media-match-app-1  | Traceback (most recent call last):                                        
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 2190, in wsgi_app
open-media-match-app-1  |     response = self.full_dispatch_request()                               
open-media-match-app-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                               
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1486, in full_dispatch_request
open-media-match-app-1  |     rv = self.handle_user_exception(e)                         
open-media-match-app-1  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                    
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1484, in full_dispatch_request
open-media-match-app-1  |     rv = self.dispatch_request()             
open-media-match-app-1  |          ^^^^^^^^^^^^^^^^^^^^^^^             
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1469, in dispatch_request
open-media-match-app-1  |     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
open-media-match-app-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-media-match-app-1  |   File "/build/OpenMediaMatch/app.py", line 92, in home
open-media-match-app-1  |     signaltypes = curation.get_all_signal_types()                         
open-media-match-app-1  |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                         
open-media-match-app-1  |   File "/build/OpenMediaMatch/blueprints/curation.py", line 308, in get_all_signal_types
open-media-match-app-1  |     for c in persistence.get_storage().get_signal_type_configs().values() 
open-media-match-app-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          
open-media-match-app-1  |   File "/build/OpenMediaMatch/storage/default.py", line 75, in get_signal_type_configs
open-media-match-app-1  |     signal_type_overrides = self._query_signal_type_overrides()   
open-media-match-app-1  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   
open-media-match-app-1  |   File "/build/OpenMediaMatch/storage/default.py", line 112, in _query_signal_type_overrides
open-media-match-app-1  |     db_records = database.db.session.execute(                                                                    
open-media-match-app-1  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/orm/scoping.py", line 738, in execute
open-media-match-app-1  |     return self._proxied.execute(                                         
open-media-match-app-1  |            ^^^^^^^^^^^^^^^^^^^^^^                                                                                
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/orm/session.py", line 2262, in execute
open-media-match-app-1  |     return self._execute_internal(                                                                               
open-media-match-app-1  |            ^^^^^^^^^^^^^^^^^^^^^^^                                        
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/orm/session.py", line 2144, in _execute_internal
open-media-match-app-1  |     result: Result[Any] = compile_state_cls.orm_execute_statement(
open-media-match-app-1  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/orm/context.py", line 293, in orm_execute_statement
open-media-match-app-1  |     result = conn.execute(                                                                                       
open-media-match-app-1  |              ^^^^^^^^^^^^^      
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1412, in execute
open-media-match-app-1  |     return meth(                                                          
open-media-match-app-1  |            ^^^^^
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/elements.py", line 516, in _execute_on_connection
open-media-match-app-1  |     return connection._execute_clauseelement(
open-media-match-app-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                             
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1635, in _execute_clauseelement
open-media-match-app-1  |     ret = self._execute_context( 
open-media-match-app-1  |           ^^^^^^^^^^^^^^^^^^^^^^                                          
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1844, in _execute_context
open-media-match-app-1  |     return self._exec_single_context(                            
open-media-match-app-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^                                     
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1984, in _exec_single_context
open-media-match-app-1  |     self._handle_dbapi_exception(
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 2339, in _handle_dbapi_exception
open-media-match-app-1  |     raise sqlalchemy_exception.with_traceback(exc_info[2]) from e                                                
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1965, in _exec_single_context
open-media-match-app-1  |     self.dialect.do_execute(                                              
open-media-match-app-1  |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/default.py", line 921, in do_execute
open-media-match-app-1  |     cursor.execute(statement, parameters)
open-media-match-app-1  | sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedTable) relation "signal_type_override" does not exist
open-media-match-app-1  | LINE 2: FROM signal_type_override                                                                                
open-media-match-app-1  |              ^                                                            
open-media-match-app-1  |  
open-media-match-app-1  | [SQL: SELECT signal_type_override.id, signal_type_override.name, signal_type_override.enabled_ratio 
open-media-match-app-1  | FROM signal_type_override]                                  
open-media-match-app-1  | (Background on this error at: https://sqlalche.me/e/20/f405)    

```

Test Plan
---------

Run with `docker compose up --build`.