### PR TITLE
Fix build on macOS Apple silicon

### DIFF
--- a/pdq/cpp/Makefile
+++ b/pdq/cpp/Makefile
@@ -1,8 +1,8 @@
 # ================================================================
 ifneq ($(findstring wasm, $(MAKECMDGOALS)), wasm)
-CXX=g++ # please customize according to your system --- Note: Apple clang on M1 is not currently supported 
+CXX=g++ # please customize according to your system
 CC=$(CXX) -g -std=c++11
-WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation -Wno-unknown-warning-option -Werror
+WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation -Wno-unknown-warning-option -Wno-deprecated-declarations -Werror
 LFLAGS=-lm -lpthread
 else
 CC=emcc -g -std=c++11 -D BUILD_WASM -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s EXPORTED_RUNTIME_METHODS=['ccall','UTF8ToString ']  -s  EXPORTED_FUNCTIONS=['_getHash'] -s FORCE_FILESYSTEM=1 -s LLD_REPORT_UNDEFINED -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s DISABLE_EXCEPTION_CATCHING=0 -s ALLOW_MEMORY_GROWTH=1
@@ -12,7 +12,7 @@ endif
 
 IFLAGS=-I../.. -I.
 # -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation is because of CImg.h
-WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation -Wno-unknown-warning-option -Werror
+WFLAGS=-Wall -Wno-char-subscripts -Wno-stringop-truncation -Wno-class-memaccess -Wno-misleading-indentation -Wno-unknown-warning-option -Wno-deprecated-declarations -Werror
 LFLAGS=-lm -lpthread
 
 CCOPT=$(CC) $(CFLAGS) $(IFLAGS) $(WFLAGS) -O3

--- a/pdq/cpp/README.md
+++ b/pdq/cpp/README.md
@@ -8,11 +8,6 @@ Please see [../README.md](https://github.com/facebook/ThreatExchange/blob/main/p
 * `CImg.h` is included for reference, though note it is not under the same license as the rest of the repository. It is expected that your company will already have image-processing logic. Dependencies of this code on `CImg.h` are confined solely to `io/pdqio.h` and `io/pdqio.cpp` which you can customize for your site.
 * ImageMagick or other JPEG/PNG libraries: for example, `brew install imagemagick` on MacOSX
 
-## MacOS on Apple M1
-
-* Currently the builtin Apple clang g++ does not work for building this implementation.
-  * Installing gcc and updating the `Makefile`s CXX to use that version of g++ instead is recommend.
-
 # Contact
 
 threatexchange@meta.com


### PR DESCRIPTION
Add -Wno-deprecated-declarations to fix build with system clang. All builds and tests complete successfully on my M4.
