### PR TITLE
[hma] Auto-select input type on bank add

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/add_to_bank_form.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/add_to_bank_form.html.j2
@@ -1,7 +1,7 @@
 {# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <button type="button" class="btn btn-light" data-bs-toggle="modal" data-bs-target="#{{bank_title}}">Add content</button>
 <!-- Modal -->
-<div class="modal fade" id="{{bank_title}}" tabindex="-1">
+<div class="modal fade" id="add-content-modal-{{bank_title}}" tabindex="-1">
     <div class="modal-dialog modal-dialog-centered modal-xl" style="width: 60%; max-width: none;">
         <div class="modal-content modal-xl" style="padding: 20px">
             <form id="add_content_to_bank_{{ bank_title }}">
@@ -12,7 +12,8 @@
                 <div class="modal-body">
                     <div class="row">
                         <div class="col">
-                            <select id="bank-add-content-type" class="form-select" name="content_type" required>
+                            <select id="bank-add-content-type-{{ bank_title }}" class="form-select" name="content_type"
+                                required>
                                 <option selected disabled value="">Select content type</option>
                                 {% for c in content %}
                                 {% if c['enabled'] %}
@@ -22,22 +23,9 @@
                             </select>
                         </div>
                         <div class="col">
-                            <input id="bank-add-file-input" class="form-control" type="file" name="file" required>
+                            <input id="bank-add-file-input-{{ bank_title }}" class="form-control" type="file"
+                                name="file" required>
                         </div>
-                        <script>
-                            const contentTypeSelect = document.getElementById('bank-add-content-type');
-                            const fileInput = document.getElementById('bank-add-file-input');
-                            contentTypeSelect.addEventListener('change', (e) => {
-                                // Special case selections for our well known types
-                                if (e.target.value === 'photo') {
-                                    fileInput.accept = "image/*";
-                                } else if (e.target.value === 'video') {
-                                    fileInput.accept = "video/*";
-                                } else {
-                                    fileInput.accept = "file";
-                                }
-                            });
-                        </script>
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -50,6 +38,3 @@
         </div>
     </div>
 </div>
-<script>
-
-</script>

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/add_to_bank_form.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/add_to_bank_form.html.j2
@@ -7,20 +7,38 @@
             <form id="add_content_to_bank_{{ bank_title }}">
                 <div class="modal-header">
                     <h1 class="modal-title fs-5">Add Content: {{ bank_title }}</h1>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button> 
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                        <div class="row" style="width: 80%">
-                                <input class="form-control" type="file" name="file" required  style="margin-bottom: 20px">
-                                <select class="form-select" name="content_type" required>
-                                    <option selected disabled value="">Select content type</option>
-                                    {% for c in content %}
-                                        {% if c['enabled'] %}
-                                            <option value="{{c['name']}}">{{c['name'].capitalize()}}</option>
-                                        {% endif %}
-                                    {% endfor %}
-                                </select>
+                    <div class="row">
+                        <div class="col">
+                            <select id="bank-add-content-type" class="form-select" name="content_type" required>
+                                <option selected disabled value="">Select content type</option>
+                                {% for c in content %}
+                                {% if c['enabled'] %}
+                                <option value="{{c['name']}}">{{c['name'].capitalize()}}</option>
+                                {% endif %}
+                                {% endfor %}
+                            </select>
                         </div>
+                        <div class="col">
+                            <input id="bank-add-file-input" class="form-control" type="file" name="file" required>
+                        </div>
+                        <script>
+                            const contentTypeSelect = document.getElementById('bank-add-content-type');
+                            const fileInput = document.getElementById('bank-add-file-input');
+                            contentTypeSelect.addEventListener('change', (e) => {
+                                // Special case selections for our well known types
+                                if (e.target.value === 'photo') {
+                                    fileInput.accept = "image/*";
+                                } else if (e.target.value === 'video') {
+                                    fileInput.accept = "video/*";
+                                } else {
+                                    fileInput.accept = "file";
+                                }
+                            });
+                        </script>
+                    </div>
                 </div>
                 <div class="modal-footer">
                     <button type="submit" class="btn btn-success">Add</button>

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/add_to_bank_form.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/add_to_bank_form.html.j2
@@ -1,5 +1,6 @@
 {# Copyright (c) Meta Platforms, Inc. and affiliates. #}
-<button type="button" class="btn btn-light" data-bs-toggle="modal" data-bs-target="#{{bank_title}}">Add content</button>
+<button type="button" class="btn btn-light" data-bs-toggle="modal"
+    data-bs-target="#add-content-modal-{{bank_title}}">Add content</button>
 <!-- Modal -->
 <div class="modal fade" id="add-content-modal-{{bank_title}}" tabindex="-1">
     <div class="modal-dialog modal-dialog-centered modal-xl" style="width: 60%; max-width: none;">

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/banks_grid.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/banks_grid.html.j2
@@ -19,34 +19,34 @@
             </tr>
         </thead>
         <tbody>
-        {% for bank in bankList %}
+            {% for bank in bankList %}
             <tr id="bank_item_{{bank['name']}}">
                 <th scope="row" style="background-color: transparent;">{{ loop.index }}</th>
                 <td style="background-color: transparent;">{{ bank['name'] }}</td>
                 <td style="background-color: transparent;">{{ bank['matching_enabled_ratio'] }}</td>
                 <td style="background-color: transparent;">
                     {% with bank_title=bank['name'] %}
-                        {% include 'components/banks/add_to_bank_form.html.j2' %}
+                    {% include 'components/banks/add_to_bank_form.html.j2' %}
                     {% endwith %}
                 </td>
             </tr>
-        {% endfor %}
+            {% endfor %}
         </tbody>
-        
+
     </table>
 </div>
 <script>
     const banksData = [
         {% for bank in bankList %}
-        {
-            name: "{{ bank.name|e }}"
-        }{% if not loop.last %},{% endif %}
-        {% endfor %}
+    {
+        name: "{{ bank.name|e }}"
+    } {% if not loop.last %}, {% endif %}
+    {% endfor %}
     ];
 
-    banksData.forEach(function(bank) {
-        const bankTitle=bank.name;
-        const addContentModal = document.getElementById(bankTitle);
+    banksData.forEach(function (bank) {
+        const bankTitle = bank.name;
+        const addContentModal = document.getElementById("add-content-modal-" + bankTitle);
         const addContentToBankForm = document.getElementById("add_content_to_bank_" + bankTitle);
         const formContent = addContentToBankForm.innerHTML;
         addContentToBankForm.addEventListener("submit", (event) => {
@@ -70,9 +70,24 @@
                 });
         })
 
+        // add file type listener
+        addContentModal.addEventListener('shown.bs.modal', function () {
+            const fileInput = document.getElementById('bank-add-file-input-' + bankTitle);
+            document.addEventListener('change', (e) => {
+                if (e.target.id === 'bank-add-content-type-' + bankTitle) {
+                    // Special case selections for our well known types
+                    if (e.target.value === 'photo') {
+                        fileInput.accept = "image/*";
+                    } else if (e.target.value === 'video') {
+                        fileInput.accept = "video/*";
+                    } else {
+                        fileInput.accept = "file";
+                    }
+                }
+            });
+        });
 
-
-        // reset modal innerHTML
+        // reset modal innerHTML on close
         addContentModal.addEventListener('hidden.bs.modal', function () {
             addContentToBankForm.innerHTML = formContent;
         });
@@ -82,40 +97,40 @@
             const hashTable = HashTable(result);
 
             // render on HTML
-            addContentToBankForm.innerHTML =  hashTable;
+            addContentToBankForm.innerHTML = hashTable;
         }
 
         const HashTable = (result) => {
             return `
-                        <div class="modal-header">
-                            <h3 class="text-success">Success!</h3>
-                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button> 
-                        </div>
-                        <div class="modal-body">
-                            <h4>Added Hashes:</h4>
-                            <p>Content ID: ${result.id}</p>
-                            <h4>Hash Values:</h4>
-                            <table class="table table-hover" =>
-                                <thead>
-                                    <tr>
-                                        <th>Key</th>
-                                        <th>Value</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    ${Object.entries(result.signals).map(([key, value]) => `
-                                        <tr>
-                                            <td>${key}</td>
-                                            <td style="overflow: scroll; max-width: 200px; white-space: no-wrap;">${value}</td>
-                                        </tr>
-                                    `).join('')}
-                                </tbody>
-                            
-                            </table>
-                        </div>
-                    `;
+<div class="modal-header">
+    <h3 class="text-success">Success!</h3>
+    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<div class="modal-body">
+    <h4>Added Hashes:</h4>
+    <p>Content ID: ${result.id}</p>
+    <h4>Hash Values:</h4>
+    <table class="table table-hover"=>
+        <thead>
+            <tr>
+                <th>Key</th>
+                <th>Value</th>
+            </tr>
+        </thead>
+        <tbody>
+            ${Object.entries(result.signals).map(([key, value]) => `
+            <tr>
+                <td>${key}</td>
+                <td style="overflow: scroll; max-width: 200px; white-space: no-wrap;">${value}</td>
+            </tr>
+            `).join('')}
+        </tbody>
+
+    </table>
+</div>
+`;
         }
 
-  });
-    
+    });
+
 </script>


### PR DESCRIPTION
Summary
---------

Reported in #1799

I think this generalizes pretty well any place we have a selector, but will leave creating a standard js function to a followup.

Also does a tiny bit of restyling on this form to use more of the bootstrap classes: https://getbootstrap.com/docs/4.0/components/forms/

Test Plan
---------

# Before
![image](https://github.com/user-attachments/assets/ab51ed28-d530-4023-9bb7-ba7f34399f1a)


# After
## No content selected
![image](https://github.com/user-attachments/assets/d87437a3-3856-44ac-bc5c-5587ef8848f4)

All files are available because content type is not selected
![image](https://github.com/user-attachments/assets/0d50f807-b224-4a89-8ed8-2978a7260a83)

(if we wanted to be comprehensive, we could disable this while type was unselected)

## Select Photo
![image](https://github.com/user-attachments/assets/898b6c0b-cf79-4917-b317-d7041cfab675)



## Select Video
![image](https://github.com/user-attachments/assets/d02b4b57-2b92-4255-80a2-347049b6356b)

