### PR TITLE
Add DotNet PDQ implementation

### DIFF
--- a/pdq/README.md
+++ b/pdq/README.md
@@ -13,6 +13,7 @@ See also the [Meta Newsroom Post](https://newsroom.fb.com/news/2019/08/open-sour
 As of November 2018 there are C++, PHP, and Java implementations.  Details are in the `*/README.md` files.
 
 ## Other Bindings and Implementations
+* C# / DotNet: [crispthinking/pdqhash](https://github.com/crispthinking/PdqHash)
 * Python: [faustomorales/pdqhash-python](https://github.com/faustomorales/pdqhash-python)
 * Rust: [darwinium-com/pdqhash](https://github.com/darwinium-com/pdqhash) - a great visualization of the algorithm also lives here.
 


### PR DESCRIPTION
Summary
---------

Hi there 👋 

We've recently open-sourced our .NET implementation of PDQ hashing, which is a port of the python implementations that exist and wanted to make it discoverable for others.

We've got some compliance tests in our pipeline that validate images that are hashed by ThreatExchange get the same PDQ hash: (We actually have a zero distance tolerance currently:)
https://github.com/crispthinking/PdqHash/blob/main/test/PdqHash.Tests/Compliance/ThreatExchangeComplianceTests.cs#L10C5-L10C50

We run the threatexchange CLI to hash the images and compare those PDQs to the PDQs we generate.

Here's an example of a test run from our main pipeline:
(https://github.com/crispthinking/PdqHash/runs/38672833269#r0s3)
