### PR TITLE
Enable custom logging format

### DIFF
--- a/hasher-matcher-actioner/pyproject.toml
+++ b/hasher-matcher-actioner/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "threatexchange",
     "flask_apscheduler",
     "python-dateutil",
+    "python-json-logger",
 ]
 
 [project.optional-dependencies]

--- a/hasher-matcher-actioner/reference_omm_configs/json_log_omm_config.py
+++ b/hasher-matcher-actioner/reference_omm_configs/json_log_omm_config.py
@@ -1,0 +1,80 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+A development version of an omm_config, with every field visible and commented.
+
+This is the configuration that is used by default for the developer instance
+which runs in the dev container by default. Every config field is present
+to make it easier to copy the file as a template for others.
+"""
+
+import logging
+from logging.config import dictConfig
+
+from OpenMediaMatch.storage.postgres.impl import DefaultOMMStore
+from OpenMediaMatch.utils.fetch_benchmarking import InfiniteRandomExchange
+from OpenMediaMatch.utils.formatters import CustomJsonFormatter
+from threatexchange.signal_type.pdq.signal import PdqSignal
+from threatexchange.signal_type.md5 import VideoMD5Signal
+from threatexchange.content_type.photo import PhotoContent
+from threatexchange.content_type.video import VideoContent
+from threatexchange.exchanges.impl.static_sample import StaticSampleSignalExchangeAPI
+from threatexchange.exchanges.impl.ncmec_api import NCMECSignalExchangeAPI
+from threatexchange.exchanges.impl.stop_ncii_api import StopNCIISignalExchangeAPI
+from threatexchange.exchanges.impl.fb_threatexchange_api import (
+    FBThreatExchangeSignalExchangeAPI,
+)
+
+# Database configuration
+DBUSER = "media_match"
+DBPASS = "hunter2"
+DBHOST = "db"
+DBNAME = "media_match"
+DATABASE_URI = f"postgresql+psycopg2://{DBUSER}:{DBPASS}@{DBHOST}/{DBNAME}"
+
+# Role configuration
+PRODUCTION = False
+ROLE_HASHER = True
+ROLE_MATCHER = True
+ROLE_CURATOR = True
+# APScheduler (background threads for development)
+TASK_FETCHER = True
+TASK_INDEXER = True
+TASK_INDEX_CACHE = True
+
+# Core functionality configuration
+STORAGE_IFACE_INSTANCE = DefaultOMMStore(
+    signal_types=[PdqSignal, VideoMD5Signal],
+    content_types=[PhotoContent, VideoContent],
+    exchange_types=[
+        StaticSampleSignalExchangeAPI,
+        InfiniteRandomExchange,  # type: ignore
+        FBThreatExchangeSignalExchangeAPI,  # type: ignore
+        NCMECSignalExchangeAPI,  # type: ignore
+        StopNCIISignalExchangeAPI,
+    ],
+)
+
+FLASK_LOGGING_CONFIG = dictConfig({
+    'version': 1,
+    'formatters': {
+        'default': {
+            'format': '[%(asctime)s] %(levelname)s in %(module)s: %(message)s',
+        },
+        'json': {
+            "()": "OpenMediaMatch.utils.formatters.CustomJsonFormatter"
+        }
+    },
+    'handlers': {'wsgi': {
+        'class': 'logging.StreamHandler',
+        'stream': 'ext://flask.logging.wsgi_errors_stream',
+        'formatter': 'json'
+    }},
+    'root': {
+        'level': 'INFO',
+        'handlers': ['wsgi']
+    }
+})
+
+# Debugging stuff
+# SQLALCHEMY_ENGINE_LOG_LEVEL = logging.INFO

--- a/hasher-matcher-actioner/reference_omm_configs/json_log_omm_config.py
+++ b/hasher-matcher-actioner/reference_omm_configs/json_log_omm_config.py
@@ -3,9 +3,9 @@
 """
 A development version of an omm_config, with every field visible and commented.
 
-This is the configuration that is used by default for the developer instance
-which runs in the dev container by default. Every config field is present
-to make it easier to copy the file as a template for others.
+This configuration is identical to development_omm_config.py, except that it
+enables json log formatting.
+
 """
 
 import logging

--- a/hasher-matcher-actioner/reference_omm_configs/json_log_omm_config.py
+++ b/hasher-matcher-actioner/reference_omm_configs/json_log_omm_config.py
@@ -55,26 +55,25 @@ STORAGE_IFACE_INSTANCE = DefaultOMMStore(
     ],
 )
 
-FLASK_LOGGING_CONFIG = dictConfig({
-    'version': 1,
-    'formatters': {
-        'default': {
-            'format': '[%(asctime)s] %(levelname)s in %(module)s: %(message)s',
+FLASK_LOGGING_CONFIG = dictConfig(
+    {
+        "version": 1,
+        "formatters": {
+            "default": {
+                "format": "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
+            },
+            "json": {"()": "OpenMediaMatch.utils.formatters.CustomJsonFormatter"},
         },
-        'json': {
-            "()": "OpenMediaMatch.utils.formatters.CustomJsonFormatter"
-        }
-    },
-    'handlers': {'wsgi': {
-        'class': 'logging.StreamHandler',
-        'stream': 'ext://flask.logging.wsgi_errors_stream',
-        'formatter': 'json'
-    }},
-    'root': {
-        'level': 'INFO',
-        'handlers': ['wsgi']
+        "handlers": {
+            "wsgi": {
+                "class": "logging.StreamHandler",
+                "stream": "ext://flask.logging.wsgi_errors_stream",
+                "formatter": "json",
+            }
+        },
+        "root": {"level": "INFO", "handlers": ["wsgi"]},
     }
-})
+)
 
 # Debugging stuff
 # SQLALCHEMY_ENGINE_LOG_LEVEL = logging.INFO

--- a/hasher-matcher-actioner/src/OpenMediaMatch/app.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/app.py
@@ -83,6 +83,10 @@ def create_app() -> flask.Flask:
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
     )
 
+    logging_config = app.config.get("FLASK_LOGGING_CONFIG")
+    if logging_config:
+        logging.config.dictConfig(logging_config)
+
     running_migrations = os.getenv("MIGRATION_COMMAND") == "1"
 
     engine_logging = app.config.get("SQLALCHEMY_ENGINE_LOG_LEVEL")

--- a/hasher-matcher-actioner/src/OpenMediaMatch/utils/formatters.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/utils/formatters.py
@@ -1,0 +1,11 @@
+from pythonjsonlogger import jsonlogger
+
+class CustomJsonFormatter(jsonlogger.JsonFormatter):
+    """
+    Outputs logs in a JSON format.
+    """
+
+    def add_fields(self, log_record, record, message_dict):
+        log_record["level"] = record.__dict__.get("levelname")
+        log_record["timestamp"] = self.formatTime(record)
+        super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)

--- a/hasher-matcher-actioner/src/OpenMediaMatch/utils/formatters.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/utils/formatters.py
@@ -1,5 +1,6 @@
 from pythonjsonlogger import jsonlogger
 
+
 class CustomJsonFormatter(jsonlogger.JsonFormatter):
     """
     Outputs logs in a JSON format.


### PR DESCRIPTION
Summary
---------

Enables custom flask log formatting. Added example omm_config with json formatting for reference

Test Plan
---------

To test, replace 
`OMM_CONFIG: /build/reference_omm_configs/development_omm_config.py`
with 
`OMM_CONFIG: /build/reference_omm_configs/json_log_omm_config.py`
in `docker-compose.yaml`, then start the app. It should then log in json format after startup.
