### PR TITLE
[py-tx] Implement NCMEC Upvote/Downvote in reference API

### DIFF
--- a/python-threatexchange/threatexchange/exchanges/clients/fb_threatexchange/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/fb_threatexchange/api.py
@@ -15,7 +15,7 @@ import urllib.parse
 import urllib.error
 
 import requests
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 from threatexchange.exchanges.clients.utils.common import TimeoutHTTPAdapter
 
 

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
@@ -174,7 +174,7 @@ class Feedback:
     @classmethod
     def get_from_entry_feedback(
         cls, entry: _XMLWrapper
-    ) -> t.Dict[str, list["Feedback"]]:
+    ) -> t.Dict[str, t.List["Feedback"]]:
         feedbacks_xml = entry.maybe("feedback")
         if not feedbacks_xml:
             return {}

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
@@ -236,7 +236,7 @@ class NCMECEntryUpdate:
     fingerprints: t.Dict[str, str]
     # The feedback (upvote/downvote) that other ESPs have given for this entry
     # Keyed the same way as fingerprints
-    feedback: t.Dict[str, list[Feedback]]
+    feedback: t.Dict[str, t.List[Feedback]]
 
     @classmethod
     def from_xml(cls, xml: _XMLWrapper) -> "NCMECEntryUpdate":
@@ -513,9 +513,11 @@ class NCMECHashAPI:
         return [StatusResult.from_xml(member) for member in _XMLWrapper(response)]
 
     def feedback_reasons(self, fingerprint_type: FingerprintType) -> t.Dict[str, str]:
-        """Get the possible negative feedback reasons for each feedback type"""
-        ret = {}
-        # Could parallelize this
+        """
+        Get the possible negative feedback reasons for this type
+
+        According to NCMEC documentation, the GUIDs
+        """
         xml = _XMLWrapper(
             self._get(NCMECEndpoint.feedback, path=f"{fingerprint_type.value}/reasons")
         )

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/data.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/data.py
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 STATUS_XML = """
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <status xmlns="https://hashsharing.ncmec.org/hashsharing/v2">

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/data.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/data.py
@@ -176,6 +176,22 @@ ENTRIES_LARGE_FINGERPRINTS = """
 </queryResult>
 """.strip()
 
+STATUS_XML = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<status xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+    <ipAddress>1.1.1.1</ipAddress>
+    <username>test_user</username>
+    <member id="1">test member</member>
+</status>
+""".strip()
+
+FEEDBACK_REASONS_XML = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<availableFeedbackReasons xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+    <reason guid="01234567-abcd-0123-4567-012345678900" name="Example Reason 1" type="Sha1"/>
+</availableFeedbackReasons>
+""".strip()
+
 AFFIRMATIVE_FEEDBACK_XML = """
 <?xml version="1.0" encoding="UTF-8"?>
 <feedbackSubmission xmlns="https://hashsharing.ncmec.org/hashsharing/v2">

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/data.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/data.py
@@ -1,0 +1,202 @@
+STATUS_XML = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<status xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+    <ipAddress>127.0.0.1</ipAddress>
+    <username>testington</username>
+    <member id="1">Sir Testington</member>
+</status>
+""".strip()
+
+NEXT_UNESCAPED = (
+    "/v2/entries?from=2017-10-20T00%3A00%3A00.000Z"
+    "&to=2017-10-30T00%3A00%3A00.000Z&start=2001&size=1000&max=3000"
+)
+
+NEXT_UNESCAPED2 = (
+    "/v2/entries?from=2017-10-20T00%3A00%3A00.000Z"
+    "&to=2017-10-30T00%3A00%3A00.000Z&start=3001&size=1000&max=4000"
+)
+NEXT_UNESCAPED3 = (
+    "/v2/entries?from=2017-10-20T00%3A00%3A00.000Z"
+    "&to=2017-10-30T00%3A00%3A00.000Z&start=4001&size=1000&max=5000"
+)
+
+ENTRIES_XML = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+    <images count="2" maxTimestamp="2017-10-24T15:10:00Z">
+        <image>
+            <member id="42">Example Member</member>
+            <timestamp>2017-10-24T15:00:00Z</timestamp>
+            <id>image1</id>
+            <classification>A1</classification>
+            <fingerprints>
+                <md5>a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1</md5>
+                <sha1>a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1</sha1>
+                <pdna>a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1...</pdna>
+            </fingerprints>
+            <feedback lastUpdateTimestamp="2023-06-01T12:48:14Z">
+                <affirmativeFeedback type="Md5" lastUpdateTimestamp="2023-06-01T12:48:14Z">
+                <members timestamp="2023-06-01T12:48:14Z">
+                    <member id="42">Example Member</member>
+                </members>
+                </affirmativeFeedback>
+                <negativeFeedback type="Sha1" lastUpdateTimestamp="2023-05-31T19:41:51Z">
+                <reasons>
+                    <reason guid="01234567-abcd-0123-4567-012345678900" name="Example Reason 1" type="Sha1"/>
+                    <members timestamp="2023-06-01T12:48:14Z">
+                        <member id="42">Example Member</member>
+                    </members>
+                </reasons>
+                </negativeFeedback>
+            </feedback>
+        </image>
+        <deletedImage>
+            <member id="43">Example Member2</member>
+            <id>image4</id>
+            <timestamp>2017-10-24T15:10:00Z</timestamp>
+        </deletedImage>
+    </images>
+    <videos count="2" maxTimestamp="2017-10-24T15:20:00Z">
+        <video>
+            <member id="42">Example Member</member>
+            <timestamp>2017-10-24T15:00:00Z</timestamp>
+            <id>video1</id>
+            <fingerprints>
+                <md5>b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1</md5>
+                <sha1>b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1</sha1>
+            </fingerprints>
+        </video>
+        <deletedVideo>
+            <member id="42">Example Member</member>
+            <id>video4</id>
+            <timestamp>2017-10-24T15:20:00Z</timestamp>
+        </deletedVideo>
+    </videos>
+    <paging>
+        <next>/v2/entries?from=2017-10-20T00%3A00%3A00.000Z&amp;to=2017-10-30T00%3A00%3A00.000Z&amp;start=2001&amp;size=1000&amp;max=3000</next>
+    </paging>
+</queryResult>
+""".strip()
+
+
+ENTRIES_XML2 = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+    <images count="1" maxTimestamp="2019-10-24T15:10:00Z">
+        <image>
+            <member id="42">Example Member</member>
+            <timestamp>2019-10-24T15:00:00Z</timestamp>
+            <id>image10</id>
+            <classification>A1</classification>
+            <fingerprints>
+                <md5>b1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1</md5>
+                <sha1>b1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1</sha1>
+                <pdna>b1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1...</pdna>
+            </fingerprints>
+            <feedback />
+        </image>
+    </images>
+    <paging>
+        <next>/v2/entries?from=2017-10-20T00%3A00%3A00.000Z&amp;to=2017-10-30T00%3A00%3A00.000Z&amp;start=3001&amp;size=1000&amp;max=4000</next>
+    </paging>
+</queryResult>
+""".strip()
+
+# This example isn't in the documentation, but shows how updates work
+ENTRIES_XML3 = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+    <videos count="2" maxTimestamp="2019-11-25T15:10:00Z">
+        <video>
+            <member id="101">TX Example</member>
+            <timestamp>2019-11-25T15:10:00Z</timestamp>
+            <id>willupdate</id>
+            <classification>A1</classification>
+            <fingerprints>
+                <md5>facefacefacefacefacefacefaceface</md5>
+            </fingerprints>
+        </video>
+        <video>
+            <member id="101">TX Example</member>
+            <timestamp>2019-11-24T15:10:00Z</timestamp>
+            <id>willdelete</id>
+            <classification>A1</classification>
+            <fingerprints>
+                <md5>bacebacebacebacebacebacebacebace</md5>
+            </fingerprints>
+        </video>
+    </videos>
+    <paging>
+        <next>/v2/entries?from=2017-10-20T00%3A00%3A00.000Z&amp;to=2017-10-30T00%3A00%3A00.000Z&amp;start=4001&amp;size=1000&amp;max=5000</next>
+    </paging>
+</queryResult>
+""".strip()
+
+ENTRIES_XML4 = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+    <videos count="2" maxTimestamp="2019-11-24T15:10:00Z">
+        <video>
+            <member id="101">TX Example</member>
+            <timestamp>2019-11-24T15:10:00Z</timestamp>
+            <id>willupdate</id>
+            <classification>A2</classification>
+            <fingerprints>
+                <md5>facefacefacefacefacefacefaceface</md5>
+            </fingerprints>
+        </video>
+        <deletedVideo>
+            <member id="101">TX Example</member>
+            <timestamp>2019-11-25T15:10:00Z</timestamp>
+            <id>willdelete</id>
+        </deletedVideo>
+    </videos>
+</queryResult>
+""".strip()
+
+ENTRIES_LARGE_FINGERPRINTS = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+    <videos count="1" maxTimestamp="2019-11-24T15:10:00Z">
+        <video>
+            <member id="101">TX Example</member>
+            <timestamp>2019-11-24T15:10:00Z</timestamp>
+            <id>largetags</id>
+            <classification>A2</classification>
+            <fingerprints>
+                <md5>facefacefacefacefacefacefaceface</md5>
+                <tmk-pdqf rel="self" href="/v2/entries/1/fingerprints/TMK_PDQF"/>
+				<videntifier rel="self" href="/v2/entries/1/fingerprints/VIDENTIFIER"/>
+            </fingerprints>
+        </video>
+    </videos>
+</queryResult>
+""".strip()
+
+AFFIRMATIVE_FEEDBACK_XML = """
+<?xml version="1.0" encoding="UTF-8"?>
+<feedbackSubmission xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+    <affirmative>
+        <!-- Intentionally left blank -->
+    </affirmative>
+</feedbackSubmission>
+""".strip()
+
+NEGATIVE_FEEDBACK_XML = """
+<?xml version="1.0" encoding="UTF-8"?>
+<feedbackSubmission xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+    <negative>
+        <reasonIds>
+            <guid>01234567-abcd-0123-4567-012345678900</guid>
+        </reasonIds>
+    </negative>
+</feedbackSubmission>
+""".strip()
+
+UPDATE_FEEDBACK_RESULT_XML = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<submissionResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+  <!-- What this returns is not documented -->
+</submissionResult>
+""".strip()

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/data.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/data.py
@@ -39,17 +39,17 @@ ENTRIES_XML = """
             </fingerprints>
             <feedback lastUpdateTimestamp="2023-06-01T12:48:14Z">
                 <affirmativeFeedback type="Md5" lastUpdateTimestamp="2023-06-01T12:48:14Z">
-                <members timestamp="2023-06-01T12:48:14Z">
-                    <member id="42">Example Member</member>
-                </members>
-                </affirmativeFeedback>
-                <negativeFeedback type="Sha1" lastUpdateTimestamp="2023-05-31T19:41:51Z">
-                <reasons>
-                    <reason guid="01234567-abcd-0123-4567-012345678900" name="Example Reason 1" type="Sha1"/>
                     <members timestamp="2023-06-01T12:48:14Z">
                         <member id="42">Example Member</member>
                     </members>
-                </reasons>
+                </affirmativeFeedback>
+                <negativeFeedback type="Sha1" lastUpdateTimestamp="2023-05-31T19:41:51Z">
+                    <reasons>
+                        <reason guid="01234567-abcd-0123-4567-012345678900" name="Example Reason 1" type="Sha1"/>
+                        <members timestamp="2023-06-01T12:48:14Z">
+                            <member id="42">Example Member</member>
+                        </members>
+                    </reasons>
                 </negativeFeedback>
             </feedback>
         </image>

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
@@ -7,6 +7,7 @@ import requests
 from threatexchange.exchanges.clients.ncmec.hash_api import (
     NCMECEntryType,
     NCMECEntryUpdate,
+    NCMECFeedbackType,
     NCMECHashAPI,
     NCMECEnvironment,
 )
@@ -185,7 +186,10 @@ def test_feedback_entries(monkeypatch):
     )
     monkeypatch.setattr(api, "_get_session", lambda: session)
 
-    result = api.submit_feedback("image1", True)
+    result = api.submit_feedback("image1", NCMECFeedbackType.md5, True)
+    result = api.submit_feedback(
+        "image1", NCMECFeedbackType.md5, False, "01234567-abcd-0123-4567-012345678900"
+    )
 
     assert len(result.updates) == 1
     update = result.updates[0]

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
@@ -207,8 +207,4 @@ def test_feedback_entries(monkeypatch):
         "image1", NCMECFeedbackType.md5, False, "01234567-abcd-0123-4567-012345678900"
     )
 
-    assert len(result.updates) == 1
-    update = result.updates[0]
-    assert update.received == 1
-    assert update.accepted == 1
-    assert update.updated == 1
+    assert result.status_code == 200

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
@@ -182,8 +182,8 @@ def test_feedback_entries(monkeypatch):
         "fake_user",
         "fake_pass",
         NCMECEnvironment.test_Industry,
-        "123",
-        {
+        member_id="123",
+        reasons_map={
             NCMECFeedbackType.md5.value: [
                 {
                     "guid": "01234567-abcd-0123-4567-012345678900",
@@ -194,8 +194,7 @@ def test_feedback_entries(monkeypatch):
         },
     )
     session = Mock(
-        strict_spec=["get", "put", "__enter__", "__exit__"],
-        get=set_api_return(STATUS_XML),
+        strict_spec=["put", "__enter__", "__exit__"],
         put=set_api_return(UPDATE_FEEDBACK_RESULT_XML),
         __enter__=lambda _: session,
         __exit__=lambda *args: None,

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
@@ -1,7 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 from unittest.mock import Mock
-import urllib.parse
 import typing as t
 import pytest
 import requests
@@ -11,166 +10,17 @@ from threatexchange.exchanges.clients.ncmec.hash_api import (
     NCMECHashAPI,
     NCMECEnvironment,
 )
-
-STATUS_XML = """
-<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<status xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
-    <ipAddress>127.0.0.1</ipAddress>
-    <username>testington</username>
-    <member id="1">Sir Testington</member>
-</status>
-""".strip()
-
-NEXT_UNESCAPED = (
-    "/v2/entries?from=2017-10-20T00%3A00%3A00.000Z"
-    "&to=2017-10-30T00%3A00%3A00.000Z&start=2001&size=1000&max=3000"
+from threatexchange.exchanges.clients.ncmec.tests.data import (
+    ENTRIES_LARGE_FINGERPRINTS,
+    ENTRIES_XML,
+    ENTRIES_XML2,
+    ENTRIES_XML3,
+    ENTRIES_XML4,
+    NEXT_UNESCAPED,
+    NEXT_UNESCAPED2,
+    NEXT_UNESCAPED3,
+    UPDATE_FEEDBACK_RESULT_XML,
 )
-
-NEXT_UNESCAPED2 = (
-    "/v2/entries?from=2017-10-20T00%3A00%3A00.000Z"
-    "&to=2017-10-30T00%3A00%3A00.000Z&start=3001&size=1000&max=4000"
-)
-NEXT_UNESCAPED3 = (
-    "/v2/entries?from=2017-10-20T00%3A00%3A00.000Z"
-    "&to=2017-10-30T00%3A00%3A00.000Z&start=4001&size=1000&max=5000"
-)
-
-ENTRIES_XML = """
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
-    <images count="2" maxTimestamp="2017-10-24T15:10:00Z">
-        <image>
-            <member id="42">Example Member</member>
-            <timestamp>2017-10-24T15:00:00Z</timestamp>
-            <id>image1</id>
-            <classification>A1</classification>
-            <fingerprints>
-                <md5>a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1</md5>
-                <sha1>a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1</sha1>
-                <pdna>a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1...</pdna>
-            </fingerprints>
-        </image>
-        <deletedImage>
-            <member id="43">Example Member2</member>
-            <id>image4</id>
-            <timestamp>2017-10-24T15:10:00Z</timestamp>
-        </deletedImage>
-    </images>
-    <videos count="2" maxTimestamp="2017-10-24T15:20:00Z">
-        <video>
-            <member id="42">Example Member</member>
-            <timestamp>2017-10-24T15:00:00Z</timestamp>
-            <id>video1</id>
-            <fingerprints>
-                <md5>b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1</md5>
-                <sha1>b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1</sha1>
-            </fingerprints>
-        </video>
-        <deletedVideo>
-            <member id="42">Example Member</member>
-            <id>video4</id>
-            <timestamp>2017-10-24T15:20:00Z</timestamp>
-        </deletedVideo>
-    </videos>
-    <paging>
-        <next>/v2/entries?from=2017-10-20T00%3A00%3A00.000Z&amp;to=2017-10-30T00%3A00%3A00.000Z&amp;start=2001&amp;size=1000&amp;max=3000</next>
-    </paging>
-</queryResult>
-""".strip()
-
-
-ENTRIES_XML2 = """
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
-    <images count="1" maxTimestamp="2019-10-24T15:10:00Z">
-        <image>
-            <member id="42">Example Member</member>
-            <timestamp>2019-10-24T15:00:00Z</timestamp>
-            <id>image10</id>
-            <classification>A1</classification>
-            <fingerprints>
-                <md5>b1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1</md5>
-                <sha1>b1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1</sha1>
-                <pdna>b1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1...</pdna>
-            </fingerprints>
-        </image>
-    </images>
-    <paging>
-        <next>/v2/entries?from=2017-10-20T00%3A00%3A00.000Z&amp;to=2017-10-30T00%3A00%3A00.000Z&amp;start=3001&amp;size=1000&amp;max=4000</next>
-    </paging>
-</queryResult>
-""".strip()
-
-# This example isn't in the documentation, but shows how updates work
-ENTRIES_XML3 = """
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
-    <videos count="2" maxTimestamp="2019-11-25T15:10:00Z">
-        <video>
-            <member id="101">TX Example</member>
-            <timestamp>2019-11-25T15:10:00Z</timestamp>
-            <id>willupdate</id>
-            <classification>A1</classification>
-            <fingerprints>
-                <md5>facefacefacefacefacefacefaceface</md5>
-            </fingerprints>
-        </video>
-        <video>
-            <member id="101">TX Example</member>
-            <timestamp>2019-11-24T15:10:00Z</timestamp>
-            <id>willdelete</id>
-            <classification>A1</classification>
-            <fingerprints>
-                <md5>bacebacebacebacebacebacebacebace</md5>
-            </fingerprints>
-        </video>
-    </videos>
-    <paging>
-        <next>/v2/entries?from=2017-10-20T00%3A00%3A00.000Z&amp;to=2017-10-30T00%3A00%3A00.000Z&amp;start=4001&amp;size=1000&amp;max=5000</next>
-    </paging>
-</queryResult>
-""".strip()
-
-ENTRIES_XML4 = """
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
-    <videos count="2" maxTimestamp="2019-11-24T15:10:00Z">
-        <video>
-            <member id="101">TX Example</member>
-            <timestamp>2019-11-24T15:10:00Z</timestamp>
-            <id>willupdate</id>
-            <classification>A2</classification>
-            <fingerprints>
-                <md5>facefacefacefacefacefacefaceface</md5>
-            </fingerprints>
-        </video>
-        <deletedVideo>
-            <member id="101">TX Example</member>
-            <timestamp>2019-11-25T15:10:00Z</timestamp>
-            <id>willdelete</id>
-        </deletedVideo>
-    </videos>
-</queryResult>
-""".strip()
-
-ENTRIES_LARGE_FINGERPRINTS = """
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
-    <videos count="1" maxTimestamp="2019-11-24T15:10:00Z">
-        <video>
-            <member id="101">TX Example</member>
-            <timestamp>2019-11-24T15:10:00Z</timestamp>
-            <id>largetags</id>
-            <classification>A2</classification>
-            <fingerprints>
-                <md5>facefacefacefacefacefacefaceface</md5>
-                <tmk-pdqf rel="self" href="/v2/entries/1/fingerprints/TMK_PDQF"/>
-				<videntifier rel="self" href="/v2/entries/1/fingerprints/VIDENTIFIER"/>
-            </fingerprints>
-        </video>
-    </videos>
-</queryResult>
-""".strip()
 
 
 def mock_get_impl(url: str, **params):
@@ -323,3 +173,22 @@ def test_large_fingerprint_entries(monkeypatch):
     assert len(update.fingerprints) == 1
     assert update.fingerprints == {"md5": "facefacefacefacefacefacefaceface"}
     assert result.next == ""
+
+
+def test_feedback_entries(monkeypatch):
+    api = NCMECHashAPI("fake_user", "fake_pass", NCMECEnvironment.test_Industry)
+    session = Mock(
+        strict_spec=["post", "__enter__", "__exit__"],
+        post=set_api_return(UPDATE_FEEDBACK_RESULT_XML),
+        __enter__=lambda _: session,
+        __exit__=lambda *args: None,
+    )
+    monkeypatch.setattr(api, "_get_session", lambda: session)
+
+    result = api.submit_feedback("image1", True)
+
+    assert len(result.updates) == 1
+    update = result.updates[0]
+    assert update.received == 1
+    assert update.accepted == 1
+    assert update.updated == 1

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
@@ -20,6 +20,7 @@ from threatexchange.exchanges.clients.ncmec.tests.data import (
     NEXT_UNESCAPED,
     NEXT_UNESCAPED2,
     NEXT_UNESCAPED3,
+    STATUS_XML,
     UPDATE_FEEDBACK_RESULT_XML,
 )
 
@@ -177,10 +178,25 @@ def test_large_fingerprint_entries(monkeypatch):
 
 
 def test_feedback_entries(monkeypatch):
-    api = NCMECHashAPI("fake_user", "fake_pass", NCMECEnvironment.test_Industry)
+    api = NCMECHashAPI(
+        "fake_user",
+        "fake_pass",
+        NCMECEnvironment.test_Industry,
+        "123",
+        {
+            NCMECFeedbackType.md5.value: [
+                {
+                    "guid": "01234567-abcd-0123-4567-012345678900",
+                    "name": "Example Reason 1",
+                    "type": "Sha1",
+                }
+            ]
+        },
+    )
     session = Mock(
-        strict_spec=["post", "__enter__", "__exit__"],
-        post=set_api_return(UPDATE_FEEDBACK_RESULT_XML),
+        strict_spec=["get", "put", "__enter__", "__exit__"],
+        get=set_api_return(STATUS_XML),
+        put=set_api_return(UPDATE_FEEDBACK_RESULT_XML),
         __enter__=lambda _: session,
         __exit__=lambda *args: None,
     )

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -6,7 +6,6 @@ Core abstractions for signal types.
 
 import abc
 import pathlib
-import random
 import typing as t
 
 from threatexchange import common


### PR DESCRIPTION
Summary
---------

Building on top of #1624 by @aryzle:
1. Remove untyped dicts and use dataclass objects
2. Deal with some weird tricky cases with parsing feedback

Test Plan
---------

updated unittests
querying lookup against test_NGO api, and saw gets work.

Will make another pass on upvote/downvote, not sure if it works yet.