### PR TITLE
[py-tx] Create rotation helper functions in PhotoContent using Pillow

### DIFF
--- a/python-threatexchange/threatexchange/content_type/content_base.py
+++ b/python-threatexchange/threatexchange/content_type/content_base.py
@@ -34,17 +34,19 @@ class ContentType:
         """
         return []
 
+
 class RotationType(StrEnum):
     """
     Enum for 8 simple rotations of an image.
-    Used to store all generated rotations of an image, 
+    Used to store all generated rotations of an image,
     whose algorithms don't have a native way to generate rotations during hashing.
     """
-    ORIGINAL = auto() # No rotation; the object is in its original orientation
-    ROTATE90 = auto() # Rotates the object 90 degrees 
-    ROTATE180 = auto() # Rotates the object 180 degrees (half-turn)
-    ROTATE270 = auto() # Rotates the object 270 degrees 
-    FLIPX = auto() # Flip the object horizontally along the X-axis 
-    FLIPY = auto() # Flip the object horizontally along the Y-axis 
-    FLIPPLUS1 = auto() # Diagonal flip along the line y = x
-    FLIPMINUS1 = auto() # Diagonal flip along the line y = -x
+
+    ORIGINAL = auto()  # No rotation; the object is in its original orientation
+    ROTATE90 = auto()  # Rotates the object 90 degrees
+    ROTATE180 = auto()  # Rotates the object 180 degrees (half-turn)
+    ROTATE270 = auto()  # Rotates the object 270 degrees
+    FLIPX = auto()  # Flip the object horizontally along the X-axis
+    FLIPY = auto()  # Flip the object horizontally along the Y-axis
+    FLIPPLUS1 = auto()  # Diagonal flip along the line y = x
+    FLIPMINUS1 = auto()  # Diagonal flip along the line y = -x

--- a/python-threatexchange/threatexchange/content_type/content_base.py
+++ b/python-threatexchange/threatexchange/content_type/content_base.py
@@ -7,7 +7,7 @@ Abstraction for different content types.
 This records all the valid signal types for a piece of content.
 """
 
-from enum import StrEnum, auto
+from enum import Enum, auto
 import typing as t
 
 from threatexchange import common
@@ -35,18 +35,18 @@ class ContentType:
         return []
 
 
-class RotationType(StrEnum):
+class RotationType(Enum):
     """
     Enum for 8 simple rotations of an image.
     Used to store all generated rotations of an image,
     whose algorithms don't have a native way to generate rotations during hashing.
     """
 
-    ORIGINAL = auto()  # No rotation; the object is in its original orientation
-    ROTATE90 = auto()  # Rotates the object 90 degrees
-    ROTATE180 = auto()  # Rotates the object 180 degrees (half-turn)
-    ROTATE270 = auto()  # Rotates the object 270 degrees
-    FLIPX = auto()  # Flip the object horizontally along the X-axis
-    FLIPY = auto()  # Flip the object horizontally along the Y-axis
-    FLIPPLUS1 = auto()  # Diagonal flip along the line y = x
-    FLIPMINUS1 = auto()  # Diagonal flip along the line y = -x
+    ORIGINAL = "original"  # No rotation; the object is in its original orientation
+    ROTATE90 = "rotate90"  # Rotates the object 90 degrees
+    ROTATE180 = "rotate180"  # Rotates the object 180 degrees (half-turn)
+    ROTATE270 = "rotate270"  # Rotates the object 270 degrees
+    FLIPX = "flipx"  # Flip the object horizontally along the X-axis
+    FLIPY = "flipy"  # Flip the object horizontally along the Y-axis
+    FLIPPLUS1 = "flipplus1"  # Diagonal flip along the line y = x
+    FLIPMINUS1 = "flipminus1"  # Diagonal flip along the line y = -x

--- a/python-threatexchange/threatexchange/content_type/content_base.py
+++ b/python-threatexchange/threatexchange/content_type/content_base.py
@@ -7,6 +7,7 @@ Abstraction for different content types.
 This records all the valid signal types for a piece of content.
 """
 
+from enum import StrEnum, auto
 import typing as t
 
 from threatexchange import common
@@ -32,3 +33,13 @@ class ContentType:
         * Video => break out photo thumbnail, close caption text, audio
         """
         return []
+
+class RotationType(StrEnum):
+    ORIGINAL = auto() # No rotation; the object is in its original orientation
+    ROTATE90 = auto() # Rotates the object 90 degrees 
+    ROTATE180 = auto() # Rotates the object 180 degrees (half-turn)
+    ROTATE270 = auto() # Rotates the object 270 degrees 
+    FLIPX = auto() # Flip the object horizontally along the X-axis 
+    FLIPY = auto() # Flip the object horizontally along the Y-axis 
+    FLIPPLUS1 = auto() # Diagonal flip along the line y = x
+    FLIPMINUS1 = auto() # Diagonal flip along the line y = -x

--- a/python-threatexchange/threatexchange/content_type/content_base.py
+++ b/python-threatexchange/threatexchange/content_type/content_base.py
@@ -35,6 +35,11 @@ class ContentType:
         return []
 
 class RotationType(StrEnum):
+    """
+    Enum for 8 simple rotations of an image.
+    Used to store all generated rotations of an image, 
+    whose algorithms don't have a native way to generate rotations during hashing.
+    """
     ORIGINAL = auto() # No rotation; the object is in its original orientation
     ROTATE90 = auto() # Rotates the object 90 degrees 
     ROTATE180 = auto() # Rotates the object 180 degrees (half-turn)

--- a/python-threatexchange/threatexchange/content_type/photo.py
+++ b/python-threatexchange/threatexchange/content_type/photo.py
@@ -24,7 +24,7 @@ class PhotoContent(ContentType):
     @classmethod
     def rotate_image(cls, image_data: bytes, angle: float) -> bytes: 
         """
-        Rotate an image by a given angle 
+        Rotate an image by a given angle.
         """
         with Image.open(io.BytesIO(image_data)) as img: 
             rotated_img = img.rotate(angle, expand=True)
@@ -77,9 +77,13 @@ class PhotoContent(ContentType):
                 return buffer.getvalue()
     
     @classmethod
-    def try_all_rotations(cls, image_data: bytes): 
+    def all_simple_rotations(cls, image_data: bytes): 
         """
-        Try all possible rotations to the image
+        Generate the 8 naive rotations of an image.
+
+        This can be helpful for testing.
+        And for image algorithms that don't have a native way to generate rotations during hashing, 
+        this can be a way to brute force rotations. 
         """
         rotations = {
             RotationType.ORIGINAL: image_data, 

--- a/python-threatexchange/threatexchange/content_type/photo.py
+++ b/python-threatexchange/threatexchange/content_type/photo.py
@@ -7,8 +7,8 @@ Wrapper around the video content type.
 from PIL import Image
 import io
 
-from .content_base import ContentType
-from threatexchange.content_type.content_base import RotationType
+from .content_base import ContentType, RotationType
+
 
 class PhotoContent(ContentType):
     """
@@ -21,25 +21,26 @@ class PhotoContent(ContentType):
       * frames from videos
       * thumbnails of videos
     """
+
     @classmethod
-    def rotate_image(cls, image_data: bytes, angle: float) -> bytes: 
+    def rotate_image(cls, image_data: bytes, angle: float) -> bytes:
         """
         Rotate an image by a given angle.
         """
-        with Image.open(io.BytesIO(image_data)) as img: 
+        with Image.open(io.BytesIO(image_data)) as img:
             rotated_img = img.rotate(angle, expand=True)
-            with io.BytesIO() as buffer: 
+            with io.BytesIO() as buffer:
                 rotated_img.save(buffer, format=img.format)
                 return buffer.getvalue()
 
     @classmethod
-    def flip_x(cls, image_data: bytes) -> bytes: 
+    def flip_x(cls, image_data: bytes) -> bytes:
         """
         Flip the image horizontally along the X-axis.
         """
-        with Image.open(io.BytesIO(image_data)) as img: 
-            flipped_img = img.transpose(Image.FLIP_TOP_BOTTOM)
-            with io.BytesIO() as buffer: 
+        with Image.open(io.BytesIO(image_data)) as img:
+            flipped_img = img.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
+            with io.BytesIO() as buffer:
                 flipped_img.save(buffer, format=img.format)
                 return buffer.getvalue()
 
@@ -49,51 +50,54 @@ class PhotoContent(ContentType):
         Flip the image vertically along the Y-axis.
         """
         with Image.open(io.BytesIO(image_data)) as img:
-            flipped_img = img.transpose(Image.FLIP_LEFT_RIGHT)
+            flipped_img = img.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
             with io.BytesIO() as buffer:
                 flipped_img.save(buffer, format=img.format)
                 return buffer.getvalue()
 
-    @classmethod   
+    @classmethod
     def flip_plus1(cls, image_data: bytes) -> bytes:
         """
         Flip the image diagonally along the line y = x.
         """
         with Image.open(io.BytesIO(image_data)) as img:
-            flipped_img = img.transpose(Image.Transpose.ROTATE_270).transpose(Image.FLIP_LEFT_RIGHT)
+            flipped_img = img.transpose(Image.Transpose.ROTATE_270).transpose(
+                Image.Transpose.FLIP_LEFT_RIGHT
+            )
             with io.BytesIO() as buffer:
                 flipped_img.save(buffer, format=img.format)
                 return buffer.getvalue()
 
-    @classmethod     
+    @classmethod
     def flip_minus1(cls, image_data: bytes) -> bytes:
         """
         Flip the image diagonally along the line y = -x.
         """
         with Image.open(io.BytesIO(image_data)) as img:
-            flipped_img = img.transpose(Image.Transpose.ROTATE_90).transpose(Image.FLIP_LEFT_RIGHT)
+            flipped_img = img.transpose(Image.Transpose.ROTATE_90).transpose(
+                Image.Transpose.FLIP_LEFT_RIGHT
+            )
             with io.BytesIO() as buffer:
                 flipped_img.save(buffer, format=img.format)
                 return buffer.getvalue()
-    
+
     @classmethod
-    def all_simple_rotations(cls, image_data: bytes): 
+    def all_simple_rotations(cls, image_data: bytes):
         """
         Generate the 8 naive rotations of an image.
 
         This can be helpful for testing.
-        And for image algorithms that don't have a native way to generate rotations during hashing, 
-        this can be a way to brute force rotations. 
+        And for image algorithms that don't have a native way to generate rotations during hashing,
+        this can be a way to brute force rotations.
         """
         rotations = {
-            RotationType.ORIGINAL: image_data, 
+            RotationType.ORIGINAL: image_data,
             RotationType.ROTATE90: cls.rotate_image(image_data, 90),
             RotationType.ROTATE180: cls.rotate_image(image_data, 180),
             RotationType.ROTATE270: cls.rotate_image(image_data, 270),
             RotationType.FLIPX: cls.flip_x(image_data),
             RotationType.FLIPY: cls.flip_y(image_data),
             RotationType.FLIPPLUS1: cls.flip_plus1(image_data),
-            RotationType.FLIPMINUS1: cls.flip_minus1(image_data)
+            RotationType.FLIPMINUS1: cls.flip_minus1(image_data),
         }
         return rotations
-        

--- a/python-threatexchange/threatexchange/content_type/photo.py
+++ b/python-threatexchange/threatexchange/content_type/photo.py
@@ -4,9 +4,11 @@
 """
 Wrapper around the video content type.
 """
+from PIL import Image
+import io
 
 from .content_base import ContentType
-
+from threatexchange.content_type.content_base import RotationType
 
 class PhotoContent(ContentType):
     """
@@ -19,3 +21,75 @@ class PhotoContent(ContentType):
       * frames from videos
       * thumbnails of videos
     """
+    @classmethod
+    def rotate_image(cls, image_data: bytes, angle: float) -> bytes: 
+        """
+        Rotate an image by a given angle 
+        """
+        with Image.open(io.BytesIO(image_data)) as img: 
+            rotated_img = img.rotate(angle, expand=True)
+            with io.BytesIO() as buffer: 
+                rotated_img.save(buffer, format=img.format)
+                return buffer.getvalue()
+
+    @classmethod
+    def flip_x(cls, image_data: bytes) -> bytes: 
+        """
+        Flip the image horizontally along the X-axis.
+        """
+        with Image.open(io.BytesIO(image_data)) as img: 
+            flipped_img = img.transpose(Image.FLIP_TOP_BOTTOM)
+            with io.BytesIO() as buffer: 
+                flipped_img.save(buffer, format=img.format)
+                return buffer.getvalue()
+
+    @classmethod
+    def flip_y(cls, image_data: bytes) -> bytes:
+        """
+        Flip the image vertically along the Y-axis.
+        """
+        with Image.open(io.BytesIO(image_data)) as img:
+            flipped_img = img.transpose(Image.FLIP_LEFT_RIGHT)
+            with io.BytesIO() as buffer:
+                flipped_img.save(buffer, format=img.format)
+                return buffer.getvalue()
+
+    @classmethod   
+    def flip_plus1(cls, image_data: bytes) -> bytes:
+        """
+        Flip the image diagonally along the line y = x.
+        """
+        with Image.open(io.BytesIO(image_data)) as img:
+            flipped_img = img.transpose(Image.Transpose.ROTATE_270).transpose(Image.FLIP_LEFT_RIGHT)
+            with io.BytesIO() as buffer:
+                flipped_img.save(buffer, format=img.format)
+                return buffer.getvalue()
+
+    @classmethod     
+    def flip_minus1(cls, image_data: bytes) -> bytes:
+        """
+        Flip the image diagonally along the line y = -x.
+        """
+        with Image.open(io.BytesIO(image_data)) as img:
+            flipped_img = img.transpose(Image.Transpose.ROTATE_90).transpose(Image.FLIP_LEFT_RIGHT)
+            with io.BytesIO() as buffer:
+                flipped_img.save(buffer, format=img.format)
+                return buffer.getvalue()
+    
+    @classmethod
+    def try_all_rotations(cls, image_data: bytes): 
+        """
+        Try all possible rotations to the image
+        """
+        rotations = {
+            RotationType.ORIGINAL: image_data, 
+            RotationType.ROTATE90: cls.rotate_image(image_data, 90),
+            RotationType.ROTATE180: cls.rotate_image(image_data, 180),
+            RotationType.ROTATE270: cls.rotate_image(image_data, 270),
+            RotationType.FLIPX: cls.flip_x(image_data),
+            RotationType.FLIPY: cls.flip_y(image_data),
+            RotationType.FLIPPLUS1: cls.flip_plus1(image_data),
+            RotationType.FLIPMINUS1: cls.flip_minus1(image_data)
+        }
+        return rotations
+        


### PR DESCRIPTION
Summary
---------
This is a part of the issue #1665
This has been discussed previously in PR #1669 

* Create RotationType enum in content_base.py 
  * Use StrEnum to make the enum’s values independent of the order
* Create 6 helper functions in PhotoContent 
  * 5 functions are to rotate the image in different angles 
  * 1 function is to try all different rotations 

Test plan
---------
@dcallies said not to write a unittest at this stage.

However, I was able to show that the code is correct by writing a simple bit of python:

```
from threatexchange.content_type.photo import PhotoContent

file_path = pathlib.Path("threatexchange/tests/hashing/resources/LA.png")
with open(file_path, "rb") as f:
    image_data = f.read()

all_rotations = PhotoContent.all_simple_rotations(image_data)

for rotation_type, image_data in all_rotations.items():
    with open(f"image_{rotation_type}.png", "wb") as w:
        w.write(image_data)
```

Then I visually inspected all the files to confirm they were rotated as expected.