### PR TITLE
[hma] Provide more detailed error when exchange fields are missing

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/curation.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/blueprints/curation.py
@@ -513,7 +513,10 @@ def exchange_create():
     try:
         cfg = dataclass_json.dataclass_load_dict(api_json, api_type.get_config_cls())
     except Exception as e:
-        abort(400, f"Failed to parse `api_json` - verify all fields are supplied. {str(e)}")
+        abort(
+            400,
+            f"Failed to parse `api_json` - verify all fields are supplied. {str(e)}",
+        )
 
     storage.exchange_update(cfg, create=True)
 


### PR DESCRIPTION
Summary
---------

<img width="462" height="199" alt="image" src="https://github.com/user-attachments/assets/a3284e92-4e21-4b93-981d-f86ad5ce3cd9" />

This is very much not intended to be a complete solution, but rather a step towards "better".

Test Plan
---------

1. Attempt to create an exchange (in the UI) which requires config values, but don't specify them.
2. Receive error stating there's missing fields.
