### PR TITLE
[pytx] Mess with init to try and get it to package

### DIFF
--- a/python-threatexchange/threatexchange/content_type/preprocess/__init__.py
+++ b/python-threatexchange/threatexchange/content_type/preprocess/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.

--- a/python-threatexchange/threatexchange/content_type/preprocess/unletterboxing.py
+++ b/python-threatexchange/threatexchange/content_type/preprocess/unletterboxing.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+
 from PIL import Image
 
 


### PR DESCRIPTION
Summary
---------

Looking at the content of 1.2.1 it somehow doesn't include the preprocessing file. I suspect that is because the file is empty, but don't know why that might be. 

Test Plan
---------

Installing locally with a non-empty file causes it to appear in the build dir when I do `python setup build`, while it doesn't when it's zero length.
