### PR TITLE
[HMA] Remove ISignalTypeConfigStore from HMA

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/background_tasks/fetcher.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/background_tasks/fetcher.py
@@ -14,7 +14,8 @@ from threatexchange.exchanges.fetch_state import (
 
 from OpenMediaMatch.background_tasks.development import get_apscheduler
 from OpenMediaMatch.persistence import get_storage
-from OpenMediaMatch.storage.interface import ISignalExchangeStore, SignalTypeConfig
+from OpenMediaMatch.storage.interface import ISignalExchangeStore
+from threatexchange.cli.storage.interfaces import SignalTypeConfig
 from OpenMediaMatch.utils.time_utils import duration_to_human_str
 
 logger = logging.getLogger(__name__)

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/interface.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/interface.py
@@ -21,7 +21,7 @@ import typing as t
 import time
 
 import flask
-
+from threatexchange.cli.storage.interfaces import ISignalTypeConfigStore
 from threatexchange.utils import dataclass_json
 from threatexchange.content_type.content_base import ContentType
 from threatexchange.signal_type.signal_base import SignalType
@@ -58,70 +58,6 @@ class IContentTypeConfigStore(metaclass=abc.ABCMeta):
         """
         Return all installed content types.
         """
-
-
-@dataclass
-class SignalTypeConfig:
-    """
-    Holder for SignalType configuration
-    """
-
-    # Signal types that are not enabled should not be used in hashing/matching
-    enabled_ratio: float
-    signal_type: t.Type[SignalType]
-
-    @property
-    def enabled(self) -> bool:
-        # TODO do a coin flip here, but also refactor this to do seeding
-        return self.enabled_ratio >= 0.0
-
-
-class ISignalTypeConfigStore(metaclass=abc.ABCMeta):
-    """Interface for accessing SignalType configuration"""
-
-    @abc.abstractmethod
-    def get_signal_type_configs(self) -> t.Mapping[str, SignalTypeConfig]:
-        """Return all installed signal types."""
-
-    @abc.abstractmethod
-    def _create_or_update_signal_type_override(
-        self, signal_type: str, enabled_ratio: float
-    ) -> None:
-        """Create or update database entry for a signal type, setting a new value."""
-
-    @t.final
-    def create_or_update_signal_type_override(
-        self, signal_type: str, enabled_ratio: float
-    ) -> None:
-        """Update enabled ratio of an installed signal type."""
-        installed_signal_types = self.get_signal_type_configs()
-        if signal_type not in installed_signal_types:
-            raise ValueError(f"Unknown signal type {signal_type}")
-        if not (0.0 <= enabled_ratio <= 1.0):
-            raise ValueError(
-                f"Invalid enabled ratio {enabled_ratio}. Must be in the range 0.0-1.0 inclusive."
-            )
-        self._create_or_update_signal_type_override(signal_type, enabled_ratio)
-
-    @t.final
-    def get_enabled_signal_types(self) -> t.Mapping[str, t.Type[SignalType]]:
-        """Helper shortcut for getting only enabled SignalTypes"""
-        return {
-            k: v.signal_type
-            for k, v in self.get_signal_type_configs().items()
-            if v.enabled
-        }
-
-    @t.final
-    def get_enabled_signal_types_for_content_type(
-        self, content_type: t.Type[ContentType]
-    ) -> t.Mapping[str, t.Type[SignalType]]:
-        """Helper shortcut for getting enabled types for a piece of content"""
-        return {
-            k: v.signal_type
-            for k, v in self.get_signal_type_configs().items()
-            if v.enabled and content_type in v.signal_type.get_content_types()
-        }
 
 
 @dataclass

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/mocked.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/mocked.py
@@ -21,7 +21,7 @@ from threatexchange.exchanges.fetch_state import (
 )
 
 from OpenMediaMatch.storage import interface
-from OpenMediaMatch.storage.interface import SignalTypeConfig
+from threatexchange.cli.storage.interfaces import SignalTypeConfig
 
 
 class MockedUnifiedStore(interface.IUnifiedStore):
@@ -49,7 +49,7 @@ class MockedUnifiedStore(interface.IUnifiedStore):
     def get_signal_type_configs(self) -> t.Mapping[str, SignalTypeConfig]:
         # Needed to bamboozle mypy into working
         s_types: t.Sequence[t.Type[SignalType]] = (PdqSignal, VideoMD5Signal)
-        return {s.get_name(): interface.SignalTypeConfig(1.0, s) for s in s_types}
+        return {s.get_name(): SignalTypeConfig(1.0, s) for s in s_types}
 
     def _create_or_update_signal_type_override(
         self, signal_type: str, enabled_ratio: float

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
@@ -37,6 +37,7 @@ from threatexchange.exchanges.fetch_state import (
 )
 
 from OpenMediaMatch.storage import interface
+from threatexchange.cli.storage.interfaces import SignalTypeConfig
 from OpenMediaMatch.storage.postgres import database, flask_utils
 
 
@@ -140,12 +141,12 @@ class DefaultOMMStore(interface.IUnifiedStore):
         sesh.add(config)
         sesh.commit()
 
-    def get_signal_type_configs(self) -> t.Mapping[str, interface.SignalTypeConfig]:
+    def get_signal_type_configs(self) -> t.Mapping[str, SignalTypeConfig]:
         # If a signal is installed, then it is enabled by default. But it may be disabled by an
         # override in the database.
         signal_type_overrides = self._query_signal_type_overrides()
         return {
-            name: interface.SignalTypeConfig(
+            name: SignalTypeConfig(
                 signal_type_overrides.get(name, 1.0),
                 st,
             )

--- a/python-threatexchange/threatexchange/cli/storage/interfaces.py
+++ b/python-threatexchange/threatexchange/cli/storage/interfaces.py
@@ -2,6 +2,7 @@
 
 """
 Common interface for persisting pytx configuration and concepts.
+
 Most of the individual components of pytx are find to use piecemeal, and
 the full interface covers the most complex and complete useage. A usecase
 with one collection of hashes using one algorithm might be better off 

--- a/python-threatexchange/threatexchange/cli/storage/interfaces.py
+++ b/python-threatexchange/threatexchange/cli/storage/interfaces.py
@@ -2,7 +2,6 @@
 
 """
 Common interface for persisting pytx configuration and concepts.
-
 Most of the individual components of pytx are find to use piecemeal, and
 the full interface covers the most complex and complete useage. A usecase
 with one collection of hashes using one algorithm might be better off 
@@ -32,27 +31,6 @@ from dataclasses import dataclass
 import typing as t
 from threatexchange.content_type.content_base import ContentType
 from threatexchange.signal_type.signal_base import SignalType
-
-
-@dataclass
-class ContentTypeConfig:
-    """
-    Holder for ContentType configuration.
-    """
-
-    # Content types that are not enabled should not be used in hashing/matching
-    enabled: bool
-    content_type: t.Type[ContentType]
-
-
-class IContentTypeConfigStore(metaclass=abc.ABCMeta):
-    """Interface for accessing ContentType configuration"""
-
-    @abc.abstractmethod
-    def get_content_type_configs(self) -> t.Mapping[str, ContentTypeConfig]:
-        """
-        Return all installed content types.
-        """
 
 
 @dataclass
@@ -117,3 +95,24 @@ class ISignalTypeConfigStore(metaclass=abc.ABCMeta):
             for k, v in self.get_signal_type_configs().items()
             if v.enabled and content_type in v.signal_type.get_content_types()
         }
+
+
+@dataclass
+class ContentTypeConfig:
+    """
+    Holder for ContentType configuration.
+    """
+
+    # Content types that are not enabled should not be used in hashing/matching
+    enabled: bool
+    content_type: t.Type[ContentType]
+
+
+class IContentTypeConfigStore(metaclass=abc.ABCMeta):
+    """Interface for accessing ContentType configuration"""
+
+    @abc.abstractmethod
+    def get_content_type_configs(self) -> t.Mapping[str, ContentTypeConfig]:
+        """
+        Return all installed content types.
+        """


### PR DESCRIPTION
Summary
This resolves the 3rd part of issue #1689 
Delete ISignalTypeConfigStore in HMA
In HMA, import ISignalTypeConfigStore from pytx to be included in IUnifiedStore

Test Plan
I was not entirely sure what to test to verify. There was a module issue, so I added the init py to allow for the module usage in HMA. I am not sure if that was the correct approach however that is the pr referenced in #1725 

Update: Yay the version change worked!
