### PR TITLE
[hma] Get devcontainer building again

### DIFF
--- a/hasher-matcher-actioner/.devcontainer/Dockerfile
+++ b/hasher-matcher-actioner/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.13-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.13
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
   && apt-get -y install --no-install-recommends postgresql-client \


### PR DESCRIPTION
Summary
---------

See https://github.com/yarnpkg/yarn/issues/9216, the fix seems to be to switch to full-numbered python containers

Test Plan
---------

Open HMA devcontainer, it builds
