### PR TITLE
[py-tx] Fix Type Errors

### DIFF
--- a/python-threatexchange/.devcontainer/Dockerfile
+++ b/python-threatexchange/.devcontainer/Dockerfile
@@ -1,6 +1,16 @@
 ARG VARIANT=3.11-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
+    cmake \
+    libavdevice-dev \
+    libavfilter-dev \
+    libavformat-dev \
+    libavcodec-dev \
+    libswresample-dev \
+    libswscale-dev \
+    libavutil-dev
+
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/python-threatexchange/setup.py
+++ b/python-threatexchange/setup.py
@@ -59,6 +59,7 @@ setup(
         "requests",
         "urllib3",  # For allow_methods
         "python-dateutil",
+        "types-python-dateutil",
         "dacite",
         "Pillow",  # pdq
         "pdqhash",  # pdq

--- a/python-threatexchange/threatexchange/signal_type/pdq/pdq_hasher.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq/pdq_hasher.py
@@ -46,7 +46,7 @@ def _pdq_from_numpy_array(array: np.ndarray) -> PDQOutput:
     return hex_str, quality
 
 
-def _convert_image_to_correct_array_dimension(image: Image) -> np.ndarray:
+def _convert_image_to_correct_array_dimension(image: Image.Image) -> np.ndarray:
     """
     Handle possible image format conversion or
     """


### PR DESCRIPTION
Summary
---------

fixes #1568
- `python -m mypy threatexchange` was failing before, fixed type errors

Also fixed `python-threatexchange` devcontainer build problems
- couldn't build vpdq before, needed to install cmake and required packages found [here](https://github.com/facebook/ThreatExchange/blob/main/vpdq/cpp/CMakeLists.txt#L75)

Test Plan
---------

tested in devcontainer inside `python-threatexchange` dir
