### PR TITLE
[HMA] Upgrade PyTX version

### DIFF
--- a/hasher-matcher-actioner/pyproject.toml
+++ b/hasher-matcher-actioner/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "flask_migrate",
     "psycopg2",
     "requests",
-    "threatexchange>=1.2.8",
+    "threatexchange>=1.2.10",
     "flask_apscheduler",
     "python-dateutil",
     "python-json-logger",


### PR DESCRIPTION
Summary
---------

Upgrades Python ThreatExchange version on HMA to ensure we use the latest version that adds the weakref fixes to help with memory

Test Plan
---------

Tested locally to make sure everything still worked as expected. 
