### PR TITLE
[HMA] Add Cache to banks to keep Content Type Counts

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/background_tasks/build_index.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/background_tasks/build_index.py
@@ -61,9 +61,14 @@ def build_index(
     # First check to see if new signals have appeared since the last build
     idx_checkpoint = index_store.get_last_index_build_checkpoint(for_signal_type)
     bank_checkpoint = bank_store.get_current_index_build_target(for_signal_type)
-    if idx_checkpoint == bank_checkpoint:
+    if idx_checkpoint is None:
+        # No index exists yet, we need to build one
+        logger.info("No index found for %s, building new index", for_signal_type.get_name())
+    elif (idx_checkpoint.last_item_timestamp == bank_checkpoint.last_item_timestamp and 
+          idx_checkpoint.last_item_id == bank_checkpoint.last_item_id):
         logger.info("%s index up to date, no build needed", for_signal_type.get_name())
         return
+    
     logger.info(
         "Building index for %s (%d signals)",
         for_signal_type.get_name(),
@@ -72,25 +77,39 @@ def build_index(
     index_cls = for_signal_type.get_index_cls()
     signal_list = []
     last_cs = None
-    content_type_counts = {}
+    bank_content_counts: dict[str, dict[str, int]] = {}  # bank_name -> {content_type -> count}
+    seen_signals = set()  # Track seen signals to avoid duplicates
     
-    # Get the bank name from the first item to update counts later
+    # Get the first item to start processing
     first_item = next(bank_store.bank_yield_content(for_signal_type), None)
     if first_item is None:
         logger.info("No content found for signal type %s", for_signal_type.get_name())
         return
         
-    bank_name = first_item.bank_name
-    signal_list.append((first_item.signal_val, first_item.bank_content_id))
-    content_type_counts[first_item.signal_type_name] = content_type_counts.get(first_item.signal_type_name, 0) + 1
+    signal_tuple = (first_item.signal_val, first_item.bank_content_id)
+    if signal_tuple not in seen_signals:
+        signal_list.append(signal_tuple)
+        seen_signals.add(signal_tuple)
+
+    # Get the bank for this content
+    bank = bank_store.get_bank(first_item.bank_name)
+    if bank:
+        if bank.name not in bank_content_counts:
+            bank_content_counts[bank.name] = {}
+        bank_content_counts[bank.name][first_item.signal_type_name] = bank_content_counts[bank.name].get(first_item.signal_type_name, 0) + 1
     
     # Process remaining items
     for last_cs in bank_store.bank_yield_content(for_signal_type):
-        tuple = (last_cs.signal_val, last_cs.bank_content_id)
-        signal_list.append(tuple)
-        # Update content type counts
-        content_type = last_cs.signal_type_name
-        content_type_counts[content_type] = content_type_counts.get(content_type, 0) + 1
+        signal_tuple = (last_cs.signal_val, last_cs.bank_content_id)
+        if signal_tuple not in seen_signals:
+            signal_list.append(signal_tuple)
+            seen_signals.add(signal_tuple)
+            # Update content type counts for the bank
+            bank = bank_store.get_bank(last_cs.bank_name)
+            if bank:
+                if bank.name not in bank_content_counts:
+                    bank_content_counts[bank.name] = {}
+                bank_content_counts[bank.name][last_cs.signal_type_name] = bank_content_counts[bank.name].get(last_cs.signal_type_name, 0) + 1
     
     built_index = index_cls.build(signal_list)
     checkpoint = SignalTypeIndexBuildCheckpoint.get_empty()
@@ -101,20 +120,22 @@ def build_index(
             total_hash_count=len(signal_list),
         )
     
-    # Update content type counts in the bank
-    if content_type_counts:
-        bank = bank_store._get_bank(bank_name)
+    # Update content type counts in each bank
+    for bank_name, counts in bank_content_counts.items():
+        bank = bank_store.get_bank(bank_name)
+        logger.info("Updating bank %s with counts %s", bank_name, counts)
         if bank:
             # Merge with existing counts if any
             existing_counts = bank.content_type_counts or {}
-            merged_counts = {**existing_counts, **content_type_counts}
+            merged_counts = {**existing_counts, **counts}
+            # Update the bank with new counts
             bank.content_type_counts = merged_counts
-            bank_store.db.session.commit()
+            bank_store.bank_update(bank)
     
+    index_store.store_signal_type_index(for_signal_type, built_index, checkpoint)
     logger.info(
-        "Indexed %d signals for %s - %s",
-        len(signal_list),
+        "Built index for %s in %s with %d content types",
         for_signal_type.get_name(),
         duration_to_human_str(int(time.time() - start)),
+        len(bank_content_counts),
     )
-    index_store.store_signal_type_index(for_signal_type, built_index, checkpoint)

--- a/hasher-matcher-actioner/src/OpenMediaMatch/background_tasks/build_index.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/background_tasks/build_index.py
@@ -72,9 +72,26 @@ def build_index(
     index_cls = for_signal_type.get_index_cls()
     signal_list = []
     last_cs = None
+    content_type_counts = {}
+    
+    # Get the bank name from the first item to update counts later
+    first_item = next(bank_store.bank_yield_content(for_signal_type), None)
+    if first_item is None:
+        logger.info("No content found for signal type %s", for_signal_type.get_name())
+        return
+        
+    bank_name = first_item.bank_name
+    signal_list.append((first_item.signal_val, first_item.bank_content_id))
+    content_type_counts[first_item.signal_type_name] = content_type_counts.get(first_item.signal_type_name, 0) + 1
+    
+    # Process remaining items
     for last_cs in bank_store.bank_yield_content(for_signal_type):
         tuple = (last_cs.signal_val, last_cs.bank_content_id)
         signal_list.append(tuple)
+        # Update content type counts
+        content_type = last_cs.signal_type_name
+        content_type_counts[content_type] = content_type_counts.get(content_type, 0) + 1
+    
     built_index = index_cls.build(signal_list)
     checkpoint = SignalTypeIndexBuildCheckpoint.get_empty()
     if last_cs is not None:
@@ -83,6 +100,17 @@ def build_index(
             last_item_id=last_cs.bank_content_id,
             total_hash_count=len(signal_list),
         )
+    
+    # Update content type counts in the bank
+    if content_type_counts:
+        bank = bank_store._get_bank(bank_name)
+        if bank:
+            # Merge with existing counts if any
+            existing_counts = bank.content_type_counts or {}
+            merged_counts = {**existing_counts, **content_type_counts}
+            bank.content_type_counts = merged_counts
+            bank_store.db.session.commit()
+    
     logger.info(
         "Indexed %d signals for %s - %s",
         len(signal_list),

--- a/hasher-matcher-actioner/src/OpenMediaMatch/migrations/versions/add_content_type_counts.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/migrations/versions/add_content_type_counts.py
@@ -1,0 +1,23 @@
+"""add content type counts
+
+Revision ID: add_content_type_counts
+Revises: 21cb8a3df884
+Create Date: 2025-04-24 10:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'add_content_type_counts'
+down_revision = '21cb8a3df884'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('bank', sa.Column('content_type_counts', postgresql.JSONB(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('bank', 'content_type_counts') 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/interface.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/interface.py
@@ -296,6 +296,8 @@ class BankConfig:
     # 0.0-1.0 - what percentage of contents should be
     # considered a match? Seeded by target content
     matching_enabled_ratio: float
+    # Cache of content type counts
+    content_type_counts: t.Optional[t.Dict[str, int]] = None
 
     @property
     def enabled(self) -> bool:

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/interface.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/interface.py
@@ -351,6 +351,7 @@ class BankContentIterationItem:
     signal_val: str
     bank_content_id: int
     bank_content_timestamp: int
+    bank_name: str
 
 
 class IBankStore(metaclass=abc.ABCMeta):

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
@@ -92,6 +92,7 @@ class Bank(db.Model):  # type: ignore[name-defined]
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(255), unique=True, index=True)
     enabled_ratio: Mapped[float] = mapped_column(default=1.0)
+    content_type_counts: Mapped[t.Optional[dict]] = mapped_column(JSON, nullable=True)
 
     content: Mapped[t.List["BankContent"]] = relationship(
         back_populates="bank", cascade="all, delete"
@@ -108,11 +109,19 @@ class Bank(db.Model):  # type: ignore[name-defined]
     )
 
     def as_storage_iface_cls(self) -> BankConfig:
-        return BankConfig(self.name, self.enabled_ratio)
+        return BankConfig(
+            name=self.name,
+            matching_enabled_ratio=self.enabled_ratio,
+            content_type_counts=self.content_type_counts
+        )
 
     @classmethod
     def from_storage_iface_cls(cls, cfg: BankConfig) -> t.Self:
-        return cls(name=cfg.name, enabled_ratio=cfg.matching_enabled_ratio)
+        return cls(
+            name=cfg.name,
+            enabled_ratio=cfg.matching_enabled_ratio,
+            content_type_counts=cfg.content_type_counts
+        )
 
     @validates("name")
     def validate_name(self, _key: str, name: str) -> str:

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/banks_grid.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/banks_grid.html.j2
@@ -14,6 +14,7 @@
             <tr>
                 <th scope="col">#</th>
                 <th scope="col">Bank Name</th>
+                <th scope="col">Content Counts</th>
                 <th scope="col">Matching Enabled Ratio</th>
                 <th scope="col">Actions</th>
             </tr>
@@ -23,6 +24,15 @@
             <tr id="bank_item_{{bank['name']}}">
                 <th scope="row" style="background-color: transparent;">{{ loop.index }}</th>
                 <td style="background-color: transparent;">{{ bank['name'] }}</td>
+                <td style="background-color: transparent;">
+                    {% if bank['content_type_counts'] %}
+                        {% for content_type, count in bank['content_type_counts'].items() %}
+                            <span class="badge bg-primary me-1">{{ content_type }}: {{ count }}</span>
+                        {% endfor %}
+                    {% else %}
+                        <span class="badge bg-secondary">No content</span>
+                    {% endif %}
+                </td>
                 <td style="background-color: transparent;">{{ bank['matching_enabled_ratio'] }}</td>
                 <td style="background-color: transparent;">
                     {% with bank_title=bank['name'] %}


### PR DESCRIPTION
Summary
---------

I'm adding a new attribute to banks to keep track of the content they contain alongside the type of content. 

This cache will be updated after each index operation to make sure the information is up to date as we build the index to prevent race conditions when adding new content.

Test Plan
---------

Tested locally
