### PR TITLE
[vpdq] Remove unused constant

### DIFF
--- a/vpdq/cpp/vpdq/cpp/io/vpdqio.cpp
+++ b/vpdq/cpp/vpdq/cpp/io/vpdqio.cpp
@@ -30,7 +30,6 @@ namespace vpdq {
 namespace io {
 
 const int TIMESTAMP_OUTPUT_PRECISION = 3;
-const int MILLISEC_IN_SEC = 1000000;
 
 bool loadHashesFromFileOrDie(
     const string& inputHashFileName,


### PR DESCRIPTION
Small quick fix. Resolves a compilation error when `-Werror` is used.

Summary
---------
There's an unused variable that causes a compilation error when `-Werror` is used. The constant doesn't appear to be used anywhere else.