### PR TITLE
[vpdq] Refactor video hashing

### DIFF
--- a/vpdq/cpp/CMakeLists.txt
+++ b/vpdq/cpp/CMakeLists.txt
@@ -45,6 +45,9 @@ set (PDQHEADERS
 set(SOURCES
     vpdq/cpp/hashing/bufferhasher.cpp
     vpdq/cpp/hashing/filehasher.cpp
+    vpdq/cpp/hashing/ffmpegutils.cpp
+    vpdq/cpp/hashing/ffmpegwrapper.cpp
+    vpdq/cpp/hashing/hasher.cpp
     vpdq/cpp/hashing/matchTwoHash.cpp
     vpdq/cpp/io/vpdqio.cpp
 )
@@ -52,6 +55,9 @@ set(SOURCES
 SET(HEADERS
     vpdq/cpp/hashing/bufferhasher.h
     vpdq/cpp/hashing/filehasher.h
+    vpdq/cpp/hashing/ffmpegutils.h
+    vpdq/cpp/hashing/ffmpegwrapper.h
+    vpdq/cpp/hashing/hasher.h
     vpdq/cpp/hashing/vpdqHashType.h
     vpdq/cpp/hashing/matchTwoHash.h
     vpdq/cpp/io/vpdqio.h

--- a/vpdq/cpp/vpdq/cpp/hashing/ffmpegutils.cpp
+++ b/vpdq/cpp/vpdq/cpp/hashing/ffmpegutils.cpp
@@ -1,0 +1,68 @@
+// ================================================================
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// ================================================================
+
+#include <algorithm>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <vpdq/cpp/hashing/ffmpegutils.h>
+#include <vpdq/cpp/hashing/ffmpegwrapper.h>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/frame.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/log.h>
+#include <libavutil/mem.h>
+#include <libswscale/swscale.h>
+}
+
+namespace facebook {
+namespace vpdq {
+namespace hashing {
+namespace ffmpeg {
+
+void saveFrameToFile(AVFramePtr frame, const std::string& filename) {
+  if (!frame) {
+    throw std::invalid_argument("Cannot save frame to file. Frame is null.");
+  }
+
+  std::ofstream outfile(filename, std::ios::out | std::ios::binary);
+  if (!outfile) {
+    throw std::runtime_error("Cannot save frame to file " + filename);
+  }
+
+  for (int y = 0; y < frame->height; y++) {
+    outfile.write(
+        reinterpret_cast<const char*>(frame->data[0] + y * frame->linesize[0]),
+        frame->width * 3);
+  }
+  outfile.close();
+}
+
+AVFramePtr createRGB24Frame(size_t const width, size_t const height) {
+  AVFramePtr frame(av_frame_alloc());
+  if (frame.get() == nullptr) {
+    throw std::bad_alloc();
+  }
+
+  frame->format = PIXEL_FORMAT;
+  frame->width = width;
+  frame->height = height;
+
+  if (av_image_alloc(
+          frame->data, frame->linesize, width, height, PIXEL_FORMAT, 1) < 0) {
+    throw std::bad_alloc();
+  }
+  return frame;
+}
+
+} // namespace ffmpeg
+} // namespace hashing
+} // namespace vpdq
+} // namespace facebook

--- a/vpdq/cpp/vpdq/cpp/hashing/ffmpegutils.h
+++ b/vpdq/cpp/vpdq/cpp/hashing/ffmpegutils.h
@@ -1,0 +1,40 @@
+// ================================================================
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// ================================================================
+
+#ifndef FFMPEGUTILS_H
+#define FFMPEGUTILS_H
+
+#include <vpdq/cpp/hashing/ffmpegwrapper.h>
+
+namespace facebook {
+namespace vpdq {
+namespace hashing {
+namespace ffmpeg {
+
+/** @brief Writes a raw AVFrame to a file.
+ *
+ * @param frame The frame to write. Must not be nullptr and its data must not be
+ *              nullptr.
+ * @param filename Name of output file.
+ * @note Useful for debugging.
+ * @note This can viewed using ffplay directly:
+ *       ffplay -f rawvideo -pixel_format rgb24
+ *       -video_size <width>x<height> <filename>
+ **/
+void saveFrameToFile(AVFramePtr frame, const std::string& filename);
+
+/** @brief Creates an RGB24 AVFrame.
+ *
+ * @param width Width of the resulting frame.
+ * @param height Height of the resulting frame.
+ * @return The RGB24 frame.
+ **/
+AVFramePtr createRGB24Frame(size_t width, size_t height);
+
+} // namespace ffmpeg
+} // namespace hashing
+} // namespace vpdq
+} // namespace facebook
+
+#endif // FFMPEGUTILS_H

--- a/vpdq/cpp/vpdq/cpp/hashing/ffmpegwrapper.cpp
+++ b/vpdq/cpp/vpdq/cpp/hashing/ffmpegwrapper.cpp
@@ -1,0 +1,143 @@
+// ================================================================
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// ================================================================
+
+#include <algorithm>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <vpdq/cpp/hashing/ffmpegwrapper.h>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/frame.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/log.h>
+#include <libavutil/mem.h>
+#include <libswscale/swscale.h>
+}
+
+namespace facebook {
+namespace vpdq {
+namespace hashing {
+namespace ffmpeg {
+
+FFmpegVideo::FFmpegVideo(const std::string& filename) : videoStreamIndex{-1U} {
+  // Open the input file
+  AVFormatContext* formatContextRawPtr{nullptr};
+  if (avformat_open_input(
+          &formatContextRawPtr, filename.c_str(), nullptr, nullptr) != 0) {
+    throw std::runtime_error("Cannot open video");
+  }
+  formatContext = AVFormatContextPtr(formatContextRawPtr);
+
+  // Retrieve stream information
+  if (avformat_find_stream_info(formatContext.get(), nullptr) < 0) {
+    throw std::runtime_error("Cannot find video stream info");
+  }
+
+  // Find the first video stream
+  for (unsigned int stream_idx{0U}; stream_idx < formatContext->nb_streams;
+       ++stream_idx) {
+    if (formatContext->streams[stream_idx]->codecpar->codec_type ==
+        AVMEDIA_TYPE_VIDEO) {
+      videoStreamIndex = stream_idx;
+      break;
+    }
+  }
+
+  if (videoStreamIndex == -1U) {
+    throw std::runtime_error("No video stream found");
+  }
+
+  // Get the video codec parameters
+  const AVCodecParameters* const codecParameters{
+      formatContext->streams[videoStreamIndex]->codecpar};
+
+  width = codecParameters->width;
+  height = codecParameters->height;
+  if (width == 0 || height == 0) {
+    throw std::runtime_error("Width or height equals 0");
+  }
+
+  // Find the video decoder
+  const AVCodec* const codec{avcodec_find_decoder(codecParameters->codec_id)};
+  if (!codec) {
+    throw std::runtime_error("Video codec id not found");
+  }
+
+  // Create the codec context
+  codecContext = AVCodecContextPtr(avcodec_alloc_context3(codec));
+  if (codecContext.get() == nullptr) {
+    throw std::runtime_error("Failed to allocate video codec context.");
+  }
+  if (avcodec_parameters_to_context(codecContext.get(), codecParameters) < 0) {
+    throw std::runtime_error(
+        "Failed to copy codec parameters to codec context.");
+  }
+
+  // Determine the number of threads to use and multithreading type
+  codecContext->thread_count = 0;
+
+  if (codec->capabilities & AV_CODEC_CAP_SLICE_THREADS) {
+    codecContext->thread_type = FF_THREAD_SLICE;
+  } else {
+    codecContext->thread_count = 1;
+  }
+
+  // Open the codec context
+  if (avcodec_open2(codecContext.get(), codec, nullptr) < 0) {
+    throw std::runtime_error("Failed to open video codec context");
+  }
+
+  // Get the framerate
+  AVRational avframeRate{
+      formatContext->streams[videoStreamIndex]->avg_frame_rate};
+  // if avg_frame_rate is 0, fall back to r_frame_rate which is the
+  // lowest framerate with which all timestamps can be represented accurately
+  if (avframeRate.num == 0 || avframeRate.den == 0) {
+    avframeRate = formatContext->streams[videoStreamIndex]->r_frame_rate;
+  }
+
+  frameRate = static_cast<double>(avframeRate.num) /
+      static_cast<double>(avframeRate.den);
+  if (frameRate == 0) {
+    throw std::runtime_error("Video framerate was detected to be zero.");
+  }
+}
+
+bool FFmpegVideo::createSwsContext() {
+  swsContext = SwsContextPtr(sws_getContext(
+      codecContext->width,
+      codecContext->height,
+      codecContext->pix_fmt,
+      width,
+      height,
+      PIXEL_FORMAT,
+      DOWNSAMPLE_METHOD,
+      nullptr,
+      nullptr,
+      nullptr));
+
+  return (swsContext.get() != nullptr);
+}
+
+FFmpegFrame::FFmpegFrame(AVFramePtr frame, uint64_t frameNumber)
+    : m_frame(std::move(frame)), m_frameNumber(frameNumber){};
+
+uint64_t FFmpegFrame::get_frame_number() const {
+  return m_frameNumber;
+};
+
+unsigned char* FFmpegFrame::get_buffer_ptr() {
+  return m_frame->data[0];
+}
+
+} // namespace ffmpeg
+} // namespace hashing
+} // namespace vpdq
+} // namespace facebook

--- a/vpdq/cpp/vpdq/cpp/hashing/ffmpegwrapper.h
+++ b/vpdq/cpp/vpdq/cpp/hashing/ffmpegwrapper.h
@@ -1,0 +1,142 @@
+// ================================================================
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// ================================================================
+
+#ifndef FFMPEGWRAPPER_H
+#define FFMPEGWRAPPER_H
+
+#include <memory>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/frame.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/log.h>
+#include <libavutil/mem.h>
+#include <libswscale/swscale.h>
+}
+
+namespace facebook {
+namespace vpdq {
+namespace hashing {
+namespace ffmpeg {
+
+// Pixel format for the image passed to PDQ
+constexpr AVPixelFormat PIXEL_FORMAT = AV_PIX_FMT_RGB24;
+
+// Downsample method for the image passed to PDQ
+constexpr int DOWNSAMPLE_METHOD = SWS_AREA;
+
+struct AVFrameDeleter {
+  void operator()(AVFrame* ptr) const {
+    if (ptr) {
+      if (ptr->data[0]) {
+        // Free memory allocated by image_alloc
+        // See createTargetFrame()
+        av_freep(&ptr->data[0]);
+      }
+      av_frame_free(&ptr);
+    }
+  }
+};
+
+struct AVPacketDeleter {
+  void operator()(AVPacket* ptr) const {
+    if (ptr) {
+      av_packet_unref(ptr);
+      av_packet_free(&ptr);
+    }
+  }
+};
+
+struct SwsContextDeleter {
+  void operator()(SwsContext* ptr) const { sws_freeContext(ptr); }
+};
+
+struct AVFormatContextDeleter {
+  void operator()(AVFormatContext* ptr) const { avformat_close_input(&ptr); }
+};
+
+struct AVCodecContextDeleter {
+  void operator()(AVCodecContext* ptr) const { avcodec_free_context(&ptr); }
+};
+
+using AVFramePtr = std::unique_ptr<AVFrame, AVFrameDeleter>;
+using AVPacketPtr = std::unique_ptr<AVPacket, AVPacketDeleter>;
+using SwsContextPtr = std::unique_ptr<SwsContext, SwsContextDeleter>;
+using AVFormatContextPtr =
+    std::unique_ptr<AVFormatContext, AVFormatContextDeleter>;
+using AVCodecContextPtr =
+    std::unique_ptr<AVCodecContext, AVCodecContextDeleter>;
+
+/**
+ * @brief Video wrapper that can open a video file.
+ **/
+class FFmpegVideo {
+ public:
+  FFmpegVideo(const std::string& filename);
+
+  /**
+   * @brief Create the SwsContext for resizing the video frames.
+   *
+   * @return True if the swscontext was successfully created otherwise false.
+   *
+   * @note If the SwsContext fails to be created the swsContext will be nullptr.
+   */
+  bool createSwsContext();
+
+  AVCodecContextPtr codecContext;
+  AVFormatContextPtr formatContext;
+  SwsContextPtr swsContext;
+  unsigned int videoStreamIndex;
+  int width;
+  int height;
+  double frameRate;
+};
+
+/**
+ * @brief AVFrame implementation of the Frame type class.
+ **/
+class FFmpegFrame {
+ public:
+  /** @brief Constructor
+   *
+   *  @param frame The AVFrame.
+   *  @param frameNumber The frame number in the video.
+   **/
+  FFmpegFrame(AVFramePtr frame, uint64_t frameNumber);
+
+  /** @brief Get the frame number.
+   *
+   *  @return The frame number.
+   **/
+  uint64_t get_frame_number() const;
+
+  /** @brief Get the pointer to the frame data buffer to be used for hashing.
+   *
+   *  @return Pointer to the frame data buffer.
+   **/
+  unsigned char* get_buffer_ptr();
+
+  // Copy
+  FFmpegFrame(FFmpegFrame const&) = delete;
+  FFmpegFrame& operator=(FFmpegFrame const&) = delete;
+
+  // Move
+  FFmpegFrame(FFmpegFrame&&) = default;
+  FFmpegFrame& operator=(FFmpegFrame&&) = default;
+
+  ~FFmpegFrame() = default;
+
+ private:
+  AVFramePtr m_frame;
+  uint64_t m_frameNumber;
+};
+
+} // namespace ffmpeg
+} // namespace hashing
+} // namespace vpdq
+} // namespace facebook
+
+#endif // FFMPEGWRAPPER_H

--- a/vpdq/cpp/vpdq/cpp/hashing/filehasher.cpp
+++ b/vpdq/cpp/vpdq/cpp/hashing/filehasher.cpp
@@ -3,24 +3,15 @@
 // ================================================================
 
 #include <algorithm>
-#include <atomic>
-#include <cassert>
-#include <cmath>
-#include <condition_variable>
 #include <cstdio>
-#include <fstream>
-#include <functional>
-#include <iomanip>
 #include <iostream>
 #include <memory>
-#include <mutex>
-#include <queue>
 #include <string>
-#include <thread>
 
-#include <vpdq/cpp/hashing/bufferhasher.h>
+#include <vpdq/cpp/hashing/ffmpegutils.h>
+#include <vpdq/cpp/hashing/ffmpegwrapper.h>
 #include <vpdq/cpp/hashing/filehasher.h>
-#include <vpdq/cpp/hashing/vpdqHashType.h>
+#include <vpdq/cpp/hashing/hasher.h>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -36,397 +27,166 @@ namespace facebook {
 namespace vpdq {
 namespace hashing {
 
-// Pixel format for the image passed to PDQ
-constexpr AVPixelFormat PIXEL_FORMAT = AV_PIX_FMT_RGB24;
+namespace {
 
-// Downsample method for the image passed to PDQ
-constexpr int DOWNSAMPLE_METHOD = SWS_AREA;
+using ffmpeg::AVFramePtr;
+using ffmpeg::AVPacketPtr;
+using ffmpeg::FFmpegFrame;
+using ffmpeg::FFmpegVideo;
 
-// Smart pointer wrapper for AVFrame*
-struct AVFrameDeleter {
-  void operator()(AVFrame* ptr) const {
-    if (ptr) {
-      if (ptr->data[0]) {
-        // Free memory allocated by image_alloc
-        // See createTargetFrame()
-        av_freep(&ptr->data[0]);
-      }
-      av_frame_free(&ptr);
-    }
-  }
-};
-
-// Smart pointer wrapper for packet
-struct AVPacketDeleter {
-  void operator()(AVPacket* ptr) const {
-    if (ptr) {
-      av_packet_unref(ptr);
-      av_packet_free(&ptr);
-    }
-  }
-};
-
-// Smart pointer wrapper for SwsContext
-struct SwsContextDeleter {
-  void operator()(SwsContext* ptr) const { sws_freeContext(ptr); }
-};
-
-using AVFramePtr = std::unique_ptr<AVFrame, AVFrameDeleter>;
-using AVPacketPtr = std::unique_ptr<AVPacket, AVPacketDeleter>;
-using SwsContextPtr = std::unique_ptr<SwsContext, SwsContextDeleter>;
-
-/* @brief Writes an AVFrame to a file
- *
- * Useful for debugging.
- * Not used by any other functions.
- *
- * This can viewed using ffplay directly:
- * ffplay -f rawvideo -pixel_format rgb24 \
- * -video_size <WIDTH>x<HEIGHT> <filename>
- *
- * @param frame
- * @param filename
- * @return void
- */
-static void saveFrameToFile(AVFrame* frame, const char* filename) {
-  if (!frame) {
-    throw std::invalid_argument("Cannot save frame to file. Frame is null.");
-  }
-
-  std::ofstream outfile(filename, std::ios::out | std::ios::binary);
-  if (!outfile) {
-    throw std::runtime_error(
-        "Cannot save frame to file " + std::string(filename));
-  }
-
-  for (int y = 0; y < frame->height; y++) {
-    outfile.write(
-        reinterpret_cast<const char*>(frame->data[0] + y * frame->linesize[0]),
-        frame->width * 3);
-  }
-  std::cout << "Saved frame to file " << filename << " with dimensions "
-            << frame->width << "x" << frame->height << std::endl;
-  outfile.close();
-}
-
-static AVFramePtr createTargetFrame(int width, int height) {
-  // Create a frame for resizing and converting the decoded frame to RGB24
-  AVFramePtr frame(av_frame_alloc());
-  if (frame.get() == nullptr) {
-    throw std::bad_alloc();
-  }
-
-  frame->format = PIXEL_FORMAT;
-  frame->width = width;
-  frame->height = height;
-
-  if (av_image_alloc(
-          frame->data, frame->linesize, width, height, PIXEL_FORMAT, 1) < 0) {
-    throw std::bad_alloc();
-  }
-  return frame;
-}
-
-class AVVideo {
+// Class that decodes FFmpeg frames and hashes them.
+class FFmpegHasher {
  public:
-  struct AVFormatContextDeleter {
-    void operator()(AVFormatContext* ptr) const { avformat_close_input(&ptr); }
-  };
-  struct AVCodecContextDeleter {
-    void operator()(AVCodecContext* ptr) const { avcodec_free_context(&ptr); }
-  };
-
-  using AVFormatContextPtr =
-      std::unique_ptr<AVFormatContext, AVFormatContextDeleter>;
-  using AVCodecContextPtr =
-      std::unique_ptr<AVCodecContext, AVCodecContextDeleter>;
-
-  AVCodecContextPtr codecContext;
-  AVFormatContextPtr formatContext;
-  SwsContextPtr swsContext;
-  int videoStreamIndex = -1;
-  int width;
-  int height;
-  double frameRate;
-
-  AVVideo(const std::string filename) {
-    // Open the input file
-    AVFormatContext* formatContextRawPtr = nullptr;
-    if (avformat_open_input(
-            &formatContextRawPtr, filename.c_str(), nullptr, nullptr) != 0) {
-      throw std::runtime_error("Cannot open video");
-    }
-    formatContext = AVFormatContextPtr(formatContextRawPtr);
-
-    // Retrieve stream information
-    if (avformat_find_stream_info(formatContext.get(), nullptr) < 0) {
-      throw std::runtime_error("Cannot find video stream info");
+  FFmpegHasher(
+      std::unique_ptr<FFmpegVideo> video,
+      unsigned int thread_count,
+      double secondsPerHash)
+      : m_video(std::move(video)),
+        m_vpdqhasher(
+            thread_count,
+            VideoMetadata{
+                static_cast<float>(m_video->frameRate),
+                static_cast<uint32_t>(m_video->width),
+                static_cast<uint32_t>(m_video->height)}) {
+    m_frameMod = static_cast<int>(secondsPerHash * m_video->frameRate);
+    if (m_frameMod == 0) {
+      // Avoid truncate to zero on corner-case where
+      // secondsPerHash = 1 and frameRate < 1.
+      m_frameMod = 1;
     }
 
-    // Find the first video stream
-    for (unsigned int i = 0; i < formatContext->nb_streams; ++i) {
-      if (formatContext->streams[i]->codecpar->codec_type ==
-          AVMEDIA_TYPE_VIDEO) {
-        videoStreamIndex = i;
+    m_decodeFrame = AVFramePtr(av_frame_alloc());
+    if (m_decodeFrame.get() == nullptr) {
+      throw std::bad_alloc();
+    }
+  }
+
+  bool run(std::vector<hashing::vpdqFeature>& pdqHashes) {
+    // Create packet used to read frames
+    // The packet is moved into processPacket() in order
+    // to reuse the same packet for each frame to avoid allocs
+    AVPacketPtr packet(av_packet_alloc());
+    if (packet.get() == nullptr) {
+      std::cerr << "Failed to allocate frame packet." << '\n';
+      return false;
+    }
+
+    // Read frames in a loop and process them
+    bool failed = false;
+    while (av_read_frame(m_video->formatContext.get(), packet.get()) == 0) {
+      // Check if the packet belongs to the video stream
+      try {
+        processPacket(*packet);
+      } catch (const std::runtime_error& e) {
+        std::cerr << "Processing frame failed: " << e.what() << '\n';
+        failed = true;
         break;
       }
     }
 
-    if (videoStreamIndex == -1) {
-      throw std::runtime_error("No video stream found");
-    }
+    if (!failed) {
+      // Flush decode buffer
+      // See for more information:
+      // https://github.com/FFmpeg/FFmpeg/blob/6a9d3f46c7fc661b86192e922ab932495d27f953/doc/examples/decode_video.c#L182
 
-    // Get the video codec parameters
-    AVCodecParameters* codecParameters =
-        formatContext->streams[videoStreamIndex]->codecpar;
-
-    width = codecParameters->width;
-    height = codecParameters->height;
-    if (width == 0 || height == 0) {
-      throw std::runtime_error("Width or height equals 0");
-    }
-
-    // Find the video decoder
-    const AVCodec* codec = avcodec_find_decoder(codecParameters->codec_id);
-    if (!codec) {
-      throw std::runtime_error("Video codec id not found");
-    }
-
-    // Create the codec context
-    codecContext = AVCodecContextPtr(avcodec_alloc_context3(codec));
-    if (codecContext.get() == nullptr) {
-      throw std::bad_alloc();
-    }
-    if (avcodec_parameters_to_context(codecContext.get(), codecParameters) <
-        0) {
-      throw std::runtime_error("Cannot copy codec parameters to context");
-    }
-
-    // Determine the number of threads to use and multithreading type
-    codecContext->thread_count = 0;
-
-    if (codec->capabilities & AV_CODEC_CAP_SLICE_THREADS) {
-      codecContext->thread_type = FF_THREAD_SLICE;
-    } else {
-      codecContext->thread_count = 1;
-    }
-
-    // Open the codec context
-    if (avcodec_open2(codecContext.get(), codec, nullptr) < 0) {
-      throw std::runtime_error("Cannot open video codec context");
-    }
-
-    // Get the framerate
-    AVRational avframeRate =
-        formatContext->streams[videoStreamIndex]->avg_frame_rate;
-
-    // if avg_frame_rate is 0, fall back to r_frame_rate which is the
-    // lowest framerate with which all timestamps can be represented accurately
-    if (avframeRate.num == 0 || avframeRate.den == 0) {
-      avframeRate = formatContext->streams[videoStreamIndex]->r_frame_rate;
-    }
-
-    frameRate = static_cast<double>(avframeRate.num) /
-        static_cast<double>(avframeRate.den);
-    if (frameRate == 0) {
-      throw std::runtime_error("Video framerate is zero");
-    }
-  }
-
-  void createSwsContext() {
-    swsContext = SwsContextPtr(sws_getContext(
-        codecContext->width,
-        codecContext->height,
-        codecContext->pix_fmt,
-        width,
-        height,
-        PIXEL_FORMAT,
-        DOWNSAMPLE_METHOD,
-        nullptr,
-        nullptr,
-        nullptr));
-
-    if (swsContext.get() == nullptr) {
-      throw std::runtime_error("Cannot create sws context");
-    }
-  }
-};
-
-class vpdqHasher {
- public:
-  struct FatFrame {
-    AVFramePtr frame;
-    int64_t frameNumber;
-  };
-
-  std::condition_variable queue_condition;
-  std::mutex queue_mutex;
-  std::queue<FatFrame> hash_queue;
-  bool done_hashing = false;
-
-  std::mutex pdqHashes_mutex;
-  std::vector<hashing::vpdqFeature>& pdqHashes;
-
-  unsigned int thread_count;
-  std::vector<std::thread> consumer_threads;
-
-  std::unique_ptr<AVVideo> video;
-  int frameMod;
-  AVFramePtr decodeFrame;
-
-  bool verbose = false;
-
-  vpdqHasher(
-      std::unique_ptr<AVVideo> video,
-      std::vector<hashing::vpdqFeature>& pdqHashes,
-      unsigned int thread_count = 0)
-      : pdqHashes(pdqHashes), video(std::move(video)) {
-    // Set thread count if specified
-    // thread_count = 1 means disable multithreading
-    if (thread_count == 0) {
-      this->thread_count = std::thread::hardware_concurrency();
-    } else {
-      this->thread_count = thread_count;
-    }
-
-    // Create consumer hasher threads if multithreading
-    if (this->thread_count != 1) {
-      consumer_threads.reserve(this->thread_count);
-      for (decltype(thread_count) i = 0; i < this->thread_count; ++i) {
-        consumer_threads.emplace_back(
-            std::thread(std::bind(&vpdqHasher::consumer, this)));
+      try {
+        processPacket(*packet);
+      } catch (const std::runtime_error& e) {
+        std::cerr << "Flushing frame buffer failed: " << e.what() << '\n';
+        failed = true;
       }
     }
 
-    decodeFrame = AVFramePtr(av_frame_alloc());
-    if (decodeFrame.get() == nullptr) {
-      throw std::bad_alloc();
-    }
+    // Signal to the threads that no more frames will be added to the queue
+    pdqHashes = m_vpdqhasher.finish();
+
+    return !failed;
   }
 
   // Decode and add vpdqFeature to the hashes vector
   // Increments the passed frame number
   // Returns back the processed packet
-  AVPacketPtr processPacket(AVPacketPtr packet) {
-    if (packet->stream_index != video->videoStreamIndex) {
+  void processPacket(AVPacket& packet) {
+    if (static_cast<unsigned int>(packet.stream_index) !=
+        m_video->videoStreamIndex) {
       // This must be called to free the packet buffer filled by av_read_frame
-      av_packet_unref(packet.get());
-      return packet;
+      av_packet_unref(&packet);
+      return;
     }
 
     // Send the packet to the decoder
-    int ret = avcodec_send_packet(video->codecContext.get(), packet.get()) < 0;
-    if (ret < 0) {
+    auto const send_packet_err =
+        avcodec_send_packet(m_video->codecContext.get(), &packet);
+    if (send_packet_err < 0) {
       throw std::runtime_error("Cannot send packet to decoder");
     }
 
     // Receive the decoded frame
-    while (ret >= 0) {
-      ret = avcodec_receive_frame(video->codecContext.get(), decodeFrame.get());
-      if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+    int receive_frame_err{};
+    while (receive_frame_err >= 0) {
+      receive_frame_err = avcodec_receive_frame(
+          m_video->codecContext.get(), m_decodeFrame.get());
+
+      // Check for receiving errors
+      if (receive_frame_err == AVERROR(EAGAIN) ||
+          receive_frame_err == AVERROR_EOF) {
         break;
-      } else if (ret < 0) {
+      } else if (receive_frame_err < 0) {
         throw std::runtime_error("Cannot receive frame from decoder");
+      } else {
+        // no error. we're good.
       }
 
-      if (get_frame_number() % frameMod == 0) {
-        AVFramePtr targetFrame;
+      // Get the current frame number from the video codec context
+      auto const frameNumber = m_video->codecContext->frame_number - 1;
+
+      if (frameNumber % m_frameMod == 0) {
+        AVFramePtr targetFrame{};
         try {
-          targetFrame = createTargetFrame(video->width, video->height);
+          targetFrame =
+              ffmpeg::createRGB24Frame(m_video->width, m_video->height);
         } catch (const std::runtime_error& e) {
-          std::cerr << e.what() << std::endl;
+          std::cerr << e.what() << '\n';
           throw;
         }
         // Resize the frame and convert to RGB24
         sws_scale(
-            video->swsContext.get(),
-            decodeFrame->data,
-            decodeFrame->linesize,
+            m_video->swsContext.get(),
+            m_decodeFrame->data,
+            m_decodeFrame->linesize,
             0,
-            video->codecContext->height,
+            m_video->codecContext->height,
             targetFrame->data,
             targetFrame->linesize);
 
-        FatFrame fatFrame{std::move(targetFrame), get_frame_number()};
-        // Use the queue if multithreaded
-        if (thread_count != 1) {
-          std::lock_guard<std::mutex> lock(queue_mutex);
-          hash_queue.push(std::move(fatFrame));
-          queue_condition.notify_one();
-        } else {
-          hasher(std::move(fatFrame));
-        }
+        /*
+        // Example of how hashing looks for GenericFrame:
+        GenericFrame frame{{}, get_frame_number()};
+        frame.m_buffer.reserve(3 * m_video->width * m_video->height);
+        std::copy_n(targetFrame->data[0], 3 * m_video->width * m_video->height,
+        std::back_inserter(frame.m_buffer));
+        // This is not used here, because it requires copying the entire frame
+        // to the GenericFrame buffer, which is slow.
+        */
+
+        FFmpegFrame frame{
+            std::move(targetFrame), static_cast<uint64_t>(frameNumber)};
+        m_vpdqhasher.push_back(std::move(frame));
       }
     }
 
     // This must be called to free the packet buffer filled by av_read_frame
-    av_packet_unref(packet.get());
-    return packet;
+    av_packet_unref(&packet);
   }
 
-  void hasher(const FatFrame fatFrame) {
-    assert(fatFrame.frame->height != 0 && fatFrame.frame->width != 0);
-
-    auto phasher = vpdq::hashing::FrameBufferHasherFactory::createFrameHasher(
-        fatFrame.frame->height, fatFrame.frame->width);
-
-    int quality;
-    pdq::hashing::Hash256 pdqHash;
-    bool ret = phasher->hashFrame(fatFrame.frame->data[0], pdqHash, quality);
-    if (!ret) {
-      throw std::runtime_error(
-          "Failed to hash frame buffer." + std::string("Frame: ") +
-          std::to_string(fatFrame.frameNumber) +
-          std::string(
-              " Frame width or height smaller than the minimum hashable dimension"));
-    }
-    if (verbose) {
-      std::cout << "PDQHash: " << pdqHash.format() << std::endl;
-    }
-
-    // Write frame to file here for debugging:
-    // This is not thread safe. Use one thread when writing to file
-    // saveFrameToFile(frame, "frame.rgb");
-
-    // Append vpdq feature to pdqHashes vector
-    std::lock_guard<std::mutex> lock(pdqHashes_mutex);
-    pdqHashes.emplace_back(vpdqFeature{
-        pdqHash,
-        static_cast<int>(fatFrame.frameNumber),
-        quality,
-        static_cast<double>(fatFrame.frameNumber) / video->frameRate});
-  }
-
-  void consumer() {
-    while (true) {
-      std::unique_lock<std::mutex> lock(queue_mutex);
-      queue_condition.wait(
-          lock, [this] { return !hash_queue.empty() || done_hashing; });
-      if (hash_queue.empty() && done_hashing)
-        break;
-      FatFrame fatFrame(std::move(hash_queue.front()));
-      hash_queue.pop();
-      lock.unlock();
-      hasher(std::move(fatFrame));
-    }
-  }
-
-  inline int64_t get_frame_number() {
-    return video->codecContext->frame_number - 1;
-  }
-
-  // This signals to the threads that no more
-  // frames will be hashed and they can exit
-  void finish() {
-    std::unique_lock<std::mutex> lock(queue_mutex);
-    done_hashing = true;
-    lock.unlock();
-    queue_condition.notify_all();
-    for (auto& thread : consumer_threads) {
-      thread.join();
-    }
-  }
+ private:
+  std::unique_ptr<FFmpegVideo> m_video;
+  VpdqHasher<FFmpegFrame> m_vpdqhasher;
+  AVFramePtr m_decodeFrame;
+  int m_frameMod{};
 };
+
+} // namespace
 
 // Get pdq hashes for selected frames every secondsPerHash
 bool hashVideoFile(
@@ -436,7 +196,7 @@ bool hashVideoFile(
     const double secondsPerHash,
     const int downsampleWidth,
     const int downsampleHeight,
-    const unsigned int thread_count) {
+    const unsigned int num_threads) {
   // These are lavu_log_constants from "libavutil/log.h"
   // It can be helpful for debugging to
   // set this to AV_LOG_DEBUG or AV_LOG_VERBOSE
@@ -451,12 +211,12 @@ bool hashVideoFile(
     av_log_set_level(AV_LOG_FATAL);
   }
 
-  std::unique_ptr<AVVideo> video;
+  std::unique_ptr<FFmpegVideo> video{};
   try {
-    video = std::make_unique<AVVideo>(inputVideoFileName);
+    video = std::make_unique<FFmpegVideo>(inputVideoFileName);
   } catch (const std::runtime_error& e) {
     std::cerr << "Error while attempting to read video file: " << e.what()
-              << std::endl;
+              << '\n';
     return false;
   }
 
@@ -470,77 +230,15 @@ bool hashVideoFile(
   }
 
   // Create image rescaler context
-  try {
-    video->createSwsContext();
-  } catch (const std::runtime_error& e) {
-    std::cerr << "Error while attempting to create sws context: " << e.what()
-              << std::endl;
+  if (!video->createSwsContext()) {
+    std::cerr << "Error while attempting to create sws context.\n";
     return false;
   }
 
   // Create frame hasher
-  vpdqHasher hasher(std::move(video), pdqHashes, thread_count);
-  hasher.verbose = verbose;
-  hasher.frameMod = secondsPerHash * hasher.video->frameRate;
-  if (hasher.frameMod == 0) {
-    // Avoid truncate to zero on corner-case where
-    // secondsPerHash = 1 and frameRate < 1.
-    hasher.frameMod = 1;
-  }
+  FFmpegHasher hasher(std::move(video), num_threads, secondsPerHash);
 
-  // Create packet used to read frames
-  // The packet is moved into processPacket() in order
-  // to reuse the same packet for each frame to avoid allocs
-  AVPacketPtr packet(av_packet_alloc());
-  if (packet.get() == nullptr) {
-    std::cerr << "Cannot allocate packet" << std::endl;
-    return false;
-  }
-
-  // Read frames in a loop and process them
-  bool failed = false;
-  while (av_read_frame(hasher.video->formatContext.get(), packet.get()) == 0) {
-    // Check if the packet belongs to the video stream
-    try {
-      packet = hasher.processPacket(std::move(packet));
-    } catch (const std::runtime_error& e) {
-      std::cerr << "Processing frame failed: " << e.what() << std::endl;
-      failed = true;
-      break;
-    }
-  }
-
-  if (!failed) {
-    // Flush decode buffer
-    // See for more information:
-    // https://github.com/FFmpeg/FFmpeg/blob/6a9d3f46c7fc661b86192e922ab932495d27f953/doc/examples/decode_video.c#L182
-
-    try {
-      hasher.processPacket(std::move(packet));
-    } catch (const std::runtime_error& e) {
-      std::cerr << "Flushing frame buffer failed: " << e.what() << std::endl;
-      failed = true;
-    }
-  }
-
-  if (thread_count != 1) {
-    // Signal to the threads that no more frames will be added to the queue
-    hasher.finish();
-  }
-
-  if (failed) {
-    return false;
-  }
-
-  // Sort out of order frames by frameNumber
-  std::sort(
-      hasher.pdqHashes.begin(),
-      hasher.pdqHashes.end(),
-      [](const vpdqFeature& a, const vpdqFeature& b) {
-        return a.frameNumber < b.frameNumber;
-      });
-
-  return true;
+  return hasher.run(pdqHashes);
 }
 
 } // namespace hashing

--- a/vpdq/cpp/vpdq/cpp/hashing/filehasher.h
+++ b/vpdq/cpp/vpdq/cpp/hashing/filehasher.h
@@ -16,20 +16,19 @@ namespace vpdq {
 namespace hashing {
 
 /**
- * Get frames from the video
- * Then get pdq hashes for selected frames every secondPerHash
+ * @brief Hashes the video file using the vpdq hashing algorithm.
  *
- * @param inputVideoFileName Input video's name
- * @param pdqHashes Vector which stores hashes
- * @param verbose If produce detailed output for diagnostic purposes
- * @param secondsPerHash The time period of picking frames in vpdq
+ * @param inputVideoFileName Input video path.
+ * @param pdqHashes Resulting vector that will contain the vpdq hash.
+ * @param verbose Output details for diagnostic purposes.
+ * @param secondsPerHash The interval for frame hashing.
  * @param downsampleWidth Width to downsample to before hashing. 0 means no
- * downsample
+ *                        downsample
  * @param downsampleHeight Height to downsample to before hashing. 0 means no
- * downsample
+ *                         downsample
  * @param num_threads Number of threads to use for hashing. 0 is auto.
  *
- * @return If successfully hash the video
+ * @return Video hashed successfully.
  */
 bool hashVideoFile(
     const std::string& inputVideoFileName,

--- a/vpdq/cpp/vpdq/cpp/hashing/hasher.cpp
+++ b/vpdq/cpp/vpdq/cpp/hashing/hasher.cpp
@@ -1,0 +1,146 @@
+// ================================================================
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// ================================================================
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <condition_variable>
+#include <cstdio>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
+
+#include <vpdq/cpp/hashing/bufferhasher.h>
+#include <vpdq/cpp/hashing/hasher.h>
+
+namespace facebook {
+namespace vpdq {
+namespace hashing {
+
+namespace {
+
+/** @brief Hash a frame using PDQ.
+ *
+ *  @param frame The frame to be hashed.
+ *  @param frameNumber The metadata from the video the frame is from.
+ *
+ *  @return The vdpdq hash of the frame.
+ **/
+template <typename TFrame>
+vpdqFeature hashFrame(TFrame& frame, const VideoMetadata& video_metadata) {
+  auto phasher = FrameBufferHasherFactory::createFrameHasher(
+      video_metadata.height, video_metadata.width);
+
+  int quality;
+  pdq::hashing::Hash256 pdqHash;
+  auto const is_hashing_successful =
+      phasher->hashFrame(frame.get_buffer_ptr(), pdqHash, quality);
+  if (!is_hashing_successful) {
+    throw std::runtime_error(
+        std::string{"Failed to hash frame buffer. Frame: "} +
+        std::to_string(frame.get_frame_number()) +
+        " Frame width or height smaller than the minimum hashable dimension");
+  }
+  return vpdqFeature{
+      pdqHash,
+      static_cast<int>(frame.get_frame_number()),
+      quality,
+      static_cast<float>(frame.get_frame_number()) / video_metadata.framerate};
+}
+
+} // namespace
+
+template <typename TFrame>
+VpdqHasher<TFrame>::VpdqHasher(
+    size_t thread_count, VideoMetadata video_metadata)
+    : m_done_hashing(false), m_video_metadata(video_metadata) {
+  // Set thread count if specified
+  if (thread_count == 0) {
+    thread_count = std::thread::hardware_concurrency();
+  } else {
+    thread_count = thread_count;
+  }
+
+  m_multithreaded = (thread_count != 1);
+
+  // Create consumer hasher threads if multithreading
+  if (m_multithreaded) {
+    consumer_threads.reserve(thread_count);
+    for (size_t thread_idx{0}; thread_idx < thread_count; ++thread_idx) {
+      consumer_threads.emplace_back(
+          std::thread(std::bind(&VpdqHasher::consumer, this)));
+    }
+  }
+}
+
+template <typename TFrame>
+void VpdqHasher<TFrame>::push_back(TFrame&& frame) {
+  if (m_multithreaded) {
+    {
+      std::lock_guard<std::mutex> lock(m_queue_mutex);
+      m_queue.push(std::move(frame));
+      m_queue_condition.notify_one();
+    }
+  } else {
+    hasher(frame);
+  }
+}
+
+template <typename TFrame>
+std::vector<vpdqFeature> VpdqHasher<TFrame>::finish() {
+  if (m_multithreaded) {
+    {
+      std::lock_guard<std::mutex> lock(m_queue_mutex);
+      m_done_hashing = true;
+    }
+
+    m_queue_condition.notify_all();
+    for (auto& thread : consumer_threads) {
+      thread.join();
+    }
+  }
+
+  // Sort out of order frames by frame number
+  std::sort(
+      std::begin(m_result),
+      std::end(m_result),
+      [](const vpdqFeature& a, const vpdqFeature& b) {
+        return a.frameNumber < b.frameNumber;
+      });
+
+  return m_result;
+}
+
+template <typename TFrame>
+void VpdqHasher<TFrame>::hasher(TFrame& frame) {
+  auto hashedFrame = hashFrame(frame, m_video_metadata);
+  {
+    std::lock_guard<std::mutex> lock(m_result_mutex);
+    m_result.push_back(std::move(hashedFrame));
+  }
+}
+
+template <typename TFrame>
+void VpdqHasher<TFrame>::consumer() {
+  while (true) {
+    std::unique_lock<std::mutex> lock(m_queue_mutex);
+    m_queue_condition.wait(
+        lock, [this] { return !m_queue.empty() || m_done_hashing; });
+    if (m_queue.empty() && m_done_hashing)
+      break;
+    auto frame = std::move(m_queue.front());
+    m_queue.pop();
+    lock.unlock();
+    hasher(frame);
+  }
+}
+
+} // namespace hashing
+} // namespace vpdq
+} // namespace facebook

--- a/vpdq/cpp/vpdq/cpp/hashing/hasher.h
+++ b/vpdq/cpp/vpdq/cpp/hashing/hasher.h
@@ -1,0 +1,148 @@
+// ================================================================
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// ================================================================
+
+#ifndef HASHER_H
+#define HASHER_H
+
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+#include <vpdq/cpp/hashing/ffmpegwrapper.h>
+#include <vpdq/cpp/hashing/vpdqHashType.h>
+
+namespace facebook {
+namespace vpdq {
+namespace hashing {
+
+/** @brief Generic class for video frames. Stores pixels in its buffer which are
+ *         used by PDQ for hashing.
+ **/
+class GenericFrame {
+ public:
+  /** @brief Constructor
+   *
+   *  @param buffer The pixel buffer used for PDQ hashing
+   *  @param frameNumber The frame number in the video.
+   **/
+  GenericFrame(std::vector<unsigned char> buffer, uint64_t frameNumber)
+      : m_buffer(std::move(buffer)), m_frameNumber(frameNumber){};
+
+  /** @brief Get the frame number.
+   *
+   *  @return The frame number.
+   **/
+  uint64_t get_frame_number() const { return m_frameNumber; }
+
+  /** @brief Get the pointer to the frame data buffer to be used for hashing.
+   *
+   *  @return Pointer to the frame data buffer.
+   **/
+  unsigned char* get_buffer_ptr() { return m_buffer.data(); }
+
+  std::vector<unsigned char> m_buffer;
+  uint64_t m_frameNumber;
+};
+
+struct VideoMetadata {
+  float framerate{};
+  uint32_t width{};
+  uint32_t height{};
+};
+
+template <typename TFrame>
+class VpdqHasher {
+ public:
+  /** @brief Construct hasher to hash frames and return a full Vpdq hash.
+   *
+   *  @param thread_count Number of threads to be used for hashing. 0 is use
+   *                      auto.
+   *  @param video_metadata Video characteristics for hashing.
+   *
+   *  @note Spawns hashing threads and begins hashing. Frames are hashed as they
+   *        are added to the queue.
+   **/
+  VpdqHasher(size_t thread_count, VideoMetadata video_metadata);
+
+  /** @brief Add a frame to the hashing queue.
+   *
+   * @param frame Frame to be hashed.
+   **/
+  void push_back(TFrame&& frame);
+
+  /** @brief Block until all frames are finished hashing and get the final
+   *         result.
+   *
+   * @return The vpdq hash for the whole video.
+   *
+   * @note Not thread safe.
+   **/
+  std::vector<vpdqFeature> finish();
+
+  VpdqHasher() = delete;
+  VpdqHasher(VpdqHasher const&) = delete;
+  VpdqHasher& operator=(VpdqHasher const&) = delete;
+  VpdqHasher(VpdqHasher&&) = delete;
+  VpdqHasher& operator=(VpdqHasher&&) = delete;
+
+ private:
+  /** @brief True if hashing is multithreaded, false if singlethreaded.
+   **/
+  bool m_multithreaded;
+
+  /** @brief Collection of hashing threads.
+   **/
+  std::vector<std::thread> consumer_threads;
+
+  /** @brief Condition variable to signal queue processing.
+   **/
+  std::condition_variable m_queue_condition;
+
+  /** @brief Mutex for the hash queue. Must be taken before touching the queue.
+   **/
+  std::mutex m_queue_mutex;
+
+  /** @brief Queue of frames to be hashed.
+   **/
+  std::queue<TFrame> m_queue;
+
+  /** @brief Mutex for the hash result. Must be taken before touching the
+   *         result.
+   **/
+  std::mutex m_result_mutex;
+
+  /** @brief PDQ hashes from the frame queue.
+   **/
+  std::vector<vpdqFeature> m_result;
+
+  /** @brief State of video hashing.
+   **/
+  bool m_done_hashing;
+
+  /** @brief Video metadata.
+   **/
+  VideoMetadata m_video_metadata;
+
+  /** @brief Hashes frames from the queue and inserts the PDQ hash into the
+   *         result.
+   **/
+  void hasher(TFrame& frame);
+
+  /** @brief Runs the hasher in a loop. Hashes frames as they are added to the
+   *         queue.
+   **/
+  void consumer();
+};
+
+// Explicit template instantiation for all frame types.
+template class VpdqHasher<GenericFrame>;
+template class VpdqHasher<ffmpeg::FFmpegFrame>;
+
+} // namespace hashing
+} // namespace vpdq
+} // namespace facebook
+
+#endif // HASHER_H

--- a/vpdq/cpp/vpdq/cpp/hashing/matchTwoHash.cpp
+++ b/vpdq/cpp/vpdq/cpp/hashing/matchTwoHash.cpp
@@ -76,8 +76,8 @@ static std::vector<vpdq::hashing::vpdqFeature>::size_type findMatches(
 }
 
 bool matchTwoHashBrute(
-    std::vector<vpdq::hashing::vpdqFeature> qHashes,
-    std::vector<vpdq::hashing::vpdqFeature> tHashes,
+    const std::vector<vpdq::hashing::vpdqFeature>& qHashes,
+    const std::vector<vpdq::hashing::vpdqFeature>& tHashes,
     const int distanceTolerance,
     const int qualityTolerance,
     double& qMatch,

--- a/vpdq/cpp/vpdq/cpp/hashing/matchTwoHash.h
+++ b/vpdq/cpp/vpdq/cpp/hashing/matchTwoHash.h
@@ -28,8 +28,8 @@ namespace hashing {
  * @return If successfully hash the video
  */
 bool matchTwoHashBrute(
-    std::vector<vpdq::hashing::vpdqFeature> qHashes,
-    std::vector<vpdq::hashing::vpdqFeature> tHashes,
+    const std::vector<vpdq::hashing::vpdqFeature>& qHashes,
+    const std::vector<vpdq::hashing::vpdqFeature>& tHashes,
     const int distanceTolerance,
     const int qualityTolerance,
     double& qMatch,


### PR DESCRIPTION
Summary
---------

Refactor video hashing. The combined class of hashing and decoding frames was complicated and difficult to understand. This PR splits it up into smaller classes, which also allows different frame types to be used in the future with minimal changes.

- Moved some FFmpeg custom types into separate files for better readability.

- Hashing is split into two new classes: `VpdqHasher` and `FFmpegHasher`.
  - `VpdqHasher` takes care of all hashing operations and just runs the generic hashing algorithm as frames are added.
    - A template is used as the frame type in `VpdqHasher` as opposed to an abstract class with derived frame types to avoid needing to dynamically allocate every frame. A generic frame is added that works without FFmpeg as an example, but is not used for anything currently. Using the direct FFmpeg data pointer is significantly faster than copying the data into the generic frame buffer.
  - New class `FFmpegHasher` that feeds FFmpeg frames to the `VpdqHasher`.

- Changed `FFmpegHasher::processPacket` to take in the data by reference instead of the full unique_ptr.
  - This is recommended by Herb Sutter [GotW 91](https://herbsutter.com/2013/06/05/gotw-91-solution-smart-pointer-parameters/) if ownership is not being transferred.

- Minor change to `matchTwoHashBrute` to pass data by `const&` instead of copying for better performance.

I did not notice a performance impact from these changes across multiple runs of regtest.

No public API changes other than `matchTwoHashBrute`.

Most of these changes are just moving common functions into grouped common modules. No major logic or anything is rewritten. I would try to split up this PR but most of it is easier to understand in the context of the full changes.

Test Plan
---------

regtest passes successfully. 
