### PR TITLE
(doc update): Change Tweak Message For Checkpointing Sanity Check Failure

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/impl.py
@@ -341,7 +341,7 @@ class DefaultOMMStore(interface.IUnifiedStore):
         existing_checkpoint = cfg.as_checkpoint(self.exchange_apis_get_installed())
         assert (
             existing_checkpoint == old_checkpoint
-        ), "Old checkpoint doesn't match, race condition?"
+        ), "Checkpoint has changed since fetch started - multiple fetch processes may be running simultaneously."
 
         api_cls = self.exchange_apis_get_installed().get(collab.api)
         assert api_cls is not None, "Invalid API cls?"


### PR DESCRIPTION
See: #1734 https://github.com/facebook/ThreatExchange/issues/1734

Summary
---------
Previously:
`Old checkpoint doesn't match, race condition?`
New message:
`Checkpoint has changed since fetch started - multiple fetch processes may be running simultaneously.`
I think this is a pretty nice message after reviewing the surrounding context.

Test Plan
---------

Only replacing error message, so no updates needed.
