### PR TITLE
[hma] automatically install available extensions in dev container

### DIFF
--- a/hasher-matcher-actioner/.devcontainer/postcreate.sh
+++ b/hasher-matcher-actioner/.devcontainer/postcreate.sh
@@ -4,8 +4,12 @@ set -e
 pip install --editable .[all]
 
 # Find Python packages in opt and install them
-for setup_script in "$(find /workspace/opt -name setup.py)"
+for setup_script in "$(find /workspace/extensions -name setup.py)"
 do
     module_dir="$(dirname "$setup_script")"
     pip install --editable "$module_dir"
+    for extension in "$(echo "import setuptools; [ print (p) for p in setuptools.find_packages('${module_dir}') ]" | python)"
+    do
+        threatexchange config extensions add "$extension"
+    done
 done


### PR DESCRIPTION
Summary
---------

Find the Python package names made available from the extensions we installed, and pass to `threatexchange config extensions add`.

Test Plan
---------

Rebuild the container