### PR TITLE
[hma] Align lookup APIs, fix more bugs

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -253,7 +253,6 @@ def lookup_get() -> t.Union[TMatchByBank, TBankMatchBySignalType]:
     else:
         signal = require_request_param("signal")
         signal_type = require_request_param("signal_type")
-        # Don't
         return lookup(signal, signal_type)
 
     selected_st = request.args.get("signal_type")

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_e2e_workflow.py
@@ -39,7 +39,7 @@ def test_add_hashes_and_find_match(app: Flask, client: FlaskClient):
     # Now match
     resp = client.get(f"/m/lookup?signal_type=pdq&signal={hashes[-1]}")
     assert resp.status_code == 200
-    assert resp.json == {"TEST_BANK": [{"bank_content_id": 16, "distance": 0}]}
+    assert resp.json == {"TEST_BANK": [{"bank_content_id": 16, "distance": "0"}]}
 
     # Test lookup with no match
     resp = client.get("/m/lookup?signal_type=pdq&signal={}".format("5" * 64))

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_match_api.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_match_api.py
@@ -1,14 +1,18 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import pytest
+import typing as t
 
+import pytest
 from flask.testing import FlaskClient
 
+from threatexchange.signal_type.pdq.signal import PdqSignal
+from threatexchange.signal_type.md5 import VideoMD5Signal
 from threatexchange.exchanges.impl.static_sample import StaticSampleSignalExchangeAPI
 
 from OpenMediaMatch.tests.utils import app
 
 from OpenMediaMatch.background_tasks import fetcher, build_index
+from OpenMediaMatch.blueprints.matching import TMatchByBank
 from OpenMediaMatch.persistence import get_storage
 from OpenMediaMatch.storage import interface as iface
 
@@ -39,6 +43,10 @@ def test_raw_lookups(client_with_sample_data: FlaskClient):
     client = client_with_sample_data
 
     storage = get_storage()
+    assert set(storage.get_signal_type_configs()) == {
+        PdqSignal.get_name(),
+        VideoMD5Signal.get_name(),
+    }
     for sig_name, signal_cfg in storage.get_signal_type_configs().items():
         assert signal_cfg.enabled
 
@@ -60,5 +68,35 @@ def test_raw_lookups(client_with_sample_data: FlaskClient):
         assert len(with_dist_matches) == match_count
 
         for match in with_dist_matches:
-            assert "content_id" in match
+            assert "bank_content_id" in match
+            assert "distance" in match
+
+
+def test_lookups(client_with_sample_data: FlaskClient):
+    client = client_with_sample_data
+
+    storage = get_storage()
+    # sanity check
+    assert set(storage.get_signal_type_configs()) == {
+        PdqSignal.get_name(),
+        VideoMD5Signal.get_name(),
+    }
+    for sig_name, signal_cfg in storage.get_signal_type_configs().items():
+        assert signal_cfg.enabled
+
+        # For each type, just lookup one signal
+        sig_str = signal_cfg.signal_type.get_examples()[0]
+
+        query_str = {"signal": sig_str, "signal_type": sig_name}
+
+        resp = client.get("/m/lookup", query_string=query_str)
+        assert resp.status_code == 200
+        resp_json = t.cast(TMatchByBank, resp.json)
+        assert len(resp_json) == 1
+        assert "SAMPLE" in resp_json
+        with_dist_matches = resp_json["SAMPLE"]
+        assert len(with_dist_matches) > 0
+
+        for match in with_dist_matches:
+            assert "bank_content_id" in match
             assert "distance" in match


### PR DESCRIPTION
Summary
---------

In #1767, I attempted to fix #1766, but missed the actual APIs in the stacktrace because I am a hack and a fraud.

Add regression tests for /lookup as well.

As part of fixing this, I added some missing type annotations, which caught a few other bugs. I also chose to align all the APIs to the same shapes, which of course will be backwards incompatible, but I don't think current users are relying on the ones I changed being 100% stable at the moment. 

Test Plan
---------

Regression tests, will ask @prenner if it really works this time. 
