### PR TITLE
[pdq] Fix pdq CI failure caused by ubuntu-latest 22.04 --> 24.04 update

### DIFF
--- a/.github/workflows/pdq-ci-cpp.yml
+++ b/.github/workflows/pdq-ci-cpp.yml
@@ -21,8 +21,15 @@ defaults:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: ["ubuntu-22.04", "ubuntu-latest"]
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y imagemagick
       - name: make
         run: make

--- a/pdq/cpp/hashing/pdqhashing.cpp
+++ b/pdq/cpp/hashing/pdqhashing.cpp
@@ -43,7 +43,7 @@ auto const dct_matrix_64 = [] {
   const size_t num_rows = 16;
   const size_t num_cols = 64;
   const float matrix_scale_factor = std::sqrt(2.0 / double{num_cols});
-
+  // some file change to cause the build to run
   std::array<float, (num_rows * num_cols)> dct_matrix;
   for (size_t i = 0; i < num_rows; i++) {
     for (size_t j = 0; j < num_cols; j++) {

--- a/pdq/cpp/hashing/pdqhashing.cpp
+++ b/pdq/cpp/hashing/pdqhashing.cpp
@@ -43,7 +43,7 @@ auto const dct_matrix_64 = [] {
   const size_t num_rows = 16;
   const size_t num_cols = 64;
   const float matrix_scale_factor = std::sqrt(2.0 / double{num_cols});
-  // some file change to cause the build to run
+
   std::array<float, (num_rows * num_cols)> dct_matrix;
   for (size_t i = 0; i < num_rows; i++) {
     for (size_t j = 0; j < num_cols; j++) {


### PR DESCRIPTION
Summary
---------

Fix pdq CI test failure on Ubuntu 24.04 (#1757 for pdq only)

`imagemagick` isn't installed by Ubuntu 24.04 by default anymore, and it's a runtime dependency of CImg for decoding images. Installing it fixes the issue.

### Changes

- Install `imagemagick` before building pdq
  - This is the ONLY required change to get the build working.

- Added multiple OS profiles to the CI to make it easier to spot a failure caused by OS differences in the future.
  - The only thing I had to debug this issue with was this runtime message: ` [CImg] *** CImgIOException *** [instance(0,0,0,0,(nil),non-shared)] CImg<unsigned char>::load(): Failed to recognize format of file './reg_test/../../data/reg-test-input/dih/bridge-1-original.jpg'.` It would have been very helpful to be able to see the failure was only occurring on one profile but not the other.

- Updated `checkout` action from v2 to v4

Test Plan
---------

CI should fail without the changes (first commit).

After the changes, CI should pass on both 22.04 and 24.04.
