### PR TITLE
[hma] Add prefixed env to config options

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/app.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/app.py
@@ -74,7 +74,10 @@ def create_app() -> flask.Flask:
             "/workspace/reference_omm_configs/development_omm_config.py"
         )
     else:
-        raise RuntimeError("No flask config given - try populating OMM_CONFIG env")
+        raise RuntimeError("No omm_config given - try populating OMM_CONFIG env")
+    # Override fields with environment variables
+    app.config.from_prefixed_env("OMM")
+
     app.config.update(
         SQLALCHEMY_DATABASE_URI=app.config.get("DATABASE_URI"),
         SQLALCHEMY_TRACK_MODIFICATIONS=False,


### PR DESCRIPTION
Summary
---------

In talking with @jagraff, it would be mighty helpful to have the ability to override the file line-by-line via environment variable. So we do that, choosing the prefix "OMM_"

Test Plan
---------

```
$ .devcontainer/startup.sh
$ curl localhost:5000/site-map |  awk  -F / '{ print $2 }' | sort | uniq -c | sort -nr
     13 c
      5 dev
      3 ui
      3 m
      2 
      1 status",
      1 static
      1 site-map",
      1 h

# Turn off the curator role by env variable, which hides all the curator APIs
$ OMM_ROLE_CURATOR='' .devcontainer/startup.sh
$ curl localhost:5000/site-map |  awk  -F / '{ print $2 }' | sort | uniq -c | sort -nr
      5 dev
      3 ui
      3 m
      2 
      1 status",
      1 static
      1 site-map",
      1 h
      1 ",
```
