### PR TITLE
[hma] Fail rather than continue if the app hook isn't a function

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/app.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/app.py
@@ -174,9 +174,8 @@ def create_app() -> flask.Flask:
         # new endpoints, etc as may be required by their environments. HMA itself
         # doesn't supply such functionality as individual deployments may have
         # different, competing, requirements.
-        hook = app.config.get("APP_HOOK", None)
-        if hook != None and callable(hook):
-            hook(app)
+        # Note: we want this to fail if the defined function isn't a function.
+        app.config.get("APP_HOOK", lambda _: None)(app)
 
     @app.route("/")
     def home():


### PR DESCRIPTION
Summary
---------

Applies https://github.com/facebook/ThreatExchange/pull/1884#discussion_r2447729849

Because this hook may be used to set up authentication, it feels important to have it set to a useful value.

Test Plan
---------

Set `APP_HOOK` to `"lol not a hook"` => should cause process to exit shortly after startup.

Don't set `APP_HOOK` => should cause process to operate as per usual.

Set `APP_HOOK` to a function => should call the function.
