### PR TITLE
[HMA] #1813 Clear out memory on index building to prevent bloating.

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/background_tasks/build_index.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/background_tasks/build_index.py
@@ -17,6 +17,7 @@ from OpenMediaMatch.storage.interface import (
     SignalTypeIndexBuildCheckpoint,
 )
 from OpenMediaMatch.utils.time_utils import duration_to_human_str
+from OpenMediaMatch.utils.memory_utils import trim_process_memory
 
 logger = logging.getLogger(__name__)
 
@@ -117,8 +118,8 @@ def build_index(
         if 'built_index' in locals() and built_index is not None:
             built_index = None
         
-        # Force garbage collection to reclaim memory
-        gc.collect()
+        # Force garbage collection to reclaim memory and attempt to free pages
+        trim_process_memory(logger, "Indexer")
     
     logger.info(
         "Indexed %d signals for %s - %s",

--- a/hasher-matcher-actioner/src/OpenMediaMatch/background_tasks/build_index.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/background_tasks/build_index.py
@@ -76,17 +76,12 @@ def build_index(
     # Use try/finally to ensure aggressive memory trim after build
     signal_count = 0
     built_index: t.Any | None = None  # keep in locals per review nit
-    checkpoint: SignalTypeIndexBuildCheckpoint | None = None
 
     try:
         built_index, checkpoint, signal_count = _prepare_index(
             for_signal_type, bank_store
         )
-        index_store.store_signal_type_index(
-            for_signal_type,
-            built_index,
-            t.cast(SignalTypeIndexBuildCheckpoint, checkpoint),
-        )
+        index_store.store_signal_type_index(for_signal_type, built_index, checkpoint)
     finally:
         # Force garbage collection to reclaim memory and attempt to free pages
         trim_process_memory(logger, "Indexer")

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -92,26 +92,11 @@ class _SignalIndexInMemoryCache:
                 )
                 return
 
-            # Replace index with aggressive cleanup for FAISS indices
-            old_index = self.index
-
             self.index = new_index
             self.checkpoint = curr_checkpoint
 
-            if old_index is not None:
-                # Try to explicitly cleanup FAISS internals
-                if hasattr(old_index, "_index") and hasattr(
-                    old_index._index, "faiss_index"
-                ):
-                    try:
-                        faiss_idx = old_index._index.faiss_index
-                        if hasattr(faiss_idx, "reset"):
-                            faiss_idx.reset()
-                    except Exception:
-                        pass
-
-                del old_index
-                trim_process_memory()
+            # Force garbage collection to reclaim memory and attempt to free pages
+            trim_process_memory()
 
         self.last_check_ts = now
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -91,26 +91,28 @@ class _SignalIndexInMemoryCache:
                     curr_checkpoint,
                 )
                 return
-            
+
             # Replace index with aggressive cleanup for FAISS indices
             old_index = self.index
-            
+
             self.index = new_index
             self.checkpoint = curr_checkpoint
 
             if old_index is not None:
                 # Try to explicitly cleanup FAISS internals
-                if hasattr(old_index, '_index') and hasattr(old_index._index, 'faiss_index'):
+                if hasattr(old_index, "_index") and hasattr(
+                    old_index._index, "faiss_index"
+                ):
                     try:
                         faiss_idx = old_index._index.faiss_index
-                        if hasattr(faiss_idx, 'reset'):
+                        if hasattr(faiss_idx, "reset"):
                             faiss_idx.reset()
                     except Exception:
                         pass
-                
+
                 del old_index
                 trim_process_memory()
-            
+
         self.last_check_ts = now
 
     def periodic_task(self) -> None:

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -31,6 +31,7 @@ from OpenMediaMatch.utils.flask_utils import (
     str_to_bool,
 )
 from OpenMediaMatch.persistence import get_storage
+from OpenMediaMatch.utils.memory_utils import trim_process_memory
 
 bp = Blueprint("matching", __name__)
 bp.register_error_handler(HTTPException, api_error_handler)
@@ -90,8 +91,26 @@ class _SignalIndexInMemoryCache:
                     curr_checkpoint,
                 )
                 return
+            
+            # Replace index with aggressive cleanup for FAISS indices
+            old_index = self.index
+            
             self.index = new_index
             self.checkpoint = curr_checkpoint
+
+            if old_index is not None:
+                # Try to explicitly cleanup FAISS internals
+                if hasattr(old_index, '_index') and hasattr(old_index._index, 'faiss_index'):
+                    try:
+                        faiss_idx = old_index._index.faiss_index
+                        if hasattr(faiss_idx, 'reset'):
+                            faiss_idx.reset()
+                    except Exception:
+                        pass
+                
+                del old_index
+                trim_process_memory()
+            
         self.last_check_ts = now
 
     def periodic_task(self) -> None:

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
@@ -456,6 +456,11 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         self.serialized_index_large_object_oid = l_obj.oid
         db.session.add(self)
         raw_conn.commit()
+        # Ensure raw connection is closed to avoid resource leaks
+        try:
+            raw_conn.close()
+        except Exception:
+            pass
 
         try:
             os.unlink(tmpfile.name)
@@ -499,6 +504,11 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
                 "deserialized - %s",
                 duration_to_human_str(int(time.time() - deserialize_start)),
             )
+        # Ensure raw connection is closed to avoid resource leaks
+        try:
+            raw_conn.close()
+        except Exception:
+            pass
         return index
 
     def as_checkpoint(self) -> SignalTypeIndexBuildCheckpoint:

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
@@ -148,7 +148,8 @@ class BankContent(db.Model):  # type: ignore[name-defined]
 
     # Should we store the content type as well?
 
-    disable_until_ts: Mapped[int] = mapped_column(default=BankContentConfig.ENABLED)
+    disable_until_ts: Mapped[int] = mapped_column(
+        default=BankContentConfig.ENABLED)
     original_content_uri: Mapped[t.Optional[str]]
 
     signals: Mapped[t.List["ContentSignal"]] = relationship(
@@ -213,7 +214,8 @@ class ExchangeConfig(db.Model):  # type: ignore[name-defined]
     api_cls: Mapped[str] = mapped_column(String(255))
     retain_api_data: Mapped[bool] = mapped_column(default=False)
     fetching_enabled: Mapped[bool] = mapped_column(default=True)
-    retain_data_with_unknown_signal_types: Mapped[bool] = mapped_column(default=False)
+    retain_data_with_unknown_signal_types: Mapped[bool] = mapped_column(
+        default=False)
     # Someday, we want writeback columns
     # report_seen: Mapped[bool] = mapped_column(default=False)
     # report_true_positive = mapped_column(default=False)
@@ -318,7 +320,8 @@ class ExchangeFetchStatus(db.Model):  # type: ignore[name-defined]
     # Storing the ts separately means we can check the timestamp without deserializing
     # the checkpoint
     checkpoint_ts: Mapped[t.Optional[int]] = mapped_column(BigInteger)
-    checkpoint_json: Mapped[t.Optional[t.Dict[str, t.Any]]] = mapped_column(JSON)
+    checkpoint_json: Mapped[t.Optional[t.Dict[str, t.Any]]
+                            ] = mapped_column(JSON)
 
     def as_checkpoint(
         self, api_cls: t.Optional[TSignalExchangeAPICls]
@@ -361,7 +364,8 @@ class ExchangeData(db.Model):  # type: ignore[name-defined]
     pickled_fetch_signal_metadata: Mapped[t.Optional[bytes]] = mapped_column(
         LargeBinary
     )
-    fetched_metadata_summary: Mapped[t.List[t.Any]] = mapped_column(JSON, default=list)
+    fetched_metadata_summary: Mapped[t.List[t.Any]
+                                     ] = mapped_column(JSON, default=list)
 
     bank_content: Mapped[t.Optional[BankContent]] = relationship(
         back_populates="imported_from",
@@ -386,7 +390,8 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
     """
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    signal_type: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+    signal_type: Mapped[str] = mapped_column(
+        String(255), unique=True, index=True)
     signal_count: Mapped[int]
     updated_to_id: Mapped[int]
     updated_to_ts: Mapped[int] = mapped_column(BigInteger)
@@ -435,7 +440,7 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         store_start_time = time.time()
         # Deep dark magic - direct access postgres large object API
         raw_conn = db.engine.raw_connection()
-        l_obj = raw_conn.lobject(0, "wb", 0, tmpfile.name)  # type: ignore[attr-defined]
+        l_obj = raw_conn.lobject(0, "wb", 0, tmpfile.name)
         self._log(
             "imported tmpfile as lobject oid %d - %s",
             l_obj.oid,
@@ -443,7 +448,8 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         )
         if self.serialized_index_large_object_oid is not None:
             if self.index_lobj_exists():
-                old_obj = raw_conn.lobject(self.serialized_index_large_object_oid, "n")  # type: ignore[attr-defined]
+                old_obj = raw_conn.lobject(
+                    self.serialized_index_large_object_oid, "n")
                 self._log("deallocating old lobject %d", old_obj.oid)
                 old_obj.unlink()
             else:
@@ -482,10 +488,11 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         # I'm sorry future debugger finding this comment.
         load_start_time = time.time()
         raw_conn = db.engine.raw_connection()
-        l_obj = raw_conn.lobject(oid, "rb")  # type: ignore[attr-defined]
+        l_obj = raw_conn.lobject(oid, "rb")
 
         with tempfile.NamedTemporaryFile("rb") as tmpfile:
-            self._log("importing lobject oid %d to tmpfile %s", l_obj.oid, tmpfile.name)
+            self._log("importing lobject oid %d to tmpfile %s",
+                      l_obj.oid, tmpfile.name)
             l_obj.export(tmpfile.name)
             tmpfile.seek(0, io.SEEK_END)
             self._log(
@@ -519,7 +526,8 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         )
 
     def _log(self, msg: str, *args: t.Any, level: int = logging.DEBUG) -> None:
-        current_app.logger.log(level, f"Index[%s] {msg}", self.signal_type, *args)
+        current_app.logger.log(
+            level, f"Index[%s] {msg}", self.signal_type, *args)
 
 
 @event.listens_for(SignalIndex, "after_delete")
@@ -528,7 +536,8 @@ def _remove_large_object_after_delete(_, connection, signal_index: SignalIndex) 
     Hopefully we don't need to rely on this, but attempt to prevent orphaned large objects.
     """
     raw_connection = connection.connection
-    l_obj = raw_connection.lobject(signal_index.serialized_index_large_object_oid, "n")
+    l_obj = raw_connection.lobject(
+        signal_index.serialized_index_large_object_oid, "n")
     l_obj.unlink()
     raw_connection.commit()
 
@@ -566,7 +575,8 @@ class ExchangeAPIConfig(db.Model):  # type: ignore[name-defined]
         if creds is None:
             self.default_credentials_json = {}
         else:
-            self.default_credentials_json = dataclass_json.dataclass_dump_dict(creds)
+            self.default_credentials_json = dataclass_json.dataclass_dump_dict(
+                creds)
 
     def as_storage_iface_cls(
         self, api_cls: TSignalExchangeAPICls

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
@@ -148,8 +148,7 @@ class BankContent(db.Model):  # type: ignore[name-defined]
 
     # Should we store the content type as well?
 
-    disable_until_ts: Mapped[int] = mapped_column(
-        default=BankContentConfig.ENABLED)
+    disable_until_ts: Mapped[int] = mapped_column(default=BankContentConfig.ENABLED)
     original_content_uri: Mapped[t.Optional[str]]
 
     signals: Mapped[t.List["ContentSignal"]] = relationship(
@@ -214,8 +213,7 @@ class ExchangeConfig(db.Model):  # type: ignore[name-defined]
     api_cls: Mapped[str] = mapped_column(String(255))
     retain_api_data: Mapped[bool] = mapped_column(default=False)
     fetching_enabled: Mapped[bool] = mapped_column(default=True)
-    retain_data_with_unknown_signal_types: Mapped[bool] = mapped_column(
-        default=False)
+    retain_data_with_unknown_signal_types: Mapped[bool] = mapped_column(default=False)
     # Someday, we want writeback columns
     # report_seen: Mapped[bool] = mapped_column(default=False)
     # report_true_positive = mapped_column(default=False)
@@ -320,8 +318,7 @@ class ExchangeFetchStatus(db.Model):  # type: ignore[name-defined]
     # Storing the ts separately means we can check the timestamp without deserializing
     # the checkpoint
     checkpoint_ts: Mapped[t.Optional[int]] = mapped_column(BigInteger)
-    checkpoint_json: Mapped[t.Optional[t.Dict[str, t.Any]]
-                            ] = mapped_column(JSON)
+    checkpoint_json: Mapped[t.Optional[t.Dict[str, t.Any]]] = mapped_column(JSON)
 
     def as_checkpoint(
         self, api_cls: t.Optional[TSignalExchangeAPICls]
@@ -364,8 +361,7 @@ class ExchangeData(db.Model):  # type: ignore[name-defined]
     pickled_fetch_signal_metadata: Mapped[t.Optional[bytes]] = mapped_column(
         LargeBinary
     )
-    fetched_metadata_summary: Mapped[t.List[t.Any]
-                                     ] = mapped_column(JSON, default=list)
+    fetched_metadata_summary: Mapped[t.List[t.Any]] = mapped_column(JSON, default=list)
 
     bank_content: Mapped[t.Optional[BankContent]] = relationship(
         back_populates="imported_from",
@@ -390,8 +386,7 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
     """
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    signal_type: Mapped[str] = mapped_column(
-        String(255), unique=True, index=True)
+    signal_type: Mapped[str] = mapped_column(String(255), unique=True, index=True)
     signal_count: Mapped[int]
     updated_to_id: Mapped[int]
     updated_to_ts: Mapped[int] = mapped_column(BigInteger)
@@ -448,8 +443,7 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         )
         if self.serialized_index_large_object_oid is not None:
             if self.index_lobj_exists():
-                old_obj = raw_conn.lobject(
-                    self.serialized_index_large_object_oid, "n")
+                old_obj = raw_conn.lobject(self.serialized_index_large_object_oid, "n")
                 self._log("deallocating old lobject %d", old_obj.oid)
                 old_obj.unlink()
             else:
@@ -462,11 +456,6 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         self.serialized_index_large_object_oid = l_obj.oid
         db.session.add(self)
         raw_conn.commit()
-        # Ensure raw connection is closed to avoid resource leaks
-        try:
-            raw_conn.close()
-        except Exception:
-            pass
 
         try:
             os.unlink(tmpfile.name)
@@ -491,8 +480,7 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         l_obj = raw_conn.lobject(oid, "rb")
 
         with tempfile.NamedTemporaryFile("rb") as tmpfile:
-            self._log("importing lobject oid %d to tmpfile %s",
-                      l_obj.oid, tmpfile.name)
+            self._log("importing lobject oid %d to tmpfile %s", l_obj.oid, tmpfile.name)
             l_obj.export(tmpfile.name)
             tmpfile.seek(0, io.SEEK_END)
             self._log(
@@ -511,11 +499,6 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
                 "deserialized - %s",
                 duration_to_human_str(int(time.time() - deserialize_start)),
             )
-        # Ensure raw connection is closed to avoid resource leaks
-        try:
-            raw_conn.close()
-        except Exception:
-            pass
         return index
 
     def as_checkpoint(self) -> SignalTypeIndexBuildCheckpoint:
@@ -526,8 +509,7 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         )
 
     def _log(self, msg: str, *args: t.Any, level: int = logging.DEBUG) -> None:
-        current_app.logger.log(
-            level, f"Index[%s] {msg}", self.signal_type, *args)
+        current_app.logger.log(level, f"Index[%s] {msg}", self.signal_type, *args)
 
 
 @event.listens_for(SignalIndex, "after_delete")
@@ -536,8 +518,7 @@ def _remove_large_object_after_delete(_, connection, signal_index: SignalIndex) 
     Hopefully we don't need to rely on this, but attempt to prevent orphaned large objects.
     """
     raw_connection = connection.connection
-    l_obj = raw_connection.lobject(
-        signal_index.serialized_index_large_object_oid, "n")
+    l_obj = raw_connection.lobject(signal_index.serialized_index_large_object_oid, "n")
     l_obj.unlink()
     raw_connection.commit()
 
@@ -575,8 +556,7 @@ class ExchangeAPIConfig(db.Model):  # type: ignore[name-defined]
         if creds is None:
             self.default_credentials_json = {}
         else:
-            self.default_credentials_json = dataclass_json.dataclass_dump_dict(
-                creds)
+            self.default_credentials_json = dataclass_json.dataclass_dump_dict(creds)
 
     def as_storage_iface_cls(
         self, api_cls: TSignalExchangeAPICls

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_postgres_storage_impl.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_postgres_storage_impl.py
@@ -51,7 +51,8 @@ def make_collab(
     api: TSignalExchangeAPICls = StaticSampleSignalExchangeAPI,
     retain_data_with_unknown_signal_types: bool = False,
 ) -> CollaborationConfigBase:
-    cfg = CollaborationConfigBase(name="SAMPLE", api=api.get_name(), enabled=True)
+    cfg = CollaborationConfigBase(
+        name="SAMPLE", api=api.get_name(), enabled=True)
     storage.exchange_update(cfg, create=True)
     if retain_data_with_unknown_signal_types:
         sesh = database.db.session
@@ -94,7 +95,8 @@ def test_fetch_to_match_e2e(storage: DefaultOMMStore) -> None:
     assert fetch_status.fetched_items == expected_fetch_count
     md5_index_status = storage.get_last_index_build_checkpoint(VideoMD5Signal)
     assert md5_index_status is not None
-    assert md5_index_status.total_hash_count == len(VideoMD5Signal.get_examples())
+    assert md5_index_status.total_hash_count == len(
+        VideoMD5Signal.get_examples())
     pdq_index_status = storage.get_last_index_build_checkpoint(PdqSignal)
     assert pdq_index_status is not None
     assert pdq_index_status.total_hash_count == len(PdqSignal.get_examples())
@@ -161,7 +163,8 @@ def test_sequential_fetch_updates(storage: DefaultOMMStore) -> None:
         target = storage.get_current_index_build_target(VideoMD5Signal)
         assert target is not None
         assert target.total_hash_count == maker.count
-        signals = {s.signal_val for s in storage.bank_yield_content(VideoMD5Signal)}
+        signals = {
+            s.signal_val for s in storage.bank_yield_content(VideoMD5Signal)}
         assert signals == maker.signals
 
     storage.exchange_commit_fetch(cfg, None, update_1, checkpoint)
@@ -220,7 +223,8 @@ def test_recover_from_index_unlink_partial_failure(storage: DefaultOMMStore):
     ).scalar_one()
     assert index_record.index_lobj_exists() is True
     raw_conn = database.db.engine.raw_connection()
-    old_obj = raw_conn.lobject(index_record.serialized_index_large_object_oid, "n")  # type: ignore[attr-defined]
+    old_obj = raw_conn.lobject(
+        index_record.serialized_index_large_object_oid, "n")
     old_obj.unlink()
     raw_conn.commit()
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_postgres_storage_impl.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_postgres_storage_impl.py
@@ -51,8 +51,7 @@ def make_collab(
     api: TSignalExchangeAPICls = StaticSampleSignalExchangeAPI,
     retain_data_with_unknown_signal_types: bool = False,
 ) -> CollaborationConfigBase:
-    cfg = CollaborationConfigBase(
-        name="SAMPLE", api=api.get_name(), enabled=True)
+    cfg = CollaborationConfigBase(name="SAMPLE", api=api.get_name(), enabled=True)
     storage.exchange_update(cfg, create=True)
     if retain_data_with_unknown_signal_types:
         sesh = database.db.session
@@ -95,8 +94,7 @@ def test_fetch_to_match_e2e(storage: DefaultOMMStore) -> None:
     assert fetch_status.fetched_items == expected_fetch_count
     md5_index_status = storage.get_last_index_build_checkpoint(VideoMD5Signal)
     assert md5_index_status is not None
-    assert md5_index_status.total_hash_count == len(
-        VideoMD5Signal.get_examples())
+    assert md5_index_status.total_hash_count == len(VideoMD5Signal.get_examples())
     pdq_index_status = storage.get_last_index_build_checkpoint(PdqSignal)
     assert pdq_index_status is not None
     assert pdq_index_status.total_hash_count == len(PdqSignal.get_examples())
@@ -163,8 +161,7 @@ def test_sequential_fetch_updates(storage: DefaultOMMStore) -> None:
         target = storage.get_current_index_build_target(VideoMD5Signal)
         assert target is not None
         assert target.total_hash_count == maker.count
-        signals = {
-            s.signal_val for s in storage.bank_yield_content(VideoMD5Signal)}
+        signals = {s.signal_val for s in storage.bank_yield_content(VideoMD5Signal)}
         assert signals == maker.signals
 
     storage.exchange_commit_fetch(cfg, None, update_1, checkpoint)
@@ -223,8 +220,7 @@ def test_recover_from_index_unlink_partial_failure(storage: DefaultOMMStore):
     ).scalar_one()
     assert index_record.index_lobj_exists() is True
     raw_conn = database.db.engine.raw_connection()
-    old_obj = raw_conn.lobject(
-        index_record.serialized_index_large_object_oid, "n")
+    old_obj = raw_conn.lobject(index_record.serialized_index_large_object_oid, "n")
     old_obj.unlink()
     raw_conn.commit()
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/utils/memory_utils.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/utils/memory_utils.py
@@ -38,9 +38,18 @@ def trim_process_memory(
             return True
         if logger:
             logger.debug("%s trim_process_memory: libc has no malloc_trim", label)
-    except Exception as exc:  # pragma: no cover — platform specific
+    except OSError as exc:  # pragma: no cover — platform specific (lib load)
         if logger:
             logger.debug(
-                "%s trim_process_memory: malloc_trim not available: %s", label, str(exc)
+                "%s trim_process_memory: failed to load libc: %s", label, str(exc)
             )
+        return False
+    except AttributeError as exc:  # pragma: no cover — platform specific (symbol)
+        if logger:
+            logger.debug(
+                "%s trim_process_memory: malloc_trim symbol not available: %s",
+                label,
+                str(exc),
+            )
+        return False
     return False

--- a/hasher-matcher-actioner/src/OpenMediaMatch/utils/memory_utils.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/utils/memory_utils.py
@@ -1,0 +1,42 @@
+import gc
+import logging
+import platform
+from typing import Optional
+
+
+def trim_process_memory(logger: Optional[logging.Logger] = None, label: str = "") -> bool:
+    """
+    Aggressively attempt to return freed memory to the OS.
+
+    - Always runs gc.collect() first
+    - On Linux/glibc systems, calls malloc_trim(0) if available
+
+    Returns True if malloc_trim was successfully invoked; False otherwise.
+    """
+    # Always collect Python garbage first
+    gc.collect()
+
+    # Only Linux/glibc generally supports malloc_trim
+    system = platform.system().lower()
+    if system != "linux":
+        if logger:
+            logger.debug("%s trim_process_memory: malloc_trim not supported on %s", label, system)
+        return False
+
+    try:
+        import ctypes  # noqa: WPS433
+
+        libc = ctypes.CDLL("libc.so.6")
+        if hasattr(libc, "malloc_trim"):
+            libc.malloc_trim(0)
+            if logger:
+                logger.info("%s Called malloc_trim(0) to release freed memory", label)
+            return True
+        if logger:
+            logger.debug("%s trim_process_memory: libc has no malloc_trim", label)
+    except Exception as exc:  # pragma: no cover — platform specific
+        if logger:
+            logger.debug("%s trim_process_memory: malloc_trim not available: %s", label, str(exc))
+    return False
+
+

--- a/hasher-matcher-actioner/src/OpenMediaMatch/utils/memory_utils.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/utils/memory_utils.py
@@ -4,7 +4,9 @@ import platform
 from typing import Optional
 
 
-def trim_process_memory(logger: Optional[logging.Logger] = None, label: str = "") -> bool:
+def trim_process_memory(
+    logger: Optional[logging.Logger] = None, label: str = ""
+) -> bool:
     """
     Aggressively attempt to return freed memory to the OS.
 
@@ -20,7 +22,9 @@ def trim_process_memory(logger: Optional[logging.Logger] = None, label: str = ""
     system = platform.system().lower()
     if system != "linux":
         if logger:
-            logger.debug("%s trim_process_memory: malloc_trim not supported on %s", label, system)
+            logger.debug(
+                "%s trim_process_memory: malloc_trim not supported on %s", label, system
+            )
         return False
 
     try:
@@ -36,7 +40,7 @@ def trim_process_memory(logger: Optional[logging.Logger] = None, label: str = ""
             logger.debug("%s trim_process_memory: libc has no malloc_trim", label)
     except Exception as exc:  # pragma: no cover — platform specific
         if logger:
-            logger.debug("%s trim_process_memory: malloc_trim not available: %s", label, str(exc))
+            logger.debug(
+                "%s trim_process_memory: malloc_trim not available: %s", label, str(exc)
+            )
     return False
-
-


### PR DESCRIPTION
Summary
---------

This is for #1813 I added memory logging around index operations ( Building, Download, Swap ) to monitor usage. I generated 150K hashes to have a big enough DB.

Without the changes here I saw a jump between reloads of 50-80MB while only freeing 5-15MB in between the process. 

Start: 
102MB → 150MB → 265MB → 285MB → 346MB → 378MB → 450MB
In a span of 10 minutes. 

PDQ loads: 48MB → 77MB → 76MB

```
CachedIndex[pdq] Index load: +48.21 MB
CachedIndex[pdq] Index load: +77.24 MB  
CachedIndex[pdq] Index load: +75.99 MB

[2025-08-08 03:57:04,926] INFO in matching: CachedIndex[video_md5] Periodic task memory: start=285.62 MB, storage=285.62 MB, end=298.36 MB (change: +12.74 MB)
[2025-08-08 03:57:05,040] INFO in matching: CachedIndex[pdq] Index load: 285.62 MB -> 362.86 MB (+77.24 MB)
[2025-08-08 03:57:35,041] INFO in matching: CachedIndex[pdq] Index load: 377.89 MB -> 453.88 MB (+75.99 MB)
```

After adding explicit GC I saw improvements, but the memory wasn't being freed between index swaps as expected. I added malloc_trim as a way to force C to free up pages. 

> malloc_trim(0) asks the C allocator to return currently unused heap pages back to the OS.

After the changes I saw logging as follows:
```
[2025-08-08 04:05:39,166] INFO in matching: CachedIndex[pdq] Index load: 216.17 MB -> 332.91 MB (+116.74 MB)
[2025-08-08 04:05:39,166] INFO in matching: CachedIndex[pdq] Replacing index type: PDQIndex
[2025-08-08 04:05:39,210] INFO in matching: CachedIndex[pdq] Called malloc_trim(0) to release freed memory
[2025-08-08 04:05:39,210] INFO in matching: CachedIndex[pdq] Cleanup complete: 215.97 MB (freed: 116.94 MB)

[2025-08-08 04:06:39,020] INFO in matching: CachedIndex[video_md5] Index load: 249.70 MB -> 261.15 MB (+11.45 MB)
[2025-08-08 04:06:39,020] INFO in matching: CachedIndex[video_md5] Replacing index type: TrivialSignalTypeIndex
[2025-08-08 04:06:39,042] INFO in matching: CachedIndex[video_md5] Called malloc_trim(0) to release freed memory
[2025-08-08 04:06:39,043] INFO in matching: CachedIndex[video_md5] Cleanup complete: 246.47 MB (freed: 14.68 MB)
```

Memory jumps are expected as we do the swap, but it being freed right after.

Test Plan
---------

<!--Replace with a description of how you tested this change, did you add test, run something locally...-->
