### PR TITLE
OMM: Update hashing to support FileHashers

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
@@ -121,9 +121,9 @@ def hash_media_from_form_data() -> dict[str, str]:
                 elif issubclass(st, FileHasher):
                     with tempfile.NamedTemporaryFile("wb") as tmp:
                         current_app.logger.debug(
-                           "Writing to %s for hashing, signal_type=%s",
-                           tmp.name,
-                           st.get_name(),
+                            "Writing to %s for hashing, signal_type=%s",
+                            tmp.name,
+                            st.get_name(),
                         )
                         with tmp.file as temp_file:  # this ensures that bytes are flushed before hashing
                             temp_file.write(bytes)

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
@@ -120,7 +120,11 @@ def hash_media_from_form_data() -> dict[str, str]:
 
                 elif issubclass(st, FileHasher):
                     with tempfile.NamedTemporaryFile("wb") as tmp:
-                        current_app.logger.debug("Writing to %s for hashing, signal_type=%s", tmp.name, st.get_name())
+                        current_app.logger.debug(
+                           "Writing to %s for hashing, signal_type=%s",
+                           tmp.name,
+                           st.get_name(),
+                        )
                         with tmp.file as temp_file:  # this ensures that bytes are flushed before hashing
                             temp_file.write(bytes)
                             path = Path(tmp.name)

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
@@ -118,6 +118,14 @@ def hash_media_from_form_data() -> dict[str, str]:
                 if issubclass(st, BytesHasher):
                     ret[st.get_name()] = st.hash_from_bytes(bytes)
 
+                elif issubclass(st, FileHasher):
+                    with tempfile.NamedTemporaryFile("wb") as tmp:
+                        current_app.logger.debug("Writing to %s for hashing, signal_type=%s", tmp.name, st.get_name())
+                        with tmp.file as temp_file:  # this ensures that bytes are flushed before hashing
+                            temp_file.write(bytes)
+                            path = Path(tmp.name)
+                            ret[st.get_name()] = st.hash_from_file(path)
+
     return ret
 
 


### PR DESCRIPTION
@Dcallies this is the change I needed to make VPDQ usable through the Curator Web UI, since it uses `hash_media_from_form_data` internally.

This is the same thing that the `hash_media` endpoint does when receiving a `url`, as that uses FileHasher, not BytesHasher.

We'd probably also need something in Hashing to have support for `URLContent` and `TextContent`, but that'd require different UI completely (text input instead of file input)