### PR TITLE
Add reset method to SignalTypeIndex and all downstream index classes

### DIFF
--- a/python-threatexchange/pyproject.toml
+++ b/python-threatexchange/pyproject.toml
@@ -42,7 +42,7 @@ extensions = [
     "pytesseract",
 ]
 dev = [
-    "pytest",
+    "pytest == 8.3.5",
     "black",
     "mypy",
     "types-python-dateutil",

--- a/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/tests/test_vpdq_faiss.py
@@ -96,6 +96,19 @@ def test_simple():
     assert res[0] == IndexMatch(VPDQSimilarityInfo(100.0, 100.0), EXAMPLE_META_DATA)
 
 
+def test_reset():
+    index = VPDQIndex.build([[HASH, EXAMPLE_META_DATA]])
+    assert index._entry_idx_to_features_and_entries[0][0] == FEATURES
+    assert len(index._index_idx_to_vpdqHex_and_entry) == len(FEATURES)
+
+    index.reset()
+
+    assert index.index.faiss_index is not None
+    assert index.index.faiss_index.ntotal == 0
+    assert len(index._entry_idx_to_features_and_entries) == 0
+    assert len(index._index_idx_to_vpdqHex_and_entry) == 0
+
+
 def test_half_match():
     index = VPDQIndex.build([[HASH, EXAMPLE_META_DATA]], query_match_threshold_pct=0)
     half_hash = FEATURES[0 : int(len(FEATURES) / 2)]

--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq_faiss.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq_faiss.py
@@ -20,6 +20,9 @@ class VPDQHashIndex:
             faiss.IndexBinaryFlat(BITS_IN_PDQ) if faiss_index is None else faiss_index
         )
 
+    def reset(self) -> None:
+        self.faiss_index.reset()
+
     def add_single_video(self, hashes: t.List[VpdqCompactFeature]) -> None:
         """
         Args:

--- a/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/vpdq_index.py
@@ -72,6 +72,14 @@ class VPDQIndex(SignalTypeIndex[IndexT]):
         ret.add_all(entries)
         return ret
 
+    def reset(self) -> None:
+        self.index.reset()
+        self._entry_idx_to_features_and_entries: t.List[
+            t.Tuple[t.List[VpdqCompactFeature], IndexT]
+        ] = []
+        self._index_idx_to_vpdqHex_and_entry: t.List[t.Tuple[int, t.List[int]]] = []
+        self._unique_vpdqHex_to_index_idx: t.Dict[str, int] = {}
+
     def add(self, signal_str: str, entry: IndexT) -> None:
         entry_id = len(self._entry_idx_to_features_and_entries)
         features = prepare_vpdq_feature(signal_str, self.quality_threshold)

--- a/python-threatexchange/threatexchange/signal_type/index.py
+++ b/python-threatexchange/threatexchange/signal_type/index.py
@@ -215,6 +215,14 @@ class SignalTypeIndex(t.Generic[T]):
         ret.add_all(entries)
         return ret
 
+    def reset(cls: t.Type[Self]) -> None:
+        """
+        Reset the index to an empty state.
+
+        Used to correctly handling garbage collection when an index is no longer needed.
+        """
+        raise NotImplementedError
+
     # TODO - probably move add() methods to a mixin instead
     def add(self, signal_str: str, entry: T) -> None:
         """

--- a/python-threatexchange/threatexchange/signal_type/pdq/pdq_faiss_matcher.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq/pdq_faiss_matcher.py
@@ -48,6 +48,9 @@ class PDQHashIndex(ABC):
         """
         pass
 
+    def reset(self) -> None:
+        self.faiss_index.reset()
+
     def search(
         self,
         queries: t.Sequence[PDQ_HASH_TYPE],
@@ -164,6 +167,9 @@ class PDQFlatHashIndex(PDQHashIndex):
         )
         super().__init__(faiss_index)
 
+    def reset(self) -> None:
+        super().reset()
+
     def add(self, hashes: t.Iterable[PDQ_HASH_TYPE], custom_ids: t.Iterable[int]):
         """
         Parameters
@@ -210,6 +216,10 @@ class PDQMultiHashIndex(PDQHashIndex):
         )
         super().__init__(faiss_index)
         self.__construct_index_rev_map()
+
+    def reset(self) -> None:
+        super().reset()
+        self.index_rev_map = None
 
     def add(
         self,

--- a/python-threatexchange/threatexchange/signal_type/pdq/pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq/pdq_index.py
@@ -44,6 +44,10 @@ class PDQIndex(SignalTypeIndex[IndexT]):
     def __len__(self) -> int:
         return len(self.local_id_to_entry)
 
+    def reset(self) -> None:
+        self.local_id_to_entry: t.List[t.Tuple[str, IndexT]] = []
+        self.index.reset()
+
     def query(self, hash: str) -> t.Sequence[PDQIndexMatch[IndexT]]:
         """
         Look up entries against the index, up to the max supported distance.

--- a/python-threatexchange/threatexchange/signal_type/pdq/pdq_index2.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq/pdq_index2.py
@@ -57,6 +57,11 @@ class PDQIndex2(SignalTypeIndex[IndexT]):
     def __len__(self) -> int:
         return len(self._idx_to_entries)
 
+    def reset(self) -> None:
+        self._deduper: t.Dict[str, int] = {}
+        self._idx_to_entries: t.List[t.List[IndexT]] = []
+        self._index.reset()
+
     def query(self, hash: str) -> t.Sequence[PDQIndexMatch[IndexT]]:
         """
         Look up entries against the index, up to the threshold.
@@ -101,6 +106,9 @@ class _PDQFaissIndex:
 
     def __init__(self, faiss_index: faiss.Index) -> None:
         self.faiss_index = faiss_index
+
+    def reset(self) -> None:
+        self.faiss_index.reset()
 
     def add(self, pdq_strings: t.Sequence[str]) -> None:
         """

--- a/python-threatexchange/threatexchange/signal_type/signal_base.py
+++ b/python-threatexchange/threatexchange/signal_type/signal_base.py
@@ -215,6 +215,9 @@ class TrivialSignalTypeIndex(index.SignalTypeIndex[index.T]):
     def __init__(self) -> None:
         self.state: t.Dict[str, t.List[index.T]] = {}
 
+    def reset(self) -> None:
+        self.state: t.Dict[str, t.List[index.T]] = {}
+
     def query(self, query: str) -> t.List[index.IndexMatch[index.T]]:
         return [
             index.IndexMatch(index.SignalSimilarityInfo(), meta)
@@ -243,6 +246,9 @@ class TrivialLinearSearchHashIndex(index.SignalTypeIndex[index.T]):
     def __init__(self) -> None:
         self.state: t.List[t.Tuple[str, index.T]] = []
 
+    def reset(self) -> None:
+        self.state: t.Dict[str, t.List[index.T]] = {}
+
     def query(self, query_hash: str) -> t.List[index.IndexMatch[index.T]]:
         ret = []
         for hash, payload in self.state:
@@ -268,6 +274,9 @@ class TrivialLinearSearchMatchIndex(index.SignalTypeIndex[index.T]):
     def __init__(self) -> None:
         self.state: t.List[t.Tuple[str, index.T]] = []
         assert issubclass(self._SIGNAL_TYPE, MatchesStr)
+
+    def reset(self) -> None:
+        self.state: t.Dict[str, t.List[index.T]] = {}
 
     def query(self, query_hash: str) -> t.List[index.IndexMatch[index.T]]:
         ret = []

--- a/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index.py
@@ -128,3 +128,10 @@ def test_supports_pickling(index):
             PDQIndexMatch(SignalSimilarityInfoWithIntDistance(16), test_entries[0][1]),
         ],
     )
+
+
+def test_reset_index(index):
+    index.reset()
+
+    assert len(index.local_id_to_entry) == 0
+    assert index.index.faiss_index.ntotal == 0

--- a/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index2.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index2.py
@@ -180,6 +180,13 @@ def test_one_entry_sample_index():
     assert len(results) == 0
 
 
-def test_reset_index(index):
-    # FIXME: There problem needs to be a test case here, though I can't get one working
-    pass
+def test_reset_index():
+    get_random_hashes = _get_hash_generator()
+    base_hashes = get_random_hashes(100)
+    index = PDQIndex2(entries=[(h, base_hashes.index(h)) for h in base_hashes])
+
+    assert len(index) == len(base_hashes)
+
+    index.reset()
+
+    assert len(index) == 0

--- a/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index2.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/test_pdq_index2.py
@@ -178,3 +178,8 @@ def test_one_entry_sample_index():
 
     results = index.query(unmatching_test_hash)
     assert len(results) == 0
+
+
+def test_reset_index(index):
+    # FIXME: There problem needs to be a test case here, though I can't get one working
+    pass

--- a/python-threatexchange/threatexchange/signal_type/trend_query.py
+++ b/python-threatexchange/threatexchange/signal_type/trend_query.py
@@ -113,6 +113,9 @@ class TrendQueryIndex(index.SignalTypeIndex[index.T]):
     def __init__(self) -> None:
         self.state: t.Dict[str, t.Tuple[TrendQuery, t.List[index.T]]] = {}
 
+    def reset(self) -> None:
+        self.state: t.Dict[str, t.Tuple[TrendQuery, t.List[index.T]]] = {}
+
     # TODO - Figure out how to properly capture hash vs search
     def query(self, hash: str) -> t.List[index.IndexMatch[index.T]]:
         ret: t.List[index.IndexMatch[index.T]] = []

--- a/python-threatexchange/threatexchange/tests/hashing/test_index_updates.py
+++ b/python-threatexchange/threatexchange/tests/hashing/test_index_updates.py
@@ -68,6 +68,12 @@ class TestTrivialTypeIndexUpdates(TestIndexUpdates):
             ("420e238441fb34901697f02f086ff466", {"meta_data": 12}),
         ]
 
+    def test_index_resets(self):
+        index: TrivialSignalTypeIndex = self.get_index(self.get_first_set())
+        index.reset()
+
+        self.assertDictEqual(index.state, {})
+
 
 class TestPdqIndexUpdates(TestIndexUpdates):
     __test__ = True
@@ -188,3 +194,10 @@ class TestPdqIndexUpdates(TestIndexUpdates):
                 {"meta_data": 12},
             ),
         ]
+
+    def test_index_resets(self):
+        index: PDQIndex = self.get_index(self.get_first_set())
+        index.reset()
+
+        self.assertListEqual(index.local_id_to_entry, [])
+        self.assertEqual(index.index.faiss_index.ntotal, 0)

--- a/python-threatexchange/threatexchange/tests/hashing/test_pdq_faiss_matcher.py
+++ b/python-threatexchange/threatexchange/tests/hashing/test_pdq_faiss_matcher.py
@@ -105,6 +105,13 @@ class TestPDQFlatHashIndex(MixinTests.PDQHashIndexCommonTests, unittest.TestCase
         assert self.index.faiss_index is not None
         assert self.index.faiss_index.ntotal == len(test_hashes)
 
+    def test_reset_index(self):
+        assert self.index.faiss_index.ntotal > 0
+
+        self.index.reset()
+        assert self.index.faiss_index is not None
+        assert self.index.faiss_index.ntotal == 0
+
     def test_hash_at(self):
         assert test_hashes[2] == self.index.hash_at(2)
 
@@ -130,6 +137,13 @@ class TestPDQFlatHashIndexWithCustomIds(
         assert self.index.faiss_index is not None
         assert self.index.faiss_index.ntotal == len(test_hashes)
 
+    def test_reset_index(self):
+        assert self.index.faiss_index.ntotal > 0
+
+        self.index.reset()
+        assert self.index.faiss_index is not None
+        assert self.index.faiss_index.ntotal == 0
+
     def test_hash_at(self):
         assert test_hashes[2] == self.index.hash_at(self.custom_ids[2])
 
@@ -152,6 +166,14 @@ class TestPDQMultiHashIndex(MixinTests.PDQHashIndexCommonTests, unittest.TestCas
 
         assert self.index.faiss_index is not None
         assert self.index.faiss_index.ntotal == len(test_hashes)
+
+    def test_reset_index(self):
+        assert self.index.faiss_index.ntotal > 0
+
+        self.index.reset()
+        assert self.index.index_rev_map is None
+        assert self.index.faiss_index is not None
+        assert self.index.faiss_index.ntotal == 0
 
     def test_hash_at(self):
         assert test_hashes[2] == self.index.hash_at(2)
@@ -177,6 +199,14 @@ class TestPDQMultiHashIndexWithCustomIds(
 
         assert self.index.faiss_index is not None
         assert self.index.faiss_index.ntotal == len(test_hashes)
+
+    def test_reset_index(self):
+        assert self.index.faiss_index.ntotal > 0
+
+        self.index.reset()
+        assert self.index.index_rev_map is None
+        assert self.index.faiss_index is not None
+        assert self.index.faiss_index.ntotal == 0
 
     def test_hash_at(self):
         assert test_hashes[2] == self.index.hash_at(self.custom_ids[2])


### PR DESCRIPTION
Summary
---------

This would hopefully provide a cleaner way to "reset" an index when we don't need it anymore, based on the ideas in https://github.com/facebook/ThreatExchange/pull/1839/files#diff-1322c39b70910bd2d549a2b05510a0502cd01be14a17be592bede1f48795dc66R101

So instead of:
```python
            old_index = self.index

            self.index = new_index
            self.checkpoint = curr_checkpoint

            if old_index is not None:
                # Try to explicitly cleanup FAISS internals
                if hasattr(old_index, "_index") and hasattr(
                    old_index._index, "faiss_index"
                ):
                    try:
                        faiss_idx = old_index._index.faiss_index
                        if hasattr(faiss_idx, "reset"):
                            faiss_idx.reset()
                    except Exception:
                        pass

                del old_index
                trim_process_memory()
```

We would have:

```python
            old_index = self.index

            self.index = new_index
            self.checkpoint = curr_checkpoint

            if old_index is not None:
                old_index.reset()
                del old_index
                trim_process_memory()
```

Test Plan
---------

I've added various tests for the reset method in each modified index.
