### PR TITLE
DESCRIPTION.rst => into `pyproject.toml` file

### DIFF
--- a/python-threatexchange/DESCRIPTION.rst
+++ b/python-threatexchange/DESCRIPTION.rst
@@ -1,1 +1,0 @@
-threatexchange is a Python Library and CLI tool for interfacing with Facebook's ThreatExchange.

--- a/python-threatexchange/pyproject.toml
+++ b/python-threatexchange/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "threatexchange"
 dynamic = ["version"]
-description = "DESCRIPTION.rst"
+description = "threatexchange is a Python Library and CLI tool for interfacing with Facebook's ThreatExchange."
 readme = "README.md"
 license = { text = "BSD" }
 authors = [


### PR DESCRIPTION
Summary
---------
<img width="1009" alt="Screenshot 2025-03-11 at 2 05 04 PM" src="https://github.com/user-attachments/assets/72d697a9-2d08-4718-9e49-24d2945d9777" />

Apparently, we can't handle `DESCRIPTION.rst`... so I think it's easier just to put it in the toml file directly.


Test Plan
---------

Yeah
