### PR TITLE
[omm] Local cache option to only serve indexes from preload

### DIFF
--- a/open-media-match/.devcontainer/omm_config.py
+++ b/open-media-match/.devcontainer/omm_config.py
@@ -26,6 +26,7 @@ ROLE_CURATOR = True
 # APScheduler (background threads for development)
 TASK_FETCHER = True
 TASK_INDEXER = True
+TASK_INDEX_CACHE = True
 
 # Core functionality configuration
 STORAGE_IFACE_INSTANCE = DefaultOMMStore(

--- a/open-media-match/src/OpenMediaMatch/app.py
+++ b/open-media-match/src/OpenMediaMatch/app.py
@@ -19,6 +19,7 @@ import typing as t
 import click
 import flask
 from flask.logging import default_handler
+from flask_apscheduler import APScheduler
 
 from threatexchange.signal_type.signal_base import SignalType, CanGenerateRandomSignal
 from threatexchange.signal_type.pdq.signal import PdqSignal
@@ -44,10 +45,8 @@ def _is_debug_mode():
     return debug.lower() not in ("0", "false", "no")
 
 
-def _is_dbg_werkzeug_reloaded_process():
+def _is_werkzeug_reloaded_process():
     """If in debug mode, are we in the reloaded process?"""
-    if not _is_debug_mode():
-        return False
     return os.environ.get("WERKZEUG_RUN_MAIN") == "true"
 
 
@@ -92,11 +91,63 @@ def create_app() -> flask.Flask:
     assert isinstance(
         storage, IUnifiedStore
     ), "STORAGE_IFACE_INSTANCE is not an instance of IUnifiedStore"
-    storage.init_flask(app)
 
     _setup_task_logging(app.logger)
 
-    is_production = app.config.get("PRODUCTION", True)
+    scheduler: APScheduler | None = None
+
+    with app.app_context():
+        # We only run apscheduler in the "outer" reloader process, else we'll
+        # have multiple executions of the the scheduler in debug mode
+        if _is_werkzeug_reloaded_process():
+            now = datetime.datetime.now()
+            scheduler = dev_apscheduler.get_apscheduler()
+            scheduler.init_app(app)
+            tasks = []
+            if app.config.get("TASK_FETCHER", False):
+                tasks.append("Fetcher")
+                scheduler.add_job(
+                    "Fetcher",
+                    fetcher.apscheduler_fetch_all,
+                    trigger="interval",
+                    seconds=60 * 4,
+                    start_date=now + datetime.timedelta(seconds=30),
+                )
+            if app.config.get("TASK_INDEXER", False):
+                tasks.append("Indexer")
+                scheduler.add_job(
+                    "Indexer",
+                    build_index.apscheduler_build_all_indices,
+                    trigger="interval",
+                    seconds=60,
+                    start_date=now + datetime.timedelta(seconds=15),
+                )
+            app.logger.info("Started Apscheduler, initial tasks: %s", tasks)
+            scheduler.start()
+
+        storage.init_flask(app)
+
+        is_production = app.config.get("PRODUCTION", True)
+        # Register Flask blueprints for whichever server roles are enabled...
+        # URL prefixing facilitates easy Layer 7 routing :)
+
+        if (
+            not is_production
+            and app.config.get("ROLE_HASHER", False)
+            and app.config.get("ROLE_MATCHER", False)
+        ):
+            app.register_blueprint(development.bp, url_prefix="/dev")
+            app.register_blueprint(ui.bp, url_prefix="/ui")
+
+        if app.config.get("ROLE_HASHER", False):
+            app.register_blueprint(hashing.bp, url_prefix="/h")
+
+        if app.config.get("ROLE_MATCHER", False):
+            app.register_blueprint(matching.bp, url_prefix="/m")
+            matching.initiate_index_cache(scheduler)
+
+        if app.config.get("ROLE_CURATOR", False):
+            app.register_blueprint(curation.bp, url_prefix="/c")
 
     @app.route("/")
     def home():
@@ -108,9 +159,9 @@ def create_app() -> flask.Flask:
         """
         Liveness/readiness check endpoint for your favourite Layer 7 load balancer
         """
-        storage = get_storage()
-        if not storage.is_ready():
-            return "NOT-READY", 503
+        if app.config.get("ROLE_MATCHER", False):
+            if any(idx.is_stale for idx in matching._INDEX_CACHE.values()):
+                return f"INDEX-STALE", 503
         return "I-AM-ALIVE", 200
 
     @app.route("/site-map")
@@ -123,28 +174,6 @@ def create_app() -> flask.Flask:
         routes = list(routes)
         routes.sort()
         return routes
-
-    # Register Flask blueprints for whichever server roles are enabled...
-    # URL prefixing facilitates easy Layer 7 routing :)
-    # Linters complain about imports off the top level, but this is needed
-    # to prevent circular imports
-
-    if (
-        not is_production
-        and app.config.get("ROLE_HASHER", False)
-        and app.config.get("ROLE_MATCHER", False)
-    ):
-        app.register_blueprint(development.bp, url_prefix="/dev")
-        app.register_blueprint(ui.bp, url_prefix="/ui")
-
-    if app.config.get("ROLE_HASHER", False):
-        app.register_blueprint(hashing.bp, url_prefix="/h")
-
-    if app.config.get("ROLE_MATCHER", False):
-        app.register_blueprint(matching.bp, url_prefix="/m")
-
-    if app.config.get("ROLE_CURATOR", False):
-        app.register_blueprint(curation.bp, url_prefix="/c")
 
     @app.cli.command("seed")
     def seed_data():
@@ -205,37 +234,5 @@ def create_app() -> flask.Flask:
         app.logger.setLevel(logging.DEBUG)
         storage = get_storage()
         build_index.build_all_indices(storage, storage, storage)
-
-    with app.app_context():
-        # We only want to run apscheduler in debug mode
-        # and only in the "outer" reloader process
-        if _is_dbg_werkzeug_reloaded_process():
-            now = datetime.datetime.now()
-            scheduler = dev_apscheduler.get_apscheduler()
-            scheduler.init_app(app)
-            tasks = []
-            if app.config.get("TASK_FETCHER", False):
-                tasks.append("Fetcher")
-                scheduler.add_job(
-                    "Fetcher",
-                    fetcher.apscheduler_fetch_all,
-                    trigger="interval",
-                    seconds=60 * 4,
-                    start_date=now + datetime.timedelta(seconds=30),
-                )
-            if app.config.get("TASK_INDEXER", False):
-                tasks.append("Indexer")
-                scheduler.add_job(
-                    "Indexer",
-                    build_index.apscheduler_build_all_indices,
-                    trigger="interval",
-                    seconds=60,
-                    start_date=now + datetime.timedelta(seconds=15),
-                )
-            if tasks:
-                app.logger.critical(
-                    "DEVELOPMENT: Started %s with apscheduler.", ", ".join(tasks)
-                )
-            scheduler.start()
 
     return app

--- a/open-media-match/src/OpenMediaMatch/app.py
+++ b/open-media-match/src/OpenMediaMatch/app.py
@@ -144,7 +144,8 @@ def create_app() -> flask.Flask:
 
         if app.config.get("ROLE_MATCHER", False):
             app.register_blueprint(matching.bp, url_prefix="/m")
-            matching.initiate_index_cache(scheduler)
+            if app.config.get("TASK_INDEX_CACHE", False):
+                matching.initiate_index_cache(app, scheduler)
 
         if app.config.get("ROLE_CURATOR", False):
             app.register_blueprint(curation.bp, url_prefix="/c")
@@ -160,7 +161,7 @@ def create_app() -> flask.Flask:
         Liveness/readiness check endpoint for your favourite Layer 7 load balancer
         """
         if app.config.get("ROLE_MATCHER", False):
-            if any(idx.is_stale for idx in matching._INDEX_CACHE.values()):
+            if matching.index_cache_is_stale():
                 return f"INDEX-STALE", 503
         return "I-AM-ALIVE", 200
 

--- a/open-media-match/src/OpenMediaMatch/background_tasks/build_index.py
+++ b/open-media-match/src/OpenMediaMatch/background_tasks/build_index.py
@@ -61,7 +61,7 @@ def build_index(
     # First check to see if new signals have appeared since the last build
     idx_checkpoint = index_store.get_last_index_build_checkpoint(for_signal_type)
     bank_checkpoint = bank_store.get_current_index_build_target(for_signal_type)
-    if idx_checkpoint is not None and idx_checkpoint == bank_checkpoint:
+    if idx_checkpoint == bank_checkpoint:
         logger.info("%s index up to date, no build needed", for_signal_type.get_name())
         return
     logger.info(

--- a/open-media-match/src/OpenMediaMatch/blueprints/matching.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/matching.py
@@ -4,21 +4,81 @@
 Endpoints for matching content and hashes.
 """
 
+from dataclasses import dataclass
+import datetime
 import random
+import typing as t
+import time
 
-from flask import Blueprint
-from flask import abort, current_app, request
+from flask import Blueprint, Flask, abort, current_app, request
+from flask_apscheduler import APScheduler
 from werkzeug.exceptions import HTTPException
 
 from threatexchange.signal_type.signal_base import SignalType
+from threatexchange.signal_type.index import SignalTypeIndex
 
-from OpenMediaMatch.storage.interface import ISignalTypeConfigStore
+from OpenMediaMatch.background_tasks.development import get_apscheduler
+from OpenMediaMatch.storage import interface
 from OpenMediaMatch.blueprints import hashing
 from OpenMediaMatch.utils.flask_utils import require_request_param, api_error_handler
 from OpenMediaMatch.persistence import get_storage
 
 bp = Blueprint("matching", __name__)
 bp.register_error_handler(HTTPException, api_error_handler)
+
+
+@dataclass
+class _SignalIndexInMemoryCache:
+    signal_type: t.Type[SignalType]
+    index: SignalTypeIndex[int]
+    checkpoint: interface.SignalTypeIndexBuildCheckpoint
+    last_check_ts: float
+
+    @property
+    def is_stale(self):
+        """
+        If we are overdue on refresh by too long, consider it stale.
+        """
+        return time.time() - self.last_check_ts > 65
+
+    @classmethod
+    def get_initial(cls, signal_type: t.Type[SignalType]) -> t.Self:
+        return cls(
+            signal_type,
+            signal_type.get_index_cls().build([]),
+            interface.SignalTypeIndexBuildCheckpoint.get_empty(),
+            0,
+        )
+
+    def reload_if_needed(self, store: interface.IUnifiedStore) -> None:
+        now = time.time()
+        # There's a race condition here, but it's unclear if we should solve it
+        curr_checkpoint = store.get_last_index_build_checkpoint(self.signal_type)
+        if curr_checkpoint is not None and self.checkpoint != curr_checkpoint:
+            new_index = store.get_signal_type_index(self.signal_type)
+            assert new_index is not None
+            self.index = new_index
+            self.checkpoint = curr_checkpoint
+        self.last_check_ts = now
+
+    def periodic_task(self) -> None:
+        app: Flask = get_apscheduler().app
+        with app.app_context():
+            storage = get_storage()
+            prev_time = self.checkpoint.last_item_timestamp
+            self.reload_if_needed(storage)
+            now_time = self.checkpoint.last_item_timestamp
+            if prev_time == now_time:
+                return  # No reload
+            app.logger.info(
+                "CachedIndex[%s] Updated %d -> %d",
+                self.signal_type.get_name(),
+                prev_time,
+                now_time,
+            )
+
+
+_INDEX_CACHE: dict[str, _SignalIndexInMemoryCache] = {}
 
 
 @bp.route("/raw_lookup")
@@ -58,7 +118,7 @@ def lookup_signal(signal: str, signal_type_name: str) -> dict[str, list[int]]:
 
 
 def _validate_and_transform_signal_type(
-    signal_type_name: str, storage: ISignalTypeConfigStore
+    signal_type_name: str, storage: interface.ISignalTypeConfigStore
 ) -> type[SignalType]:
     """
     Accepts a signal type name and returns the corresponding signal type class,
@@ -201,3 +261,25 @@ def index_status():
             }
         status_by_name[name] = status
     return status_by_name
+
+
+def initiate_index_cache(scheduler: APScheduler | None) -> None:
+    global _INDEX_CACHE
+    storage = get_storage()
+    _INDEX_CACHE = {
+        st.signal_type.get_name(): _SignalIndexInMemoryCache.get_initial(st.signal_type)
+        for st in storage.get_signal_type_configs().values()
+    }
+    if scheduler is not None:
+        for name, cache in _INDEX_CACHE.items():
+            scheduler.add_job(
+                f"Match Index Refresh[{name}]",
+                cache.periodic_task,
+                trigger="interval",
+                seconds=30,
+                start_date=datetime.datetime.now() - datetime.timedelta(seconds=29),
+            )
+        scheduler.app.logger.info(
+            "Added Matcher refresh tasks: %s",
+            [f"CachedIndex[{n}]" for n in _INDEX_CACHE],
+        )

--- a/open-media-match/src/OpenMediaMatch/storage/interface.py
+++ b/open-media-match/src/OpenMediaMatch/storage/interface.py
@@ -164,12 +164,13 @@ class ISignalTypeIndexStore(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_signal_type_index(
-        self, signal_type: t.Type[SignalType]
+        self,
+        signal_type: t.Type[SignalType],
     ) -> t.Optional[SignalTypeIndex[int]]:
         """
         Return the built index for this SignalType.
 
-        For OMM, the indexed values are BankedIDs
+        For OMM, the indexed values are the ids of BankedContent
         """
 
     @abc.abstractmethod
@@ -468,7 +469,7 @@ class IBankStore(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def get_current_index_build_target(
         self, signal_type: t.Type[SignalType]
-    ) -> t.Optional[SignalTypeIndexBuildCheckpoint]:
+    ) -> SignalTypeIndexBuildCheckpoint:
         """Get information about the total bank size for skipping an index build"""
 
     @abc.abstractmethod
@@ -508,13 +509,3 @@ class IUnifiedStore(
         testing.
         """
         return
-
-    @abc.abstractmethod
-    def is_ready(self) -> bool:
-        """
-        Whether this instead is ready to serve requests.
-
-        This may not be the right place for this in the long term,
-        but being able to recieving matching traffic is an important,
-        but possibly slow, step.
-        """

--- a/open-media-match/src/OpenMediaMatch/storage/mocked.py
+++ b/open-media-match/src/OpenMediaMatch/storage/mocked.py
@@ -57,7 +57,7 @@ class MockedUnifiedStore(interface.IUnifiedStore):
 
     # Index
     def get_signal_type_index(
-        self, signal_type: type[SignalType]
+        self, signal_type: t.Type[SignalType]
     ) -> t.Optional[SignalTypeIndex[int]]:
         return signal_type.get_index_cls().build(
             (example_signal, fake_id)

--- a/open-media-match/src/OpenMediaMatch/storage/mocked.py
+++ b/open-media-match/src/OpenMediaMatch/storage/mocked.py
@@ -182,8 +182,8 @@ class MockedUnifiedStore(interface.IUnifiedStore):
 
     def get_current_index_build_target(
         self, signal_type: t.Type[SignalType]
-    ) -> t.Optional[interface.SignalTypeIndexBuildCheckpoint]:
-        return None
+    ) -> interface.SignalTypeIndexBuildCheckpoint:
+        return interface.SignalTypeIndexBuildCheckpoint.get_empty()
 
     def bank_yield_content(
         self, signal_type: t.Optional[t.Type[SignalType]] = None, batch_size: int = 100

--- a/open-media-match/src/OpenMediaMatch/tests/omm_config.py
+++ b/open-media-match/src/OpenMediaMatch/tests/omm_config.py
@@ -14,6 +14,7 @@ ROLE_CURATOR = True
 
 TASK_FETCHER = False
 TASK_INDEXER = False
+TASK_INDEX_CACHE = False
 
 # This can help debug tests on the database
 # SQLALCHEMY_ENGINE_LOG_LEVEL = logging.INFO


### PR DESCRIPTION
Summary
---------

This feels more gross than I expected, but:
1. Allow a config option to control indices via cache
2. Then create tasks to populate those caches in the background

There's definitely still some improvements that could be done here - going from postgres -> local file, but then not persisting the local file is something that could be improved.

Test Plan
---------

1. Setup big PDQ index with 10M hashes
2. Build index - 4 minutes
3. Start up server from cold, pre-loads index in ~45 seconds
4. Query multiple times from UI, here was the last of 3:

```
[2023-12-22 04:46:46,990] DEBUG in ui: [query] hashing input
[2023-12-22 04:46:46,994] DEBUG in hashing: Processing upload of type photo, filename=high-saturation.jpg, mimetype=image/jpeg
[2023-12-22 04:46:47,055] DEBUG in ui: [query] performing lookup
[2023-12-22 04:46:47,055] DEBUG in matching: performing lookup
[2023-12-22 04:46:47,057] DEBUG in matching: [lookup_signal] querying index
[2023-12-22 04:46:47,089] DEBUG in matching: [lookup_signal] query complete
[2023-12-22 04:46:47,090] DEBUG in matching: getting bank content
[2023-12-22 04:46:47,097] DEBUG in matching: lookup matches 36 content ids (36 enabled)
[2023-12-22 04:46:47,097] DEBUG in matching: lookup matches 3 banks (3 enabled)
[2023-12-22 04:46:47,103] INFO in _internal: 127.0.0.1 - - [22/Dec/2023 04:46:47] "POST /ui/query HTTP/1.1" 200 -
```
Summary: 
1. ~65ms to hash
2. ~34ms to query
3. ~8ms to get metadata
4. 58 ms E2E for hash & match