### PR TITLE
[vpdq] Add vpdq Dockerfile for development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "vpdq devcontainer",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "../Dockerfile.vpdq"
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/Dockerfile.vpdq
+++ b/Dockerfile.vpdq
@@ -1,0 +1,19 @@
+# Dockerfile for development of vpdq. 
+
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    python3-venv \
+    python3-dev \
+    python-is-python3 \
+    git \
+    build-essential \
+    make cmake pkg-config \
+    clang-format \
+    ffmpeg libavdevice-dev libavfilter-dev libavformat-dev libavcodec-dev libswresample-dev libswscale-dev libavutil-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /ThreatExchange
+WORKDIR /ThreatExchange

--- a/vpdq/CONTRIBUTING.md
+++ b/vpdq/CONTRIBUTING.md
@@ -4,6 +4,7 @@ vPDQ has a CPP implementation and a Python binding that is created with Cython.
 
 Note: Python scripts are used for testing the CPP implementation, but they do not require the Python binding to be installed. They are located in the [cpp](./cpp) folder.
 
+See the CPP section in the [README](./README.md#cpp-implementation) for how to setup a development environmnet.
 
 ## Contributing
 Please see [CONTRIBUTING](../CONTRIBUTING.md) for how to make contributions develop locally and open PRs
@@ -63,7 +64,8 @@ python -m black ./
 ```
 
 ### Dependencies
-All dependencies from the CPP implementation are required to build the binding. See [README](../README.md) for more information.
+
+All dependencies from the CPP implementation are required to build the binding. See [README](./README.md#cpp-implementation) for more information.
 
 Ubuntu may require `python3-dev` to compile the bindings and `pkg-config` packages to compile vpdq.
 


### PR DESCRIPTION
Summary
---------

- Add Dockerfile for development convenience
  - Note: User still needs to setup and use venv for the Python bindings. This container is just for setting up an environment. But `pip install -e .` works out the box for the bindings.
- Add devcontainer config to use the Dockerfile with VSCode
  - Autogenerated by the devcontainer VSCode extension.
- Add Docker documentation
- Added the missing `pkg-config` to dependencies
- Fixed some documentation markdown issues
  - [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) VSCode extension is very handy.

Not sure the best practice if other devcontainers are added to the repo, but for now this works.

Test Plan
---------

Markdown renders as expected.

Container builds successfully.

vpdq and Python bindings build successfully and pass all tests in the container. 
