### PR TITLE
[omm] Allow overriding the host and db name via environment variables.

### DIFF
--- a/open-media-match/docker-compose.yaml
+++ b/open-media-match/docker-compose.yaml
@@ -4,6 +4,8 @@ x-postgres-variables: &postgres-variables
   POSTGRES_USER: media_match
   # TODO: Use a secret instead.
   POSTGRES_PASSWORD: hunter2
+  POSTGRESS_HOST: db
+  POSTGRESS_DBNAME: media_match
 
 services:
   app:

--- a/open-media-match/omm_config.py
+++ b/open-media-match/omm_config.py
@@ -6,8 +6,8 @@ from threatexchange.signal_type.md5 import VideoMD5Signal
 PRODUCTION = True
 DBUSER = os.environ.get("POSTGRES_USER", "media_match")
 DBPASS = os.environ.get("POSTGRES_PASSWORD", "hunter2")
-DBHOST = "db"
-DBNAME = "media_match"
+DBHOST = os.environ.get("POSTGRESS_HOST", "db")
+DBNAME = os.environ.get("POSTGRESS_DBNAME", "media_match")
 DATABASE_URI = f"postgresql+psycopg2://{DBUSER}:{DBPASS}@{DBHOST}/{DBNAME}"
 
 # Role configuration


### PR DESCRIPTION
Summary
---------

I didn't think I'd need this initially, but I've been trying to spin up the 2 services (app and db) in my own compose and point at it with my own service name that is something other than `db`.

Test Plan
---------

Ran it locally and it still works.
