### PR TITLE
[py-tx] Implementation of IVF faiss indices in PDQ

### DIFF
--- a/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index2.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index2.py
@@ -178,3 +178,31 @@ def test_one_entry_sample_index():
 
     results = index.query(unmatching_test_hash)
     assert len(results) == 0
+
+
+def test_flat_index_selection():
+    """Test flat index selection for small datasets"""
+    get_random_hashes = _get_hash_generator()
+    base_hashes = get_random_hashes(100)
+    index = PDQIndex2.build([(h, i) for i, h in enumerate(base_hashes)])
+    assert isinstance(index._index.faiss_index, faiss.IndexFlatL2)
+
+
+def test_ivf_index_selection():
+    """Test IVF index selection for large datasets"""
+    get_random_hashes = _get_hash_generator()
+    base_hashes = get_random_hashes(2000)
+    index = PDQIndex2.build([(h, i) for i, h in enumerate(base_hashes)])
+    assert isinstance(index._index.faiss_index, faiss.IndexIVFFlat)
+
+
+def test_build_method():
+    """Test build method creates valid index"""
+    get_random_hashes = _get_hash_generator()
+    base_hashes = get_random_hashes(500)
+    index = PDQIndex2.build([(h, i) for i, h in enumerate(base_hashes)])
+
+    query_hash = base_hashes[0]
+    results = index.query(query_hash)
+    assert len(results) >= 1
+    assert any(r.metadata == 0 for r in results)


### PR DESCRIPTION
Summary
---------

PDQ now using IVF Faiss for better scalability (as we move away from the old imp)

- Adds PDQSignalTypeIndex2 that automatically switches between flat and IVF indices based on dataset size
- Uses IVF-Faiss for datasets >= 1000 entries (as you said), flat index for less than
- Maintains backward compatibility with existing PDQIndex
- Updates signal.py to use the new index implementation as default (if we're not swapping yet, I'll change it back)

https://github.com/facebook/ThreatExchange/issues/1613

Test Plan
---------

Run the tests....

`python3 -m pytest threatexchange/signal_type/tests/test_pdq_signal_type_index2.py -v -W ignore::DeprecationWarning`

Passes.. ?
