### PR TITLE
[pytx] Add back in libav install

### DIFF
--- a/python-threatexchange/.devcontainer/Dockerfile
+++ b/python-threatexchange/.devcontainer/Dockerfile
@@ -1,7 +1,15 @@
 ARG VARIANT=3.14-trixie
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
-RUN apt-get update -y && apt-get upgrade -y && apt-get install -y cmake 
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
+    cmake \
+    libavdevice-dev \
+    libavfilter-dev \
+    libavformat-dev \
+    libavcodec-dev \
+    libswresample-dev \
+    libswscale-dev \
+    libavutil-dev
 
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi


### PR DESCRIPTION
Summary
---------

In #1904 , I just removed these installs because casual googling didn't give me answers. Now that I found https://github.com/yarnpkg/yarn/issues/9216 and the underyling issue is fixed, add it back in.

Test Plan
---------

Rebuilt container, it succeeds.
