### PR TITLE
[omm] fix benchmark only_signal_types

### DIFF
--- a/open-media-match/src/OpenMediaMatch/storage/postgres/impl.py
+++ b/open-media-match/src/OpenMediaMatch/storage/postgres/impl.py
@@ -352,7 +352,7 @@ class DefaultOMMStore(interface.IUnifiedStore):
                 continue
             pickled_original_data = pickle.dumps(val)
             as_signal_types = api_cls.naive_convert_to_signal_type(
-                signal_types, cfg, {raw_k: val}
+                signal_types, collab_config, {raw_k: val}
             )
 
             if xd is None:


### PR DESCRIPTION
Summary
---------

Accidentally broke this during the update validation refactor.

Test Plan
---------

Manually fetch with

```
{"new_items_per_fetch": 20, "updates_per_fetch_iter": 1, "deletes_per_fetch_iter": 1, "only_signal_types": ["pdq"]}
```

See only PDQ
