### PR TITLE
Add required copyright headers to files missing it

### DIFF
--- a/Dockerfile.vpdq
+++ b/Dockerfile.vpdq
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 # Dockerfile for development of vpdq. 
 
 FROM ubuntu:24.04

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/curation.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/curation.py
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 import re
 import typing as t
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/migrations/env.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/migrations/env.py
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 import logging
 from logging.config import fileConfig
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/migrations/script.py.mako
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/migrations/script.py.mako
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 """${message}
 
 Revision ID: ${up_revision}

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/bootstrap.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/bootstrap.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <!doctype html>
 <html lang="en">
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/add_to_bank_form.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/add_to_bank_form.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <h3> Add Content to Bank</h3>
 <form id="add_content_to_bank">
     <div class="row">

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks_grid.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks_grid.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <h3> Banks </h3>
 <div class="w-50 my-1">
     <form action="/ui/create_bank" method="post" enctype="multipart/form-data">

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/content_signal.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/content_signal.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <div class="row row-cols-1 row-cols-md-3 mb-3 text-center">
     <div class="col">
         <div class="card rounded-3 shadow-sm">

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/create_exchange_modal.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/create_exchange_modal.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <!-- Button trigger modal -->
 <button type="button" class="btn btn-outline-success" data-bs-toggle="modal" data-bs-target="#createExchange">
     Create Exchange

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/dev_mode_bar.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/dev_mode_bar.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <div class="container my-3">
     <div class="alert alert-primary" role="alert">
         <div class="d-flex flex-row align-items-center">

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/exchange_status.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/exchange_status.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <table class="table">
     <thead>
         <tr>

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/index_status.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/index_status.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <h3>Index Status</h3>
 <table class="table">
     <thead>

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/match_dbg_upload.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/match_dbg_upload.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <div class="card text-dark bg-light box-shadow h-md-250 h-100 mx-auto">
     <div class="row align-items-center m-2">
         <div class="col" id="{{ upload_id }}-img">

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/match_form.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/match_form.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <h3>Match File</h3>
 <form id="match_file">
     <div class="row">

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/nav_bar.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/nav_bar.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <nav class="navbar navbar-expand-lg bg-primary" data-bs-theme="dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="{{ url_for('.home') }}">Open Media Match</a>

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/pages/banks.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/pages/banks.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <div class="container my-3">
     {% include "components/banks_grid.html.j2" %}
 </div>

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/pages/exchanges.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/pages/exchanges.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <div class="container my-3">
     <h3>Exchange Status</h3>
     {% include 'components/create_exchange_modal.html.j2' %}

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/pages/home.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/pages/home.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 {% if not production %}
 {% include "components/dev_mode_bar.html.j2" %}
 {% endif %}

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/pages/match_dbg.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/pages/match_dbg.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <div class="container">
     <div class="py-5 text-center">
         <h3>Matching and SignalType Debugger</h3>

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 import typing as t
 
 from flask.testing import FlaskClient

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_database.py
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 import typing as t
 from flask import Flask
 from sqlalchemy import select, and_

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/utils.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 import os
 import pytest
 import typing as t

--- a/hasher-matcher-actioner/src/OpenMediaMatch/utils/formatters.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/utils/formatters.py
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 from pythonjsonlogger import jsonlogger
 
 

--- a/vpdq/cpp/pdq/cpp/hashing/torben.cpp
+++ b/vpdq/cpp/pdq/cpp/hashing/torben.cpp
@@ -1,13 +1,15 @@
 // ================================================================
-// The following code is public domain.
-// Algorithm by Torben Mogensen, implementation by N. Devillard.
-// This code in public domain.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // ================================================================
 
 namespace facebook {
 namespace pdq {
 namespace hashing {
 
+/**
+ * The following code is public domain.
+ * Algorithm by Torben Mogensen, implementation by N. Devillard.
+ */
 float torben(float m[], int n) {
   int i, less, greater, equal;
   float min, max, guess, maxltguess, mingtguess;

--- a/vpdq/cpp/pdq/cpp/hashing/torben.h
+++ b/vpdq/cpp/pdq/cpp/hashing/torben.h
@@ -1,20 +1,18 @@
 // ================================================================
-// The following code is public domain.
-// Algorithm by Torben Mogensen, implementation by N. Devillard.
-// This code in public domain.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // ================================================================
 
 #ifndef TORBEN_H
 #define TORBEN_H
-/*
- * The following code is public domain.
- * Algorithm by Torben Mogensen, implementation by N. Devillard.
- * This code in public domain.
- */
 
 namespace facebook {
 namespace pdq {
 namespace hashing {
+
+/**
+ * The following code is public domain.
+ * Algorithm by Torben Mogensen, implementation by N. Devillard.
+ */
 float torben(float m[], int n);
 } // namespace hashing
 } // namespace pdq

--- a/vpdq/python/tools/generate_hashes.py
+++ b/vpdq/python/tools/generate_hashes.py
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 import vpdq  # type: ignore
 from pathlib import Path
 from typing import Union, Sequence


### PR DESCRIPTION
Summary
---------

The internal linter is complaining again, so do a fixup. There were a couple of tricky cases
1. jinja template files, which I chose to implement via `{# Comment #}`
2. A section of vpdq declared in the public domain in #1508. I am not a lawyer, so I tried to pick a compromise solution, @Ianwal seems to have left github so can't ask him his opinion.

Test Plan
---------

Let's see if CI is happy, and then I'll just view the HMA UI to make sure it still loads
