### PR TITLE
[omm] CRUD API functionality for storing credentials

### DIFF
--- a/open-media-match/.devcontainer/omm_config.py
+++ b/open-media-match/.devcontainer/omm_config.py
@@ -12,6 +12,9 @@ from threatexchange.signal_type.md5 import VideoMD5Signal
 from threatexchange.content_type.photo import PhotoContent
 from threatexchange.content_type.video import VideoContent
 from threatexchange.exchanges.impl.static_sample import StaticSampleSignalExchangeAPI
+from threatexchange.exchanges.impl.fb_threatexchange_api import (
+    FBThreatExchangeSignalExchangeAPI,
+)
 
 # Database configuration
 DBUSER = "media_match"
@@ -34,7 +37,11 @@ TASK_INDEX_CACHE = False  # Needs a fix to allow initial startup
 STORAGE_IFACE_INSTANCE = DefaultOMMStore(
     signal_types=[PdqSignal, VideoMD5Signal],
     content_types=[PhotoContent, VideoContent],
-    exchange_types=[StaticSampleSignalExchangeAPI, InfiniteRandomExchange],
+    exchange_types=[
+        StaticSampleSignalExchangeAPI,
+        InfiniteRandomExchange,
+        FBThreatExchangeSignalExchangeAPI,
+    ],
 )
 
 # Debugging stuff

--- a/open-media-match/src/OpenMediaMatch/background_tasks/fetcher.py
+++ b/open-media-match/src/OpenMediaMatch/background_tasks/fetcher.py
@@ -97,7 +97,7 @@ def _fetch(
         return
     log("Fetching signals for %s from %s", collab.name, collab.api)
 
-    api_cls = collab_store.exchange_get_type_configs().get(collab.api)
+    api_cls = collab_store.exchange_apis_get_installed().get(collab.api)
     assert (
         api_cls is not None
     ), f"No such SignalExchangeAPI '{collab.api}' - maybe it was deleted?"

--- a/open-media-match/src/OpenMediaMatch/blueprints/curation.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/curation.py
@@ -180,8 +180,26 @@ def _get_collab(name: str):
 # Fetching/Exchanges (aka collaborations)
 @bp.route("/exchanges/apis", methods=["GET"])
 def exchange_api_list() -> list[str]:
-    exchange_apis = persistence.get_storage().exchange_get_type_configs()
+    exchange_apis = persistence.get_storage().exchange_type_get_configs()
     return list(exchange_apis)
+
+
+@bp.route("/exchanges/api/<string:api_name", methods=["GET", "POST", "PUT"])
+def exchange_api_config_get_or_update(api_name: str) -> dict[str, t.Any]:
+    api = persistence.get_storage().exchange_type_get_configs().get(api_name)
+    if api is None:
+        abort(400, f"no such Exchange API '{api_name}'")
+    if request.method == "POST":
+        pass
+    elif request.method == "PUT":
+        pass
+    return {"has_custom_credentials": api.credentials is not None}
+
+
+@bp.route("/exchanges/api/<string:api_name", methods=["DELETE"])
+def exchange_api_config_delete(api_name: str) -> dict[str, t.Any]:
+    persistence.get_storage().exchange_type_delete(api_name)
+    return {"success": True}
 
 
 @bp.route("/exchanges", methods=["POST"])

--- a/open-media-match/src/OpenMediaMatch/blueprints/curation.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/curation.py
@@ -180,13 +180,13 @@ def _get_collab(name: str):
 # Fetching/Exchanges (aka collaborations)
 @bp.route("/exchanges/apis", methods=["GET"])
 def exchange_api_list() -> list[str]:
-    exchange_apis = persistence.get_storage().exchange_type_get_configs()
+    exchange_apis = persistence.get_storage().exchange_apis_get_configs()
     return list(exchange_apis)
 
 
 @bp.route("/exchanges/api/<string:api_name>", methods=["GET", "POST", "PUT"])
 def exchange_api_config_get_or_update(api_name: str) -> dict[str, t.Any]:
-    api = persistence.get_storage().exchange_type_get_configs().get(api_name)
+    api = persistence.get_storage().exchange_apis_get_configs().get(api_name)
     if api is None:
         abort(400, f"no such Exchange API '{api_name}'")
     if request.method == "POST":
@@ -217,7 +217,7 @@ def exchange_create():
         abort(400, "Field `api_json` must be object")
 
     storage = persistence.get_storage()
-    api_types = storage.exchange_get_type_configs()
+    api_types = storage.exchange_apis_get_installed()
 
     if api_type_name is None:
         abort(400, "Field `api_type` is required")

--- a/open-media-match/src/OpenMediaMatch/blueprints/curation.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/curation.py
@@ -184,7 +184,7 @@ def exchange_api_list() -> list[str]:
     return list(exchange_apis)
 
 
-@bp.route("/exchanges/api/<string:api_name", methods=["GET", "POST", "PUT"])
+@bp.route("/exchanges/api/<string:api_name>", methods=["GET", "POST", "PUT"])
 def exchange_api_config_get_or_update(api_name: str) -> dict[str, t.Any]:
     api = persistence.get_storage().exchange_type_get_configs().get(api_name)
     if api is None:
@@ -194,12 +194,6 @@ def exchange_api_config_get_or_update(api_name: str) -> dict[str, t.Any]:
     elif request.method == "PUT":
         pass
     return {"has_custom_credentials": api.credentials is not None}
-
-
-@bp.route("/exchanges/api/<string:api_name", methods=["DELETE"])
-def exchange_api_config_delete(api_name: str) -> dict[str, t.Any]:
-    persistence.get_storage().exchange_type_delete(api_name)
-    return {"success": True}
 
 
 @bp.route("/exchanges", methods=["POST"])

--- a/open-media-match/src/OpenMediaMatch/blueprints/ui.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/ui.py
@@ -33,6 +33,13 @@ def _index_info() -> dict[str, dict[str, t.Any]]:
     return index
 
 
+def _api_cls_info() -> dict[str, dict[str, t.Any]]:
+    return {
+        name: {"has_auth": cfg.credentials is not None}
+        for name, cfg in get_storage().exchange_apis_get_configs().items()
+    }
+
+
 def _collab_info() -> dict[str, dict[str, t.Any]]:
     storage = get_storage()
     collabs = storage.exchanges_get()
@@ -91,7 +98,7 @@ def home():
     template_vars = {
         "signal": curation.get_all_signal_types(),
         "content": curation.get_all_content_types(),
-        "exchangeApiList": curation.exchange_api_list(),
+        "exchange_apis": _api_cls_info(),
         "bankList": curation.banks_index(),
         "production": current_app.config.get("PRODUCTION", True),
         "index": _index_info(),

--- a/open-media-match/src/OpenMediaMatch/blueprints/ui.py
+++ b/open-media-match/src/OpenMediaMatch/blueprints/ui.py
@@ -35,7 +35,11 @@ def _index_info() -> dict[str, dict[str, t.Any]]:
 
 def _api_cls_info() -> dict[str, dict[str, t.Any]]:
     return {
-        name: {"has_auth": cfg.credentials is not None}
+        name: {
+            "auth_note": ""
+            if not cfg.supports_auth
+            else ("(may need auth)" if cfg.credentials is None else "(has credentials)")
+        }
         for name, cfg in get_storage().exchange_apis_get_configs().items()
     }
 

--- a/open-media-match/src/OpenMediaMatch/storage/interface.py
+++ b/open-media-match/src/OpenMediaMatch/storage/interface.py
@@ -31,6 +31,7 @@ from threatexchange.exchanges.fetch_state import (
     FetchedSignalMetadata,
     TUpdateRecordKey,
 )
+from threatexchange.exchanges.auth import CredentialHelper
 from threatexchange.exchanges.signal_exchange_api import (
     TSignalExchangeAPI,
     TSignalExchangeAPICls,
@@ -195,6 +196,16 @@ class ISignalTypeIndexStore(metaclass=abc.ABCMeta):
         """
 
 
+@dataclass
+class SignalExchangeAPIConfig:
+    """
+    Holder for SignalExchangeAPIConfig configuration.
+    """
+
+    exchange_cls: TSignalExchangeAPICls
+    credentials: t.Optional[CredentialHelper] = None
+
+
 @dataclass(kw_only=True)
 class FetchStatus:
     checkpoint_ts: t.Optional[int]
@@ -227,9 +238,28 @@ class ISignalExchangeStore(metaclass=abc.ABCMeta):
     """Interface for accessing SignalExchange configuration"""
 
     @abc.abstractmethod
-    def exchange_get_type_configs(self) -> t.Mapping[str, TSignalExchangeAPICls]:
+    def exchange_type_get_configs(self) -> t.Mapping[str, SignalExchangeAPIConfig]:
         """
         Return all installed SignalExchange types.
+        """
+
+    @abc.abstractmethod
+    def exchange_type_update(
+        self, cfg: SignalExchangeAPIConfig, *, create: bool = False
+    ) -> None:
+        """
+        Create or update the config for exchange API.
+
+        If create is false, if the name doesn't exist it will throw
+        If create is true, if the name already exists it will throw
+        """
+
+    @abc.abstractmethod
+    def exchange_type_delete(self, name: str) -> None:
+        """
+        Delete collaboration/exchange.
+
+        No exception is thrown if a config with that name doesn't exist
         """
 
     @abc.abstractmethod
@@ -239,7 +269,7 @@ class ISignalExchangeStore(metaclass=abc.ABCMeta):
         """
         Create or update a collaboration/exchange.
 
-        If create is false, if the name doesn't .
+        If create is false, if the name doesn't exist it will throw
         If create is true, if the name already exists it will throw
         """
 

--- a/open-media-match/src/OpenMediaMatch/storage/interface.py
+++ b/open-media-match/src/OpenMediaMatch/storage/interface.py
@@ -244,22 +244,9 @@ class ISignalExchangeStore(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def exchange_type_update(
-        self, cfg: SignalExchangeAPIConfig, *, create: bool = False
-    ) -> None:
+    def exchange_type_update(self, cfg: SignalExchangeAPIConfig) -> None:
         """
-        Create or update the config for exchange API.
-
-        If create is false, if the name doesn't exist it will throw
-        If create is true, if the name already exists it will throw
-        """
-
-    @abc.abstractmethod
-    def exchange_type_delete(self, name: str) -> None:
-        """
-        Delete collaboration/exchange.
-
-        No exception is thrown if a config with that name doesn't exist
+        Update the config for an installed exchange API.
         """
 
     @abc.abstractmethod

--- a/open-media-match/src/OpenMediaMatch/storage/interface.py
+++ b/open-media-match/src/OpenMediaMatch/storage/interface.py
@@ -202,7 +202,7 @@ class SignalExchangeAPIConfig:
     Holder for SignalExchangeAPIConfig configuration.
     """
 
-    exchange_cls: TSignalExchangeAPICls
+    api_cls: TSignalExchangeAPICls
     credentials: t.Optional[CredentialHelper] = None
 
 
@@ -237,14 +237,20 @@ class FetchStatus:
 class ISignalExchangeStore(metaclass=abc.ABCMeta):
     """Interface for accessing SignalExchange configuration"""
 
-    @abc.abstractmethod
-    def exchange_type_get_configs(self) -> t.Mapping[str, SignalExchangeAPIConfig]:
+    def exchange_apis_get_installed(self) -> t.Mapping[str, TSignalExchangeAPICls]:
         """
         Return all installed SignalExchange types.
         """
+        return {k: v.api_cls for k, v in self.exchange_apis_get_configs().items()}
 
     @abc.abstractmethod
-    def exchange_type_update(self, cfg: SignalExchangeAPIConfig) -> None:
+    def exchange_apis_get_configs(self) -> t.Mapping[str, SignalExchangeAPIConfig]:
+        """
+        Returns the configuration for all installed exchange types
+        """
+
+    @abc.abstractmethod
+    def exchange_api_config_update(self, cfg: SignalExchangeAPIConfig) -> None:
         """
         Update the config for an installed exchange API.
         """

--- a/open-media-match/src/OpenMediaMatch/storage/mocked.py
+++ b/open-media-match/src/OpenMediaMatch/storage/mocked.py
@@ -82,11 +82,21 @@ class MockedUnifiedStore(interface.IUnifiedStore):
         return None
 
     # Exchanges
-    def exchange_get_type_configs(self) -> t.Mapping[str, TSignalExchangeAPICls]:
-        return {e.get_name(): e for e in (StaticSampleSignalExchangeAPI,)}
+    def exchange_type_get_configs(
+        self,
+    ) -> t.Mapping[str, interface.SignalExchangeAPIConfig]:
+        return {
+            e.get_name(): interface.SignalExchangeAPIConfig(e)
+            for e in (StaticSampleSignalExchangeAPI,)
+        }
+
+    def exchange_type_update(
+        self, cfg: interface.SignalExchangeAPIConfig, *, create: bool = False
+    ) -> None:
+        raise Exception("Not implemented")
 
     def exchange_get_api_instance(self, api_cls_name: str) -> TSignalExchangeAPI:
-        return self.exchange_get_type_configs()[api_cls_name]()
+        return self.exchange_type_get_configs()[api_cls_name].exchange_cls()
 
     def exchange_update(
         self, cfg: CollaborationConfigBase, *, create: bool = False

--- a/open-media-match/src/OpenMediaMatch/storage/mocked.py
+++ b/open-media-match/src/OpenMediaMatch/storage/mocked.py
@@ -94,7 +94,7 @@ class MockedUnifiedStore(interface.IUnifiedStore):
         raise Exception("Not implemented")
 
     def exchange_get_api_instance(self, api_cls_name: str) -> TSignalExchangeAPI:
-        return self.exchange_type_get_configs()[api_cls_name].exchange_cls()
+        return self.exchange_type_get_configs()[api_cls_name].api_cls()
 
     def exchange_update(
         self, cfg: CollaborationConfigBase, *, create: bool = False

--- a/open-media-match/src/OpenMediaMatch/storage/mocked.py
+++ b/open-media-match/src/OpenMediaMatch/storage/mocked.py
@@ -90,9 +90,7 @@ class MockedUnifiedStore(interface.IUnifiedStore):
             for e in (StaticSampleSignalExchangeAPI,)
         }
 
-    def exchange_type_update(
-        self, cfg: interface.SignalExchangeAPIConfig, *, create: bool = False
-    ) -> None:
+    def exchange_type_update(self, cfg: interface.SignalExchangeAPIConfig) -> None:
         raise Exception("Not implemented")
 
     def exchange_get_api_instance(self, api_cls_name: str) -> TSignalExchangeAPI:

--- a/open-media-match/src/OpenMediaMatch/storage/postgres/database.py
+++ b/open-media-match/src/OpenMediaMatch/storage/postgres/database.py
@@ -489,3 +489,19 @@ class SignalTypeOverride(db.Model):  # type: ignore[name-defined]
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(255), unique=True, index=True)
     enabled_ratio: Mapped[float] = mapped_column(default=1.0)
+
+
+class ExchangeAPIConfig(db.Model):  # type: ignore[name-defined]
+    """
+    Store any per-API config we might need.
+    """
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    api: Mapped[str] = mapped_column(unique=True)
+    # If the credentials can't be produced at docker build time, here's a
+    # backup location to store them. You'll have to modify the OMM code to
+    # use them how your API expects if it's not one of the natively supported
+    # Exchange types.
+    # This should correspond to threatexchange.exchanges.authCredentialHelper
+    # object
+    defaul_credentials_json: Mapped[t.Dict[str, t.Any]] = mapped_column(JSON)

--- a/open-media-match/src/OpenMediaMatch/storage/postgres/database.py
+++ b/open-media-match/src/OpenMediaMatch/storage/postgres/database.py
@@ -520,8 +520,9 @@ class ExchangeAPIConfig(db.Model):  # type: ignore[name-defined]
         self, api_cls: TSignalExchangeAPICls
     ) -> SignalExchangeAPIConfig:
         creds = None
-        if self.default_credentials_json:
-            creds = dataclass_json.dataclass_load_dict(
-                self.default_credentials_json, auth.CredentialHelper
-            )
+        if issubclass(api_cls, auth.SignalExchangeWithAuth):
+            if self.default_credentials_json:
+                creds = dataclass_json.dataclass_load_dict(
+                    self.default_credentials_json, api_cls.get_credential_cls()
+                )
         return SignalExchangeAPIConfig(api_cls, creds)

--- a/open-media-match/src/OpenMediaMatch/storage/postgres/database.py
+++ b/open-media-match/src/OpenMediaMatch/storage/postgres/database.py
@@ -512,16 +512,16 @@ class ExchangeAPIConfig(db.Model):  # type: ignore[name-defined]
 
     def serialize_credentials(self, creds: auth.CredentialHelper | None) -> None:
         if creds is None:
-            self.defaul_credentials_json = {}
+            self.default_credentials_json = {}
         else:
-            self.defaul_credentials_json = dataclass_json.dataclass_dump_dict(creds)
+            self.default_credentials_json = dataclass_json.dataclass_dump_dict(creds)
 
     def as_storage_iface_cls(
         self, api_cls: TSignalExchangeAPICls
     ) -> SignalExchangeAPIConfig:
         creds = None
-        if self.defaul_credentials_json:
+        if self.default_credentials_json:
             creds = dataclass_json.dataclass_load_dict(
-                self.defaul_credentials_json, auth.CredentialHelper
+                self.default_credentials_json, auth.CredentialHelper
             )
         return SignalExchangeAPIConfig(api_cls, creds)

--- a/open-media-match/src/OpenMediaMatch/templates/components/content_signal.html.j2
+++ b/open-media-match/src/OpenMediaMatch/templates/components/content_signal.html.j2
@@ -35,7 +35,7 @@
             <div class="card-body">
                 <ul class="list-unstyled mt-3">
                     {% for name, c in exchange_apis.items() %}
-                    <li> {{ name }} {% if c['has_auth'] %} (authed) {% endif %}</li>
+                    <li> {{ name }} {{ c['auth_note'] }}</li>
                     {% endfor %}
                 </ul>
             </div>

--- a/open-media-match/src/OpenMediaMatch/templates/components/content_signal.html.j2
+++ b/open-media-match/src/OpenMediaMatch/templates/components/content_signal.html.j2
@@ -7,7 +7,7 @@
             <div class="card-body">
                 <ul class="list-unstyled mt-3">
                     {% for s in signal %}
-                    <li> {{s['name']}}: {{s['enabled_ratio'] * 100}}% Enabled </li>
+                    <li> {{ s['name'] }}: {{ s['enabled_ratio'] * 100 }}% Enabled </li>
                     {% endfor %}
                 </ul>
             </div>
@@ -21,7 +21,7 @@
             <div class="card-body">
                 <ul class="list-unstyled mt-3">
                     {% for c in content %}
-                    <li> {{c['name']}}: {% if c['enabled'] %} Enabled {% else %} Disabled {% endif %} </li>
+                    <li> {{ c['name'] }}: {% if c['enabled'] %} Enabled {% else %} Disabled {% endif %} </li>
                     {% endfor %}
                 </ul>
             </div>
@@ -34,8 +34,8 @@
             </div>
             <div class="card-body">
                 <ul class="list-unstyled mt-3">
-                    {% for name in exchangeApiList %}
-                    <li> {{name}} </li>
+                    {% for name, c in exchange_apis.items() %}
+                    <li> {{ name }} {% if c['has_auth'] %} (authed) {% endif %}</li>
                     {% endfor %}
                 </ul>
             </div>

--- a/open-media-match/src/OpenMediaMatch/tests/test_postgres_storage_impl.py
+++ b/open-media-match/src/OpenMediaMatch/tests/test_postgres_storage_impl.py
@@ -40,7 +40,7 @@ def storage(app: Flask) -> t.Iterator[DefaultOMMStore]:
     }
     assert (
         StaticSampleSignalExchangeAPI.get_name()
-        in storage_instance.exchange_get_type_configs()
+        in storage_instance.exchange_apis_get_installed()
     )
     yield storage_instance
 
@@ -222,7 +222,6 @@ def test_exchange_type_confg(storage: DefaultOMMStore):
                 t.cast(TSignalExchangeAPICls, FBThreatExchangeSignalExchangeAPI),
                 fb_auth,
             ),
-            create=True,
         )
 
     new_exchange_types = dict(storage.exchange_types)
@@ -235,7 +234,7 @@ def test_exchange_type_confg(storage: DefaultOMMStore):
     # Sanity, no db record yet
     api_confg = storage.exchange_type_get_configs().get(api_name)
     assert api_confg is not None
-    assert api_confg.exchange_cls is FBThreatExchangeSignalExchangeAPI
+    assert api_confg.api_cls is FBThreatExchangeSignalExchangeAPI
     assert api_confg.credentials is None
 
     # Can't set credentials for something that doesn't take it
@@ -245,7 +244,6 @@ def test_exchange_type_confg(storage: DefaultOMMStore):
                 t.cast(TSignalExchangeAPICls, StaticSampleSignalExchangeAPI),
                 auth.CredentialHelper(),
             ),
-            create=True,
         )
 
     storage.exchange_type_update(
@@ -253,7 +251,6 @@ def test_exchange_type_confg(storage: DefaultOMMStore):
             t.cast(TSignalExchangeAPICls, FBThreatExchangeSignalExchangeAPI),
             fb_auth,
         ),
-        create=True,
     )
 
 

--- a/open-media-match/src/OpenMediaMatch/tests/test_postgres_storage_impl.py
+++ b/open-media-match/src/OpenMediaMatch/tests/test_postgres_storage_impl.py
@@ -210,16 +210,16 @@ class _UnknownSampleExchangeAPI(StaticSampleSignalExchangeAPI):
 
 def test_exchange_type_confg(storage: DefaultOMMStore):
     # Configs should always exist for all configured types
-    existing = storage.exchange_type_get_configs()
-    assert set(existing) == set(storage.exchange_types)
+    existing = storage.exchange_apis_get_configs()
+    assert set(existing) == set(storage.exchange_apis_get_installed())
 
     fb_auth = FBThreatExchangeCredentials(f"{0:08}|{0:020}")
 
     # Can't set a config type that doesn't exist
     with pytest.raises(Exception):
-        storage.exchange_type_update(
+        storage.exchange_api_config_update(
             interface.SignalExchangeAPIConfig(
-                t.cast(TSignalExchangeAPICls, FBThreatExchangeSignalExchangeAPI),
+                t.cast(TSignalExchangeAPICls, _UnknownSampleExchangeAPI),
                 fb_auth,
             ),
         )
@@ -232,26 +232,26 @@ def test_exchange_type_confg(storage: DefaultOMMStore):
     storage.exchange_types = new_exchange_types
 
     # Sanity, no db record yet
-    api_confg = storage.exchange_type_get_configs().get(api_name)
-    assert api_confg is not None
-    assert api_confg.api_cls is FBThreatExchangeSignalExchangeAPI
-    assert api_confg.credentials is None
+    api_config = storage.exchange_apis_get_configs().get(api_name)
+    assert api_config is not None
+    assert api_config.api_cls is FBThreatExchangeSignalExchangeAPI
+    assert api_config.credentials is None
 
     # Can't set credentials for something that doesn't take it
     with pytest.raises(Exception):
-        storage.exchange_type_update(
+        storage.exchange_api_config_update(
             interface.SignalExchangeAPIConfig(
                 t.cast(TSignalExchangeAPICls, StaticSampleSignalExchangeAPI),
                 auth.CredentialHelper(),
             ),
         )
 
-    storage.exchange_type_update(
-        interface.SignalExchangeAPIConfig(
-            t.cast(TSignalExchangeAPICls, FBThreatExchangeSignalExchangeAPI),
-            fb_auth,
-        ),
+    val_to_set = interface.SignalExchangeAPIConfig(
+        t.cast(TSignalExchangeAPICls, FBThreatExchangeSignalExchangeAPI),
+        fb_auth,
     )
+    storage.exchange_api_config_update(val_to_set)
+    assert val_to_set == storage.exchange_apis_get_configs().get(api_name)
 
 
 def test_exchange_get_data(storage: DefaultOMMStore):


### PR DESCRIPTION
Summary
---------

* Adds database storage for exchange type configs
* Adds a simple API to view them

Test Plan
---------

* new unittest
* Run `TX_ACCESS_TOKEN='xxxx' flask auth fb_threatexchange` as well as the same token with `flask auth --from-str=fb_threatexchange`
* Also added this on the UI:

## Pre-auth
![image](https://github.com/facebook/ThreatExchange/assets/1654004/2c9637d4-9946-4486-983d-e5cdee18b8f7)

## Post-auth
![image](https://github.com/facebook/ThreatExchange/assets/1654004/11568fae-90d9-4d9a-826d-544e160fd2a5)

