### PR TITLE
[hma][ui] Split up home into subpages

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/ui.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/ui.py
@@ -104,19 +104,46 @@ def _collab_info() -> dict[str, dict[str, t.Any]]:
 @bp.route("/")
 def home():
     """
-    Sanity check endpoint showing a basic status page
+    UI Landing page
     """
 
     template_vars = {
         "signal": curation.get_all_signal_types(),
         "content": curation.get_all_content_types(),
         "exchange_apis": _api_cls_info(),
-        "bankList": curation.banks_index(),
         "production": current_app.config.get("PRODUCTION", True),
         "index": _index_info(),
         "collabs": _collab_info(),
     }
-    return render_template("bootstrap.html.j2", **template_vars)
+    return render_template("bootstrap.html.j2", page="home", **template_vars)
+
+
+@bp.route("/banks")
+def banks():
+    """
+    Bank management page
+    """
+    return render_template(
+        "bootstrap.html.j2", page="banks", bankList=curation.banks_index()
+    )
+
+
+@bp.route("/exchanges")
+def exchanges():
+    """
+    Exchange management page
+    """
+    return render_template(
+        "bootstrap.html.j2", page="exchanges", collabs=_collab_info()
+    )
+
+
+@bp.route("/match")
+def match_dbg():
+    """
+    Bank management page
+    """
+    return render_template("bootstrap.html.j2", page="match_dbg")
 
 
 @bp.route("/create_bank", methods=["POST"])

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/bootstrap.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/bootstrap.html.j2
@@ -13,7 +13,7 @@
 <body>
     <nav class="navbar bg-primary">
         <div class="container">
-            <a class="navbar-brand" href="#">Open Media Match</a>
+            <a class="navbar-brand text-light" href="#">Open Media Match</a>
         </div>
     </nav>
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/bootstrap.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/bootstrap.html.j2
@@ -11,52 +11,9 @@
 </head>
 
 <body>
-    <nav class="navbar bg-primary">
-        <div class="container">
-            <a class="navbar-brand text-light" href="#">Open Media Match</a>
-        </div>
-    </nav>
+    {% include "components/nav_bar.html.j2" %}
 
-    {% if not production %}
-    {% include "components/dev_mode_bar.html.j2" %}
-    {% endif %}
-
-    <div class="container my-3">
-        {% include "components/content_signal.html.j2" %}
-    </div>
-
-    <div class="container my-4">
-        <hr />
-    </div>
-
-    <div class="container my-3">
-        {% include "components/banks_grid.html.j2" %}
-    </div>
-
-    <div class="container my-3">
-        {% include "components/add_to_bank_form.html.j2" %}
-    </div>
-
-    <div class="container my-3">
-        {% include "components/match_form.html.j2" %}
-    </div>
-
-    <div class="container my-4">
-        <hr />
-    </div>
-
-    <div class="container my-3">
-        {% include "components/index_status.html.j2" %}
-
-    </div>
-
-    <div class="container my-4">
-        <hr />
-    </div>
-
-    <div class="container my-3">
-        {% include "components/exchange_status.html.j2" %}
-    </div>
+    {% include "pages/" ~ page ~ ".html.j2" %}
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/exchange_status.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/exchange_status.html.j2
@@ -1,5 +1,3 @@
-<h3>Exchange Status</h3>
-{% include 'components/create_exchange_modal.html.j2' %}
 <table class="table">
     <thead>
         <tr>


### PR DESCRIPTION
Summary
---------

Alas, my hope of keeping only a single mondo UI page is shattered. Instead we populate the navbar with subpages.

Test Plan
---------

Click on all the navbar links, look at it.

# Home
![image](https://github.com/facebook/ThreatExchange/assets/1654004/662ffdfc-d57a-4aa3-a698-1eede00d7c2c)


# Banks
![image](https://github.com/facebook/ThreatExchange/assets/1654004/3f04d371-e61e-4efc-9483-5ee79d40ddb5)

# Exchanges
![image](https://github.com/facebook/ThreatExchange/assets/1654004/7653157b-08b1-4b86-bd29-3aa9d6ed2a6f)


# Match Debug
![image](https://github.com/facebook/ThreatExchange/assets/1654004/023ed737-7cb8-4aa8-a56b-c8ae0c5c5b95)



