### PR TITLE
HMA: Enable gunicorn task scheduling

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/app.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/app.py
@@ -119,7 +119,9 @@ def create_app() -> flask.Flask:
         # DO NOT RUN multiple workers with TASK_FETCHER=True or TASK_INDEXER=True -
         # running multiple instances of these tasks may cause database conflicts
         # or other undesireable behavior
-        if (_is_werkzeug_reloaded_process() or _is_gunicorn()) and not running_migrations:
+        if (
+            _is_werkzeug_reloaded_process() or _is_gunicorn()
+        ) and not running_migrations:
             now = datetime.datetime.now()
             scheduler = dev_apscheduler.get_apscheduler()
             scheduler.init_app(app)

--- a/hasher-matcher-actioner/src/OpenMediaMatch/app.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/app.py
@@ -48,6 +48,10 @@ def _is_werkzeug_reloaded_process():
     return os.environ.get("WERKZEUG_RUN_MAIN") == "true"
 
 
+def _is_gunicorn():
+    return "gunicorn" in os.environ.get("SERVER_SOFTWARE", "")
+
+
 def _setup_task_logging(app_logger: logging.Logger):
     """Clownily replace module loggers with our own"""
     fetcher.logger = app_logger.getChild("Fetcher")
@@ -106,9 +110,16 @@ def create_app() -> flask.Flask:
     scheduler: APScheduler | None = None
 
     with app.app_context():
+        # For Werkzeug/debug deployments:
         # We only run apscheduler in the "outer" reloader process, else we'll
         # have multiple executions of the the scheduler in debug mode
-        if _is_werkzeug_reloaded_process() and not running_migrations:
+        #
+        # For Gunicorn/production deployments:
+        # There is currently no check for multiple schedulers running.
+        # DO NOT RUN multiple workers with TASK_FETCHER=True or TASK_INDEXER=True -
+        # running multiple instances of these tasks may cause database conflicts
+        # or other undesireable behavior
+        if (_is_werkzeug_reloaded_process() or _is_gunicorn()) and not running_migrations:
             now = datetime.datetime.now()
             scheduler = dev_apscheduler.get_apscheduler()
             scheduler.init_app(app)


### PR DESCRIPTION
Fixes #1566

In order to prevent the apscheduler from executing twice in debug mode, hasher-matcher-actioner checks whether WERKZEUG_RUN_MAIN=="true" before starting the scheduler, because in debug mode the Flask service will initialize twice - werkzeug will set that environment variable only for the "outer" process, meaning that if werkzeug is the WSGI server this is a reliable way to only run the scheduler once in debug mode. However, the "production" version of HMA uses gunicorn as the WSGI server. Since gunicorn doesn't set that enviornment variable, the production version of HMA will incorrectly not trigger the scheduler. This PR fixes this by adding a check for debug mode before checking for WERKZEUG_RUN_MAIN in the environment.

