### PR TITLE
[hma] Require pytx >= 1.2.2

### DIFF
--- a/hasher-matcher-actioner/pyproject.toml
+++ b/hasher-matcher-actioner/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "flask_migrate",
     "psycopg2",
     "requests",
-    "threatexchange>=1.2.0",
+    "threatexchange>=1.2.2",
     "flask_apscheduler",
     "python-dateutil",
     "python-json-logger",

--- a/hasher-matcher-actioner/pyproject.toml
+++ b/hasher-matcher-actioner/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "flask_migrate",
     "psycopg2",
     "requests",
-    "threatexchange",
+    "threatexchange>=1.2.0",
     "flask_apscheduler",
     "python-dateutil",
     "python-json-logger",


### PR DESCRIPTION
Summary
---------

With migration of interfaces, we now need higher versions by default!

Test Plan
---------

Go go gadget continuous integration
