### PR TITLE
Fix crash due to missing MAX_CONTENT_LENGTH configuration value

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/hashing.py
@@ -124,9 +124,18 @@ def hash_media() -> dict[str, str]:
 
     try:
         # Get response with content length tracking
-        max_content_length = int(
-            current_app.config.get("MAX_CONTENT_LENGTH", DEFAULT_MAX_CONTENT_LENGTH)
-        )
+        max_content_length = current_app.config.get("MAX_CONTENT_LENGTH")
+        if max_content_length is None:
+            max_content_length = DEFAULT_MAX_CONTENT_LENGTH
+        
+        # cast to integer if necessary (the value could have come from an environment variable)
+        if isinstance(max_content_length, str):
+            if not max_content_length.isdigit():
+                logger.error(f"MAX_CONTENT_LENGTH misconfigured, expected integer, received: {max_content_length}")
+                abort(500, "Service misconfigured, see logs for details")
+
+            max_content_length = int(max_content_length)
+
         with _check_content_length_stream_response(
             media_url, max_content_length
         ) as download_resp:

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_hashing.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_hashing.py
@@ -155,3 +155,35 @@ def test_content_length_validation(mock_get, mock_head, client):
     # Test with acceptable content length
     response = client.get("/h/hash?url=https://example.com/image.jpg")
     assert response.status_code != 413
+
+@patch("requests.head")
+def test_content_length_validation_default(mock_head, client, app):
+    with app.app_context():
+        # Override MAX_CONTENT_LENGTH to None, simulating it not 
+        # being present in an OMM_CONFIG file:
+        app.config["MAX_CONTENT_LENGTH"] = None
+
+        # Mock successful HEAD response with large content length
+        mock_head_resp = Mock()
+        mock_head_resp.headers = {"content-length": str(DEFAULT_MAX_CONTENT_LENGTH + 1)}
+        mock_head_resp.raise_for_status = (
+            Mock()
+        )  # Add this to prevent the raise_for_status() call from failing
+        mock_head.return_value = mock_head_resp
+
+        # Test with large content length
+        response = client.get("/h/hash?url=https://example.com/image.jpg")
+        assert response.status_code == 413
+        assert "Content too large" in response.get_data(as_text=True)
+
+@patch("requests.head")
+def test_content_length_validation_misconfiguration(client, app):
+    with app.app_context():
+        # Override MAX_CONTENT_LENGTH to a non-integer value, simulating it 
+        # being set from the environment variables incorrectly:
+        app.config["MAX_CONTENT_LENGTH"] = "not-an-integer"
+
+        # Test with large content length
+        response = client.get("/h/hash?url=https://example.com/image.jpg")
+        assert response.status_code == 500
+        assert "Service misconfigured, see logs for details" in response.get_data(as_text=True)


### PR DESCRIPTION
Summary
---------

This fixes #1842, which was potentially the case if you were using existing configuration files from before #1822 was merged, where a new configuration variable of `MAX_CONTENT_LENGTH` was introduced.

Test Plan
---------

Have added additional pytest test cases to catch this misconfiguration.
