### PR TITLE
[HMA] Swap to use jemalloc to reduce memory fragmentation

### DIFF
--- a/hasher-matcher-actioner/.devcontainer/Dockerfile
+++ b/hasher-matcher-actioner/.devcontainer/Dockerfile
@@ -1,8 +1,11 @@
 FROM mcr.microsoft.com/vscode/devcontainers/python:3.13
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-  && apt-get -y install --no-install-recommends postgresql-client \
+  && apt-get -y install --no-install-recommends postgresql-client libjemalloc2 \
   && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Use jemalloc to avoid RSS growth from glibc heap fragmentation (see #1813)
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi

--- a/hasher-matcher-actioner/Dockerfile
+++ b/hasher-matcher-actioner/Dockerfile
@@ -1,6 +1,16 @@
 FROM python:3.13-bullseye
 
 WORKDIR /app
+
+# Use jemalloc instead of glibc malloc. FAISS and other native extensions
+# fragment glibc's heap so badly that freed pages are never returned to the
+# OS, causing RSS to grow with every index rebuild. jemalloc's per-size-class
+# arenas and aggressive madvise(MADV_DONTNEED) prevent this.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libjemalloc2 \
+    && rm -rf /var/lib/apt/lists/*
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+
 COPY pyproject.toml ./
 
 RUN pip install .[prod]


### PR DESCRIPTION
Summary
---------

Switch the Docker image's memory allocator from glibc malloc to jemalloc to address the steady RSS growth observed during index rebuild cycles (#1813).

FAISS indexes allocate large C++ buffers that are interleaved with small Python objects on glibc's heap. When freed, glibc cannot return those pages to the OS if any live allocation sits on the same page, and `malloc_trim(0)` can only reclaim from the top of the brk heap. 

jemalloc uses per-size-class arenas that avoid this interleaving and aggressively returns pages via `madvise(MADV_DONTNEED)`. It's a drop-in ABI-compatible replacement making this safe while helping memory growth.

