### PR TITLE
[vpdq] Fix failure if system returns 0 thread count

### DIFF
--- a/vpdq/cpp/vpdq/cpp/hashing/hasher.h
+++ b/vpdq/cpp/vpdq/cpp/hashing/hasher.h
@@ -190,6 +190,11 @@ VpdqHasher<TFrame>::VpdqHasher(
   // Set thread count if specified
   if (thread_count == 0) {
     thread_count = std::thread::hardware_concurrency();
+    // Some platforms may return 0 for hardware_concurrency(), per the standard.
+    // If that occurs, set it to single-threaded.
+    if (thread_count == 0) {
+      thread_count = 1;
+    }
   }
 
   m_multithreaded = (thread_count != 1);


### PR DESCRIPTION
Summary
---------

Fix (rare) case of platform returning `0` thread count via [`std::thread::hardware_concurrency()`](https://en.cppreference.com/w/cpp/thread/thread/hardware_concurrency) causing hashing failure.

Current behavior:

If the user provides `0` for the thread-count to get an automatic number of hashing threads and hardware_concurrency returns `0`, then the video will not be hashed.

Expected behavior:

If the user provides `0` for the thread-count to get an automatic number of hashing threads and hardware_concurrency returns `0`, then the video will should be hashed with a single-thread.

---

Simulated scenario where the bug does occur causes immediate regtest failure:

Modified code to set thread_count to 0:

```cpp
template <typename TFrame>
VpdqHasher<TFrame>::VpdqHasher(
    size_t thread_count, VideoMetadata video_metadata)
    : m_done_hashing(false), m_video_metadata(video_metadata) {
  // Set thread count if specified
  if (thread_count == 0) {
    // thread_count = std::thread::hardware_concurrency();
    thread_count = 0; // <--- SIMULATED SCENARIO
  }

  m_multithreaded = (thread_count != 1);

  // Create consumer hasher threads if multithreading
  if (m_multithreaded) {
    consumer_threads.reserve(thread_count);
    for (size_t thread_idx{0}; thread_idx < thread_count; ++thread_idx) {
      consumer_threads.emplace_back(std::thread(&VpdqHasher::consumer, this));
    }
  }
}
```

regtest failure:

```sh
python/tests/test_vpdq_hash.py ..F                                                                             [100%]

====================================================== FAILURES ======================================================
________________________________________________ test_compare_hashes _________________________________________________

    def test_compare_hashes():
        """This regression test is creating hashes from sample videos and compare them with the provided hashes line by line.
        Two VPDQ features are considered the same if each line of the hashes are within DISTANCE_TOLERANCE.
        For hashes that have a quality lower than QUALITY_TOLERANCE, the test will skip them for comparing.
        """
        test_files = get_test_file_paths()
    
        for file in test_files:
            # Load the hash file truth
            hash_file = Path(f"{HASH_FOLDER}/{file.stem}.txt")
            assert hash_file.is_file()
            ret = test_util.read_file_to_hash(hash_file)
            assert ret is not None
            sample_hashes[file] = ret
    
            # Calculate the hash of file
            assert file.is_file()
            ret = vpdq.computeHash(input_video_filename=file, seconds_per_hash=0)
            assert ret is not None
            test_hashes[file] = ret
    
            print("Comparing hash for video:", file)
            hash1 = test_hashes[file]
            hash2 = sample_hashes[file]
>           assert len(hash1) == len(hash2)
E           AssertionError: assert 0 == 673
E            +  where 0 = len([])
E            +  and   673 = len([VpdqFeature(quality=100, frame_number=0, hash={'w': [57172, 52, 28084, 42147, 33752, 64361, 2109, 28646, 51603, 2034,...9, 27960, 9913, 42285]}, hex='a52d26b96d38d3491a79f80f0ff2c1936fe6083dfb4987d8a4b36da40034de54', timestamp=0.167), ...])

python/tests/test_vpdq_hash.py:129: AssertionError
```

I did not experience this bug directly. I noticed it while working on the scikit-build PR when I randomly opened the file.

---

Also added a few style fixes in this file.

The first commit solves the bug. The second commit is style fixes and misc cleanup.

Test Plan
---------

Single/multithreaded tests run by CI should cover any potential regressions.

Simulated scenario shows that this is a bug and that it should be fixed by simply setting the thread count to 1 if `hardware_concurrency()` returns 0.

Did not test the fix with a platform where it returns 0 and did not step through with a debugger, but reading the logic shows that if it does return 0 then the thread count will be set to 1 and it will be single-threaded which should work as expected.