### PR TITLE
[py-tx] updated the covaraince of TUpdateRecordValue to allow for mor…

### DIFF
--- a/python-threatexchange/threatexchange/exchanges/fetch_state.py
+++ b/python-threatexchange/threatexchange/exchanges/fetch_state.py
@@ -21,7 +21,7 @@ Self = t.TypeVar("Self")
 # Note - key is artificially restricted, but it's simple to add more or even
 #        remove the restriction entirely if eventually needed
 TUpdateRecordKey = t.TypeVar("TUpdateRecordKey", str, int, t.Tuple[str, str])
-TUpdateRecordValue = t.TypeVar("TUpdateRecordValue")
+TUpdateRecordValue = t.TypeVar("TUpdateRecordValue", covariant=True)
 
 
 @dataclass

--- a/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/signal_exchange_api.py
@@ -309,8 +309,8 @@ class SignalExchangeAPIWithSimpleUpdates(
         state.TFetchCheckpoint,
         state.TFetchedSignalMetadata,
         t.Tuple[str, str],
-        t.Any,
-    ]
+        state.TFetchedSignalMetadata,
+    ],
 ):
     """
     An API that conveniently maps directly into the form needed by index.


### PR DESCRIPTION
This PR addresses the t.any type in issue #1255 and helps to impose stronger typing in SignalExchangeAPIWithSimpleUpdates by replacing t.Any with state.TFetchedSignalMetadata and making state.TUpdateRecordValue covariant.

Changes:
Replaced t.Any with state.TFetchedSignalMetadata in SignalExchangeAPIWithSimpleUpdates to enhance type specificity and ensure compatibility with the expected metadata structure.

Made state.TUpdateRecordValue Covariant to resolve iterator conflicts in fetch_iter usage across multiple files. The updated covariance improves flexibility and compatibility in the FetchDelta data class, enabling fetch_iter to handle both states.TFetchedSignalMetadata and state.TUpdateRecordValue as well as pre-existing subclass iterator changes.

Effected File List: Cli_state.py, Signal_exchange.py, Fb_threatexchnage.py, File_api.py, Static_sample.py, Stop_ncii_api.py, Techagainstterrorism.py, Test_state.py. 

Testing:
Ran all of the type checking with  “python -m mypy threatexchange”, then did further testing with 
 mypy --check-untyped-defs for each affected file in the above effect file list.

When running the specific unit tests, all related tests pass with no changes in functionality; however, test cases in the hashing library fail, which is consistent with the main branch before these changes. 

Related Tests: 
threatexchange/exchanges/tests/test_state.py                         
threatexchange/exchanges/tests/test_state_compatibility.py   
