### PR TITLE
[pytx] Convert threatexchange/tests/ to py.test

### DIFF
--- a/python-threatexchange/threatexchange/tests/test_api.py
+++ b/python-threatexchange/threatexchange/tests/test_api.py
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import os
-import unittest
+import pytest
 import collections.abc
 
 from threatexchange.exchanges.clients.fb_threatexchange.api import ThreatExchangeAPI
@@ -14,24 +14,25 @@ THREAT_EXCHANGE_INTEGRATION_TEST_TOKEN = os.getenv(
 )
 
 
-@unittest.skipUnless(
-    THREAT_EXCHANGE_INTEGRATION_TEST_TOKEN,
-    "Integration Test requires tokens. Use THREAT_EXCHANGE_INTEGRATION_TEST_TOKEN environment variable.",
+@pytest.fixture
+def api():
+    return ThreatExchangeAPI(THREAT_EXCHANGE_INTEGRATION_TEST_TOKEN)
+
+
+need_token = pytest.mark.skipif(
+    not THREAT_EXCHANGE_INTEGRATION_TEST_TOKEN,
+    reason="Integration Test requires tokens. Use THREAT_EXCHANGE_INTEGRATION_TEST_TOKEN environment variable.",
 )
-class APIIntegrationTest(unittest.TestCase):
-    def setUp(self):
-        self.api = ThreatExchangeAPI(THREAT_EXCHANGE_INTEGRATION_TEST_TOKEN)
 
-    def test_get_threat_privacy_groups_member(self):
-        """
-        Assumes that the app (if token is provided) will have at least one
-        privacy group.
-        """
-        response = self.api.get_threat_privacy_groups_member()
-        self.assertTrue(
-            isinstance(response, collections.abc.Sequence)
-            and not isinstance(response, staticmethod),
-            "API returned something that's not a list!",
-        )
 
-        self.assertTrue(isinstance(response[0], ThreatPrivacyGroup))
+@need_token
+def test_get_threat_privacy_groups_member(api):
+    """
+    Assumes that the app (if token is provided) will have at least one
+    privacy group.
+    """
+    response = api.get_threat_privacy_groups_member()
+    assert isinstance(response, collections.abc.Sequence) and not isinstance(
+        response, (str, bytes)
+    ), "API returned something that's not a list!"
+    assert isinstance(response[0], ThreatPrivacyGroup)

--- a/python-threatexchange/threatexchange/tests/test_common.py
+++ b/python-threatexchange/threatexchange/tests/test_common.py
@@ -1,10 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import unittest
-
 import threatexchange.common
 
 
-class TestCommon(unittest.TestCase):
-    def test_camel_case_to_underscore(self):
-        assert threatexchange.common.camel_case_to_underscore("AbcXyz") == "abc_xyz"
+def test_camel_case_to_underscore():
+    assert threatexchange.common.camel_case_to_underscore("AbcXyz") == "abc_xyz"


### PR DESCRIPTION
Summary
---------
* This resolves issue #1685 
* I updated these 2 tests from unittest to pytest
  * https://github.com/facebook/ThreatExchange/blob/main/python-threatexchange/threatexchange/tests/test_api.py
  * https://github.com/facebook/ThreatExchange/blob/main/python-threatexchange/threatexchange/tests/test_common.py

Test Plan
---------

<!--Replace with a description of how you tested this change, did you add test, run something locally...-->
