### PR TITLE
Fixed tests for Python PDQ implementation

### DIFF
--- a/pdq/python/pdqhashing/tests/hash256_test.py
+++ b/pdq/python/pdqhashing/tests/hash256_test.py
@@ -20,7 +20,7 @@ class Hash256Test(unittest.TestCase):
 
     def test_correct_hex_format(self) -> None:
         hash = Hash256.fromHexString(self.SAMPLE_HASH)
-        self.assertNotEquals(hash, None)
+        self.assertNotEqual(hash, None)
 
     def test_clone(self) -> None:
         hash = Hash256.fromHexString(self.SAMPLE_HASH)

--- a/pdq/python/pdqhashing/tests/pdq_test.py
+++ b/pdq/python/pdqhashing/tests/pdq_test.py
@@ -6,7 +6,7 @@ from pdqhashing.hasher.pdq_hasher import PDQHasher
 from pdqhashing.types.hash256 import Hash256
 import unittest
 
-SAMPLE_MEDIA = os.path.dirname(__file__) + "/../../../../data/"
+SAMPLE_MEDIA = os.path.dirname(__file__) + "/../../../data/"
 
 
 class PdqTest(unittest.TestCase):


### PR DESCRIPTION
Fixed tests for Python pdq implementation.

Summary
---------

Fixed SAMPLE_MEDIA path (had one too many parent dirs) within[ pdq_test.py](https://github.com/facebook/ThreatExchange/blob/ee9b1b516ab55d698efb1e28dae1f721f45eb16e/pdq/python/pdqhashing/tests/pdq_test.py). Also changed `self.assertNotEquals` to `self.assertNotEqual` on line 23 of [ pdq_test.py](https://github.com/facebook/ThreatExchange/blob/ee9b1b516ab55d698efb1e28dae1f721f45eb16e/pdq/python/pdqhashing/tests/pdq_test.py) (note: typo in commit message).

Tests within pdq/python/pdqhashing/tests now complete correctly (pytest, Python3.12, MacOS 14.5)

Test Plan
---------

Run existing tests for Python build.