### PR TITLE
Remove IContentTypeConfigStore from HMA

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/interface.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/interface.py
@@ -22,6 +22,7 @@ import time
 
 import flask
 
+from threatexchange.cli.storage.interfaces import IContentTypeConfigStore
 from threatexchange.utils import dataclass_json
 from threatexchange.content_type.content_base import ContentType
 from threatexchange.signal_type.signal_base import SignalType
@@ -48,16 +49,6 @@ class ContentTypeConfig:
     # Content types that are not enabled should not be used in hashing/matching
     enabled: bool
     content_type: t.Type[ContentType]
-
-
-class IContentTypeConfigStore(metaclass=abc.ABCMeta):
-    """Interface for accessing ContentType configuration"""
-
-    @abc.abstractmethod
-    def get_content_type_configs(self) -> t.Mapping[str, ContentTypeConfig]:
-        """
-        Return all installed content types.
-        """
 
 
 @dataclass

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/mocked.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/mocked.py
@@ -20,6 +20,7 @@ from threatexchange.exchanges.fetch_state import (
     TUpdateRecordKey,
 )
 
+from threatexchange.cli.storage import interfaces
 from OpenMediaMatch.storage import interface
 from OpenMediaMatch.storage.interface import SignalTypeConfig
 
@@ -40,9 +41,9 @@ class MockedUnifiedStore(interface.IUnifiedStore):
     def is_ready(self) -> bool:
         return True
 
-    def get_content_type_configs(self) -> t.Mapping[str, interface.ContentTypeConfig]:
+    def get_content_type_configs(self) -> t.Mapping[str, interfaces.ContentTypeConfig]:
         return {
-            c.get_name(): interface.ContentTypeConfig(True, c)
+            c.get_name(): interfaces.ContentTypeConfig(True, c)
             for c in (PhotoContent, VideoContent)
         }
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
@@ -36,6 +36,7 @@ from threatexchange.exchanges.fetch_state import (
     TUpdateRecordKey,
 )
 
+from threatexchange.cli.storage import interfaces
 from OpenMediaMatch.storage import interface
 from OpenMediaMatch.storage.postgres import database, flask_utils
 
@@ -88,9 +89,9 @@ class DefaultOMMStore(interface.IUnifiedStore):
             exchange_types
         ), "All exchange types must have unique names"
 
-    def get_content_type_configs(self) -> t.Mapping[str, interface.ContentTypeConfig]:
+    def get_content_type_configs(self) -> t.Mapping[str, interfaces.ContentTypeConfig]:
         return {
-            name: interface.ContentTypeConfig(True, ct)
+            name: interfaces.ContentTypeConfig(True, ct)
             for name, ct in self.content_types.items()
         }
 


### PR DESCRIPTION
Summary
---------
* This resolves the 3rd part of issue #1688 
* Delete IContentTypeConfigStore in HMA 
* In HMA, import IContentTypeConfigStore from pytx to be included in IUnifiedStore
* Import interfaces from pytx to use in [storage/mocked.py](https://github.com/facebook/ThreatExchange/compare/main...haianhng31:IContentTypeConfigStore3?expand=1#diff-8c3aa92bb914526d0a98d8fdb37914d004b1109fa2e0e4822a6e01a3582d563f) and [storage/postgres/impl.py](https://github.com/facebook/ThreatExchange/compare/main...haianhng31:IContentTypeConfigStore3?expand=1#diff-d75ccee7de8e3db45cc3428fbc79b181b36857278c19f3f24432f78dcc2fb3ed) to make sure that the return types match 
