### PR TITLE
Update CONTRIBUTING.md git configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,6 @@ Here's an easy way to get started:
 Next, [fork](https://help.github.com/articles/fork-a-repo/) your own copy of the repo.
 Here's where you'll push development branches. Note the name, we'll need it in the next step.
 
-Lastly, we'll add the fork as the preferred repo to push to
-
-    # From the root directory of your locally cloned repo
-     git config push.default fork
-
 There are some common [git aliases](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases) you may use, which you can add if you'd like:
 
     # you can add --global to these to affect all your repos


### PR DESCRIPTION
With "simple" now being the default behavior for push, let's remove the notes about messing with upstream.

Additionally, a lot of these fields used --global which is not preferred for a project-specific contributing.