### PR TITLE
[pdq][php] Set static init flag after static buffer init

### DIFF
--- a/pdq/php/ext/pdq/impl/pdqhashing.c
+++ b/pdq/php/ext/pdq/impl/pdqhashing.c
@@ -790,7 +790,7 @@ static float* fill_dct_matrix_64_cached() {
           cos((M_PI / 2 / 64.0) * (i+1) * (2 * j + 1));
       }
     }
-    initialized = false;
+    initialized = true;
   }
   return &buffer[0];
 }


### PR DESCRIPTION
Summary
---------

Set static initialization flag to true after initializing buffer.

The same issue was fixed in PDQ CPP implementation in #1338 in [pdqhashing.cpp](https://github.com/facebook/ThreatExchange/pull/1338/files#diff-ddffedc0b273b16ae0671ec5cd14c2dd3b80df8749eeb771f393f1710d441543).

Note that this function is still not reentrant or thread-safe.

Test Plan
---------

Have not tested locally. I'm not familiar with PHP. It should be fine.
