### PR TITLE
[pdq] Constant initialize DCT buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ pdq/java/bazel-testlogs/
 .vscode/
 *.d.ts
 .idea/
+venv/


### PR DESCRIPTION
Summary
---------

Changed DCT buffer to be constant initialized.  

The function which initializes and returns the DCT static buffer was updated to be reentrant in #1338 in [pdqhashing.cpp](https://github.com/facebook/ThreatExchange/pull/1338/files#diff-ddffedc0b273b16ae0671ec5cd14c2dd3b80df8749eeb771f393f1710d441543). The change was to protect filling the static buffer from multiple threads by using std::call_once. However, this is unnecessary because it can just be constant initialized because the buffer is never modified after initialization.

In this PR, the buffer is changed to a `std::array`, so it can be returned from the function. The convenience pointers to its offsets are changed to references in `fillFloatLumaFromRGB`.

Other misc changes:

- Updated some variable names in the function for readability.

- Added `venv/` to `.gitignore` for dev convenience

References:

[cppreference.com](https://en.cppreference.com/w/cpp/language/initialization) initialization article (I don't own the standard):


> All non-local variables with static [storage duration](https://en.cppreference.com/w/cpp/language/storage_duration) are initialized as part of program startup, before the execution of the [main function](https://en.cppreference.com/w/cpp/language/main_function) begins (unless deferred, see below). All non-local variables with thread-local storage duration are initialized as part of thread launch, sequenced-before the execution of the thread function begins. For both of these classes of variables, initialization occurs in two distinct stages:

Anecdote: If compiled with C++20 (ex. https://godbolt.org/z/jejqn6M4Y), this function actually turns into a lookup table. I thought that was interesting.

Test Plan
---------

Tested vpdq and pdq. All tests pass. No concurrency issues when ran with sanitizers (vpdq CI does this).