### PR TITLE
Prenner/fix hashing images

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
@@ -53,16 +53,17 @@ def hash_media() -> dict[str, str]:
     ret: dict[str, str] = {}
 
     # For images, we may need to copy the file suffix (.png, jpeg, etc) for it to work
-    with tempfile.NamedTemporaryFile("wb", delete=False) as tmp:
+    with tempfile.NamedTemporaryFile("wb") as tmp:
         current_app.logger.debug("Writing to %s", tmp.name)
         tmp.write(download_resp.content)
-    path = Path(tmp.name)
-    for st in signal_types.values():
-        # At this point, every BytesHasher is a FileHasher, but we could
-        # explicitly pull those out to avoiding storing any copies of
-        # data locally, even temporarily
-        if issubclass(st, FileHasher):
-            ret[st.get_name()] = st.hash_from_file(path)
+        tmp.flush()  # this ensures that bytes from PNGs are written
+        path = Path(tmp.name)
+        for st in signal_types.values():
+            # At this point, every BytesHasher is a FileHasher, but we could
+            # explicitly pull those out to avoiding storing any copies of
+            # data locally, even temporarily
+            if issubclass(st, FileHasher):
+                ret[st.get_name()] = st.hash_from_file(path)
     return ret
 
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
@@ -55,8 +55,8 @@ def hash_media() -> dict[str, str]:
     # For images, we may need to copy the file suffix (.png, jpeg, etc) for it to work
     with tempfile.NamedTemporaryFile("wb") as tmp:
         current_app.logger.debug("Writing to %s", tmp.name)
-        tmp.write(download_resp.content)
-        tmp.flush()  # this ensures that bytes from PNGs are written
+        with tmp.file as temp_file:  # this ensures that bytes are flushed before hashing
+            temp_file.write(download_resp.content)
         path = Path(tmp.name)
         for st in signal_types.values():
             # At this point, every BytesHasher is a FileHasher, but we could

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
@@ -53,16 +53,16 @@ def hash_media() -> dict[str, str]:
     ret: dict[str, str] = {}
 
     # For images, we may need to copy the file suffix (.png, jpeg, etc) for it to work
-    with tempfile.NamedTemporaryFile("wb") as tmp:
+    with tempfile.NamedTemporaryFile("wb", delete=False) as tmp:
         current_app.logger.debug("Writing to %s", tmp.name)
         tmp.write(download_resp.content)
-        path = Path(tmp.name)
-        for st in signal_types.values():
-            # At this point, every BytesHasher is a FileHasher, but we could
-            # explicitly pull those out to avoiding storing any copies of
-            # data locally, even temporarily
-            if issubclass(st, FileHasher):
-                ret[st.get_name()] = st.hash_from_file(path)
+    path = Path(tmp.name)
+    for st in signal_types.values():
+        # At this point, every BytesHasher is a FileHasher, but we could
+        # explicitly pull those out to avoiding storing any copies of
+        # data locally, even temporarily
+        if issubclass(st, FileHasher):
+            ret[st.get_name()] = st.hash_from_file(path)
     return ret
 
 


### PR DESCRIPTION
Summary
---------

as detailed [here](https://techcoalition.slack.com/archives/C05J9LVJCVA/p1734121388960719?thread_ts=1733947726.316889&cid=C05J9LVJCVA), PNGs fail to hash when passed to the /h/hash endpoint. PNG hashes work via the threatexchange CLI because it is guaranteed that the contents are flushed before hashing occurs:
```
with tempfile.NamedTemporaryFile("wb", delete=False) as tmp:
    logging.debug("Writing -- to %s", tmp.name)
    tmp.write(resp.content)
filename = pathlib.Path(tmp.name)
```

but when `filename` is set in the `with` block, this is not the case for PNGs. manually call `flush` to fix this

https://discuss.python.org/t/should-tempfile-namedtemporaryfile-automatically-flush-the-buffer/17388 - in python 3.13 (we are on 3.11) there is a `delete_on_close` that we could use but [deletion](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) isn't guaranteed


Test Plan
---------
Confirmed that the endpoint can now hash PNGs with `flush` added
