### PR TITLE
Fix ModuleNotFoundError "packaging" when using docker

### DIFF
--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -64,6 +64,7 @@ setup(
         "pdqhash",  # pdq
         "faiss-cpu",  # faiss
         "numpy",  # faiss
+        "packaging",  # fix ModuleNotFoundError: No module named 'packaging' in faiss/loader.py when running docker container
     ],
     extras_require=extras_require,
     entry_points={

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -64,7 +64,8 @@ setup(
         "pdqhash",  # pdq
         "faiss-cpu",  # faiss
         "numpy",  # faiss
-        "packaging",  # fix ModuleNotFoundError: No module named 'packaging' in faiss/loader.py when running docker container
+        "packaging",  # fix ModuleNotFoundError: No module named 'packaging'
+        # in faiss/loader.py when running docker container
     ],
     extras_require=extras_require,
     entry_points={


### PR DESCRIPTION
Summary:
---------
Fix ModuleNotFoundError "packaging" when using CLI from docker.

Tested on M1 pro mac and seems to fix it.
In case of issues with other devices I kindly request for RFC before merging.


Fixes:
---------
Cannot run the docker container:
https://github.com/facebook/ThreatExchange/blob/main/python-threatexchange/README.md#run-the-cli-in-docker-container

Tested on M1 pro mac, below sample of the output I get without the change:

docker run threatexchange {command}
Traceback (most recent call last):
  File "/usr/local/bin/threatexchange", line 5, in <module>
    from threatexchange.cli.main import main
  File "/usr/local/lib/python3.11/site-packages/threatexchange/cli/main.py", line 43, in <module>
    from threatexchange.signal_type.pdq import signal
  File "/usr/local/lib/python3.11/site-packages/threatexchange/signal_type/pdq/__init__.py", line 5, in <module>
    from .signal import PdqSignal
  File "/usr/local/lib/python3.11/site-packages/threatexchange/signal_type/pdq/signal.py", line 19, in <module>
    from threatexchange.signal_type.pdq.pdq_index import PDQIndex
  File "/usr/local/lib/python3.11/site-packages/threatexchange/signal_type/pdq/pdq_index.py", line 16, in <module>
    from threatexchange.signal_type.pdq.pdq_faiss_matcher import (
  File "/usr/local/lib/python3.11/site-packages/threatexchange/signal_type/pdq/pdq_faiss_matcher.py", line 4, in <module>
    import faiss
  File "/usr/local/lib/python3.11/site-packages/faiss/__init__.py", line 16, in <module>
    from .loader import *
  File "/usr/local/lib/python3.11/site-packages/faiss/loader.py", line 6, in <module>
    from packaging.version import Version
ModuleNotFoundError: No module named 'packaging'

