### PR TITLE
[pytx] Replace levenstein library with one with a different license

### DIFF
--- a/python-threatexchange/pyproject.toml
+++ b/python-threatexchange/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 keywords = ["facebook", "threatexchange", "ncmec", "stopncii", "pdq"]
 requires-python = ">=3.8"
 dependencies = [
-    "python-Levenshtein",
+    "weighted-levenshtein",
     "requests",
     "urllib3",  # For allow_methods
     "python-dateutil",

--- a/python-threatexchange/threatexchange/cli/cli_config.py
+++ b/python-threatexchange/threatexchange/cli/cli_config.py
@@ -33,7 +33,6 @@ from threatexchange.cli.cli_state import CliSimpleState, CliIndexStore
 from threatexchange.storage import interfaces as iface
 from threatexchange.utils import dataclass_json
 
-
 CONFIG_FILENAME = "config.json"
 
 

--- a/python-threatexchange/threatexchange/cli/match_cmd.py
+++ b/python-threatexchange/threatexchange/cli/match_cmd.py
@@ -33,7 +33,6 @@ from threatexchange.content_type.photo import PhotoContent
 from threatexchange.signal_type.signal_base import MatchesStr, TextHasher, FileHasher
 from threatexchange.cli import command_base
 
-
 TMatcher = t.Callable[[pathlib.Path], t.List[IndexMatch]]
 
 

--- a/python-threatexchange/threatexchange/content_type/file.py
+++ b/python-threatexchange/threatexchange/content_type/file.py
@@ -4,6 +4,7 @@
 """
 Wrapper around the file content type.
 """
+
 import logging
 from pathlib import Path
 from .photo import PhotoContent

--- a/python-threatexchange/threatexchange/content_type/photo.py
+++ b/python-threatexchange/threatexchange/content_type/photo.py
@@ -4,6 +4,7 @@
 """
 Wrapper around the video content type.
 """
+
 from PIL import Image
 from pathlib import Path
 import io

--- a/python-threatexchange/threatexchange/content_type/video.py
+++ b/python-threatexchange/threatexchange/content_type/video.py
@@ -4,6 +4,7 @@
 """
 Wrapper around the video content type.
 """
+
 import typing as t
 
 from threatexchange.content_type.content_base import ContentType

--- a/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/ncmec/hash_api.py
@@ -23,7 +23,6 @@ import requests
 from urllib3.util.retry import Retry
 from threatexchange.exchanges.clients.utils.common import TimeoutHTTPAdapter
 
-
 _DATE_FORMAT_STR = "%Y-%m-%dT%H:%M:%SZ"
 _DEFAULT_ELE = ET.Element("")
 

--- a/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
+++ b/python-threatexchange/threatexchange/exchanges/clients/techagainstterrorism/tests/test_api.py
@@ -10,7 +10,6 @@ from threatexchange.exchanges.clients.techagainstterrorism.api import (
     TATIdeology,
 )
 
-
 mock_hashes: t.List[TATHashListEntry] = [
     TATHashListEntry(
         hash_digest="123abc",

--- a/python-threatexchange/threatexchange/exchanges/fetch_state.py
+++ b/python-threatexchange/threatexchange/exchanges/fetch_state.py
@@ -7,7 +7,6 @@ Many implementations will choose to extend these to add additional metadata
 needed to power API features.
 """
 
-
 from dataclasses import dataclass
 from enum import IntEnum
 from abc import ABC, abstractmethod

--- a/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/fb_threatexchange_api.py
@@ -7,7 +7,6 @@ https://developers.facebook.com/programs/threatexchange
 https://developers.facebook.com/docs/threat-exchange/reference/apis/
 """
 
-
 from collections import defaultdict
 import typing as t
 import time

--- a/python-threatexchange/threatexchange/exchanges/impl/file_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/file_api.py
@@ -7,7 +7,6 @@ This is useful if you don't have access to an API, but still have a list of
 hashes from somewhere.
 """
 
-
 import os
 import typing as t
 from dataclasses import dataclass, field

--- a/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/ncmec_api.py
@@ -6,7 +6,6 @@ SignalExchangeAPI impl for the NCMEC hash exchange API
 @see NCMECSignalExchangeAPI
 """
 
-
 import logging
 import time
 import typing as t
@@ -22,7 +21,6 @@ from threatexchange.exchanges.collab_config import (
 from threatexchange.signal_type.signal_base import SignalType
 from threatexchange.signal_type.md5 import VideoMD5Signal
 from threatexchange.signal_type.pdq.signal import PdqSignal
-
 
 _API_NAME: str = "ncmec"
 

--- a/python-threatexchange/threatexchange/exchanges/impl/static_sample.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/static_sample.py
@@ -9,7 +9,6 @@ access to any API.
 The CLI defaults to this being the only collaboration.
 """
 
-
 import typing as t
 
 from threatexchange.signal_type.signal_base import SignalType

--- a/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
+++ b/python-threatexchange/threatexchange/exchanges/impl/stop_ncii_api.py
@@ -2,7 +2,6 @@
 
 """SignalExchangeAPI implementation for StopNCII.org"""
 
-
 from functools import lru_cache
 import time
 import typing as t

--- a/python-threatexchange/threatexchange/extensions/manifest.py
+++ b/python-threatexchange/threatexchange/extensions/manifest.py
@@ -8,7 +8,6 @@ See the README.md in this directory for more information.
 tl;dr: Have a module with TX_MANIFEST that is assigned this class.
 """
 
-
 from dataclasses import dataclass
 import importlib
 import typing as t

--- a/python-threatexchange/threatexchange/extensions/pdf/__init__.py
+++ b/python-threatexchange/threatexchange/extensions/pdf/__init__.py
@@ -3,7 +3,6 @@
 from threatexchange.extensions.manifest import ThreatExchangeExtensionManifest
 from threatexchange.extensions.pdf.content import PDFContent
 
-
 TX_MANIFEST = ThreatExchangeExtensionManifest(
     content_types=(PDFContent,),
 )

--- a/python-threatexchange/threatexchange/extensions/pdq_ocr/__init__.py
+++ b/python-threatexchange/threatexchange/extensions/pdq_ocr/__init__.py
@@ -3,7 +3,6 @@
 from threatexchange.extensions.manifest import ThreatExchangeExtensionManifest
 from threatexchange.extensions.pdq_ocr.pdq_ocr import PdqOcrSignal
 
-
 TX_MANIFEST = ThreatExchangeExtensionManifest(
     signal_types=(PdqOcrSignal,),
 )

--- a/python-threatexchange/threatexchange/extensions/tlsh/__init__.py
+++ b/python-threatexchange/threatexchange/extensions/tlsh/__init__.py
@@ -3,7 +3,6 @@
 from threatexchange.extensions.manifest import ThreatExchangeExtensionManifest
 from threatexchange.extensions.tlsh.text_tlsh import TextTLSHSignal
 
-
 TX_MANIFEST = ThreatExchangeExtensionManifest(
     signal_types=(TextTLSHSignal,),
 )

--- a/python-threatexchange/threatexchange/extensions/tlsh/tests/test_tlsh_hash_and_match.py
+++ b/python-threatexchange/threatexchange/extensions/tlsh/tests/test_tlsh_hash_and_match.py
@@ -1,7 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 import unittest
 
-
 try:
     import tlsh as _
 

--- a/python-threatexchange/threatexchange/extensions/vpdq/manifest.py
+++ b/python-threatexchange/threatexchange/extensions/vpdq/manifest.py
@@ -3,7 +3,6 @@
 from threatexchange.extensions.manifest import ThreatExchangeExtensionManifest
 from threatexchange.extensions.vpdq.vpdq import VPDQSignal
 
-
 TX_MANIFEST = ThreatExchangeExtensionManifest(
     signal_types=(VPDQSignal,),
 )

--- a/python-threatexchange/threatexchange/signal_type/pdq/pdq_hasher.py
+++ b/python-threatexchange/threatexchange/signal_type/pdq/pdq_hasher.py
@@ -7,7 +7,6 @@ import numpy as np
 from PIL import Image
 import typing as t
 
-
 PDQOutput = t.Tuple[
     str, int
 ]  # hexadecimal representation of the Hash vector and a numerical quality value

--- a/python-threatexchange/threatexchange/signal_type/raw_text.py
+++ b/python-threatexchange/threatexchange/signal_type/raw_text.py
@@ -8,7 +8,7 @@ Wrapper around the raw text signal type.
 from dataclasses import dataclass
 import typing as t
 
-import Levenshtein
+from weighted_levenshtein import lev
 
 from threatexchange import common
 from threatexchange.content_type.content_base import ContentType
@@ -28,7 +28,7 @@ class RawTextDistance(index.SignalSimilarityInfo):
     We re-project it onto the length of the query string.
     """
 
-    distance: int
+    distance: float
     query_str_len: int
 
     @property
@@ -42,7 +42,7 @@ class RawTextDistance(index.SignalSimilarityInfo):
         return 1 - self.diff_fraction
 
     @classmethod
-    def from_levenshtein(cls, needle: str, distance: int) -> "RawTextDistance":
+    def from_levenshtein(cls, needle: str, distance: float) -> "RawTextDistance":
         return cls(distance, len(needle))
 
     def pretty_str(self) -> str:
@@ -84,7 +84,8 @@ class RawTextSignal(
                 ldiff, max_match_distance
             )
 
-        distance: int = Levenshtein.distance(a, b)
+        distance: float = lev(a, b)
+
         return signal_base.SignalComparisonResult(
             distance <= max_match_distance,
             RawTextDistance.from_levenshtein(a, distance),

--- a/python-threatexchange/threatexchange/signal_type/tests/test_hash_from_x.py
+++ b/python-threatexchange/threatexchange/signal_type/tests/test_hash_from_x.py
@@ -12,7 +12,6 @@ from threatexchange.signal_type.pdq import signal
 from threatexchange.signal_type.signal_base import TextHasher
 import typing as t
 
-
 SIGNAL_TYPES_TO_TEST = [
     md5.VideoMD5Signal,
     signal.PdqSignal,

--- a/python-threatexchange/threatexchange/tests/hashing/test_pdq_utils.py
+++ b/python-threatexchange/threatexchange/tests/hashing/test_pdq_utils.py
@@ -12,7 +12,6 @@ from threatexchange.tests.hashing.utils import (
     get_similar_hash,
 )
 
-
 test_hashes = [
     "0000000000000000000000000000000000000000000000000000000000000000",
     "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f",


### PR DESCRIPTION
Summary
---------

The levenstein library we were using before had a restrictive license. I did a quick search for possible replacements and found the weighted-levenstein library, which uses MIT. 

As part of this, I updated to the newest version of black, which generated many many formatting changes.

Test Plan
---------

Existing unittests pass
