### PR TITLE
[tmk] Fix build on Linux with latest FAISS

### DIFF
--- a/tmk/cpp/Makefile
+++ b/tmk/cpp/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Windows_NT)
   OMP_LIB=-lgomp
 else
   CC_IF_WIN=$(CXX) -O2 -std=c++14 -I../.. 
-  OMP_LIB=-lomp
+  OMP_LIB=-lgomp
 endif
 
 # ----------------------------------------------------------------

--- a/tmk/cpp/bin/tmk-query-with-faiss.cpp
+++ b/tmk/cpp/bin/tmk-query-with-faiss.cpp
@@ -7,7 +7,7 @@ java TETagQuery tag-to-details --page-size 10 --hash-dir ./tetmk
 media_type_long_hash_video
 
 g++ \
-  -Xpreprocessor -fopenmp -lomp \
+  -Xpreprocessor -fopenmp -lgomp \
     -O2 -std=c++14 \
     -I. -I./tmk -I./pdq -I../../faiss \
     tmk/bin/tmk-query-with-faiss.cpp \
@@ -340,7 +340,7 @@ int main(int argc, char** argv) {
     printf("Searching for the %d nearest neighbors\n", k);
   }
 
-  std::vector<faiss::Index::idx_t> nearest_neighbor_indices(k * num_queries);
+  std::vector<faiss::idx_t> nearest_neighbor_indices(k * num_queries);
   std::vector<float> nearest_neighbor_distances(k * num_queries);
 
   faiss_index.search(


### PR DESCRIPTION
Summary
---------

Fixes broken build of tmk-query-with-faiss on Linux systems with the latest version of FAISS.

Test Plan
---------

Tested on Ubuntu 22.04 with GCC 12. Should work with default GCC 11 too.

1. Built FAISS from sources (took latest commit in the FAISS repo).
2. Built "parallel" TMK version `make parallel`. 
