### PR TITLE
[py-tx] Validate hash length

### DIFF
--- a/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/stopncii/api.py
@@ -10,7 +10,7 @@ import typing as t
 
 import dacite
 import requests
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 from threatexchange.exchanges.clients.utils.common import TimeoutHTTPAdapter
 
 

--- a/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
@@ -340,7 +340,7 @@ class SignalExchangeAPIWithSimpleUpdates(
                 logging.warning(
                     "Invalid fingerprint (%s): %s",
                     s_type.get_name(),
-                    signal_str,
+                    signal_str if len(signal_str) < 100 else signal_str[:100] + "...",
                 )
                 continue
             inner = ret.get(s_type)

--- a/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
@@ -6,6 +6,8 @@ The SignalExchangeAPI talks to external APIs to read/write signals
 @see SignalExchangeAPI
 """
 
+import logging
+
 from abc import ABC, abstractmethod
 import typing as t
 
@@ -331,6 +333,15 @@ class SignalExchangeAPIWithSimpleUpdates(
         for (type_str, signal_str), metadata in fetched.items():
             s_type = type_by_name.get(type_str)
             if s_type is None or metadata is None:
+                continue
+            try:
+                s_type.validate_signal_str(signal_str)
+            except ValueError:
+                logging.warning(
+                    "Invalid fingerprint (%s): %s",
+                    s_type.get_name(),
+                    signal_str,
+                )
                 continue
             inner = ret.get(s_type)
             if inner is None:

--- a/python-threatexchange/threatexchange/signal_type/pdq/signal.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq/signal.py
@@ -109,4 +109,6 @@ class PdqSignal(
             "c186f9619659658c4b6916daf934496985f4259c72c39676ab9edb631c3c349c",
             # Github octocat - https://github.com/logos
             "62c9789627838f69f23cf98c29e37836d61c87c31c59587c4b49a783f496725c",
+            # https://github.com/facebook/ThreatExchange/issues/1609 - bad entry
+            "00000000000000000000000000000000",
         ]

--- a/python-threatexchange/threatexchange/signal_type/pdq/signal.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq/signal.py
@@ -110,5 +110,5 @@ class PdqSignal(
             # Github octocat - https://github.com/logos
             "62c9789627838f69f23cf98c29e37836d61c87c31c59587c4b49a783f496725c",
             # https://github.com/facebook/ThreatExchange/issues/1609 - bad entry
-            "00000000000000000000000000000000",
+            # "00000000000000000000000000000000",
         ]


### PR DESCRIPTION
Summary
---------

fixes #1609

validates hash length in SignalExchangeAPIWithSimpleUpdates (used by stopNCII, file, etc)

Test Plan
---------

reproduce error by adding `"00000000000000000000000000000000"` to the list of example PDQ hashes and try to run `tx fetch`
```
...
Building index for pdq with 17 signals...
Traceback (most recent call last):
  File "/home/vscode/.local/bin/tx", line 33, in <module>
    sys.exit(load_entry_point('threatexchange', 'console_scripts', 'tx')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 321, in main
    inner_main()
  File "/workspaces/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 314, in inner_main
    execute_command(settings, namespace)
  File "/workspaces/ThreatExchange/python-threatexchange/threatexchange/cli/main.py", line 157, in execute_command
    command.execute(settings)
  File "/workspaces/ThreatExchange/python-threatexchange/threatexchange/cli/fetch_cmd.py", line 163, in execute
    DatasetCommand().execute_generate_indices(settings)
  File "/workspaces/ThreatExchange/python-threatexchange/threatexchange/cli/dataset_cmd.py", line 292, in execute_generate_indices
    index = index_cls.build(signals.items())
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/ThreatExchange/python-threatexchange/threatexchange/signal_type/index.py", line 216, in build
    ret.add_all(entries)
  File "/workspaces/ThreatExchange/python-threatexchange/threatexchange/signal_type/pdq/pdq_index.py", line 75, in add_all
    self.index.add(
  File "/workspaces/ThreatExchange/python-threatexchange/threatexchange/signal_type/pdq/pdq_faiss_matcher.py", line 240, in add
    self.faiss_index.add_with_ids(numpy.array(vectors), numpy.array(i64_ids))
...
```
after rebuilding `tx` with the fix in `SignalExchangeAPIWithSimpleUpdates`, error goes away as the offending entry is ignored (note the count 17 went down to 16)
```
...
Building index for pdq with 16 signals...
Index for pdq ready
...
```