### PR TITLE
Add UI_ENABLED config variable for HMA

### DIFF
--- a/hasher-matcher-actioner/reference_omm_configs/development_omm_config.py
+++ b/hasher-matcher-actioner/reference_omm_configs/development_omm_config.py
@@ -35,6 +35,7 @@ PRODUCTION = False
 ROLE_HASHER = True
 ROLE_MATCHER = True
 ROLE_CURATOR = True
+UI_ENABLED = True
 # APScheduler (background threads for development)
 TASK_FETCHER = True
 TASK_INDEXER = True

--- a/hasher-matcher-actioner/reference_omm_configs/scaled_deployment_curator_omm_config.py
+++ b/hasher-matcher-actioner/reference_omm_configs/scaled_deployment_curator_omm_config.py
@@ -20,3 +20,4 @@ DATABASE_URI = f"postgresql+psycopg2://{DBUSER}:{DBPASS}@{DBHOST}/{DBNAME}"
 # Role configuration
 PRODUCTION = True
 ROLE_CURATOR = True
+UI_ENABLED = True

--- a/hasher-matcher-actioner/src/OpenMediaMatch/app.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/app.py
@@ -149,17 +149,15 @@ def create_app() -> flask.Flask:
 
         storage.init_flask(app)
 
-        is_production = app.config.get("PRODUCTION", True)
+        is_ui_enabled = app.config.get("UI_ENABLED", False)
         # Register Flask blueprints for whichever server roles are enabled...
         # URL prefixing facilitates easy Layer 7 routing :)
 
-        if (
-            not is_production
-            and app.config.get("ROLE_HASHER", False)
-            and app.config.get("ROLE_MATCHER", False)
-        ):
-            app.register_blueprint(development.bp, url_prefix="/dev")
+        if is_ui_enabled:
             app.register_blueprint(ui.bp, url_prefix="/ui")
+
+        if not app.config.get("PRODUCTION", False):
+            app.register_blueprint(development.bp, url_prefix="/dev")
 
         if app.config.get("ROLE_HASHER", False):
             app.register_blueprint(hashing.bp, url_prefix="/h")
@@ -174,7 +172,7 @@ def create_app() -> flask.Flask:
 
     @app.route("/")
     def home():
-        dst = "status" if is_production else "ui"
+        dst = "status" if is_ui_enabled else "ui"
         return flask.redirect(f"/{dst}")
 
     @app.route("/status")

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/ui.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/ui.py
@@ -116,7 +116,7 @@ def home():
         "signal": curation.get_all_signal_types(),
         "content": curation.get_all_content_types(),
         "exchange_apis": _api_cls_info(),
-        "production": current_app.config.get("PRODUCTION", True),
+        "production": current_app.config.get("PRODUCTION", False),
         "index": _index_info(),
         "collabs": _collab_info(),
         "is_banks_seeded": contains_seed_bank_0 and contains_seed_bank_1,


### PR DESCRIPTION
Summary
---------

Add UI_ENABLED config variable.

This allows users to enable the UI in production environments by setting UI_ENABLED to True in their OMM config. I modified the code to split the logic for handling when it's a production environment and handling when the UI is enabled.

* PRODUCTION now defaults to False
* UI_ENABLED defaults to False

Test Plan
---------

Unit tests. I also verified the dev-specific buttons on the homepage don't show when it's not production.