### PR TITLE
[hma] add recovery from lobj failure

### DIFF
--- a/hasher-matcher-actioner/pyproject.toml
+++ b/hasher-matcher-actioner/pyproject.toml
@@ -34,6 +34,7 @@ all = [
     "pytest",
     "types-Flask-Migrate",
     "types-requests",
+    "types-psycopg2",
     "types-python-dateutil",
     "gunicorn",
     "flask_apscheduler"

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -74,7 +74,15 @@ class _SignalIndexInMemoryCache:
         curr_checkpoint = store.get_last_index_build_checkpoint(self.signal_type)
         if curr_checkpoint is not None and self.checkpoint != curr_checkpoint:
             new_index = store.get_signal_type_index(self.signal_type)
-            assert new_index is not None
+            if new_index is None:
+                app: Flask = get_apscheduler().app
+                app.logger.error(
+                    "CachedIndex[%s] index checkpoint(%r)"
+                    + " says new index available but unable to get it",
+                    self.signal_type.get_name(),
+                    curr_checkpoint,
+                )
+                return
             self.index = new_index
             self.checkpoint = curr_checkpoint
         self.last_check_ts = now

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
@@ -189,7 +189,9 @@ class DefaultOMMStore(interface.IUnifiedStore):
             )
         ).scalar_one_or_none()
 
-        return db_record.load_signal_index() if db_record is not None else None
+        if db_record is None or not db_record.index_lobj_exists():
+            return None
+        return db_record.load_signal_index()
 
     def store_signal_type_index(
         self,
@@ -213,22 +215,15 @@ class DefaultOMMStore(interface.IUnifiedStore):
     def get_last_index_build_checkpoint(
         self, signal_type: t.Type[SignalType]
     ) -> t.Optional[interface.SignalTypeIndexBuildCheckpoint]:
-        row = database.db.session.execute(
-            select(
-                database.SignalIndex.updated_to_ts,
-                database.SignalIndex.updated_to_id,
-                database.SignalIndex.signal_count,
-            ).where(database.SignalIndex.signal_type == signal_type.get_name())
-        ).one_or_none()
+        db_record = database.db.session.execute(
+            select(database.SignalIndex).where(
+                database.SignalIndex.signal_type == signal_type.get_name()
+            )
+        ).scalar_one_or_none()
 
-        if row is None:
+        if db_record is None or not db_record.index_lobj_exists():
             return None
-        updated_to_ts, updated_to_id, total_count = row._tuple()
-        return interface.SignalTypeIndexBuildCheckpoint(
-            last_item_timestamp=updated_to_ts,
-            last_item_id=updated_to_id,
-            total_hash_count=total_count,
-        )
+        return db_record.as_checkpoint()
 
     # Collabs
     def exchange_update(
@@ -418,10 +413,10 @@ class DefaultOMMStore(interface.IUnifiedStore):
                     )
                 )
             else:
-                op_helpers[xd.id] = (
-                    _BulkDbOpExchangeDataHelper.from_existing_exchange_data(
-                        xd, as_signal_types
-                    )
+                op_helpers[
+                    xd.id
+                ] = _BulkDbOpExchangeDataHelper.from_existing_exchange_data(
+                    xd, as_signal_types
                 )
                 if pickled_fetch_signal_metadata != xd.pickled_fetch_signal_metadata:
                     xd_to_update.append(

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
@@ -413,10 +413,10 @@ class DefaultOMMStore(interface.IUnifiedStore):
                     )
                 )
             else:
-                op_helpers[
-                    xd.id
-                ] = _BulkDbOpExchangeDataHelper.from_existing_exchange_data(
-                    xd, as_signal_types
+                op_helpers[xd.id] = (
+                    _BulkDbOpExchangeDataHelper.from_existing_exchange_data(
+                        xd, as_signal_types
+                    )
                 )
                 if pickled_fetch_signal_metadata != xd.pickled_fetch_signal_metadata:
                     xd_to_update.append(

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
@@ -227,7 +227,7 @@ def test_exchange_api_set_auth(app: Flask, client: FlaskClient):
     tx_name = FBThreatExchangeSignalExchangeAPI.get_name()
     # Monkeypatch installed types
     storage.exchange_types = {  # type:ignore
-        api_cls.get_name(): api_cls
+        api_cls.get_name(): api_cls  # type:ignore
         for api_cls in (
             FBThreatExchangeSignalExchangeAPI,
             StaticSampleSignalExchangeAPI,

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
@@ -227,7 +227,7 @@ def test_exchange_api_set_auth(app: Flask, client: FlaskClient):
     tx_name = FBThreatExchangeSignalExchangeAPI.get_name()
     # Monkeypatch installed types
     storage.exchange_types = {  # type:ignore
-        api_cls.get_name(): api_cls  # type:ignore
+        api_cls.get_name(): api_cls
         for api_cls in (
             FBThreatExchangeSignalExchangeAPI,
             StaticSampleSignalExchangeAPI,

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_postgres_storage_impl.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_postgres_storage_impl.py
@@ -303,9 +303,9 @@ def test_exchange_get_data(storage: DefaultOMMStore):
     cfg = make_collab(storage)
     fetch(storage)
     patched_signal_types = dict(storage.exchange_types)
-    patched_signal_types[
-        _UnknownSampleExchangeAPI.get_name()
-    ] = _UnknownSampleExchangeAPI
+    patched_signal_types[_UnknownSampleExchangeAPI.get_name()] = (
+        _UnknownSampleExchangeAPI
+    )
     storage.exchange_types = patched_signal_types
 
     signal_types = list(storage.get_enabled_signal_types().values())

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_postgres_storage_impl.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_postgres_storage_impl.py
@@ -189,6 +189,51 @@ def test_sequential_fetch_updates(storage: DefaultOMMStore) -> None:
     assert md5_index_status.total_hash_count == maker.count
 
 
+def test_recover_from_index_unlink_partial_failure(storage: DefaultOMMStore):
+    """
+    SignalTypeIndex is stored in the postgres large object interface.
+
+    As part of swapping over to the new index, we need to unlink the old
+    interface, but there is a race here because unlinking may not happen
+    in a transaction. See github.com/facebook/ThreatExchange/issues/1673
+    """
+    bank_cfg = interface.BankConfig("TEST", matching_enabled_ratio=1.0)
+    storage.bank_update(bank_cfg, create=True)
+    storage.bank_add_content(
+        bank_cfg.name, {VideoMD5Signal: VideoMD5Signal.get_examples()[0]}
+    )
+
+    def build_and_assert_ok():
+        build(storage)
+        index_status = storage.get_last_index_build_checkpoint(VideoMD5Signal)
+        assert index_status.total_hash_count == 1
+        index = storage.get_signal_type_index(VideoMD5Signal)
+        assert index is not None
+
+    build_and_assert_ok()
+
+    # Now we'll fake that the large object borked
+    index_record = database.db.session.execute(
+        select(database.SignalIndex).where(
+            database.SignalIndex.signal_type == VideoMD5Signal.get_name()
+        )
+    ).scalar_one()
+    assert index_record.index_lobj_exists() is True
+    raw_conn = database.db.engine.raw_connection()
+    old_obj = raw_conn.lobject(index_record.serialized_index_large_object_oid, "n")  # type: ignore[attr-defined]
+    old_obj.unlink()
+    raw_conn.commit()
+
+    # Now we should have a dangling record
+    index_status = storage.get_last_index_build_checkpoint(VideoMD5Signal)
+    assert index_status is None
+    index = storage.get_signal_type_index(VideoMD5Signal)
+    assert index is None
+
+    # We should be able to recover by rebuilding
+    build_and_assert_ok()
+
+
 class _UnknownSampleExchangeAPI(StaticSampleSignalExchangeAPI):
     """Returns all the sample data, but can't convert to any types"""
 
@@ -258,9 +303,9 @@ def test_exchange_get_data(storage: DefaultOMMStore):
     cfg = make_collab(storage)
     fetch(storage)
     patched_signal_types = dict(storage.exchange_types)
-    patched_signal_types[_UnknownSampleExchangeAPI.get_name()] = (
-        _UnknownSampleExchangeAPI
-    )
+    patched_signal_types[
+        _UnknownSampleExchangeAPI.get_name()
+    ] = _UnknownSampleExchangeAPI
     storage.exchange_types = patched_signal_types
 
     signal_types = list(storage.get_enabled_signal_types().values())


### PR DESCRIPTION
Summary
---------

Fixes an issue reported in #1673

My best guess on how this happened is because of a partial failure on deletion - I had thought that this would be enforced by transactions, but it appears in production it's possible object unlink can go through without the object being fully deleted.

It might also be possible to add this with a listener of some kind, but making this segment a little more defensive might be overall a good idea in general.

Test Plan
---------

Reproduced the issue in a unittest, then make the fix. 
