### PR TITLE
[vpdq] Fix CI python-threatexchange action failure due to missing apt-get update

### DIFF
--- a/.github/workflows/python-threatexchange-ci.yaml
+++ b/.github/workflows/python-threatexchange-ci.yaml
@@ -30,6 +30,7 @@ jobs:
           python-version: "3.11"
       - name: Install vpdq dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y python3-dev pkg-config cmake ffmpeg libavcodec-dev libavformat-dev libavdevice-dev libavutil-dev libswscale-dev libswresample-dev libavfilter-dev
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Summary
---------

Fix for CI failure (#1711)

See [Github Runner Ubuntu docs](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners) for reasoning:

> Always run sudo apt-get update before installing a package. In case the apt index is stale, this command fetches and re-indexes any available packages, which helps prevent package installation failures.

Test Plan
---------

Tested with full CI run on my fork: https://github.com/ianwal/ThreatExchange/actions/runs/12309870754/job/34357563408?pr=26

I verified the rest of the Actions in this repo run apt-get update before apt-get install.