### PR TITLE
[PyTx] Optimization to Serialize/Deserialize and interface to clean data.

### DIFF
--- a/python-threatexchange/threatexchange/signal_type/index.py
+++ b/python-threatexchange/threatexchange/signal_type/index.py
@@ -239,9 +239,17 @@ class SignalTypeIndex(t.Generic[T]):
 
         Could also be premature optimization, you decide!
         """
-        fout.write(pickle.dumps(self))
+        pickle.dump(self, fout, protocol=pickle.HIGHEST_PROTOCOL)
 
     @classmethod
     def deserialize(cls: t.Type[Self], fin: t.BinaryIO) -> Self:
         """Instantiate an index from a previous call to serialize"""
-        return pickle.loads(fin.read())
+        return pickle.load(fin)
+
+    def dispose(self) -> None:
+        """
+        Release any native resources or large auxiliary structures held by the
+        index implementation. Default is a no-op; implementations that wrap
+        native libraries (e.g., FAISS) should override.
+        """
+        return None


### PR DESCRIPTION
Summary
---------

This PR attempt to help reduction of peak memory by making some changes on how we serialize/deserialize data and makes index cleanup explicit and reliable:

- Switches index serialization/deserialization to streamed pickle APIs.
- Introduces a `dispose()` hook on indices and implements it for FAISS-backed PDQ indexes.
- Adds a weakref-based finalizer in the FAISS wrapper as a safety net so resources are cleaned up on GC/exit.

Why pickle changes:

Before: `pickle.dumps()`/`pickle.loads(fin.read())` created a duplicate of the entire index in memory, temporarily inflating RSS by the size of the serialized blob.

Now: `pickle.dump()`/`pickle.load()` stream directly to/from the file, lowering peak memory and reducing allocator fragmentation during load/store.

Test Plan
---------

<!--Replace with a description of how you tested this change, did you add test, run something locally...-->
