### PR TITLE
[omm] Add the rest of the default exchanges

### DIFF
--- a/open-media-match/.devcontainer/omm_config.py
+++ b/open-media-match/.devcontainer/omm_config.py
@@ -12,6 +12,8 @@ from threatexchange.signal_type.md5 import VideoMD5Signal
 from threatexchange.content_type.photo import PhotoContent
 from threatexchange.content_type.video import VideoContent
 from threatexchange.exchanges.impl.static_sample import StaticSampleSignalExchangeAPI
+from threatexchange.exchanges.impl.ncmec_api import NCMECSignalExchangeAPI
+from threatexchange.exchanges.impl.stop_ncii_api import StopNCIISignalExchangeAPI
 from threatexchange.exchanges.impl.fb_threatexchange_api import (
     FBThreatExchangeSignalExchangeAPI,
 )
@@ -41,6 +43,8 @@ STORAGE_IFACE_INSTANCE = DefaultOMMStore(
         StaticSampleSignalExchangeAPI,
         InfiniteRandomExchange,
         FBThreatExchangeSignalExchangeAPI,
+        NCMECSignalExchangeAPI,
+        StopNCIISignalExchangeAPI,
     ],
 )
 


### PR DESCRIPTION
Summary
---------
Now that we can authenticate the individual exchanges, go ahead and add the rest that come with `fb_threatexchange`.

Test Plan
---------

Look at the UI: 
![image](https://github.com/facebook/ThreatExchange/assets/1654004/31736a04-e8b2-401f-8cac-2050fc80e877)

