### PR TITLE
Add bank filtering to lookup endpoints

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_match_api.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_match_api.py
@@ -100,3 +100,129 @@ def test_lookups(client_with_sample_data: FlaskClient):
         for match in with_dist_matches:
             assert "bank_content_id" in match
             assert "distance" in match
+
+
+@pytest.fixture()
+def client_with_multi_bank_data(app) -> FlaskClient:
+    """Fixture that sets up multiple banks with sample data for testing bank filtering."""
+    storage = get_storage()
+
+    # Create multiple banks
+    storage.bank_update(iface.BankConfig("BANK_A", 1.0), create=True)
+    storage.bank_update(iface.BankConfig("BANK_B", 1.0), create=True)
+    storage.bank_update(iface.BankConfig("BANK_C", 1.0), create=True)
+
+    # Add content to each bank using PDQ signals
+    pdq_signal = PdqSignal.get_examples()[0]
+    storage.bank_add_content("BANK_A", {PdqSignal: pdq_signal})
+    storage.bank_add_content("BANK_B", {PdqSignal: pdq_signal})
+    storage.bank_add_content("BANK_C", {PdqSignal: pdq_signal})
+
+    # Build indices
+    build_index.build_all_indices(storage, storage, storage)
+
+    client = app.test_client()
+    assert client.get("/status").status_code == 200
+    return client
+
+
+def test_raw_lookup_with_bank_filter(client_with_multi_bank_data: FlaskClient):
+    """Test /m/raw_lookup endpoint with bank filtering."""
+    client = client_with_multi_bank_data
+
+    sig_str = PdqSignal.get_examples()[0]
+    query_str = {"signal": sig_str, "signal_type": PdqSignal.get_name()}
+
+    # Test without bank filter - should return all banks
+    resp = client.get("/m/raw_lookup", query_string=query_str)
+    assert resp.status_code == 200
+    all_matches = resp.json["matches"]  # type: ignore
+    assert len(all_matches) == 3  # One from each bank
+
+    # Test filtering by single bank
+    query_str["banks"] = "BANK_A"  # type: ignore
+    resp = client.get("/m/raw_lookup", query_string=query_str)
+    assert resp.status_code == 200
+    bank_a_matches = resp.json["matches"]  # type: ignore
+    assert len(bank_a_matches) == 1
+
+    # Test filtering by multiple banks
+    query_str["banks"] = "BANK_A,BANK_B"  # type: ignore
+    resp = client.get("/m/raw_lookup", query_string=query_str)
+    assert resp.status_code == 200
+    multi_bank_matches = resp.json["matches"]  # type: ignore
+    assert len(multi_bank_matches) == 2
+
+    # Test filtering by non-existent bank
+    query_str["banks"] = "NON_EXISTENT_BANK"  # type: ignore
+    resp = client.get("/m/raw_lookup", query_string=query_str)
+    assert resp.status_code == 200
+    no_matches = resp.json["matches"]  # type: ignore
+    assert len(no_matches) == 0
+
+
+def test_raw_lookup_with_distance_and_bank_filter(
+    client_with_multi_bank_data: FlaskClient,
+):
+    """Test /m/raw_lookup with both distance and bank filtering."""
+    client = client_with_multi_bank_data
+
+    sig_str = PdqSignal.get_examples()[0]
+    query_str = {
+        "signal": sig_str,
+        "signal_type": PdqSignal.get_name(),
+        "include_distance": True,
+        "banks": "BANK_A,BANK_B",
+    }
+
+    resp = client.get("/m/raw_lookup", query_string=query_str)
+    assert resp.status_code == 200
+    matches = resp.json["matches"]  # type: ignore
+    assert len(matches) == 2
+
+    for match in matches:
+        assert "bank_content_id" in match
+        assert "distance" in match
+
+
+def test_lookup_with_bank_filter(client_with_multi_bank_data: FlaskClient):
+    """Test /m/lookup endpoint with bank filtering."""
+    client = client_with_multi_bank_data
+
+    sig_str = PdqSignal.get_examples()[0]
+    query_str = {"signal": sig_str, "signal_type": PdqSignal.get_name()}
+
+    # Test without bank filter - should return all banks
+    resp = client.get("/m/lookup", query_string=query_str)
+    assert resp.status_code == 200
+    resp_json = t.cast(TMatchByBank, resp.json)
+    assert len(resp_json) == 3
+    assert "BANK_A" in resp_json
+    assert "BANK_B" in resp_json
+    assert "BANK_C" in resp_json
+
+    # Test filtering by single bank
+    query_str["banks"] = "BANK_A"  # type: ignore
+    resp = client.get("/m/lookup", query_string=query_str)
+    assert resp.status_code == 200
+    resp_json = t.cast(TMatchByBank, resp.json)
+    assert len(resp_json) == 1
+    assert "BANK_A" in resp_json
+    assert len(resp_json["BANK_A"]) > 0
+
+    # Test filtering by multiple banks
+    query_str["banks"] = "BANK_A,BANK_C"  # type: ignore
+    resp = client.get("/m/lookup", query_string=query_str)
+    assert resp.status_code == 200
+    resp_json = t.cast(TMatchByBank, resp.json)
+    assert len(resp_json) == 2
+    assert "BANK_A" in resp_json
+    assert "BANK_C" in resp_json
+    assert "BANK_B" not in resp_json
+
+    # Test filtering by non-existent bank
+    query_str["banks"] = "NON_EXISTENT_BANK"  # type: ignore
+    resp = client.get("/m/lookup", query_string=query_str)
+    assert resp.status_code == 200
+    resp_json = t.cast(TMatchByBank, resp.json)
+    assert len(resp_json) == 0


### PR DESCRIPTION
## Summary
- Implements optional bank filtering for `/m/lookup` and `/h/raw_lookup` endpoints
- Allows clients to restrict search results to specific banks using a comma-separated list
- Addresses the feature request in issue #1875

## Changes Made
- Modified `raw_lookup()` endpoint to accept optional `banks` parameter
- Modified `lookup_get()` endpoint to accept optional `banks` parameter  
- Modified `lookup_post()` endpoint to accept optional `banks` parameter
- Updated `lookup_signal()` helper function to filter by banks
- Updated `lookup_signal_with_distance()` helper function to filter by banks
- Updated `lookup()` function to filter enabled banks by requested banks

## API Usage
```bash
# Filter lookup by banks
GET /m/lookup?signal_type=pdq&signal=hash&banks=BANK_A,BANK_B

# Filter raw lookup by banks
GET /h/raw_lookup?signal_type=pdq&signal=hash&banks=BANK_A
```

## Implementation Details
- Banks parameter is optional and accepts comma-separated bank names
- When provided, results are filtered to only include content from the specified banks
- When not provided, behavior is unchanged (all enabled banks are searched)
- Filtering is applied after existing enable/disable and coinflip logic

## Test Plan
- Manually tested syntax validation with Python
- CI will run full test suite including type checking and linting
- Integration testing should verify that:
  - Requests without banks parameter work as before
  - Requests with banks parameter only return results from specified banks
  - Invalid bank names are handled appropriately

Fixes #1875