### PR TITLE
[vpdq] Fix TSan + UBSan false-positive

### DIFF
--- a/vpdq/cpp/CMakeLists.txt
+++ b/vpdq/cpp/CMakeLists.txt
@@ -47,20 +47,22 @@ set(CMAKE_SHARED_LINKER_FLAGS_ASAN
     "Linker lags to be used to create shared libraries for Asan build type." FORCE)
 
 # Tsan
+# Note: We can't use undefined and thread sanitizers at the same time because
+# of a false-positive bug where thread sanitizer reports on itself with std::thread(). See https://github.com/google/sanitizers/issues/1106
 set(CMAKE_C_FLAGS_TSAN
-    "${CMAKE_C_FLAGS_DEBUG} -fsanitize=thread,undefined -fno-omit-frame-pointer" CACHE STRING
+    "${CMAKE_C_FLAGS_DEBUG} -fsanitize=thread -fno-omit-frame-pointer" CACHE STRING
     "Flags used by the C compiler for Asan build type or configuration." FORCE)
 
 set(CMAKE_CXX_FLAGS_TSAN
-    "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=thread,undefined -fno-omit-frame-pointer" CACHE STRING
+    "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=thread -fno-omit-frame-pointer" CACHE STRING
     "Flags used by the C++ compiler for Asan build type or configuration." FORCE)
 
 set(CMAKE_EXE_LINKER_FLAGS_TSAN
-    "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=thread,undefined" CACHE STRING
+    "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=thread" CACHE STRING
     "Linker flags to be used to create executables for Tsan build type." FORCE)
 
 set(CMAKE_SHARED_LINKER_FLAGS_TSAN
-    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=thread,undefined" CACHE STRING
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=thread" CACHE STRING
     "Linker lags to be used to create shared libraries for Tsan build type." FORCE)
 endif()
 


### PR DESCRIPTION
Summary
---------

I noticed a data race was detected on my fork CI and local runs.

This appears to be a false-positive with some interaction with TSan and UBSan and std::thread.

https://github.com/google/sanitizers/issues/1106

This issue recommends disabling both TSan and UBSan to fix it.

Example:

```
==================
WARNING: ThreadSanitizer: data race (pid=200212)
  Write of size 8 at 0x7204000017b0 by thread T23:
    #0 pipe ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1850 (libtsan.so.2+0x579ea) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 __sanitizer::IsAccessibleMemoryRange(unsigned long, unsigned long) ../../../../src/libsanitizer/sanitizer_common/sanitizer_posix_libcdep.cpp:276 (libubsan.so.1+0x210d3) (BuildId: 7fb91acab7dace1c66b29cc8969bf4b0128afa15)
    #2 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (facebook::vpdq::hashing::VpdqHasher<facebook::vpdq::hashing::ffmpeg::FFmpegFrame>::*)(), facebook::vpdq::hashing::VpdqHasher<facebook::vpdq::hashing::ffmpeg::FFmpegFrame>*> > >::~_State_impl() <null> (vpdq-hash-video+0x5fcc1) (BuildId: 70e10dc391c5ba367758ccecc13912d023daf43e)
    #3 <null> <null> (libstdc++.so.6+0xecdbc) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)

  Previous write of size 8 at 0x7204000017b0 by thread T21:
    #0 pipe ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1850 (libtsan.so.2+0x579ea) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 __sanitizer::IsAccessibleMemoryRange(unsigned long, unsigned long) ../../../../src/libsanitizer/sanitizer_common/sanitizer_posix_libcdep.cpp:276 (libubsan.so.1+0x210d3) (BuildId: 7fb91acab7dace1c66b29cc8969bf4b0128afa15)
    #2 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (facebook::vpdq::hashing::VpdqHasher<facebook::vpdq::hashing::ffmpeg::FFmpegFrame>::*)(), facebook::vpdq::hashing::VpdqHasher<facebook::vpdq::hashing::ffmpeg::FFmpegFrame>*> > >::~_State_impl() <null> (vpdq-hash-video+0x5fcc1) (BuildId: 70e10dc391c5ba367758ccecc13912d023daf43e)
    #3 <null> <null> (libstdc++.so.6+0xecdbc) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)

  Thread T23 (tid=200259, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xeceb0) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
    #2 facebook::vpdq::hashing::VpdqHasher<facebook::vpdq::hashing::ffmpeg::FFmpegFrame>::VpdqHasher(unsigned int, facebook::vpdq::hashing::VideoMetadata) /home/ubuntu/github/ThreatExchange/vpdq/cpp/vpdq/../vpdq/cpp/hashing/hasher.h:210 (vpdq-hash-video+0x42364) (BuildId: 70e10dc391c5ba367758ccecc13912d023daf43e)
    #3 FFmpegHasher /home/ubuntu/github/ThreatExchange/vpdq/cpp/vpdq/cpp/hashing/filehasher.cpp:48 (vpdq-hash-video+0x3c3c2) (BuildId: 70e10dc391c5ba367758ccecc13912d023daf43e)
    #4 facebook::vpdq::hashing::hashVideoFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<facebook::vpdq::hashing::vpdqFeature, std::allocator<facebook::vpdq::hashing::vpdqFeature> >&, bool, double, int, int, unsigned int) /home/ubuntu/github/ThreatExchange/vpdq/cpp/vpdq/cpp/hashing/filehasher.cpp:247 (vpdq-hash-video+0x3e898) (BuildId: 70e10dc391c5ba367758ccecc13912d023daf43e)
    #5 main /home/ubuntu/github/ThreatExchange/vpdq/cpp/apps/vpdq-hash-video.cpp:172 (vpdq-hash-video+0x3ad34) (BuildId: 70e10dc391c5ba367758ccecc13912d023daf43e)

  Thread T21 (tid=200257, finished) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xeceb0) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
    #2 facebook::vpdq::hashing::VpdqHasher<facebook::vpdq::hashing::ffmpeg::FFmpegFrame>::VpdqHasher(unsigned int, facebook::vpdq::hashing::VideoMetadata) /home/ubuntu/github/ThreatExchange/vpdq/cpp/vpdq/../vpdq/cpp/hashing/hasher.h:210 (vpdq-hash-video+0x42364) (BuildId: 70e10dc391c5ba367758ccecc13912d023daf43e)
    #3 FFmpegHasher /home/ubuntu/github/ThreatExchange/vpdq/cpp/vpdq/cpp/hashing/filehasher.cpp:48 (vpdq-hash-video+0x3c3c2) (BuildId: 70e10dc391c5ba367758ccecc13912d023daf43e)
    #4 facebook::vpdq::hashing::hashVideoFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<facebook::vpdq::hashing::vpdqFeature, std::allocator<facebook::vpdq::hashing::vpdqFeature> >&, bool, double, int, int, unsigned int) /home/ubuntu/github/ThreatExchange/vpdq/cpp/vpdq/cpp/hashing/filehasher.cpp:247 (vpdq-hash-video+0x3e898) (BuildId: 70e10dc391c5ba367758ccecc13912d023daf43e)
    #5 main /home/ubuntu/github/ThreatExchange/vpdq/cpp/apps/vpdq-hash-video.cpp:172 (vpdq-hash-video+0x3ad34) (BuildId: 70e10dc391c5ba367758ccecc13912d023daf43e)

SUMMARY: ThreadSanitizer: data race ../../../../src/libsanitizer/sanitizer_common/sanitizer_posix_libcdep.cpp:276 in __sanitizer::IsAccessibleMemoryRange(unsigned long, unsigned long)
```

Notice in the summary that the data race is in `IsAccessibleMemoryRange` and not vpdq our any of our code. This means it's almost certainly not something we can fix.

I would rather have TSan than UBSan, so I removed UBSan from that build to fix the issue. UBSan runs fine with the ASan profile for now, which we run in CI, so we're still covered for UBSan there.

Test Plan
---------

I ran it several times locally and never experienced the data race error again. I'm fairly confident this is a false-positive.