### PR TITLE
Add image hash distance

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/match_dbg_upload.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/match_dbg_upload.html.j2
@@ -1,16 +1,20 @@
 {# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <div class="card text-dark bg-light box-shadow h-md-250 h-100 mx-auto">
-    <div class="row align-items-center m-2">
-        <div class="col" id="{{ upload_id }}-img">
-            <svg class="bd-placeholder-img card-img-top" width="180" height="180" xmlns="http://www.w3.org/2000/svg"
-                role="img" preserveAspectRatio="xMidYMid slice" focusable="false">
+    <div class="row align-items-center m-3">
+        <div class="vstack gap-2" id="{{ upload_id }}-img">
+            <div class="vstack justify-content-center align-items-center w-100 h-180 bg-secondary card"
+                style="height: 180px;">
                 <title>Placeholder</title>
                 <rect width="100%" height="100%" fill="#868e96" />
-                <text x="50%" y="50%" fill="#dee2e6" dy=".3em" dominant-baseline="middle" text-anchor="middle">Select
-                    File</text>
-            </svg>
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                    stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+                    <circle cx="9" cy="9" r="2" />
+                    <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
+                </svg>
+            </div>
         </div>
-        <div class="col align-items-center">
+        <div class="col align-items-center mt-2">
             <input class="form-control" type="file" onchange="OMM.match_dbg.onFileChange('{{ upload_id }}')"
                 id="{{ upload_id }}-file-upload">
         </div>

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/pages/match_dbg.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/pages/match_dbg.html.j2
@@ -4,7 +4,7 @@
         <h3>Matching and SignalType Debugger</h3>
         <p class="lead">Directly upload files and URLs to explore matching algorithms.</p>
     </div>
-    <div class="row justify-content-center gx-5">
+    <div class="row justify-content-center gx-3">
         <div class="col-6">
             {% with upload_id="match_dbg_left" %}
             {% include "components/match_dbg_upload.html.j2" %}
@@ -16,19 +16,18 @@
             {% endwith %}
         </div>
     </div>
-    <div class="container my-2" hidden> {# TODO: implement the rest #}
-        <div class="row justify-content-center">
-            <div class="col-4">
-                <div class="card p-4">
-                    <h4 class="card-title text-center">Match Results</h4>
-                    <ul>
-                        <li>Verdict: Match</li>
-                        <li>PDQ: 31</li>
-                        <li>md5: 0</li>
-                    </ul>
-                </div>
-            </div>
-        </div>
+    <div id="match-dbg-distance-container" class="card my-2 w-100 p-3 bg-light" hidden>
+        <h4 class="card-title">Hash distance</h4>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Algorithm</th>
+                    <th>Match</th>
+                    <th>Distance</th>
+                </tr>
+            </thead>
+            <tbody id="match-dbg-distance-results"></tbody>
+        </table>
     </div>
 </div>
 


### PR DESCRIPTION
Summary
---------

Adds distance between two image hashes on the match debug page.

<img width="958" alt="Screenshot 2024-10-03 at 4 09 07 PM" src="https://github.com/user-attachments/assets/48958aff-ce92-4f26-b65f-1e76317e81dc">
<img width="952" alt="Screenshot 2024-10-03 at 4 09 18 PM" src="https://github.com/user-attachments/assets/6ede558b-dd2a-4c60-a73c-9768653e5a6c">

Test Plan
---------

- Upload two images, verify that the distance is displayed
- Replace one of the images, verify that the distance is re-calculated
