### PR TITLE
fix: enable Cython C++ mode to resolve cppclass build error

### DIFF
--- a/vpdq/CMakeLists.txt
+++ b/vpdq/CMakeLists.txt
@@ -27,7 +27,7 @@ add_custom_command(
   COMMENT
     "Making ${CMAKE_CURRENT_BINARY_DIR}/python/vpdq.cpp from ${CMAKE_CURRENT_SOURCE_DIR}/python/vpdq.pyx"
   COMMAND
-    Python::Interpreter -m cython "${CMAKE_CURRENT_SOURCE_DIR}/python/vpdq.pyx"
+    Python::Interpreter -m cython --cplus "${CMAKE_CURRENT_SOURCE_DIR}/python/vpdq.pyx"
     --output-file "${CMAKE_CURRENT_SOURCE_DIR}/python/vpdq.cpp"
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/python/vpdq.pyx
   VERBATIM)


### PR DESCRIPTION
Summary
---------

Cython was compiling the .pyx file in C mode, causing the "Using 'cppclass' while Cython is not in c++ mode" error. Added --cplus to the cython invocation and updated configuration to ensure C++ compilation.

Test Plan
---------
```
/ThreatExchange/vpdq# python -m pytest
======================================================================== test session starts ========================================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /ThreatExchange/vpdq
configfile: pyproject.toml
collected 3 items

python/tests/test_vpdq_hash.py ...                                                                                                                            [100%]

======================================================================== 3 passed in 15.28s =========================================================================
```
