### PR TITLE
added missing created_on field to TAT API

### DIFF
--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
@@ -3,6 +3,7 @@
 """Simple implementation for the Tech Against Terrorism Hash List REST API"""
 
 from dataclasses import dataclass
+import datetime
 from enum import Enum
 import requests
 import logging
@@ -32,6 +33,7 @@ class TATHashListEntry:
     file_type: str
     deleted: bool
     updated_on: float
+    created_on: datetime
     id: int
 
 

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
@@ -19,6 +19,7 @@ mock_hashes: t.List[TATHashListEntry] = [
         file_type="mp4",
         deleted=False,
         updated_on=1704901040.222779,
+        created_on='2025-03-03 23:05:22,587',
         id=2819,
     ),
     TATHashListEntry(
@@ -28,6 +29,7 @@ mock_hashes: t.List[TATHashListEntry] = [
         file_type="mp4",
         deleted=False,
         updated_on=1704901040.24492,
+        created_on='2025-03-03 23:05:22,587',
         id=2820,
     ),
     TATHashListEntry(
@@ -37,6 +39,7 @@ mock_hashes: t.List[TATHashListEntry] = [
         file_type="gif",
         deleted=False,
         updated_on=1704901040.25555,
+        created_on='2025-03-03 23:05:22,587',
         id=2821,
     ),
 ]

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
@@ -19,7 +19,7 @@ mock_hashes: t.List[TATHashListEntry] = [
         file_type="mp4",
         deleted=False,
         updated_on=1704901040.222779,
-        created_on='2025-03-03 23:05:22,587',
+        created_on="2025-03-03 23:05:22,587",
         id=2819,
     ),
     TATHashListEntry(
@@ -29,7 +29,7 @@ mock_hashes: t.List[TATHashListEntry] = [
         file_type="mp4",
         deleted=False,
         updated_on=1704901040.24492,
-        created_on='2025-03-03 23:05:22,587',
+        created_on="2025-03-03 23:05:22,587",
         id=2820,
     ),
     TATHashListEntry(
@@ -39,7 +39,7 @@ mock_hashes: t.List[TATHashListEntry] = [
         file_type="gif",
         deleted=False,
         updated_on=1704901040.25555,
-        created_on='2025-03-03 23:05:22,587',
+        created_on="2025-03-03 23:05:22,587",
         id=2821,
     ),
 ]


### PR DESCRIPTION
Summary
---------

Added the missing created on field to the `TATHashListEntry` in `techagainstterrorism/api.py`

Test Plan
---------

Manual:
`tx fetch` should now successfully run

Auto
`pytest`
