### PR TITLE
Check for hasher role in /lookup endpoint

### DIFF
--- a/hasher-matcher-actioner/.devcontainer/postcreate.sh
+++ b/hasher-matcher-actioner/.devcontainer/postcreate.sh
@@ -3,7 +3,7 @@ set -e
 
 pip install --editable .[all]
 
-# Find Python packages in opt and install them
+# Find Python packages in extensions and install them
 for setup_script in "$(find /workspace/extensions -name setup.py)"
 do
     module_dir="$(dirname "$setup_script")"

--- a/hasher-matcher-actioner/src/OpenMediaMatch/app.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/app.py
@@ -7,7 +7,7 @@ import warnings
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     from threatexchange.signal_type.pdq import signal as _
-## Resume regularly scheduled imports
+# Resume regularly scheduled imports
 
 import logging
 import os

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -139,7 +139,7 @@ def query_index(
     try:
         signal = signal_type.validate_signal_str(signal)
     except Exception as e:
-        abort(400, f"invalid signal type: {e}")
+        abort(400, f"invalid signal: {e}")
 
     index = _get_index(signal_type)
 
@@ -205,6 +205,9 @@ def lookup_get():
     """
     # Url was passed as a query param?
     if request.args.get("url", None):
+        if not current_app.config.get("ROLE_HASHER", False):
+            abort(403, "Hashing is disabled, missing role")
+
         hashes = hashing.hash_media()
         resp = {}
         for signal_type in hashes.keys():
@@ -230,6 +233,9 @@ def lookup_post():
     Output:
      * List of matching banks
     """
+    if not current_app.config.get("ROLE_HASHER", False):
+        abort(403, "Hashing is disabled, missing role")
+
     hashes = hashing.hash_media_post()
 
     resp = {}


### PR DESCRIPTION
Summary
---------

fixes #1703 

TODO:
- [ ]  unit test

Test Plan
---------

1. set `ROLE_HASHER = False` in development_omm_config.py
2. start server
3. try GET/POST to `/lookup` endpoint, should error now with 403 "Hashing is disabled, missing role"
