### PR TITLE
[hma] Use consistent variable naming in scaled reference configs

### DIFF
--- a/hasher-matcher-actioner/reference_omm_configs/scaled_deployment_cron_omm_config.py
+++ b/hasher-matcher-actioner/reference_omm_configs/scaled_deployment_cron_omm_config.py
@@ -16,8 +16,8 @@ import os
 # Database configuration
 DBUSER = os.environ.get("POSTGRES_USER", "media_match")
 DBPASS = os.environ.get("POSTGRES_PASSWORD", "hunter2")
-DBHOST = os.environ.get("POSTGRESS_HOST", "db")
-DBNAME = os.environ.get("POSTGRESS_DBNAME", "media_match")
+DBHOST = os.environ.get("POSTGRES_HOST", os.environ.get("POSTGRESS_HOST", "db"))
+DBNAME = os.environ.get("POSTGRES_DBNAME", os.environ.get("POSTGRESS_DBNAME", "media_match"))
 DATABASE_URI = f"postgresql+psycopg2://{DBUSER}:{DBPASS}@{DBHOST}/{DBNAME}"
 
 # Role configuration

--- a/hasher-matcher-actioner/reference_omm_configs/scaled_deployment_curator_omm_config.py
+++ b/hasher-matcher-actioner/reference_omm_configs/scaled_deployment_curator_omm_config.py
@@ -13,8 +13,8 @@ import os
 # Database configuration
 DBUSER = os.environ.get("POSTGRES_USER", "media_match")
 DBPASS = os.environ.get("POSTGRES_PASSWORD", "hunter2")
-DBHOST = os.environ.get("POSTGRESS_HOST", "db")
-DBNAME = os.environ.get("POSTGRESS_DBNAME", "media_match")
+DBHOST = os.environ.get("POSTGRES_HOST", os.environ.get("POSTGRESS_HOST", "db"))
+DBNAME = os.environ.get("POSTGRES_DBNAME", os.environ.get("POSTGRESS_DBNAME", "media_match"))
 DATABASE_URI = f"postgresql+psycopg2://{DBUSER}:{DBPASS}@{DBHOST}/{DBNAME}"
 
 # Role configuration

--- a/hasher-matcher-actioner/reference_omm_configs/scaled_deployment_hasher_omm_config.py
+++ b/hasher-matcher-actioner/reference_omm_configs/scaled_deployment_hasher_omm_config.py
@@ -20,8 +20,8 @@ import os
 # Database configuration
 DBUSER = os.environ.get("POSTGRES_USER", "media_match")
 DBPASS = os.environ.get("POSTGRES_PASSWORD", "hunter2")
-DBHOST = os.environ.get("POSTGRESS_HOST", "db")
-DBNAME = os.environ.get("POSTGRESS_DBNAME", "media_match")
+DBHOST = os.environ.get("POSTGRES_HOST", os.environ.get("POSTGRESS_HOST", "db"))
+DBNAME = os.environ.get("POSTGRES_DBNAME", os.environ.get("POSTGRESS_DBNAME", "media_match"))
 DATABASE_URI = f"postgresql+psycopg2://{DBUSER}:{DBPASS}@{DBHOST}/{DBNAME}"
 
 # Role configuration

--- a/hasher-matcher-actioner/reference_omm_configs/scaled_deployment_matcher_omm_config.py
+++ b/hasher-matcher-actioner/reference_omm_configs/scaled_deployment_matcher_omm_config.py
@@ -15,8 +15,8 @@ import os
 # Database configuration
 DBUSER = os.environ.get("POSTGRES_USER", "media_match")
 DBPASS = os.environ.get("POSTGRES_PASSWORD", "hunter2")
-DBHOST = os.environ.get("POSTGRESS_HOST", "db")
-DBNAME = os.environ.get("POSTGRESS_DBNAME", "media_match")
+DBHOST = os.environ.get("POSTGRES_HOST", os.environ.get("POSTGRESS_HOST", "db"))
+DBNAME = os.environ.get("POSTGRES_DBNAME", os.environ.get("POSTGRESS_DBNAME", "media_match"))
 DATABASE_URI = f"postgresql+psycopg2://{DBUSER}:{DBPASS}@{DBHOST}/{DBNAME}"
 
 # Role configuration


### PR DESCRIPTION
Summary
---------

Two of the four variables had an extra 'S', which looks like a typo. To maintain backwards compatibility, we continue checking the typo'd name too.

Test Plan
---------

Tested by discovering the typo :)
