### PR TITLE
add endpoint to delete a content_signal from a bank

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/curation.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/curation.py
@@ -212,6 +212,19 @@ def _bank_add_signals(
     }
 
 
+@bp.route("/bank/<bank_name>/content/<content_id>", methods=["DELETE"])
+def bank_delete_content(bank_name: str, content_id: int):
+    """
+    Remove a signal from a bank.
+    """
+    storage = persistence.get_storage()
+    bank = storage.get_bank(bank_name)
+    if not bank:
+        abort(404, f"bank '{bank_name}' not found")
+
+    storage.bank_remove_content(bank.name, content_id)
+    return {"message": "Done"}
+
 @bp.route("/bank/<bank_name>/signal", methods=["POST"])
 def bank_add_as_signals(bank_name: str):
     """

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/curation.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/curation.py
@@ -222,8 +222,9 @@ def bank_delete_content(bank_name: str, content_id: int):
     if not bank:
         abort(404, f"bank '{bank_name}' not found")
 
-    storage.bank_remove_content(bank.name, content_id)
-    return {"message": "Done"}
+    count = storage.bank_remove_content(bank.name, content_id)
+    return {"deleted": count}
+
 
 @bp.route("/bank/<bank_name>/signal", methods=["POST"])
 def bank_add_as_signals(bank_name: str):

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/interface.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/interface.py
@@ -511,7 +511,7 @@ class IBankStore(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def bank_remove_content(self, bank_name: str, content_id: int) -> None:
+    def bank_remove_content(self, bank_name: str, content_id: int) -> int:
         """Remove content from bank by id"""
 
     @abc.abstractmethod

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/mocked.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/mocked.py
@@ -190,7 +190,7 @@ class MockedUnifiedStore(interface.IUnifiedStore):
         # TODO
         raise Exception("Not implemented")
 
-    def bank_remove_content(self, bank_name: str, content_id: int) -> None:
+    def bank_remove_content(self, bank_name: str, content_id: int) -> int:
         # TODO
         raise Exception("Not implemented")
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
@@ -566,11 +566,14 @@ class DefaultOMMStore(interface.IUnifiedStore):
         sesh.commit()
         return content.id
 
-    def bank_remove_content(self, bank_name: str, content_id: int) -> None:
-        database.db.session.execute(
-            delete(database.BankContent).where(database.BankContent.id == content_id)
+    def bank_remove_content(self, bank_name: str, content_id: int) -> int:
+        result = database.db.session.execute(
+            delete(database.BankContent)
+            .where(database.BankContent.id == content_id)
+            .where(database.BankContent.imported_from_id.is_(None))
         )
         database.db.session.commit()
+        return result.rowcount
 
     def get_current_index_build_target(
         self, signal_type: t.Type[SignalType]

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
@@ -567,10 +567,9 @@ class DefaultOMMStore(interface.IUnifiedStore):
         return content.id
 
     def bank_remove_content(self, bank_name: str, content_id: int) -> int:
+        # TODO: throw an exception if deleting imported content
         result = database.db.session.execute(
-            delete(database.BankContent)
-            .where(database.BankContent.id == content_id)
-            .where(database.BankContent.imported_from_id.is_(None))
+            delete(database.BankContent).where(database.BankContent.id == content_id)
         )
         database.db.session.commit()
         return result.rowcount

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
@@ -153,6 +153,7 @@ def test_banks_add_hash(client: FlaskClient):
         },
     }
 
+
 def test_banks_delete_hash(client: FlaskClient):
     bank_name = "NEW_BANK"
     image_url = "https://github.com/facebook/ThreatExchange/blob/main/pdq/data/bridge-mods/aaa-orig.jpg?raw=true"
@@ -160,11 +161,17 @@ def test_banks_delete_hash(client: FlaskClient):
     create_bank(client, bank_name)
     add_hash_to_bank(client, bank_name, image_url, 1)
 
-    post_response = client.delete(
-        f"/c/bank/{bank_name}/content/1"
-    )
+    post_response = client.delete(f"/c/bank/{bank_name}/content/1")
 
     assert post_response.status_code == 200
+    assert post_response.json == {"deleted": 1}
+
+    # Test against image
+    post_response = client.get(
+        f"/m/raw_lookup?signal_type=pdq&signal={IMAGE_URL_TO_PDQ[image_url]}"
+    )
+    assert post_response.status_code == 200
+    assert post_response.json == {"matches": []}
 
 
 def test_banks_add_metadata(client: FlaskClient):

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
@@ -153,6 +153,19 @@ def test_banks_add_hash(client: FlaskClient):
         },
     }
 
+def test_banks_delete_hash(client: FlaskClient):
+    bank_name = "NEW_BANK"
+    image_url = "https://github.com/facebook/ThreatExchange/blob/main/pdq/data/bridge-mods/aaa-orig.jpg?raw=true"
+
+    create_bank(client, bank_name)
+    add_hash_to_bank(client, bank_name, image_url, 1)
+
+    post_response = client.delete(
+        f"/c/bank/{bank_name}/content/1"
+    )
+
+    assert post_response.status_code == 200
+
 
 def test_banks_add_metadata(client: FlaskClient):
     bank_name = "NEW_BANK"

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
@@ -166,13 +166,6 @@ def test_banks_delete_hash(client: FlaskClient):
     assert post_response.status_code == 200
     assert post_response.json == {"deleted": 1}
 
-    # Test against image
-    post_response = client.get(
-        f"/m/raw_lookup?signal_type=pdq&signal={IMAGE_URL_TO_PDQ[image_url]}"
-    )
-    assert post_response.status_code == 200
-    assert post_response.json == {"matches": []}
-
 
 def test_banks_add_metadata(client: FlaskClient):
     bank_name = "NEW_BANK"


### PR DESCRIPTION
Summary
---------

- add functionality to delete a content_signal from a bank
- there's already a implementation for `bank_remove_content` that I utilized

Test Plan
---------
- tested locally by adding something to a bank and then hitting the new endpoint to delete it 