### PR TITLE
[CI] Fix PyPi Publishing

### DIFF
--- a/.github/workflows/python-threatexchange-release.yaml
+++ b/.github/workflows/python-threatexchange-release.yaml
@@ -24,11 +24,11 @@ jobs:
       - name: Install packaging dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools
+          pip install build hatchling hatch-fancy-pypi-readme
           pip install -e ".[package]"
       - name: Package threatexchange
         run: |
-          python ./setup.py sdist bdist_wheel
+          python -m build
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Summary
---------

I broke PyPi publishing when changing to pyproject.toml...

I can build the wheel locally, so hoping there's no problems

```
python -m build
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - hatch-fancy-pypi-readme
  - hatchling
* Getting build dependencies for sdist...
* Building sdist...
* Building wheel from sdist
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - hatch-fancy-pypi-readme
  - hatchling
* Getting build dependencies for wheel...
* Building wheel...
Successfully built threatexchange-1.2.7.tar.gz and threatexchange-1.2.7-py3-none-any.whl
```

Test Plan
---------
Ran build locally
