### PR TITLE
[pytx] Rearchitect classify command with text/image/hybrid subcommands

### DIFF
--- a/python-threatexchange/threatexchange/cli/classify_cmd.py
+++ b/python-threatexchange/threatexchange/cli/classify_cmd.py
@@ -45,6 +45,11 @@ class ClassifyTextCommand(command_base.Command):
             help="text string, file path, or - for stdin",
         )
         ap.add_argument(
+            "--mod-api",
+            action="store_true",
+            help="use OpenAI Moderation API (default)",
+        )
+        ap.add_argument(
             "-a", "--show-all", action="store_true", help="show all categories"
         )
         ap.add_argument(
@@ -57,10 +62,12 @@ class ClassifyTextCommand(command_base.Command):
     def __init__(
         self,
         input: str,
+        mod_api: bool = False,
         show_all: bool = False,
         model: str = "omni-moderation-latest",
     ):
         self.input = input
+        self.mod_api = mod_api
         self.show_all = show_all
         self.model = model
 
@@ -74,6 +81,8 @@ class ClassifyTextCommand(command_base.Command):
         else:
             text = self.input
 
+        # Default to mod-api if no API flag specified
+        # (currently only mod-api is supported)
         try:
             classifier = OpenAIModerationClassifier(model=self.model)
         except MissingAPIKeyError as e:
@@ -101,6 +110,11 @@ class ClassifyImageCommand(command_base.Command):
             help="image file path or URL",
         )
         ap.add_argument(
+            "--mod-api",
+            action="store_true",
+            help="use OpenAI Moderation API (default)",
+        )
+        ap.add_argument(
             "-a", "--show-all", action="store_true", help="show all categories"
         )
         ap.add_argument(
@@ -113,10 +127,12 @@ class ClassifyImageCommand(command_base.Command):
     def __init__(
         self,
         input: str,
+        mod_api: bool = False,
         show_all: bool = False,
         model: str = "omni-moderation-latest",
     ):
         self.input = input
+        self.mod_api = mod_api
         self.show_all = show_all
         self.model = model
 
@@ -142,6 +158,11 @@ class ClassifyHybridCommand(command_base.Command):
             help="text caption or description for the image",
         )
         ap.add_argument(
+            "--mod-api",
+            action="store_true",
+            help="use OpenAI Moderation API (default)",
+        )
+        ap.add_argument(
             "-a", "--show-all", action="store_true", help="show all categories"
         )
         ap.add_argument(
@@ -155,11 +176,13 @@ class ClassifyHybridCommand(command_base.Command):
         self,
         image: str,
         text: str,
+        mod_api: bool = False,
         show_all: bool = False,
         model: str = "omni-moderation-latest",
     ):
         self.image = image
         self.text = text
+        self.mod_api = mod_api
         self.show_all = show_all
         self.model = model
 


### PR DESCRIPTION
Summary
---------
  - Rearchitect classify command from API-centric to content-type-centric structure                                                    
  - Replace modapi subcommand with text, image, and hybrid subcommands                                                                 
  - text subcommand fully implemented (same behavior as previous modapi for text)                                                      
  - image and hybrid subcommands are stubs (raise "not implemented yet")                                                               
  - Add --mod-api flag to all subcommands to explicitly select OpenAI Moderation API (default if not specified)                        

Test Plan
---------
```
(.venv) suvamsh@suvamsh-mbp python-threatexchange % threatexchange classify text "i will kill myself"
  self_harm         97.59%  FLAGGED
  self_harm_intent  99.89%  FLAGGED
  violence          42.85%  FLAGGED
(.venv) suvamsh@suvamsh-mbp python-threatexchange % threatexchange classify text "i will kill myself" -a
  csam                     0.00%  
  harassment               0.07%  
  harassment_threatening   0.08%  
  hate                     0.00%  
  hate_threatening         0.00%  
  illicit                  0.38%  
  illicit_violent          0.00%  
  self_harm               97.59%  FLAGGED
  self_harm_instructions   0.03%  
  self_harm_intent        99.89%  FLAGGED
  sexual                   0.01%  
  violence                42.86%  FLAGGED
  violence_graphic         0.16%  
(.venv) suvamsh@suvamsh-mbp python-threatexchange % threatexchange classify text "hello" --mod-api
None
(.venv) suvamsh@suvamsh-mbp python-threatexchange % threatexchange classify text "i hate you" --mod-api
  harassment  80.53%  FLAGGED
```
