### PR TITLE
[vpdq] Fix Python Github Action release

### DIFF
--- a/.github/workflows/vpdq-release.yaml
+++ b/.github/workflows/vpdq-release.yaml
@@ -25,6 +25,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r packaging-requirements.txt
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-dev pkg-config cmake ffmpeg libavcodec-dev libavformat-dev libavdevice-dev libavutil-dev libswscale-dev libswresample-dev libavfilter-dev
 
       - name: Package
         run: |


### PR DESCRIPTION
Summary
---------

Add build dependencies so release so that Github Action doesn't fail during Python build.

I think you can just re-run the action and don't need the version bumped to v0.1.1.

Test Plan
---------

Build tested working on my fork (publish fails though, obviously):

https://github.com/ianwal/ThreatExchange/actions/runs/7580134442/job/20645457925