### PR TITLE
Fix threatexchange-ci vpdq build, bump action versions

### DIFF
--- a/.github/workflows/python-threatexchange-ci.yaml
+++ b/.github/workflows/python-threatexchange-ci.yaml
@@ -24,10 +24,13 @@ jobs:
     name: Lint and Type-Check python
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Install vpdq dependencies
+        run: |
+          sudo apt-get install -y python3-dev pkg-config cmake ffmpeg libavcodec-dev libavformat-dev libavdevice-dev libavutil-dev libswscale-dev libswresample-dev libavfilter-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -44,9 +47,9 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.11']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install ffmpeg
@@ -54,6 +57,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install ffmpeg
+      - name: Install vpdq dependencies
+        run: |
+          sudo apt-get install -y python3-dev pkg-config cmake ffmpeg libavcodec-dev libavformat-dev libavdevice-dev libavutil-dev libswscale-dev libswresample-dev libavfilter-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Summary
---------

- Fix vpdq CI for #1568 by installing dependencies.

- Bump CI action versions
  - `vpdq-ci-python.yaml` runs these new versions so might as well upgrade now that we're touching this file.

Let me know if you think of something better. Not too experienced with Github Actions, so maybe there is a way to avoid duplicating this. Alternatively, we could shove this in a bash file in vpdq directory and run that instead.

Test Plan
---------

Ran it on my fork and vpdq successfully builds. Other format (unrelated to vpdq) format errors still cause the overall workflow to fail, though.
