### PR TITLE
Update TAT API base URL

### DIFF
--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/api.py
@@ -70,7 +70,7 @@ class TATHashListAPI:
     For our Hash List documentation: https://terrorismanalytics.org/docs/hash-list-v1
     """
 
-    BASE_URL: t.ClassVar[str] = "https://beta.terrorismanalytics.org/"
+    BASE_URL: t.ClassVar[str] = "https://app.terrorismanalytics.org/"
 
     def __init__(self, username: str, password: str) -> None:
         self.username = username


### PR DESCRIPTION
Summary
---------

We received an update from Tech Against Terrorism that they are changing the subdomain of their API:

<img width="839" alt="image" src="https://github.com/user-attachments/assets/24ef0ee0-d27f-4a70-ba77-94738fb209e6" />


Test Plan
---------

I verified their server responds when I `curl` it using the new subdomain, so I'm pretty confident this will work.