### PR TITLE
[pytx] Fix state file rename logic on windows #1852

### DIFF
--- a/python-threatexchange/threatexchange/cli/cli_state.py
+++ b/python-threatexchange/threatexchange/cli/cli_state.py
@@ -14,7 +14,6 @@ import pickle
 import pathlib
 import typing as t
 import logging
-import os
 
 from threatexchange.signal_type.index import SignalTypeIndex
 from threatexchange.signal_type.signal_base import SignalType
@@ -181,10 +180,4 @@ class CliSimpleState(helpers.SimpleFetchedStateStore):
         tmpfile = file.with_name(f".{file.name}")
         with tmpfile.open("wb") as f:
             pickle.dump(delta, f)
-
-        # delete the target file first if it exists, otherwise windows doesn't like it
-        if os.path.exists(file):
-            os.remove(file)
-
-        # move temp file to target
-        tmpfile.rename(file)
+        tmpfile.replace(file)


### PR DESCRIPTION
Summary
---------

Renaming a temp file to a file that already exists doesn't work on Windows, this adds code to delete the file first.

Test Plan
---------

Tested locally.
