### PR TITLE
[HMA] Change matching API to return more metadata

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -280,7 +280,7 @@ def lookup(signal, signal_type_name):
         match = results_by_bank_content_id.get(content.id)
         results[content.bank.name].append(
             {
-                "content_id": content.id,
+                "bank_content_id": content.id,
                 "distance": match.similarity_info.distance,
             }
         )

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -278,7 +278,7 @@ def lookup(signal, signal_type_name):
             # is it possible to return the content_signal.signal_val here?
             {
                 "content_id": content.id,
-                "distance": match.similarity_info.pretty_str(),
+                "distance": match.similarity_info.distance,
             }
         )
     return results

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -271,7 +271,7 @@ def lookup(signal, signal_type_name):
     results = defaultdict(list)
     for content in enabled_content:
         if content.bank.name not in enabled_banks:
-            next
+            continue
 
         match = results_by_content_id.get(content.id)
         results[content.bank.name].append(

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -256,7 +256,7 @@ def lookup(signal, signal_type_name):
         r.metadata: r for r in query_index(signal, signal_type_name)
     }
     storage = get_storage()
-    contents = storage.bank_content_get(results_by_content_id.keys())
+    contents = storage.bank_content_get(results_by_content_id)
     enabled_content = [c for c in contents if c.enabled]
     current_app.logger.debug(
         "lookup matches %d content ids (%d enabled_content)",

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -258,8 +258,6 @@ def lookup(signal, signal_type_name):
         "lookup matches %d content ids (%d enabled_content)", len(contents),
         len(enabled_content)
     )
-    if not enabled_content:
-        return []
     banks = {c.bank.name: c.bank for c in enabled_content}
     rand = random.Random(request.args.get("seed"))
     coinflip = rand.random()

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -275,7 +275,6 @@ def lookup(signal, signal_type_name):
 
         match = results_by_content_id.get(content.id)
         results[content.bank.name].append(
-            # is it possible to return the content_signal.signal_val here?
             {
                 "content_id": content.id,
                 "distance": match.similarity_info.distance,

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -202,7 +202,9 @@ def lookup_get():
      Also (applies to both cases):
      * Optional seed (content id) for consistent coinflip
     Output:
-     * List of matching banks
+     * JSON object with a key of each bank name with matches.
+       For each bank, there is list of objects containing details
+       about each match.
     """
     if request.args.get("url", None):
         if not current_app.config.get("ROLE_HASHER", False):
@@ -231,7 +233,9 @@ def lookup_post():
      * Uploaded file.
      * Optional seed (content id) for consistent coinflip
     Output:
-     * List of matching banks
+     * JSON object with a key of each bank name with matches.
+       For each bank, there is list of objects containing details
+       about each match.
     """
     if not current_app.config.get("ROLE_HASHER", False):
         abort(403, "Hashing is disabled, missing role")

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -270,7 +270,7 @@ def lookup(signal, signal_type_name):
         b.name for b in banks.values() if b.matching_enabled_ratio >= coinflip
     }
     current_app.logger.debug(
-        "lookup matches %d banks (%d enabled_content)", len(banks), len(enabled_banks)
+        "lookup matches %d banks (%d enabled_banks)", len(banks), len(enabled_banks)
     )
     results = defaultdict(list)
     for content in enabled_content:

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -252,11 +252,11 @@ def lookup_post():
 
 def lookup(signal, signal_type_name):
     current_app.logger.debug("performing lookup")
-    results_by_content_id = {
+    results_by_bank_content_id = {
         r.metadata: r for r in query_index(signal, signal_type_name)
     }
     storage = get_storage()
-    contents = storage.bank_content_get(results_by_content_id)
+    contents = storage.bank_content_get(results_by_bank_content_id)
     enabled_content = [c for c in contents if c.enabled]
     current_app.logger.debug(
         "lookup matches %d content ids (%d enabled_content)",
@@ -277,7 +277,7 @@ def lookup(signal, signal_type_name):
         if content.bank.name not in enabled_banks:
             continue
 
-        match = results_by_content_id.get(content.id)
+        match = results_by_bank_content_id.get(content.id)
         results[content.bank.name].append(
             {
                 "content_id": content.id,

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -275,6 +275,7 @@ def lookup(signal, signal_type_name):
 
         match = results_by_content_id.get(content.id)
         results[content.bank.name].append(
+            # is it possible to return the content_signal.signal_val here?
             {
                 "content_id": content.id,
                 "distance": match.similarity_info.pretty_str(),

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -253,23 +253,24 @@ def lookup(signal, signal_type_name):
     }
     storage = get_storage()
     contents = storage.bank_content_get(results_by_content_id.keys())
-    enabled = [c for c in contents if c.enabled]
+    enabled_content = [c for c in contents if c.enabled]
     current_app.logger.debug(
-        "lookup matches %d content ids (%d enabled)", len(contents), len(enabled)
+        "lookup matches %d content ids (%d enabled_content)", len(contents),
+        len(enabled_content)
     )
-    if not enabled:
+    if not enabled_content:
         return []
-    banks = {c.bank.name: c.bank for c in enabled}
+    banks = {c.bank.name: c.bank for c in enabled_content}
     rand = random.Random(request.args.get("seed"))
     coinflip = rand.random()
     enabled_banks = {
         b.name for b in banks.values() if b.matching_enabled_ratio >= coinflip
     }
     current_app.logger.debug(
-        "lookup matches %d banks (%d enabled)", len(banks), len(enabled_banks)
+        "lookup matches %d banks (%d enabled_content)", len(banks), len(enabled_banks)
     )
     results = defaultdict(list)
-    for content in enabled:
+    for content in enabled_content:
         if content.bank.name not in enabled_banks:
             next
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -255,8 +255,9 @@ def lookup(signal, signal_type_name):
     contents = storage.bank_content_get(results_by_content_id.keys())
     enabled_content = [c for c in contents if c.enabled]
     current_app.logger.debug(
-        "lookup matches %d content ids (%d enabled_content)", len(contents),
-        len(enabled_content)
+        "lookup matches %d content ids (%d enabled_content)",
+        len(contents),
+        len(enabled_content),
     )
     banks = {c.bank.name: c.bank for c in enabled_content}
     rand = random.Random(request.args.get("seed"))

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
@@ -42,7 +42,9 @@ def test_raw_hash_add_to_match_no_distance(app: Flask, client: FlaskClient):
     assert resp.json == {"TEST_BANK": [{"content_id": 16, "distance": "0"}]}
 
     # Test lookup with no match
-    resp = client.get(f"/m/lookup?signal_type=pdq&signal=5555555555555555555555555555555555555555555555555555555555555555")
+    resp = client.get(
+        "/m/lookup?signal_type=pdq&signal=5555555555555555555555555555555555555555555555555555555555555555"
+    )
     assert resp.status_code == 200
     assert resp.json == {}
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
@@ -37,9 +37,9 @@ def test_raw_hash_add_to_match_no_distance(app: Flask, client: FlaskClient):
     assert build_info["size"] == len(hashes)
 
     # Now match
-    resp = client.get(f"/m/raw_lookup?signal_type=pdq&signal={hashes[-1]}")
+    resp = client.get(f"/m/lookup?signal_type=pdq&signal={hashes[-1]}")
     assert resp.status_code == 200
-    assert resp.json == {"matches": [16]}
+    assert resp.json == {"TEST_BANK": [{"content_id": 16, "distance": "0"}]}
 
 
 def test_raw_hash_add_to_match_with_distance(app: Flask, client: FlaskClient):
@@ -67,7 +67,7 @@ def test_raw_hash_add_to_match_with_distance(app: Flask, client: FlaskClient):
 
     # Now match
     resp = client.get(
-        f"/m/raw_lookup?signal_type=pdq&include_distance=true&signal={hashes[-1]}"
+        f"/m/lookup?signal_type=pdq&include_distance=true&signal={hashes[-1]}"
     )
     assert resp.status_code == 200
-    assert resp.json == {"matches": [{"content_id": 16, "distance": "0"}]}
+    assert resp.json == {"TEST_BANK": [{"content_id": 16, "distance": "0"}]}

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
@@ -13,7 +13,7 @@ from OpenMediaMatch.background_tasks.build_index import build_all_indices
 from threatexchange.signal_type.pdq.signal import PdqSignal
 
 
-def test_raw_hash_add_to_match_no_distance(app: Flask, client: FlaskClient):
+def test_add_hashes_and_find_match(app: Flask, client: FlaskClient):
     bank_name = "TEST_BANK"
     create_bank(client, bank_name)
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
@@ -39,7 +39,7 @@ def test_add_hashes_and_find_match(app: Flask, client: FlaskClient):
     # Now match
     resp = client.get(f"/m/lookup?signal_type=pdq&signal={hashes[-1]}")
     assert resp.status_code == 200
-    assert resp.json == {"TEST_BANK": [{"content_id": 16, "distance": 0}]}
+    assert resp.json == {"TEST_BANK": [{"bank_content_id": 16, "distance": 0}]}
 
     # Test lookup with no match
     resp = client.get(

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
@@ -41,6 +41,11 @@ def test_raw_hash_add_to_match_no_distance(app: Flask, client: FlaskClient):
     assert resp.status_code == 200
     assert resp.json == {"TEST_BANK": [{"content_id": 16, "distance": "0"}]}
 
+    # Test lookup with no match
+    resp = client.get(f"/m/lookup?signal_type=pdq&signal=5555555555555555555555555555555555555555555555555555555555555555")
+    assert resp.status_code == 200
+    assert resp.json == {}
+
 
 def test_raw_hash_add_to_match_with_distance(app: Flask, client: FlaskClient):
     bank_name = "TEST_BANK"

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
@@ -47,34 +47,3 @@ def test_raw_hash_add_to_match_no_distance(app: Flask, client: FlaskClient):
     )
     assert resp.status_code == 200
     assert resp.json == {}
-
-
-def test_raw_hash_add_to_match_with_distance(app: Flask, client: FlaskClient):
-    bank_name = "TEST_BANK"
-    create_bank(client, bank_name)
-
-    # PDQ hashes
-    hashes = PdqSignal.get_examples()
-    for pdq in hashes:
-        resp = client.post(f"/c/bank/{bank_name}/signal", json={"pdq": pdq})
-        assert resp.status_code == 200
-
-    # No background tasks in the test, so let's trigger it manually
-    storage = get_storage()
-    build_all_indices(storage, storage, storage)
-
-    # Sanity check that the index is build
-    resp = client.get(f"/m/index/status?signal_type=pdq")
-    assert resp.status_code == 200
-    all_build_info = resp.json
-    assert "pdq" in all_build_info  # type: ignore
-    build_info = all_build_info["pdq"]  # type: ignore
-    assert build_info["present"] == True
-    assert build_info["size"] == len(hashes)
-
-    # Now match
-    resp = client.get(
-        f"/m/lookup?signal_type=pdq&include_distance=true&signal={hashes[-1]}"
-    )
-    assert resp.status_code == 200
-    assert resp.json == {"TEST_BANK": [{"content_id": 16, "distance": "0"}]}

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
@@ -39,7 +39,7 @@ def test_add_hashes_and_find_match(app: Flask, client: FlaskClient):
     # Now match
     resp = client.get(f"/m/lookup?signal_type=pdq&signal={hashes[-1]}")
     assert resp.status_code == 200
-    assert resp.json == {"TEST_BANK": [{"content_id": 16, "distance": "0"}]}
+    assert resp.json == {"TEST_BANK": [{"content_id": 16, "distance": 0}]}
 
     # Test lookup with no match
     resp = client.get(

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
@@ -43,7 +43,7 @@ def test_add_hashes_and_find_match(app: Flask, client: FlaskClient):
 
     # Test lookup with no match
     resp = client.get(
-        "/m/lookup?signal_type=pdq&signal=5555555555555555555555555555555555555555555555555555555555555555"
+        "/m/lookup?signal_type=pdq&signal={}".format("5" * 64)
     )
     assert resp.status_code == 200
     assert resp.json == {}


### PR DESCRIPTION
Summary
---------

This PR changes the API responses for the GET and POST `/m/lookup` APIs based on issue #1681. The motivation being - users of the API need to know the content IDs so that they can turn content IDs off if they're causing false positives. Also, callers may find it useful to log / analyze matching distance as well.

**API response before:** (API just returns list on bank names with matches)
```
["FOO_BANK"]
```

**API response w/this change:** (API returns a dict of bank names with matches + details about each match)
```
{
    "FOO_BANK": [
        {
            "content_id": 16,
            "distance": "13"
        }
    ]
}
```

Note: I modified tests that were calling `/raw_lookup` because there were no tests for the `/lookup` API. I also did that in part because I think we could remove `raw_lookup` once this is merged since the main benefit of that API to me was that it returned the content IDs.

@Dcallies I'm opening this as a draft because I couldn't figure out how to get `3P_exchange_type` and `3P_Records` from the issue. If it's not too hard to add, we can do it now. Otherwise, this is good enough to be valuable to me as-is.

Test Plan
---------

Unit tests + testing in my local HMA dev instance

Here's an example from my dev instance:
```shell
$ curl -s "http://localhost:5000/m/lookup?signal_type=pdq&signal=cccccccc33133333eccecccc33313333cccccccc33313333cce6cccc33933333" | jq
{
  "FOO_BANK": [
    {
      "content_id": 81842,
      "distance": 20
    },
    {
      "content_id": 82244,
      "distance": 10
    },
    {
      "content_id": 82519,
      "distance": 18
    },
    {
      "content_id": 82850,
      "distance": 18
    },
    {
      "content_id": 82870,
      "distance": 18
    },
    {
      "content_id": 82883,
      "distance": 24
    },
    {
      "content_id": 91618,
      "distance": 14
    }
  ]
}
```
