### PR TITLE
[vpdq] Handle pthread error in devcontainer; ignore more build dirs

### DIFF
--- a/vpdq/.gitignore
+++ b/vpdq/.gitignore
@@ -8,6 +8,9 @@
 *.swp
 *.swo
 
+build/
+cpp/libraries-dirs.txt
 cpp/test
 cpp/build
 output-hashes/*
+python/vpdq.cpp

--- a/vpdq/cpp/CMakeLists.txt
+++ b/vpdq/cpp/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.17)
 
-set(CMAKE_CXX_FLAGS "-O2 -fPIC -pthread -Wall -Wextra -Werror -Wno-unused-function -Wno-deprecated-declarations")
-
+set(CMAKE_CXX_FLAGS "-O2 -fPIC -Wall -Wextra -Werror -Wno-unused-function -Wno-deprecated-declarations")
 project(VPDQ)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET

--- a/vpdq/cpp/CMakeLists.txt
+++ b/vpdq/cpp/CMakeLists.txt
@@ -1,7 +1,16 @@
 cmake_minimum_required(VERSION 3.17)
 
+project(VPDQ CXX)
+
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_FLAGS "-O2 -fPIC -Wall -Wextra -Werror -Wno-unused-function -Wno-deprecated-declarations")
-project(VPDQ)
+
+# Enable threads
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+# Find libav* FFmpeg libraries
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET
     libavdevice
@@ -13,7 +22,6 @@ pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET
     libavutil
 )
 
-set(CMAKE_CXX_STANDARD 14)
 
 set (PDQSOURCES
     pdq/cpp/common/pdqhashtypes.cpp
@@ -75,21 +83,25 @@ add_executable(vpdq-hash-video
 
 target_link_libraries(vpdq
     PkgConfig::LIBAV
+    Threads::Threads
 )
 
 target_link_libraries(match-hashes-byline
     vpdq
     PkgConfig::LIBAV
+    Threads::Threads
 )
 
 target_link_libraries(match-hashes-brute
     vpdq
     PkgConfig::LIBAV
+    Threads::Threads
 )
 
 target_link_libraries(vpdq-hash-video
     vpdq
     PkgConfig::LIBAV
+    Threads::Threads
 )
 
 # Write the library dirs to a new-line delimited file for Cython to be able to locate LIBAV files

--- a/vpdq/cpp/CMakeLists.txt
+++ b/vpdq/cpp/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.17)
 
-set(CMAKE_CXX_FLAGS "-O2 -fPIC -Wall -Wextra -Werror -Wno-unused-function -Wno-deprecated-declarations")
+set(CMAKE_CXX_FLAGS "-O2 -fPIC -pthread -Wall -Wextra -Werror -Wno-unused-function -Wno-deprecated-declarations")
+
 project(VPDQ)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET

--- a/vpdq/setup.py
+++ b/vpdq/setup.py
@@ -35,6 +35,7 @@ libav_libraries: List[str]= [
     "avutil",
 ]
 libraries: List[str] = libav_libraries
+extra_link_args: List[str] = ["-lpthread"]
 
 
 def make_clean() -> None:
@@ -93,6 +94,7 @@ EXTENSIONS = [
         extra_objects=[str(LIBVPDQ_PATH)],
         library_dirs=lib_dirs,
         include_dirs=include_dirs,
+        extra_link_args=extra_link_args,
     )
 ]
 


### PR DESCRIPTION
Summary
---------

The only environment I was able to get vpdq working before was the docker image container we are using for omm (because I'm on a lamer windows machine).

I attempted to install 0.2.0 there, but wasn't able to get it to install without some more changes.

The problem I had:
```
  INFO:setup.py:Compiling libvpdq with Make...
      CRITICAL:setup.py:/usr/bin/ld: libvpdq.a(filehasher.cpp.o): undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
      /usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
      collect2: error: ld returned 1 exit status
      make[2]: *** [CMakeFiles/vpdq-hash-video.dir/build.make:111: vpdq-hash-video] Error 1
      make[1]: *** [CMakeFiles/Makefile2:101: CMakeFiles/vpdq-hash-video.dir/all] Error 2
      make: *** [Makefile:103: all] Error 2
```

Random googling says -pthread. I didn't do enough research to tell if I only needed this flag in some circumstances.

Test Plan
---------

```
cd vpdq
pip install .
vpdq /host-home-folder/Videos/test.mp4  # See hashes
...
```
