### PR TITLE
[hma] Fix CI for new mypy version

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
@@ -214,7 +214,7 @@ def test_exchange_api_set_auth(app: Flask, client: FlaskClient):
     tx_name = FBThreatExchangeSignalExchangeAPI.get_name()
     # Monkeypatch installed types
     storage.exchange_types = {  # type:ignore
-        api_cls.get_name(): api_cls  # type:ignore
+        api_cls.get_name(): api_cls
         for api_cls in (
             FBThreatExchangeSignalExchangeAPI,
             StaticSampleSignalExchangeAPI,


### PR DESCRIPTION
Summary
---------
We have some old #type:  ignore from when Mypy wasn't able to parse some of the more complicate generics, but a new version seems to be able to handle them. We're not getting an error for an unneeded type:ignore


Test Plan
---------

mypy locally, it passes
