### PR TITLE
[pytx] Add back support for Python 3.7

### DIFF
--- a/.github/workflows/python-threatexchange-ci.yaml
+++ b/.github/workflows/python-threatexchange-ci.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.x']
+        python-version: ['3.7', '3.8', '3.9', '3.x']
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/python-threatexchange-release.yaml
+++ b/.github/workflows/python-threatexchange-release.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.7"
       - name: Install packaging dependencies
         run: |
           python -m pip install --upgrade pip

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -64,6 +64,7 @@ setup(
         "pdqhash==0.2.3",  # pdq
         "faiss-cpu==1.7.3",  # faiss
         "numpy==1.24.2",  # faiss
+        "typing-extensions",
     ],
     extras_require=extras_require,
     entry_points={

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -60,10 +60,10 @@ setup(
         "urllib3==1.26.17",  # For allow_methods
         "python-dateutil==2.8.2",
         "dacite==1.7.0",  # 0.18.0 broken our tests due to faulty caching
-        "Pillow==10.0.1",  # pdq
+        "Pillow~=9.4.0",  # pdq
         "pdqhash==0.2.3",  # pdq
         "faiss-cpu==1.7.3",  # faiss
-        "numpy==1.24.2",  # faiss
+        "numpy~=1.21.2",  # faiss
         "typing-extensions==4.7.0",
     ],
     extras_require=extras_require,

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -64,7 +64,7 @@ setup(
         "pdqhash==0.2.3",  # pdq
         "faiss-cpu==1.7.3",  # faiss
         "numpy==1.24.2",  # faiss
-        "typing-extensions",
+        "typing-extensions==4.7.0",
     ],
     extras_require=extras_require,
     entry_points={

--- a/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
@@ -8,6 +8,7 @@ The SignalExchangeAPI talks to external APIs to read/write signals
 
 from abc import ABC, abstractmethod
 import typing as t
+from typing_extensions import final
 
 from threatexchange import common
 from threatexchange.exchanges.collab_config import CollaborationConfigBase
@@ -176,7 +177,7 @@ class SignalExchangeAPI(
         return new
 
     @classmethod
-    @t.final
+    @final
     def naive_fetch_merge(
         cls,
         old: t.Dict[

--- a/python-threatexchange/threatexchange/signal_type/index.py
+++ b/python-threatexchange/threatexchange/signal_type/index.py
@@ -22,6 +22,7 @@ At scale, the flow for matching looks something like:
 from dataclasses import dataclass
 import pickle
 import typing as t
+from typing_extensions import Protocol
 
 
 T = t.TypeVar("T")
@@ -29,7 +30,7 @@ S_Co = t.TypeVar("S_Co", covariant=True, bound="SignalSimilarityInfo")
 CT = t.TypeVar("CT", bound="Comparable")
 
 
-class Comparable(t.Protocol):
+class Comparable(Protocol):
     """Helper for annotating comparable types."""
 
     def __lt__(self: CT, other: CT) -> bool:


### PR DESCRIPTION
Summary
---------
Our team relies heavily on Python 3.7 and would like to use `threatexchange` to fetch hash updates. This is my attempt at making this library compatible with 3.7 as well. 

It seems like the only things we strictly need 3.8 for are `final` and `Protocol` which were introduced in 3.8. To make things compatible with 3.7, I'm importing these from `typing-extesions`.

Test Plan
---------
Tested in python `3.10` and `3.7` virtual environments and confirmed that `threatexchange` was installed and imported successfully.
