### PR TITLE
[HMA] Bypass Enabled Ratio for UI

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/matching.py
@@ -79,7 +79,8 @@ class _SignalIndexInMemoryCache:
     def reload_if_needed(self, store: interface.IUnifiedStore) -> None:
         now = time.time()
         # There's a race condition here, but it's unclear if we should solve it
-        curr_checkpoint = store.get_last_index_build_checkpoint(self.signal_type)
+        curr_checkpoint = store.get_last_index_build_checkpoint(
+            self.signal_type)
         if curr_checkpoint is not None and self.checkpoint != curr_checkpoint:
             new_index = store.get_signal_type_index(self.signal_type)
             if new_index is None:
@@ -139,7 +140,8 @@ def raw_lookup():
     """
     signal = require_request_param("signal")
     signal_type_name = require_request_param("signal_type")
-    include_distance = str_to_bool(request.args.get("include_distance", "false"))
+    include_distance = str_to_bool(
+        request.args.get("include_distance", "false"))
     lookup_signal_func = (
         lookup_signal_with_distance if include_distance else lookup_signal
     )
@@ -151,7 +153,8 @@ def query_index(
     signal: str, signal_type_name: str
 ) -> t.Sequence[IndexMatchUntyped[SignalSimilarityInfo, int]]:
     storage = get_storage()
-    signal_type = _validate_and_transform_signal_type(signal_type_name, storage)
+    signal_type = _validate_and_transform_signal_type(
+        signal_type_name, storage)
 
     try:
         signal = signal_type.validate_signal_str(signal)
@@ -284,16 +287,17 @@ def lookup_post() -> TBankMatchBySignalType:
         abort(403, "Hashing is disabled, missing role")
 
     hashes = hashing.hash_media_from_form_data()
+    bypass_coinflip = request.args.get("bypass_coinflip", "false") == "true"
 
     resp = {}
     for signal_type in hashes.keys():
         signal = hashes[signal_type]
-        resp[signal_type] = lookup(signal, signal_type)
+        resp[signal_type] = lookup(signal, signal_type, bypass_coinflip)
 
     return resp
 
 
-def lookup(signal: str, signal_type_name: str) -> TMatchByBank:
+def lookup(signal: str, signal_type_name: str, bypass_coinflip: bool = False) -> TMatchByBank:
     current_app.logger.debug("performing lookup")
     results_by_bank_content_id = {
         r.metadata: r for r in query_index(signal, signal_type_name)
@@ -308,13 +312,20 @@ def lookup(signal: str, signal_type_name: str) -> TMatchByBank:
         len(enabled_content),
     )
     banks = {c.bank.name: c.bank for c in enabled_content}
+
+    # Always allow all banks, whether matching is enabled or not if bypass_coinflip is True
     rand = random.Random(request.args.get("seed"))
-    coinflip = rand.random()
+    coinflip = rand.random() if not bypass_coinflip else 0
+    current_app.logger.debug(
+        "coinflip: %s", coinflip)
     enabled_banks = {
         b.name for b in banks.values() if b.matching_enabled_ratio >= coinflip
     }
     current_app.logger.debug(
-        "lookup matches %d banks (%d enabled_banks)", len(banks), len(enabled_banks)
+        "enabled_banks: %s", enabled_banks)
+    current_app.logger.debug(
+        "lookup matches %d banks (%d enabled_banks)", len(
+            banks), len(enabled_banks)
     )
     results = defaultdict(list)
     for content in enabled_content:
@@ -412,10 +423,12 @@ def compare():
     for signal_type_str in request_data.keys():
         hashes_to_compare = request_data.get(signal_type_str)
         if type(hashes_to_compare) != list:
-            abort(400, f"Comparison hashes for {signal_type_str} was not a list")
+            abort(
+                400, f"Comparison hashes for {signal_type_str} was not a list")
         if hashes_to_compare.__len__() != 2:
             abort(400, f"Comparison hash list lenght must be exactly 2")
-        signal_type = _validate_and_transform_signal_type(signal_type_str, storage)
+        signal_type = _validate_and_transform_signal_type(
+            signal_type_str, storage)
         try:
             left = signal_type.validate_signal_str(hashes_to_compare[0])
             right = signal_type.validate_signal_str(hashes_to_compare[1])
@@ -439,7 +452,8 @@ def initiate_index_cache(app: Flask, scheduler: APScheduler | None) -> None:
                 f"Match Index Refresh[{name}]",
                 entry.periodic_task,
                 trigger="interval",
-                seconds=int(app.config.get("TASK_INDEX_CACHE_INTERVAL_SECONDS", 30)),
+                seconds=int(app.config.get(
+                    "TASK_INDEX_CACHE_INTERVAL_SECONDS", 30)),
                 start_date=datetime.datetime.now() - datetime.timedelta(seconds=29),
             )
         scheduler.app.logger.info(

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/ui.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/ui.py
@@ -109,10 +109,8 @@ def home():
 
     # Check if SEED_BANK_0 and SEED_BANK_1 exist yet
     bank_list = curation.banks_index()
-    contains_seed_bank_0 = any(
-        bank.name == "SEED_BANK_0" for bank in bank_list)
-    contains_seed_bank_1 = any(
-        bank.name == "SEED_BANK_1" for bank in bank_list)
+    contains_seed_bank_0 = any(bank.name == "SEED_BANK_0" for bank in bank_list)
+    contains_seed_bank_1 = any(bank.name == "SEED_BANK_1" for bank in bank_list)
 
     template_vars = {
         "signal": curation.get_all_signal_types(),
@@ -174,10 +172,10 @@ def upload():
     signals = hashing.hash_media_from_form_data()
 
     # Get bypass parameter from form data (default to True for backward compatibility)
-    bypass_enabled_ratio = request.form.get(
-        'bypass_enabled_ratio', 'true').lower() == 'true'
-    current_app.logger.debug(
-        f"[query] bypass_enabled_ratio: {bypass_enabled_ratio}")
+    bypass_enabled_ratio = (
+        request.form.get("bypass_enabled_ratio", "true").lower() == "true"
+    )
+    current_app.logger.debug(f"[query] bypass_enabled_ratio: {bypass_enabled_ratio}")
 
     current_app.logger.debug("[query] performing lookup")
     banks = {

--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/ui.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/ui.py
@@ -109,8 +109,10 @@ def home():
 
     # Check if SEED_BANK_0 and SEED_BANK_1 exist yet
     bank_list = curation.banks_index()
-    contains_seed_bank_0 = any(bank.name == "SEED_BANK_0" for bank in bank_list)
-    contains_seed_bank_1 = any(bank.name == "SEED_BANK_1" for bank in bank_list)
+    contains_seed_bank_0 = any(
+        bank.name == "SEED_BANK_0" for bank in bank_list)
+    contains_seed_bank_1 = any(
+        bank.name == "SEED_BANK_1" for bank in bank_list)
 
     template_vars = {
         "signal": curation.get_all_signal_types(),
@@ -171,11 +173,17 @@ def upload():
     current_app.logger.debug("[query] hashing input")
     signals = hashing.hash_media_from_form_data()
 
+    # Get bypass parameter from form data (default to True for backward compatibility)
+    bypass_enabled_ratio = request.form.get(
+        'bypass_enabled_ratio', 'true').lower() == 'true'
+    current_app.logger.debug(
+        f"[query] bypass_enabled_ratio: {bypass_enabled_ratio}")
+
     current_app.logger.debug("[query] performing lookup")
     banks = {
         b
         for st_name, signal in signals.items()
-        for b in matching.lookup(signal, st_name)
+        for b in matching.lookup(signal, st_name, bypass_coinflip=bypass_enabled_ratio)
     }
 
     return {"hashes": signals, "banks": sorted(banks)}

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/banks_grid.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/banks_grid.html.j2
@@ -23,7 +23,17 @@
             <tr id="bank_item_{{bank['name']}}">
                 <th scope="row" style="background-color: transparent;">{{ loop.index }}</th>
                 <td style="background-color: transparent;">{{ bank['name'] }}</td>
-                <td style="background-color: transparent;">{{ bank['matching_enabled_ratio'] }}</td>
+                <td style="background-color: transparent;">
+                    {% if bank['matching_enabled_ratio'] < 1.0 %}
+                        <span class="badge bg-warning rounded-pill" title="Partial rollout: Only {{ (bank['matching_enabled_ratio'] * 100) | round(1) }}% chance this bank will match in production">
+                            {{ (bank['matching_enabled_ratio'] * 100) | round(1) }}%
+                        </span>
+                    {% else %}
+                        <span class="badge bg-success rounded-pill" title="100% chance this bank will match in production">
+                            {{ (bank['matching_enabled_ratio'] * 100) | round(1) }}%
+                        </span>
+                    {% endif %}
+                </td>
                 <td style="background-color: transparent;">
                     {% with bank_title=bank['name'] %}
                     {% include 'components/banks/add_to_bank_form.html.j2' %}

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/match_form.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/match_form.html.j2
@@ -1,6 +1,11 @@
 {# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <div class="card">
     <div class="card-header">Find Content in Banks</div>
+    <div class="alert alert-info alert-dismissible fade show mx-3 mt-3 mb-0" role="alert" id="bypass-warning">
+        <i class="bi bi-info-circle-fill me-2"></i>
+        <small><strong>Note:</strong> Bypass enabled ratio is checked - this will search all banks regardless of their matching enabled ratio.</small>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
     <form id="match_file" class="card-body">
         <div class="row">
             <div class="col">
@@ -23,6 +28,16 @@
                 <!-- for spacing -->
             </div>
         </div>
+        <div class="row mt-3">
+            <div class="col">
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" name="bypass_enabled_ratio" id="bypass-enabled-ratio" checked>
+                    <label class="form-check-label" for="bypass-enabled-ratio">
+                        <small>Bypass enabled ratio check (search all banks regardless of their matching enabled ratio)</small>
+                    </label>
+                </div>
+            </div>
+        </div>
     </form>
     <div id="matches">
         <!-- Added to by javascript -->
@@ -32,23 +47,43 @@
 <script>
     const match_form = document.getElementById("match_file");
     const matches = document.getElementById("matches");
+    const bypassCheckbox = document.getElementById("bypass-enabled-ratio");
+    const bypassWarning = document.getElementById("bypass-warning");
     let banks = [];
+    
+    // Toggle warning visibility based on checkbox state
+    const toggleWarning = () => {
+        if (bypassCheckbox.checked) {
+            bypassWarning.style.display = 'block';
+        } else {
+            bypassWarning.style.display = 'none';
+        }
+    };
+    
+    // Initialize warning state
+    toggleWarning();
+    
+    // Listen for checkbox changes
+    bypassCheckbox.addEventListener('change', toggleWarning);
     match_form.addEventListener("submit", (event) => {
         event.preventDefault();
         const formData = new FormData();
 
         // Append the selected file and content type to the FormData
         formData.append(event.target.media.value, event.target.file.files[0]);
+        
+        // Append the bypass enabled ratio parameter
+        formData.append('bypass_enabled_ratio', event.target.bypass_enabled_ratio.checked);
 
         fetch('/ui/query', {
             method: 'POST',
             body: formData
         })
             .then(response => response.json())
-            .then(data => {
+            .then(async (data) => {
                 // Handle the response from the server here
                 banks = data.banks;
-                renderMatchResult(data);
+                await renderMatchResult(data);
                 highlightMatchedResults(data);
             })
             .catch(error => {
@@ -64,27 +99,74 @@
         })
     }
     
-    const renderMatchResult = (result) => {
-        // Render matched banks
-        const banksList = result.banks.map(bank => `<li>${bank}</li>`).join('');
+    // Function to fetch bank data including enabled ratios
+    const fetchBankData = async (bankNames) => {
+        try {
+            const bankPromises = bankNames.map(bankName => 
+                fetch(`/c/bank/${bankName}`)
+                    .then(response => response.json())
+                    .catch(error => {
+                        console.error(`Error fetching bank ${bankName}:`, error);
+                        return { name: bankName, matching_enabled_ratio: 'Unknown' };
+                    })
+            );
+            
+            const bankDataArray = await Promise.all(bankPromises);
+            return bankDataArray.reduce((acc, bankData) => {
+                acc[bankData.name] = bankData;
+                return acc;
+            }, {});
+        } catch (error) {
+            console.error('Error fetching bank data:', error);
+            return {};
+        }
+    };
+
+    const renderMatchResult = async (result) => {
+        // Fetch bank data with enabled ratios
+        const bankData = await fetchBankData(result.banks);
+        
+        // Render matched banks with enabled ratios
+        const banksList = result.banks.map(bankName => {
+            const bank = bankData[bankName];
+            const enabledRatio = bank ? (bank.matching_enabled_ratio * 100).toFixed(1) : 'Unknown';
+            const badgeClass = bank && bank.matching_enabled_ratio > 0.8 ? 'bg-success' : 
+                              bank && bank.matching_enabled_ratio > 0.5 ? 'bg-warning' : 'bg-danger';
+            
+            return `
+                <li class="list-group-item">
+                    <span class="fw-bold">${bankName}</span>
+                    <span class="badge ${badgeClass} rounded-pill ms-2" title="Matching Enabled Ratio">
+                        ${enabledRatio}%
+                    </span>
+                </li>
+            `;
+        }).join('');
+        
         const content = `
                 <div class="card-body">
-                    <h5>Matched Banks</h5>
-                    <ul>${banksList}</ul>
-                    <h5>Hash Values:</h5>
-                    <table class="table table-hover" style="max-height: 100px;">
-                        <tr>
-                            <th>Key</th>
-                            <th>Value</th>
-                        </tr>
-                        ${Object.entries(result.hashes).map(([key, value]) => `
-                            <tr>
-                                <td>${key}</td>
-                                <td style="overflow: scroll; max-width: 200px; white-space: no-wrap;">${value}</td>
-                            </tr>
-                        `).join('')}
-                    </table>
-                    <button type="button" class="btn btn-secondary" onclick="clearMatches()">Clear</button>
+                    <h5 class="card-title">Matched Banks</h5>
+                    <ul class="list-group list-group-flush mb-3">${banksList}</ul>
+                    <h5 class="card-title">Hash Values:</h5>
+                    <div class="table-responsive" style="max-height: 300px; overflow-y: auto;">
+                        <table class="table table-hover table-sm">
+                            <thead class="table-light sticky-top">
+                                <tr>
+                                    <th>Key</th>
+                                    <th>Value</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                ${Object.entries(result.hashes).map(([key, value]) => `
+                                    <tr>
+                                        <td class="fw-medium">${key}</td>
+                                        <td class="font-monospace text-truncate" style="max-width: 200px;" title="${value}">${value}</td>
+                                    </tr>
+                                `).join('')}
+                            </tbody>
+                        </table>
+                    </div>
+                    <button type="button" class="btn btn-secondary mt-3" onclick="clearMatches()">Clear</button>
                 </div>
         `
         // Append both the banks and hashes sections to the "matches" element

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/match_form.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/match_form.html.j2
@@ -130,13 +130,14 @@
         const banksList = result.banks.map(bankName => {
             const bank = bankData[bankName];
             const enabledRatio = bank ? (bank.matching_enabled_ratio * 100).toFixed(1) : 'Unknown';
-            const badgeClass = bank && bank.matching_enabled_ratio > 0.8 ? 'bg-success' : 
-                              bank && bank.matching_enabled_ratio > 0.5 ? 'bg-warning' : 'bg-danger';
+            // Only tooltip if not 100% enabled, use warning color for partial rollouts
+            const badgeClass = bank && bank.matching_enabled_ratio < 1.0 ? 'bg-warning' : 'bg-success';
+            const showBadge = bank && bank.matching_enabled_ratio < 1.0;
             
             return `
                 <li class="list-group-item">
                     <span class="fw-bold">${bankName}</span>
-                    <span class="badge ${badgeClass} rounded-pill ms-2" title="Matching Enabled Ratio">
+                    <span class="badge ${badgeClass} rounded-pill ms-2" title="${showBadge ? `Partial rollout: Only ${enabledRatio}% chance this bank will match in production` : ''}">
                         ${enabledRatio}%
                     </span>
                 </li>

--- a/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/match_form.html.j2
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/templates/components/banks/match_form.html.j2
@@ -137,7 +137,7 @@
             return `
                 <li class="list-group-item">
                     <span class="fw-bold">${bankName}</span>
-                    <span class="badge ${badgeClass} rounded-pill ms-2" title="${showBadge ? `Partial rollout: Only ${enabledRatio}% chance this bank will match in production` : ''}">
+                    <span class="badge ${badgeClass} rounded-pill ms-2" title="${showBadge ? `This bank is only partially enabled, and may not count as matching in production based on coinflip. Enable the bank at 100% to ensure it matches consistently.` : ''}">
                         ${enabledRatio}%
                     </span>
                 </li>


### PR DESCRIPTION
Summary
---------

Fixes #1844

This PR Allows for the front-end to bypass the enabled ratio on queries to match content as well as add the functionality to the matching lookup as an optional arg. 

This is useful to check what the content may match on different banks regardless of the enabled_ratio while also giving a visual of what is the current enabled value for the banks. This is an optional setting on the UI as to keep the same behavior.

Test Plan
---------
Tested locally adding the same image to multiple banks and then changing their enabled ratio. I then requested the match bypassing enabled ratio and all got returned and then did a couple without the bypass to see the coinflip still working.

Before:

<img width="2551" height="1068" alt="Screenshot 2025-08-26 at 9 22 00 PM" src="https://github.com/user-attachments/assets/fcc79e5f-f087-4cd5-8878-b34d18e87453" />

After:

<img width="2549" height="909" alt="Screenshot 2025-08-26 at 9 37 08 PM" src="https://github.com/user-attachments/assets/ced6f777-8ad7-47a6-b54d-4761489be620" />
<img width="2538" height="876" alt="Screenshot 2025-08-26 at 9 37 01 PM" src="https://github.com/user-attachments/assets/a731f7f8-f959-4db9-a1f6-60b2bf4cba60" />
<img width="2534" height="1249" alt="Screenshot 2025-08-26 at 9 36 39 PM" src="https://github.com/user-attachments/assets/747734bb-14c7-475b-8788-7c95d11112ef" />
