### PR TITLE
ncmec: store checkpoint on large fetches

### DIFF
--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
@@ -565,7 +565,7 @@ class NCMECHashAPI:
             )
 
     def get_entries_iter(
-        self, *, start_timestamp: int = 0, end_timestamp: int = 0
+        self, *, start_timestamp: int = 0, end_timestamp: int = 0, next_: str = ""
     ) -> t.Iterator[GetEntriesResponse]:
         """
         A simple wrapper around get_entries to keep fetching until complete.
@@ -574,7 +574,6 @@ class NCMECHashAPI:
         much of the data you have fetched. @see get_entries
         """
         has_more = True
-        next_ = ""
         while has_more:
             result = self.get_entries(
                 start_timestamp=start_timestamp,

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
@@ -565,7 +565,11 @@ class NCMECHashAPI:
             )
 
     def get_entries_iter(
-        self, *, start_timestamp: int = 0, end_timestamp: int = 0, next_: str = ""
+        self,
+        *,
+        start_timestamp: int = 0,
+        end_timestamp: int = 0,
+        checkpointed_paging_url: str = "",
     ) -> t.Iterator[GetEntriesResponse]:
         """
         A simple wrapper around get_entries to keep fetching until complete.
@@ -574,6 +578,7 @@ class NCMECHashAPI:
         much of the data you have fetched. @see get_entries
         """
         has_more = True
+        next_ = checkpointed_paging_url
         while has_more:
             result = self.get_entries(
                 start_timestamp=start_timestamp,

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/data.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/data.py
@@ -23,6 +23,14 @@ NEXT_UNESCAPED3 = (
     "&to=2017-10-30T00%3A00%3A00.000Z&start=4001&size=1000&max=5000"
 )
 
+ENTRIES_NO_DATA_XML = """
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">
+    <images count="0"/>
+    <videos count="0"/>
+</queryResult>
+""".strip()
+
 ENTRIES_XML = """
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <queryResult xmlns="https://hashsharing.ncmec.org/hashsharing/v2">

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
@@ -91,6 +91,7 @@ def empty_api_response(monkeypatch: pytest.MonkeyPatch):
         resp.content  # Set the rest of Request's internal state
         return resp
 
+    session = None
     session = Mock(
         strict_spec=["get", "__enter__", "__exit__"],
         get=_mock_get_impl,

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/tests/test_hash_api.py
@@ -14,6 +14,7 @@ from threatexchange.exchanges.clients.ncmec.hash_api import (
 )
 from threatexchange.exchanges.clients.ncmec.tests.data import (
     ENTRIES_LARGE_FINGERPRINTS,
+    ENTRIES_NO_DATA_XML,
     ENTRIES_XML,
     ENTRIES_XML2,
     ENTRIES_XML3,
@@ -70,6 +71,29 @@ def api(monkeypatch: pytest.MonkeyPatch):
     session = Mock(
         strict_spec=["get", "__enter__", "__exit__"],
         get=mock_get_impl,
+        _put=Mock(),
+        __enter__=lambda _: session,
+        __exit__=lambda *args: None,
+    )
+    monkeypatch.setattr(api, "_get_session", lambda: session)
+    return api
+
+
+@pytest.fixture
+def empty_api_response(monkeypatch: pytest.MonkeyPatch):
+    api = NCMECHashAPI("fake_user", "fake_pass", NCMECEnvironment.test_Industry)
+
+    def _mock_get_impl(url: str, **params):
+        content = ENTRIES_NO_DATA_XML
+        resp = requests.Response()
+        resp._content = content.encode()
+        resp.status_code = 200
+        resp.content  # Set the rest of Request's internal state
+        return resp
+
+    session = Mock(
+        strict_spec=["get", "__enter__", "__exit__"],
+        get=_mock_get_impl,
         _put=Mock(),
         __enter__=lambda _: session,
         __exit__=lambda *args: None,

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -39,8 +39,8 @@ class NCMECCheckpoint(
 
     # The biggest value of "to", and the next "from"
     get_entries_max_ts: int
-    next_fetch: str
-    last_fetch_time: int
+    next_fetch: t.Optional[str] = ""
+    last_fetch_time: t.Optional[int] = 0
 
     def get_progress_timestamp(self) -> t.Optional[int]:
         return self.get_entries_max_ts
@@ -245,7 +245,7 @@ class NCMECSignalExchangeAPI(
         next_fetch = ""
         if checkpoint is not None:
             start_time = checkpoint.get_entries_max_ts
-            next_fetch = checkpoint.next_fetch
+            next_fetch = checkpoint.next_fetch or ""
         # Avoid being exactly at end time for updates showing up multiple
         # times in the fetch, since entries are not ordered by time
         end_time = int(time.time()) - 5
@@ -324,9 +324,8 @@ class NCMECSignalExchangeAPI(
                         ),
                     )
                     current_next_fetch = entry.next
-                    updates = []
-                else:
-                    updates.extend(entry.updates)
+                    break
+                updates.extend(entry.updates)
             else:  # AKA a successful fetch
                 # If we're hovering near the single-fetch limit for a period
                 # of time, we can likely safely expand our range.

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -282,7 +282,9 @@ class NCMECSignalExchangeAPI(
             updates: t.List[api.NCMECEntryUpdate] = []
             for i, entry in enumerate(
                 client.get_entries_iter(
-                    start_timestamp=current_start, end_timestamp=current_end, next_=current_next_fetch,
+                    start_timestamp=current_start,
+                    end_timestamp=current_end,
+                    next_=current_next_fetch,
                 )
             ):
                 if i == 0:  # First batch, check for overfetch
@@ -315,8 +317,11 @@ class NCMECSignalExchangeAPI(
                     log(f"large fetch ({i}), up to {len(updates)}. storing checkpoint")
                     yield state.FetchDelta(
                         {f"{entry.member_id}-{entry.id}": entry for entry in updates},
-                        NCMECCheckpoint(get_entries_max_ts=current_start, next_fetch=entry.next, last_fetch_time=int(time.time())),
-
+                        NCMECCheckpoint(
+                            get_entries_max_ts=current_start,
+                            next_fetch=entry.next,
+                            last_fetch_time=int(time.time()),
+                        ),
                     )
                     current_next_fetch = entry.next
                     updates = []
@@ -342,7 +347,11 @@ class NCMECSignalExchangeAPI(
                     low_fetch_counter = 0
                 yield state.FetchDelta(
                     {f"{entry.member_id}-{entry.id}": entry for entry in updates},
-                    NCMECCheckpoint(get_entries_max_ts=current_end, next_fetch="", last_fetch_time=int(time.time())),
+                    NCMECCheckpoint(
+                        get_entries_max_ts=current_end,
+                        next_fetch="",
+                        last_fetch_time=int(time.time()),
+                    ),
                 )
                 current_start = current_end
                 current_next_fetch = ""

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -371,7 +371,7 @@ class NCMECSignalExchangeAPI(
                     low_fetch_counter = 0
 
                 yield state.FetchDelta(
-                    [],
+                    {},
                     NCMECCheckpoint(get_entries_max_ts=current_end),
                 )
                 current_paging_url = ""

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -45,7 +45,7 @@ class NCMECCheckpoint(
     # a timestamp for the last fetch time, specifically used with a paging_url
     # NCMEC suggests not storing paging_urls long term so we consider them invalid
     # 12hr after the last_fetch_time
-    last_fetch_time: int = field(hash=True, default_factory=lambda: int(time.time()))
+    last_fetch_time: int = field(default_factory=lambda: int(time.time()))
 
     def get_progress_timestamp(self) -> t.Optional[int]:
         return self.get_entries_max_ts

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -41,13 +41,13 @@ class NCMECCheckpoint(
 
     # The biggest value of "to", and the next "from"
     get_entries_max_ts: int
-    # A url to fetch the next page of results.
+    # A url to fetch the next page of results
     # Only reference this value through get_paging_url_if_recent
-    paging_url: str
-    # a timestamp for the last fetch time, specifically used with a paging_url.
+    paging_url: str = ""
+    # a timestamp for the last fetch time, specifically used with a pagingpyth_url
     # NCMEC suggests not storing paging_urls long term so we consider them invalid
     # 12hr after the last_fetch_time
-    last_fetch_time: int
+    last_fetch_time: int = field(hash=True, default_factory=lambda: int(time.time()))
 
     def get_progress_timestamp(self) -> t.Optional[int]:
         return self.get_entries_max_ts
@@ -68,6 +68,14 @@ class NCMECCheckpoint(
         ### field 'max_timestamp' renamed to 'get_entries_max_ts'
         if "max_timestamp" in d:
             d["get_entries_max_ts"] = d.pop("max_timestamp")
+
+        # 1.0.0 => 1.2.3:
+        # Add last_fetch_time
+        # note: the default_factory value was not being set correctly when
+        # reading from pickle
+        if not "last_fetch_time" in d:
+            d["last_fetch_time"] = int(time.time())
+
         self.__dict__ = d
 
 

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -310,7 +310,10 @@ class NCMECSignalExchangeAPI(
                         # Our entry estimatation (based on the cursor parameters)
                         # occasionally seem to over-estimate
                         log(f"est {entry.estimated_entries_in_range} entries")
-                elif i % 100 == 0:
+
+                updates.extend(entry.updates)
+
+                if i % 100 == 0:
                     # If we get down to one second, we can potentially be
                     # fetching an arbitrary large amount of data in one go,
                     # so store the checkpoint occasionally
@@ -324,8 +327,8 @@ class NCMECSignalExchangeAPI(
                         ),
                     )
                     current_next_fetch = entry.next
-                    break
-                updates.extend(entry.updates)
+                    updates = []
+
             else:  # AKA a successful fetch
                 # If we're hovering near the single-fetch limit for a period
                 # of time, we can likely safely expand our range.

--- a/python-threatexchange/threatexchange/exchanges/impl/tests/test_ncmec.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/tests/test_ncmec.py
@@ -3,7 +3,11 @@
 import typing as t
 import pytest
 
-from threatexchange.exchanges.clients.ncmec.tests.test_hash_api import api
+from threatexchange.exchanges.clients.ncmec.tests.test_hash_api import (
+    api,
+    empty_api_response,
+)
+from threatexchange.exchanges.fetch_state import FetchDelta
 from threatexchange.exchanges.impl.ncmec_api import (
     NCMECCollabConfig,
     NCMECSignalExchangeAPI,
@@ -27,34 +31,95 @@ def exchange(api: NCMECHashAPI, monkeypatch: pytest.MonkeyPatch):
     return signal_exchange
 
 
+@pytest.fixture
+def empty_exchange(empty_api_response: NCMECHashAPI, monkeypatch: pytest.MonkeyPatch):
+    collab = NCMECCollabConfig(NCMECEnvironment.Industry, "Test")
+    signal_exchange = NCMECSignalExchangeAPI(collab, "user", "pass")
+    monkeypatch.setattr(
+        signal_exchange, "get_client", lambda _environment: empty_api_response
+    )
+    return signal_exchange
+
+
+def assert_delta(
+    delta: FetchDelta,
+    updates: set[str],
+    progress_timestamp: int,
+    is_stale: bool,
+    get_entries_max_ts: int,
+    paging_url: str,
+) -> None:
+    assert set(delta.updates) == updates
+    assert len(delta.updates) == len(updates)
+    assert delta.checkpoint.get_progress_timestamp() == progress_timestamp
+    assert delta.checkpoint.is_stale() is is_stale
+    assert delta.checkpoint.get_entries_max_ts == get_entries_max_ts
+    assert delta.checkpoint.paging_url == paging_url
+
+
 def test_fetch(exchange: NCMECSignalExchangeAPI, monkeypatch: pytest.MonkeyPatch):
     frozen_time = 1664496000
     monkeypatch.setattr("time.time", lambda: frozen_time)
     it = exchange.fetch_iter([], None)
-    # Since our test data from test_hash_api is is all in one fetch sequence,
-    # we'd have to craft some specialized data to get the NCMECSignalAPI split it
-    # into multiple updates
+    total_updates: t.Dict[str, NCMECEntryUpdate] = {}
 
     # Fetch 1
     delta = next(it, None)
     assert delta is not None
-    assert len(delta.updates) == 7
-    total_updates: t.Dict[str, NCMECEntryUpdate] = {}
+    exchange.naive_fetch_merge(total_updates, delta.updates)
+    assert_delta(
+        delta,
+        {
+            "42-image1",
+            "43-image4",
+            "42-video1",
+            "42-video4",
+        },
+        0,
+        False,
+        0,
+        "/v2/entries?from=2017-10-20T00%3A00%3A00.000Z&to=2017-10-30T00%3A00%3A00.000Z&start=2001&size=1000&max=3000",
+    )
+
+    # Fetch 2
+    delta = next(it, None)
+    assert delta is not None
+    assert len(delta.updates) == 1
     exchange.naive_fetch_merge(total_updates, delta.updates)
 
-    assert delta.checkpoint.get_progress_timestamp() == frozen_time - 5
-    assert delta.checkpoint.is_stale() is False
-    assert delta.checkpoint.get_entries_max_ts == frozen_time - 5
+    assert_delta(
+        delta,
+        {"42-image10"},
+        0,
+        False,
+        0,
+        "/v2/entries?from=2017-10-20T00%3A00%3A00.000Z&to=2017-10-30T00%3A00%3A00.000Z&start=3001&size=1000&max=4000",
+    )
 
-    assert set(delta.updates) == {
-        "43-image4",
-        "42-image1",
-        "42-video1",
-        "42-video4",
-        "42-image10",
-        "101-willdelete",
-        "101-willupdate",
-    }
+    # Fetch 3
+    delta = next(it, None)
+    assert len(delta.updates) == 2
+    exchange.naive_fetch_merge(total_updates, delta.updates)
+    assert_delta(
+        delta,
+        {"101-willupdate", "101-willdelete"},
+        0,
+        False,
+        0,
+        "/v2/entries?from=2017-10-20T00%3A00%3A00.000Z&to=2017-10-30T00%3A00%3A00.000Z&start=4001&size=1000&max=5000",
+    )
+
+    # Fetch 4
+    delta = next(it, None)
+    assert len(delta.updates) == 2
+    exchange.naive_fetch_merge(total_updates, delta.updates)
+    assert_delta(delta, {"101-willupdate", "101-willdelete"}, 0, False, 0, "")
+
+    ## No more data, but one final checkpoint
+    delta = next(it, None)
+    assert len(delta.updates) == 0
+    progress_timestamp = frozen_time - 5
+    assert_delta(delta, set(), progress_timestamp, False, progress_timestamp, "")
 
     as_signals = NCMECSignalExchangeAPI.naive_convert_to_signal_type(
         [VideoMD5Signal], exchange.collab, total_updates
@@ -63,8 +128,8 @@ def test_fetch(exchange: NCMECSignalExchangeAPI, monkeypatch: pytest.MonkeyPatch
         "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1": NCMECSignalMetadata({42: set()}),
         "facefacefacefacefacefacefaceface": NCMECSignalMetadata({101: {"A2"}}),
     }
-    ## No more data
-    assert next(it, None) is None
+
+    assert next(it, None) is None  # We fetched everything
 
     # Test esp_id filter
     collab = NCMECCollabConfig(NCMECEnvironment.Industry, "Test")
@@ -90,3 +155,17 @@ def test_fetch(exchange: NCMECSignalExchangeAPI, monkeypatch: pytest.MonkeyPatch
         "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1": NCMECSignalMetadata({42: set()}),
         "facefacefacefacefacefacefaceface": NCMECSignalMetadata({101: {"A2"}}),
     }
+
+
+def test_empty_fetch(
+    empty_exchange: NCMECSignalExchangeAPI, monkeypatch: pytest.MonkeyPatch
+):
+    it = empty_exchange.fetch_iter([], None)
+    # No updates
+    delta = next(it, None)
+    assert delta is not None
+    assert len(delta.updates) == 0
+    assert_delta(delta, set(), 0, False, 0, "")
+
+    delta = next(it, None)
+    assert delta is None  # We fetched everything

--- a/python-threatexchange/threatexchange/exchanges/tests/test_state_compatibility.py
+++ b/python-threatexchange/threatexchange/exchanges/tests/test_state_compatibility.py
@@ -148,7 +148,7 @@ def get_NCMECCheckpoint() -> t.Tuple[NCMECCheckpoint, t.Sequence[object]]:
     max_ts = 1197433091
 
     # 1.0.x
-    current = NCMECCheckpoint(get_entries_max_ts=max_ts)
+    current = NCMECCheckpoint(get_entries_max_ts=max_ts, next="", last_fetch_time=0)
 
     # 0.99.x
     @dataclass

--- a/python-threatexchange/threatexchange/exchanges/tests/test_state_compatibility.py
+++ b/python-threatexchange/threatexchange/exchanges/tests/test_state_compatibility.py
@@ -148,18 +148,18 @@ def get_NCMECCheckpoint() -> t.Tuple[NCMECCheckpoint, t.Sequence[object]]:
     max_ts = 1197433091
 
     current = NCMECCheckpoint(
-        get_entries_max_ts=max_ts, next_fetch="", last_fetch_time=0
+        get_entries_max_ts=max_ts, paging_url="", last_fetch_time=0
     )
 
     # 1.0.x
     @dataclass
     class NCMECCheckpointWithoutNext(FetchCheckpointBase):
         """
-        0.99.x => 1.0.0
+        0.99.x => 1.2.3
 
         get_entries_max_ts: int =>
             get_entries_max_ts: int
-            next_fetch: str
+            paging_url: str
             last_fetch_time: int
         """
 

--- a/python-threatexchange/threatexchange/exchanges/tests/test_state_compatibility.py
+++ b/python-threatexchange/threatexchange/exchanges/tests/test_state_compatibility.py
@@ -147,8 +147,23 @@ def get_NCMECCheckpoint() -> t.Tuple[NCMECCheckpoint, t.Sequence[object]]:
     ## Current
     max_ts = 1197433091
 
+    current = NCMECCheckpoint(
+        get_entries_max_ts=max_ts, next_fetch="", last_fetch_time=0
+    )
+
     # 1.0.x
-    current = NCMECCheckpoint(get_entries_max_ts=max_ts, next="", last_fetch_time=0)
+    @dataclass
+    class NCMECCheckpointWithoutNext(FetchCheckpointBase):
+        """
+        0.99.x => 1.0.0
+
+        get_entries_max_ts: int =>
+            get_entries_max_ts: int
+            next_fetch: str
+            last_fetch_time: int
+        """
+
+        get_entries_max_ts: int
 
     # 0.99.x
     @dataclass
@@ -161,9 +176,10 @@ def get_NCMECCheckpoint() -> t.Tuple[NCMECCheckpoint, t.Sequence[object]]:
 
         max_timestamp: int
 
+    checkpoint_without_next = NCMECCheckpointWithoutNext(get_entries_max_ts=max_ts)
     ts_moved = NCMECCheckpointTsMoved(max_timestamp=max_ts)
 
-    return (current, [ts_moved])
+    return (current, [checkpoint_without_next, ts_moved])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Summary
---------
sometimes ncmec fails to make progress after hitting a second w/ a large number of results: https://github.com/facebook/ThreatExchange/issues/1679. when that happens (diff of end and start is a second and we have lots of data), store checkpoints occasionally via a next pointer

Test Plan
---------

confirmed that resuming from a checkpoint works around the cursed second
