### PR TITLE
[pytx] Add Tech Against Terrorism Hash API

### DIFF
--- a/python-threatexchange/threatexchange/exchanges/clients/fb_threatexchange/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/fb_threatexchange/api.py
@@ -9,15 +9,12 @@ TODO: Slim down to only what we need
 import copy
 import json
 import typing as t
-import os
-import pathlib
 import re
 
 import urllib.parse
 import urllib.error
 
 import requests
-from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from threatexchange.exchanges.clients.utils.common import TimeoutHTTPAdapter
 

--- a/python-threatexchange/threatexchange/exchanges/clients/fb_threatexchange/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/fb_threatexchange/api.py
@@ -19,6 +19,7 @@ import urllib.error
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
+from threatexchange.exchanges.clients.utils.common import TimeoutHTTPAdapter
 
 
 from .api_representations import ThreatPrivacyGroup
@@ -27,22 +28,6 @@ from .api_representations import ThreatPrivacyGroup
 def is_valid_app_token(token: str) -> bool:
     """Returns true if the string looks like a valid token"""
     return bool(re.match("[0-9]{8,}(?:%7C|\\|)[a-zA-Z0-9_\\-]{20,}", token))
-
-
-class TimeoutHTTPAdapter(HTTPAdapter):
-    """
-    Plug into requests to get a well-behaved session that does not wait for eternity.
-    H/T: https://findwork.dev/blog/advanced-usage-python-requests-timeouts-retries-hooks/#setting-default-timeouts
-    """
-
-    def __init__(self, *args, timeout=5, **kwargs):
-        self.timeout = timeout
-        super().__init__(*args, **kwargs)
-
-    def send(self, request, *, timeout=None, **kwargs):
-        if timeout is None:
-            timeout = self.timeout
-        return super().send(request, timeout=timeout, **kwargs)
 
 
 class _CursoredResponse:

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
@@ -23,7 +23,6 @@ from requests.packages.urllib3.util.retry import Retry
 from threatexchange.exchanges.clients.utils.common import TimeoutHTTPAdapter
 
 
-
 _DATE_FORMAT_STR = "%Y-%m-%dT%H:%M:%SZ"
 _DEFAULT_ELE = ET.Element("")
 

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
@@ -20,9 +20,8 @@ import urllib.parse
 
 import requests
 from requests.packages.urllib3.util.retry import Retry
+from threatexchange.exchanges.clients.utils.common import TimeoutHTTPAdapter
 
-# Maybe move to a common library someday
-from threatexchange.exchanges.clients.fb_threatexchange.api import TimeoutHTTPAdapter
 
 
 _DATE_FORMAT_STR = "%Y-%m-%dT%H:%M:%SZ"

--- a/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
@@ -11,9 +11,7 @@ import typing as t
 import dacite
 import requests
 from requests.packages.urllib3.util.retry import Retry
-
-# Maybe move to a common library someday
-from threatexchange.exchanges.clients.fb_threatexchange.api import TimeoutHTTPAdapter
+from threatexchange.exchanges.clients.utils.common import TimeoutHTTPAdapter
 
 
 @enum.unique

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
@@ -59,6 +59,9 @@ class TATHashListAPI:
     This API delivers a JSON file containing a comprehensive list of all hashed terrorist content within the TAT system.
 
     The list is refreshed daily.
+
+    For more information on our collection process please visit: https://terrorismanalytics.org/about/how-it-works
+    Our Hash List documentation: https://terrorismanalytics.org/docs/hash-list-v1
     """
 
     BASE_URL: t.ClassVar[str] = "https://beta.terrorismanalytics.org/"

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
@@ -131,8 +131,9 @@ class TATHashListAPI:
         )
         return auth_response.get("token")
 
-
-    def get_hash_list(self, ideology: str = TATIdeology._all.value) -> TATHashListResponse:
+    def get_hash_list(
+        self, ideology: str = TATIdeology._all.value
+    ) -> TATHashListResponse:
         """
         Get the Hash List JSON file presigned URL ( 5 Minute expiry ) and metadata: TATHashListResponse
         """
@@ -149,5 +150,3 @@ class TATHashListAPI:
         except Exception as exception:
             logging.error("Failed to get hash list: %s", exception)
             raise Exception("Failed to fetch Hash List: %s", exception)
-
-

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
@@ -1,0 +1,163 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Simple implementation for the Tech Against Terrorism Hash List REST API"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+import logging
+import typing as t
+from contextlib import contextmanager
+
+import dacite
+import requests
+from requests.packages.urllib3.util.retry import Retry
+
+# Maybe move to a common library someday
+from threatexchange.exchanges.clients.fb_threatexchange.api import TimeoutHTTPAdapter
+
+
+logger = logging.basicConfig(level=logging.INFO)
+
+
+class TATIdeology(Enum):
+  islamist = "islamist"
+  far_right = "far-right"
+  _all = "all"
+
+
+@dataclass
+class TATHashListResponse:
+  file_url: t.AnyStr
+  file_name: t.AnyStr
+  created_on: datetime
+  total_hashes: int
+  ideology: TATIdeology
+
+
+class TATEndpoint(Enum):
+  authenticate = "token-auth/tcap/"
+  hash_list = "api/hash-list"
+
+
+class TATHashListAPI:
+  """
+  A wrapper around the Tech Against Terrorism Hash List API
+
+  The verification and collection of terrorist content are conducted by TAT OSINT Analysts and automated processes. 
+  Subsequently, the content is classified and hashed by the TAT Archive hashing and classification services.
+
+  This API delivers a JSON file containing a comprehensive list of all hashed terrorist content within the TAT system.
+
+  The list is refreshed nightly.
+  """
+
+  BASE_URL: t.ClassVar[t.AnyStr] = "https://beta.terrorismanalytics.org/"
+
+  def __init__(
+      self, 
+      username: t.AnyStr,
+      password: t.AnyStr
+    ) -> None:
+    self.username = username,
+    self.password = password
+
+
+  @contextmanager
+  def _get_session(self, auth_token: t.Optional[t.AnyStr] = None):
+    session = requests.Session()
+    session.mount(
+      self.BASE_URL,
+      adapter=TimeoutHTTPAdapter(
+        timeout=60,
+        max_retries=Retry(
+          total=4,
+          status_forcelist=[429, 500, 502, 503, 504],
+          # No retry for post. Could probably add timeout...
+          allowed_methods=["HEAD", "GET", "OPTIONS"],
+          backoff_factor=0.2,  # ~1.5 seconds of retries
+        ),
+      )
+    )
+
+    if auth_token:
+      session.headers.update({"Authorization": f"Bearer {auth_token}"})
+
+    try:
+      yield session
+    finally:
+      session.close()
+
+
+  def _get(self, endpoint: TATEndpoint, auth_token: t.Optional[t.AnyStr] = None) -> t.Any:
+    """
+        Perform an HTTP GET request, and return the JSON response payload.
+
+        Same timeouts and retry strategy as `_get_session` above.
+    """
+    with self._get_session(auth_token) as session:
+      url = self.BASE_URL + endpoint
+      response = session.get(url=url)
+      response.raise_for_status()
+      return response.json()
+
+
+  def _post(self, endpoint: TATEndpoint, data=None) -> t.Any:
+    """
+        Perform an HTTP POST request, and return the JSON response payload.
+
+        Same timeouts and retry strategy as `_get_session` above.
+    """
+    with self._get_session() as session:
+      url = self.BASE_URL + endpoint
+      response = session.post(url=url, data=data)
+      response.raise_for_status()
+      return response.json()
+
+
+  def authenticate(self, username: t.AnyStr, password: t.AnyStr) -> t.AnyStr | None:
+    """
+    Authenticate with TCAP services and obtain a JWT token
+    """
+    logger.info("Authenticating with TCAP: %s", username)
+
+    try:
+      auth_response = self._post(
+        TATEndpoint.authenticate, 
+        data={"username": username, "password": password}
+      )
+      return auth_response.get("token")
+    
+    except Exception as e:
+      logger.error("Error authenticating with TCAP: %s", e)
+      return None
+
+
+
+  def get_hash_list(self, ideology: TATIdeology = TATIdeology._all) -> TATHashListResponse | None:
+    """
+    Get the Hash List presigned URL ( 5 Minute expiry ) and metadata: TATHashListResponse
+    """
+
+    try:
+      token = self.authenticate(self.username, self.password)
+
+      if token is not None:
+        logger.info("Getting hash list")
+        response = self._get(
+          TATEndpoint.hash_list + ideology.value,
+          auth_token=token
+        )
+
+        return response
+      
+      else:
+        logger.error("Error getting hash list: %s", e)
+        raise Exception("Unable authenticating with TCAP")
+      
+    except Exception as e:
+      logger.error("Error getting hash list: %s", e)
+      return None
+    
+
+

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
@@ -15,9 +15,6 @@ from requests.packages.urllib3.util.retry import Retry
 from threatexchange.exchanges.clients.fb_threatexchange.api import TimeoutHTTPAdapter
 
 
-logger = logging.basicConfig(level=logging.INFO)
-
-
 class TATIdeology(Enum):
   islamist = "islamist"
   far_right = "far-right"
@@ -122,21 +119,21 @@ class TATHashListAPI:
     """
 
     if not isinstance(username, str) or not isinstance(password, str):
-      # logger.error("Username or password not valid")
+      logging.error("Username or password not valid")
       return None
 
-    # logger.info("Authenticating with TCAP: %s", username)
+    logging.info("Authenticating with TCAP: %s", username)
 
 
     try:
       auth_response = self._post(
-        TATEndpoint.authenticate.value  , 
+        TATEndpoint.authenticate.value, 
         data={"username": username, "password": password, "resend": False}
       )
       return auth_response.get("token")
     
     except Exception as e:
-      # logger.error("Error authenticating with TCAP: %s", e)
+      logging.error("Error authenticating with TCAP: %s", e)
       return None
 
 
@@ -150,7 +147,7 @@ class TATHashListAPI:
       token = self.authenticate(self.username, self.password)
 
       if token is not None:
-        # logger.info("Fetching hash list")
+        logging.info("Fetching hash list")
         response = self._get(
           f"{TATEndpoint.hash_list.value}/{ideology}",
           auth_token=token
@@ -159,7 +156,7 @@ class TATHashListAPI:
         return response
     
       else:
-        # logger.error("Error getting hash list: %s", e)
+        logging.error("Error getting hash list: %s", e)
         raise Exception("Unable authenticating with TCAP")
 
     except requests.exceptions.HTTPError as http_err:
@@ -167,7 +164,7 @@ class TATHashListAPI:
       
       
     except Exception as e:
-      # logger.error("Error getting hash list: %s", e)
+      logging.error("Error getting hash list: %s", e)
       return {"error": str(e)}
     
 

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
@@ -13,6 +13,7 @@ from requests.packages.urllib3.util.retry import Retry
 
 # Maybe move to a common library someday
 from threatexchange.exchanges.clients.fb_threatexchange.api import TimeoutHTTPAdapter
+import requests
 
 
 class TATIdeology(Enum):
@@ -146,7 +147,7 @@ class TATHashListAPI:
         try:
             token = self.authenticate(self.username, self.password)
 
-            endpoint = TATEndpoint.hash_list.value + ideology
+            endpoint = f"{TATEndpoint.hash_list.value}/{ideology}"
 
             print("ENDPOINT", endpoint)
 

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 import logging
-from typing import Any, ClassVar, Optional
+import typing as t
 from contextlib import contextmanager
 import requests
 from requests.packages.urllib3.util.retry import Retry
@@ -16,160 +16,153 @@ from threatexchange.exchanges.clients.fb_threatexchange.api import TimeoutHTTPAd
 
 
 class TATIdeology(Enum):
-  islamist = "islamist"
-  far_right = "far-right"
-  _all = "all"
+    islamist = "islamist"
+    far_right = "far-right"
+    _all = "all"
 
 
 @dataclass
 class TATAPIErrorResponse:
-  error: str
+    error: str
+
 
 @dataclass
 class TATHashListResponse:
-  file_url: str
-  file_name: str
-  created_on: datetime
-  total_hashes: int
-  ideology: TATIdeology
+    file_url: str
+    file_name: str
+    created_on: datetime
+    total_hashes: int
+    ideology: t.Union[
+        TATIdeology._all.value, TATIdeology.far_right.value, TATIdeology.islamist.value
+    ]
+
 
 @dataclass
 class TATUser:
-  user: Any
-  token: str
+    user: t.Any
+    token: str
+
 
 class TATEndpoint(Enum):
-  authenticate = "token-auth/tcap/"
-  hash_list = "api/hash-list"
+    authenticate = "token-auth/tcap/"
+    hash_list = "api/hash-list"
 
 
 class TATHashListAPI:
-  """
-  A wrapper around the Tech Against Terrorism Hash List API
-
-  The verification and collection of terrorist content are conducted by TAT OSINT Analysts and automated processes. 
-  Subsequently, the content is classified and hashed by the TAT Archive hashing and classification services.
-
-  This API delivers a JSON file containing a comprehensive list of all hashed terrorist content within the TAT system.
-
-  The list is refreshed daily.
-  """
-
-  BASE_URL: ClassVar[str] = "https://beta.terrorismanalytics.org/"
-
-  def __init__(
-      self, 
-      username: str,
-      password: str
-    ) -> None:
-    self.username = username
-    self.password = password
-
-
-  @contextmanager
-  def _get_session(self, auth_token: Optional[str] = None):
-    session = requests.Session()
-    session.mount(
-      self.BASE_URL,
-      adapter=TimeoutHTTPAdapter(
-        timeout=60,
-        max_retries=Retry(
-          total=4,
-          status_forcelist=[429, 500, 502, 503, 504],
-          allowed_methods=["HEAD", "GET", "OPTIONS"],
-          backoff_factor=0.2,  # ~1.5 seconds of retries
-        ),
-      )
-    )
-
-    if auth_token:
-      session.headers.update({"Authorization": f"Bearer {auth_token}"})
-
-    try:
-      yield session
-    finally:
-      session.close()
-
-
-  def _get(self, endpoint: TATEndpoint, auth_token: Optional[str] = None) -> Any:
     """
+    A wrapper around the Tech Against Terrorism Hash List API
+
+    The verification and collection of terrorist content are conducted by TAT OSINT Analysts and automated processes.
+    Subsequently, the content is classified and hashed by the TAT Archive hashing and classification services.
+
+    This API delivers a JSON file containing a comprehensive list of all hashed terrorist content within the TAT system.
+
+    The list is refreshed daily.
+    """
+
+    BASE_URL: t.ClassVar[str] = "https://beta.terrorismanalytics.org/"
+
+    def __init__(self, username: str, password: str) -> None:
+        self.username = username
+        self.password = password
+
+    @contextmanager
+    def _get_session(self, auth_token: t.Optional[str] = None):
+        session = requests.Session()
+        session.mount(
+            self.BASE_URL,
+            adapter=TimeoutHTTPAdapter(
+                timeout=60,
+                max_retries=Retry(
+                    total=4,
+                    status_forcelist=[429, 500, 502, 503, 504],
+                    allowed_methods=["HEAD", "GET", "OPTIONS"],
+                    backoff_factor=0.2,  # ~1.5 seconds of retries
+                ),
+            ),
+        )
+
+        if auth_token:
+            session.headers.update({"Authorization": f"Bearer {auth_token}"})
+
+        try:
+            yield session
+        finally:
+            session.close()
+
+    def _get(self, endpoint: str, auth_token: t.Optional[str] = None) -> t.Any:
+        """
         Perform an HTTP GET request, and return the JSON response payload.
 
         Same timeouts and retry strategy as `_get_session` above.
-    """
-    with self._get_session(auth_token) as session:
-      url = self.BASE_URL + endpoint.value
-      response = session.get(url=url)
-      response.raise_for_status()
-      return response.json()
+        """
+        with self._get_session(auth_token) as session:
+            url = self.BASE_URL + endpoint
+            response = session.get(url=url)
+            response.raise_for_status()
+            return response.json()
 
-
-  def _post(self, endpoint: TATEndpoint, data=None) -> Any:
-    """
+    def _post(self, endpoint: TATEndpoint, data=None) -> t.Any:
+        """
         Perform an HTTP POST request, and return the JSON response payload.
 
         Same timeouts and retry strategy as `_get_session` above.
-    """
-    with self._get_session() as session:
-      url = self.BASE_URL + endpoint.value
-      response = session.post(url=url, data=data)
-      response.raise_for_status()
-      return response.json()
+        """
+        with self._get_session() as session:
+            url = self.BASE_URL + endpoint.value
+            response = session.post(url=url, data=data)
+            response.raise_for_status()
+            return response.json()
 
+    def authenticate(self, username: str, password: str) -> t.Optional[str]:
+        """
+        Authenticate with TCAP services and obtain a JWT token
+        """
 
-  def authenticate(self, username: str, password: str) -> str | None:
-    """
-    Authenticate with TCAP services and obtain a JWT token
-    """
+        if not isinstance(username, str) or not isinstance(password, str):
+            logging.error("Username or password not valid")
+            return None
 
-    if not isinstance(username, str) or not isinstance(password, str):
-      logging.error("Username or password not valid")
-      return None
+        logging.info("Authenticating with TCAP: %s", username)
 
-    logging.info("Authenticating with TCAP: %s", username)
+        try:
+            auth_response = self._post(
+                TATEndpoint.authenticate,
+                data={"username": username, "password": password, "resend": False},
+            )
+            return auth_response.get("token")
 
+        except Exception as e:
+            logging.error("Error authenticating with TCAP: %s", e)
+            return None
 
-    try:
-      auth_response = self._post(
-        TATEndpoint.authenticate, 
-        data={"username": username, "password": password, "resend": False}
-      )
-      return auth_response.get("token")
-    
-    except Exception as e:
-      logging.error("Error authenticating with TCAP: %s", e)
-      return None
+    def get_hash_list(
+        self, ideology: str = TATIdeology._all.value
+    ) -> t.Union[TATHashListResponse, TATAPIErrorResponse]:
+        """
+        Get the Hash List JSON file presigned URL ( 5 Minute expiry ) and metadata: TATHashListResponse
+        """
 
+        try:
+            token = self.authenticate(self.username, self.password)
 
+            endpoint = TATEndpoint.hash_list.value + ideology
 
-  def get_hash_list(self, ideology: TATIdeology = TATIdeology._all) -> TATHashListResponse | TATAPIErrorResponse:
-    """
-    Get the Hash List JSON file presigned URL ( 5 Minute expiry ) and metadata: TATHashListResponse
-    """
+            print("ENDPOINT", endpoint)
 
-    try:
-      token = self.authenticate(self.username, self.password)
+            if token is not None:
+                logging.info("Fetching hash list")
+                response = self._get(endpoint, auth_token=token)
 
-      if token is not None:
-        logging.info("Fetching hash list")
-        response = self._get(
-          TATEndpoint.hash_list,
-          auth_token=token
-        )
-        
-        return TATHashListResponse(**response)
-    
-      else:
-        logging.error("Error getting hash list: %s", e)
-        raise Exception("Unable authenticating with TCAP")
+                return TATHashListResponse(**response)
 
-    except requests.exceptions.HTTPError as http_err:
-        return TATAPIErrorResponse(error=str(http_err))
-      
-      
-    except Exception as e:
-      logging.error("Error getting hash list: %s", e)
-      return TATAPIErrorResponse(error=str(e))
-    
+            else:
+                logging.error("Authentication failed")
+                raise Exception("Unable authenticating with TCAP")
 
+        except requests.exceptions.HTTPError as http_err:
+            return TATAPIErrorResponse(error=str(http_err))
 
+        except Exception as e:
+            logging.error("Error getting hash list: %s", e)
+            return TATAPIErrorResponse(error=str(e))

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
@@ -149,4 +149,4 @@ class TATHashListAPI:
 
         except Exception as exception:
             logging.error("Failed to get hash list: %s", exception)
-            raise Exception("Failed to fetch Hash List: %s", exception)
+            raise

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/test.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/test.py
@@ -1,0 +1,5 @@
+from api import TATHashListAPI
+
+api = TATHashListAPI(username='e3zTLn3L', password='6iA@EQg4BMH&zQD!')
+response = api.get_hash_list('test')
+print("Response >>> ", response)

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/test.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/test.py
@@ -1,5 +1,0 @@
-from api import TATHashListAPI
-
-api = TATHashListAPI(username='e3zTLn3L', password='6iA@EQg4BMH&zQD!')
-response = api.get_hash_list('test')
-print("Response >>> ", response)

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
@@ -11,7 +11,7 @@ from threatexchange.exchanges.clients.techagainstterrorism.api import (
 
 def mock_get_hash_list(
     ideology: str = TATIdeology._all.value,
-) -> t.Union[TATHashListResponse, dict[str, str]]:
+) -> t.Union[TATHashListResponse, t.Dict[str, str]]:
 
     if ideology not in TATIdeology._value2member_map_:
         return {
@@ -27,14 +27,14 @@ def mock_get_hash_list(
     )
 
 
-def mock_authenticate() -> str | None:
+def mock_get_auth_token() -> str:
     return "mock_token"
 
 
 @pytest.fixture
 def api(monkeypatch) -> TATHashListAPI:
     api_instance = TATHashListAPI(username="valid_user", password="valid_pass")
-    monkeypatch.setattr(api_instance, "authenticate", mock_authenticate)
+    monkeypatch.setattr(api_instance, "get_auth_token", mock_get_auth_token)
     monkeypatch.setattr(api_instance, "get_hash_list", mock_get_hash_list)
     return api_instance
 

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
@@ -1,0 +1,85 @@
+import typing as t
+import pytest
+from threatexchange.exchanges.clients.techagainstterrorism.api import (
+   TATIdeology,
+   TATHashListResponse,
+   TATHashListAPI
+)
+
+def mock_get_hash_list(ideology: TATIdeology = TATIdeology._all.value) -> TATHashListResponse:
+    
+    if ideology not in TATIdeology._value2member_map_:
+        return {'http_error': f'400 Client Error: Bad Request for url: https://test/api/hash-list/{ideology}'}
+
+    return TATHashListResponse(
+      file_url=f"https://hash-list.s3.com/19700101_{ideology}_hashes.json",
+      file_name=f"19790101_{ideology}_hashes.json",
+      created_on="2021-08-01T00:00:00Z",
+      total_hashes=1000,
+      ideology=ideology
+    )
+
+
+def mock_authenticate() -> str | None:
+    return "mock_token"
+
+
+@pytest.fixture
+def api(monkeypatch) -> TATHashListAPI:
+    api_instance = TATHashListAPI(username="valid_user", password="valid_pass")
+    monkeypatch.setattr(api_instance, "authenticate", mock_authenticate)
+    monkeypatch.setattr(api_instance, "get_hash_list", mock_get_hash_list)
+    return api_instance
+
+
+def test_get_islamist_hash_list(api: TATHashListAPI) -> None:
+    response = api.get_hash_list(ideology=TATIdeology.islamist.value)
+
+    assert response == TATHashListResponse(
+      file_url=f"https://hash-list.s3.com/19700101_{TATIdeology.islamist.value}_hashes.json",
+      file_name=f"19790101_{TATIdeology.islamist.value}_hashes.json",
+      created_on="2021-08-01T00:00:00Z",
+      total_hashes=1000,
+      ideology=TATIdeology.islamist.value
+    )
+
+
+def test_get_far_right_hash_list(api: TATHashListAPI) -> None:
+    response = api.get_hash_list(ideology=TATIdeology.far_right.value)
+
+    assert response == TATHashListResponse(
+      file_url=f"https://hash-list.s3.com/19700101_{TATIdeology.far_right.value}_hashes.json",
+      file_name=f"19790101_{TATIdeology.far_right.value}_hashes.json",
+      created_on="2021-08-01T00:00:00Z",
+      total_hashes=1000,
+      ideology=TATIdeology.far_right.value
+    )
+
+
+def test_get_all_hash_list(api: TATHashListAPI) -> None:
+    response = api.get_hash_list(TATIdeology._all.value)
+
+    assert response == TATHashListResponse(
+      file_url=f"https://hash-list.s3.com/19700101_{TATIdeology._all.value}_hashes.json",
+      file_name=f"19790101_{TATIdeology._all.value}_hashes.json",
+      created_on="2021-08-01T00:00:00Z",
+      total_hashes=1000,
+      ideology=TATIdeology._all.value
+    )
+
+
+def test_get_default_hash_list(api: TATHashListAPI) -> None:
+    response = api.get_hash_list()
+
+    assert response == TATHashListResponse(
+      file_url=f"https://hash-list.s3.com/19700101_{TATIdeology._all.value}_hashes.json",
+      file_name=f"19790101_{TATIdeology._all.value}_hashes.json",
+      created_on="2021-08-01T00:00:00Z",
+      total_hashes=1000,
+      ideology=TATIdeology._all.value
+    )
+
+
+def test_incorrect_ideology_hash_list(api: TATHashListAPI) -> None:
+    response = api.get_hash_list("invalid_ideology")
+    assert response == {'http_error': '400 Client Error: Bad Request for url: https://test/api/hash-list/invalid_ideology'}

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
@@ -6,10 +6,10 @@ from threatexchange.exchanges.clients.techagainstterrorism.api import (
    TATHashListAPI
 )
 
-def mock_get_hash_list(ideology: TATIdeology = TATIdeology._all.value) -> TATHashListResponse:
+def mock_get_hash_list(ideology: str = TATIdeology._all.value) -> t.Union[TATHashListResponse, dict[str, str]]:
     
     if ideology not in TATIdeology._value2member_map_:
-        return {'http_error': f'400 Client Error: Bad Request for url: https://test/api/hash-list/{ideology}'}
+        return {'error': f'400 Client Error: Bad Request for url: https://test/api/hash-list/{ideology}'}
 
     return TATHashListResponse(
       file_url=f"https://hash-list.s3.com/19700101_{ideology}_hashes.json",
@@ -82,4 +82,4 @@ def test_get_default_hash_list(api: TATHashListAPI) -> None:
 
 def test_incorrect_ideology_hash_list(api: TATHashListAPI) -> None:
     response = api.get_hash_list("invalid_ideology")
-    assert response == {'http_error': '400 Client Error: Bad Request for url: https://test/api/hash-list/invalid_ideology'}
+    assert response == {'error': '400 Client Error: Bad Request for url: https://test/api/hash-list/invalid_ideology'}

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 import typing as t
 import pytest
 from datetime import datetime

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
@@ -1,22 +1,29 @@
 import typing as t
 import pytest
+from datetime import datetime
+
 from threatexchange.exchanges.clients.techagainstterrorism.api import (
-   TATIdeology,
-   TATHashListResponse,
-   TATHashListAPI
+    TATIdeology,
+    TATHashListResponse,
+    TATHashListAPI,
 )
 
-def mock_get_hash_list(ideology: str = TATIdeology._all.value) -> t.Union[TATHashListResponse, dict[str, str]]:
-    
+
+def mock_get_hash_list(
+    ideology: str = TATIdeology._all.value,
+) -> t.Union[TATHashListResponse, dict[str, str]]:
+
     if ideology not in TATIdeology._value2member_map_:
-        return {'error': f'400 Client Error: Bad Request for url: https://test/api/hash-list/{ideology}'}
+        return {
+            "error": f"400 Client Error: Bad Request for url: https://test/api/hash-list/{ideology}"
+        }
 
     return TATHashListResponse(
-      file_url=f"https://hash-list.s3.com/19700101_{ideology}_hashes.json",
-      file_name=f"19790101_{ideology}_hashes.json",
-      created_on="2021-08-01T00:00:00Z",
-      total_hashes=1000,
-      ideology=ideology
+        file_url=f"https://hash-list.s3.com/19700101_{ideology}_hashes.json",
+        file_name=f"19790101_{ideology}_hashes.json",
+        created_on=datetime.strptime("2021-08-01T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ"),
+        total_hashes=1000,
+        ideology=ideology,
     )
 
 
@@ -36,11 +43,11 @@ def test_get_islamist_hash_list(api: TATHashListAPI) -> None:
     response = api.get_hash_list(ideology=TATIdeology.islamist.value)
 
     assert response == TATHashListResponse(
-      file_url=f"https://hash-list.s3.com/19700101_{TATIdeology.islamist.value}_hashes.json",
-      file_name=f"19790101_{TATIdeology.islamist.value}_hashes.json",
-      created_on="2021-08-01T00:00:00Z",
-      total_hashes=1000,
-      ideology=TATIdeology.islamist.value
+        file_url=f"https://hash-list.s3.com/19700101_islamist_hashes.json",
+        file_name=f"19790101_islamist_hashes.json",
+        created_on=datetime.strptime("2021-08-01T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ"),
+        total_hashes=1000,
+        ideology=TATIdeology.islamist.value,
     )
 
 
@@ -48,11 +55,11 @@ def test_get_far_right_hash_list(api: TATHashListAPI) -> None:
     response = api.get_hash_list(ideology=TATIdeology.far_right.value)
 
     assert response == TATHashListResponse(
-      file_url=f"https://hash-list.s3.com/19700101_{TATIdeology.far_right.value}_hashes.json",
-      file_name=f"19790101_{TATIdeology.far_right.value}_hashes.json",
-      created_on="2021-08-01T00:00:00Z",
-      total_hashes=1000,
-      ideology=TATIdeology.far_right.value
+        file_url=f"https://hash-list.s3.com/19700101_far-right_hashes.json",
+        file_name=f"19790101_far-right_hashes.json",
+        created_on=datetime.strptime("2021-08-01T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ"),
+        total_hashes=1000,
+        ideology=TATIdeology.far_right.value,
     )
 
 
@@ -60,11 +67,11 @@ def test_get_all_hash_list(api: TATHashListAPI) -> None:
     response = api.get_hash_list(TATIdeology._all.value)
 
     assert response == TATHashListResponse(
-      file_url=f"https://hash-list.s3.com/19700101_{TATIdeology._all.value}_hashes.json",
-      file_name=f"19790101_{TATIdeology._all.value}_hashes.json",
-      created_on="2021-08-01T00:00:00Z",
-      total_hashes=1000,
-      ideology=TATIdeology._all.value
+        file_url=f"https://hash-list.s3.com/19700101_all_hashes.json",
+        file_name=f"19790101_all_hashes.json",
+        created_on=datetime.strptime("2021-08-01T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ"),
+        total_hashes=1000,
+        ideology=TATIdeology._all.value,
     )
 
 
@@ -72,14 +79,16 @@ def test_get_default_hash_list(api: TATHashListAPI) -> None:
     response = api.get_hash_list()
 
     assert response == TATHashListResponse(
-      file_url=f"https://hash-list.s3.com/19700101_{TATIdeology._all.value}_hashes.json",
-      file_name=f"19790101_{TATIdeology._all.value}_hashes.json",
-      created_on="2021-08-01T00:00:00Z",
-      total_hashes=1000,
-      ideology=TATIdeology._all.value
+        file_url=f"https://hash-list.s3.com/19700101_all_hashes.json",
+        file_name=f"19790101_all_hashes.json",
+        created_on=datetime.strptime("2021-08-01T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ"),
+        total_hashes=1000,
+        ideology=TATIdeology._all.value,
     )
 
 
 def test_incorrect_ideology_hash_list(api: TATHashListAPI) -> None:
     response = api.get_hash_list("invalid_ideology")
-    assert response == {'error': '400 Client Error: Bad Request for url: https://test/api/hash-list/invalid_ideology'}
+    assert response == {
+        "error": "400 Client Error: Bad Request for url: https://test/api/hash-list/invalid_ideology"
+    }

--- a/python-threatexchange/threatexchange/exchanges/clients/utils/common.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/utils/common.py
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 from requests.adapters import HTTPAdapter
 
 

--- a/python-threatexchange/threatexchange/exchanges/clients/utils/common.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/utils/common.py
@@ -1,0 +1,17 @@
+from requests.adapters import HTTPAdapter
+
+
+class TimeoutHTTPAdapter(HTTPAdapter):
+    """
+    Plug into requests to get a well-behaved session that does not wait for eternity.
+    H/T: https://findwork.dev/blog/advanced-usage-python-requests-timeouts-retries-hooks/#setting-default-timeouts
+    """
+
+    def __init__(self, *args, timeout=5, **kwargs):
+        self.timeout = timeout
+        super().__init__(*args, **kwargs)
+
+    def send(self, request, *, timeout=None, **kwargs):
+        if timeout is None:
+            timeout = self.timeout
+        return super().send(request, timeout=timeout, **kwargs)


### PR DESCRIPTION
Summary
---------
Hi

Bruce here from Tech Against Terrorism 👋 

This PR contains Step 1 from [this issue](https://github.com/facebook/ThreatExchange/issues/1610) integrating the Tech Against Terrorism Hash List API into `python-threatexchange`

I used StopNSCII & NCMEC inside `/client/exchanges/` as initial guidance. 

**Caveat**
Our API returns a pre-signed URL to a JSON file for our hash list, instead of paginated results. I'm wondering how we want to handle this moving forward into part 2 (Once we're happy with part 1) ? 

Test Plan
---------
**Manual**
For manual testing you can use python shell to simply instantiate the `TATHashListAPI` with your TCAP username and password.

```
tat_api = TATHashListAPI(username=USER_NAME, password=PASSWORD)
response = tat_api.get_hash_list()
```

**Automated**
I have written unit tests `techagainstterrorism/tests` so `pytest` will do it.
