### PR TITLE
[omm] bug fixes for db foreign keys; store original API data

### DIFF
--- a/open-media-match/src/OpenMediaMatch/storage/interface.py
+++ b/open-media-match/src/OpenMediaMatch/storage/interface.py
@@ -28,6 +28,8 @@ from threatexchange.signal_type.index import SignalTypeIndex
 from threatexchange.exchanges.fetch_state import (
     FetchCheckpointBase,
     CollaborationConfigBase,
+    FetchedSignalMetadata,
+    TUpdateRecordKey,
 )
 from threatexchange.exchanges.signal_exchange_api import (
     TSignalExchangeAPI,
@@ -315,10 +317,13 @@ class ISignalExchangeStore(metaclass=abc.ABCMeta):
     def exchange_get_data(
         self,
         collab_name: str,
-        key: str,
-    ) -> t.Optional[dict[str, t.Any]]:
+        key: TUpdateRecordKey,
+    ) -> FetchedSignalMetadata:
         """
         Get API-specific collaboration data by key.
+
+        This is only stored if the configuration for the exchange enables it,
+        otherwise an exception should be thrown.
         """
 
 

--- a/open-media-match/src/OpenMediaMatch/storage/mocked.py
+++ b/open-media-match/src/OpenMediaMatch/storage/mocked.py
@@ -16,6 +16,8 @@ from threatexchange.signal_type.signal_base import SignalType
 from threatexchange.exchanges.fetch_state import (
     FetchCheckpointBase,
     CollaborationConfigBase,
+    FetchedSignalMetadata,
+    TUpdateRecordKey,
 )
 
 from OpenMediaMatch.storage import interface
@@ -133,9 +135,9 @@ class MockedUnifiedStore(interface.IUnifiedStore):
     def exchange_get_data(
         self,
         collab_name: str,
-        key: str,
-    ) -> t.Optional[dict[str, t.Any]]:
-        return None
+        key: TUpdateRecordKey,
+    ) -> FetchedSignalMetadata:
+        raise Exception("Not implemented")
 
     def get_banks(self) -> t.Mapping[str, interface.BankConfig]:
         return dict(self.banks)


### PR DESCRIPTION
Summary
---------
* Maybe the last tweaks to stored ExchangeData for a while, the ability to download and retain everything that the API gives back
* Fix a few database bugs exposed as a result.


Test Plan
---------

New unittest
