### PR TITLE
[hma] Add /status/live 

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/app.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/app.py
@@ -265,14 +265,12 @@ def create_app() -> OpenAPI:
             "200": {"description": "Service is alive"},
             "503": {"description": "Service is not ready"},
         },
-        summary="Health check (deprecated)",
+        summary="Health check",
         description=(
-            "Combined liveness/readiness check. Deprecated: prefer /livez for"
-            " liveness checks and /readyz for readiness checks. Health-check"
-            " clients that act on HTTP status codes alone (most load balancers"
-            " and orchestrators) cannot distinguish the failure modes this"
-            " endpoint reports, so using it as a liveness check causes restart"
-            " loops during cold start while the index is still loading."
+            "Returns 200 if the server is healthy and should serve traffic."
+            " If you need a separate check that the server is alive, check"
+            " for a non-empty return from this endpoint or use a 200 return"
+            " from /status/live."
         ),
     )
     def status():
@@ -287,47 +285,23 @@ def create_app() -> OpenAPI:
         return "I-AM-ALIVE", 200
 
     @app.get(
-        "/livez",
+        "/status/live",
         tags=[Tag(name="Core")],
         responses={"200": {"description": "Service is alive"}},
         summary="Liveness check",
         description=(
-            "Liveness check. Returns 200 if the process can serve HTTP. Does"
-            " not check index state - this is intentional, so that"
-            " health-check clients acting on status codes alone do not"
-            " restart the instance during cold start before the index has"
-            " loaded. Failing this should imply the process is wedged and"
-            " needs to be restarted."
+            "Liveness check. Returns 200 if the process can serve HTTP."
+            " Unlike /status, this endpoint intentionally does not check"
+            " index state, so health-check clients that act on HTTP status"
+            " codes alone (e.g. Kubernetes livenessProbe, and equivalents on"
+            " other orchestrators and load balancers) do not restart the"
+            " instance during cold start before the index has loaded."
+            " Failing this should imply the process is wedged and needs to"
+            " be restarted."
         ),
     )
-    def livez():
-        return "OK", 200
-
-    @app.get(
-        "/readyz",
-        tags=[Tag(name="Core")],
-        responses={
-            "200": {"description": "Service is ready to serve traffic"},
-            "503": {"description": "Service is not ready"},
-        },
-        summary="Readiness check",
-        description=(
-            "Readiness check. Returns 503 when a matcher has not yet loaded"
-            " its index (INDEX-NOT-LOADED) or when the cached index is stale"
-            " (INDEX-STALE), and 200 READY otherwise. Instances failing this"
-            " should be removed from the load balancer's serving set but not"
-            " restarted - restarting will not refresh a stale cache and may"
-            " cascade if the underlying cause is shared infrastructure (e.g."
-            " the database)."
-        ),
-    )
-    def readyz():
-        if app.config.get("ROLE_MATCHER", False):
-            if not matching.index_cache_is_ready():
-                return "INDEX-NOT-LOADED", 503
-            if matching.index_cache_is_stale():
-                return "INDEX-STALE", 503
-        return "READY", 200
+    def status_live():
+        return "I-AM-ALIVE", 200
 
     @app.get(
         "/site-map",

--- a/hasher-matcher-actioner/src/OpenMediaMatch/app.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/app.py
@@ -268,10 +268,11 @@ def create_app() -> OpenAPI:
         summary="Health check (deprecated)",
         description=(
             "Combined liveness/readiness check. Deprecated: prefer /livez for"
-            " liveness probes and /readyz for readiness probes. Pointing a"
-            " Kubernetes livenessProbe at this endpoint can cause"
-            " CrashLoopBackOff during cold start, since 503 is returned while"
-            " the index is still loading."
+            " liveness checks and /readyz for readiness checks. Health-check"
+            " clients that act on HTTP status codes alone (most load balancers"
+            " and orchestrators) cannot distinguish the failure modes this"
+            " endpoint reports, so using it as a liveness check causes restart"
+            " loops during cold start while the index is still loading."
         ),
     )
     def status():
@@ -291,9 +292,12 @@ def create_app() -> OpenAPI:
         responses={"200": {"description": "Service is alive"}},
         summary="Liveness check",
         description=(
-            "Kubernetes-style liveness probe. Returns 200 if the process can"
-            " serve HTTP. Does not check index state - failing this should"
-            " imply the pod needs to be restarted."
+            "Liveness check. Returns 200 if the process can serve HTTP. Does"
+            " not check index state - this is intentional, so that"
+            " health-check clients acting on status codes alone do not"
+            " restart the instance during cold start before the index has"
+            " loaded. Failing this should imply the process is wedged and"
+            " needs to be restarted."
         ),
     )
     def livez():
@@ -308,10 +312,13 @@ def create_app() -> OpenAPI:
         },
         summary="Readiness check",
         description=(
-            "Kubernetes-style readiness probe. Returns 503 when a matcher pod"
-            " has not yet loaded its index, or when the cached index is"
-            " stale. Pods failing this should be removed from service"
-            " endpoints but not restarted."
+            "Readiness check. Returns 503 when a matcher has not yet loaded"
+            " its index (INDEX-NOT-LOADED) or when the cached index is stale"
+            " (INDEX-STALE), and 200 READY otherwise. Instances failing this"
+            " should be removed from the load balancer's serving set but not"
+            " restarted - restarting will not refresh a stale cache and may"
+            " cascade if the underlying cause is shared infrastructure (e.g."
+            " the database)."
         ),
     )
     def readyz():

--- a/hasher-matcher-actioner/src/OpenMediaMatch/app.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/app.py
@@ -265,8 +265,14 @@ def create_app() -> OpenAPI:
             "200": {"description": "Service is alive"},
             "503": {"description": "Service is not ready"},
         },
-        summary="Health check",
-        description="Liveness/readiness check",
+        summary="Health check (deprecated)",
+        description=(
+            "Combined liveness/readiness check. Deprecated: prefer /livez for"
+            " liveness probes and /readyz for readiness probes. Pointing a"
+            " Kubernetes livenessProbe at this endpoint can cause"
+            " CrashLoopBackOff during cold start, since 503 is returned while"
+            " the index is still loading."
+        ),
     )
     def status():
         """
@@ -278,6 +284,43 @@ def create_app() -> OpenAPI:
             if matching.index_cache_is_stale():
                 return "INDEX-STALE", 503
         return "I-AM-ALIVE", 200
+
+    @app.get(
+        "/livez",
+        tags=[Tag(name="Core")],
+        responses={"200": {"description": "Service is alive"}},
+        summary="Liveness check",
+        description=(
+            "Kubernetes-style liveness probe. Returns 200 if the process can"
+            " serve HTTP. Does not check index state - failing this should"
+            " imply the pod needs to be restarted."
+        ),
+    )
+    def livez():
+        return "OK", 200
+
+    @app.get(
+        "/readyz",
+        tags=[Tag(name="Core")],
+        responses={
+            "200": {"description": "Service is ready to serve traffic"},
+            "503": {"description": "Service is not ready"},
+        },
+        summary="Readiness check",
+        description=(
+            "Kubernetes-style readiness probe. Returns 503 when a matcher pod"
+            " has not yet loaded its index, or when the cached index is"
+            " stale. Pods failing this should be removed from service"
+            " endpoints but not restarted."
+        ),
+    )
+    def readyz():
+        if app.config.get("ROLE_MATCHER", False):
+            if not matching.index_cache_is_ready():
+                return "INDEX-NOT-LOADED", 503
+            if matching.index_cache_is_stale():
+                return "INDEX-STALE", 503
+        return "READY", 200
 
     @app.get(
         "/site-map",

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
@@ -74,8 +74,10 @@ def test_status_response(client: FlaskClient, monkeypatch: MonkeyPatch):
 
 def test_livez_always_alive(client: FlaskClient, monkeypatch: MonkeyPatch):
     """
-    /livez must never fail because of index state - that would cause
-    CrashLoopBackOff during cold start.
+    /livez must never fail because of index state - that would cause a
+    restart loop during cold start under any health-check client that
+    triggers restarts on non-2xx (k8s livenessProbe, equivalents on other
+    platforms).
     """
     response = client.get("/livez")
     assert response.status_code == 200

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
@@ -72,6 +72,80 @@ def test_status_response(client: FlaskClient, monkeypatch: MonkeyPatch):
     assert response.data == b"I-AM-ALIVE"
 
 
+def test_livez_always_alive(client: FlaskClient, monkeypatch: MonkeyPatch):
+    """
+    /livez must never fail because of index state - that would cause
+    CrashLoopBackOff during cold start.
+    """
+    response = client.get("/livez")
+    assert response.status_code == 200
+    assert response.data == b"OK"
+
+    cache_val = matching._SignalIndexInMemoryCache(
+        PdqSignal,
+        PDQIndex2(),
+        SignalTypeIndexBuildCheckpoint(0, 0, 0),
+        last_check_ts=0.0,
+        sec_old_before_stale=65,
+    )
+    monkeypatch.setattr(
+        matching, "_get_index_cache", lambda: {PdqSignal.get_name(): cache_val}
+    )
+
+    # Index not loaded - /livez still alive
+    assert not cache_val.is_ready
+    response = client.get("/livez")
+    assert response.status_code == 200
+    assert response.data == b"OK"
+
+    # Index stale - /livez still alive
+    cache_val.last_check_ts = 1
+    assert cache_val.is_stale
+    response = client.get("/livez")
+    assert response.status_code == 200
+    assert response.data == b"OK"
+
+
+def test_readyz_response(client: FlaskClient, monkeypatch: MonkeyPatch):
+    response = client.get("/readyz")
+    assert response.status_code == 200
+    assert response.data == b"READY"
+
+    cache_val = matching._SignalIndexInMemoryCache(
+        PdqSignal,
+        PDQIndex2(),
+        SignalTypeIndexBuildCheckpoint(0, 0, 0),
+        last_check_ts=0.0,
+        sec_old_before_stale=0,
+    )
+    monkeypatch.setattr(
+        matching, "_get_index_cache", lambda: {PdqSignal.get_name(): cache_val}
+    )
+
+    # Index not yet loaded
+    response = client.get("/readyz")
+    assert response.status_code == 503
+    assert response.data == b"INDEX-NOT-LOADED"
+
+    # Loaded; staleness disabled by config
+    cache_val.last_check_ts = 1
+    response = client.get("/readyz")
+    assert response.status_code == 200
+    assert response.data == b"READY"
+
+    # Loaded but stale
+    cache_val.sec_old_before_stale = 65
+    response = client.get("/readyz")
+    assert response.status_code == 503
+    assert response.data == b"INDEX-STALE"
+
+    # Loaded and fresh
+    cache_val.last_check_ts = time.time()
+    response = client.get("/readyz")
+    assert response.status_code == 200
+    assert response.data == b"READY"
+
+
 def test_openapi_documentation_available(client: FlaskClient):
     response = client.get("/openapi/openapi.json")
     assert response.status_code == 200

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_api.py
@@ -72,16 +72,16 @@ def test_status_response(client: FlaskClient, monkeypatch: MonkeyPatch):
     assert response.data == b"I-AM-ALIVE"
 
 
-def test_livez_always_alive(client: FlaskClient, monkeypatch: MonkeyPatch):
+def test_status_live_always_alive(client: FlaskClient, monkeypatch: MonkeyPatch):
     """
-    /livez must never fail because of index state - that would cause a
-    restart loop during cold start under any health-check client that
-    triggers restarts on non-2xx (k8s livenessProbe, equivalents on other
-    platforms).
+    /status/live must never fail because of index state - that would cause
+    a restart loop during cold start under any health-check client that
+    triggers restarts on non-2xx (e.g. Kubernetes livenessProbe, and
+    equivalents on other orchestrators and load balancers).
     """
-    response = client.get("/livez")
+    response = client.get("/status/live")
     assert response.status_code == 200
-    assert response.data == b"OK"
+    assert response.data == b"I-AM-ALIVE"
 
     cache_val = matching._SignalIndexInMemoryCache(
         PdqSignal,
@@ -94,58 +94,18 @@ def test_livez_always_alive(client: FlaskClient, monkeypatch: MonkeyPatch):
         matching, "_get_index_cache", lambda: {PdqSignal.get_name(): cache_val}
     )
 
-    # Index not loaded - /livez still alive
+    # Index not loaded - /status/live still alive
     assert not cache_val.is_ready
-    response = client.get("/livez")
+    response = client.get("/status/live")
     assert response.status_code == 200
-    assert response.data == b"OK"
+    assert response.data == b"I-AM-ALIVE"
 
-    # Index stale - /livez still alive
+    # Index stale - /status/live still alive
     cache_val.last_check_ts = 1
     assert cache_val.is_stale
-    response = client.get("/livez")
+    response = client.get("/status/live")
     assert response.status_code == 200
-    assert response.data == b"OK"
-
-
-def test_readyz_response(client: FlaskClient, monkeypatch: MonkeyPatch):
-    response = client.get("/readyz")
-    assert response.status_code == 200
-    assert response.data == b"READY"
-
-    cache_val = matching._SignalIndexInMemoryCache(
-        PdqSignal,
-        PDQIndex2(),
-        SignalTypeIndexBuildCheckpoint(0, 0, 0),
-        last_check_ts=0.0,
-        sec_old_before_stale=0,
-    )
-    monkeypatch.setattr(
-        matching, "_get_index_cache", lambda: {PdqSignal.get_name(): cache_val}
-    )
-
-    # Index not yet loaded
-    response = client.get("/readyz")
-    assert response.status_code == 503
-    assert response.data == b"INDEX-NOT-LOADED"
-
-    # Loaded; staleness disabled by config
-    cache_val.last_check_ts = 1
-    response = client.get("/readyz")
-    assert response.status_code == 200
-    assert response.data == b"READY"
-
-    # Loaded but stale
-    cache_val.sec_old_before_stale = 65
-    response = client.get("/readyz")
-    assert response.status_code == 503
-    assert response.data == b"INDEX-STALE"
-
-    # Loaded and fresh
-    cache_val.last_check_ts = time.time()
-    response = client.get("/readyz")
-    assert response.status_code == 200
-    assert response.data == b"READY"
+    assert response.data == b"I-AM-ALIVE"
 
 
 def test_openapi_documentation_available(client: FlaskClient):


### PR DESCRIPTION
## Summary

Splits the combined `/status` health check into separate `/livez` (liveness) and `/readyz` (readiness) endpoints. Closes #1905.

### Why the previous fix didn't work

#1912 disambiguated the cold-start case (`INDEX-NOT-LOADED`) from staleness (`INDEX-STALE`) in the response *body*, but most health-check clients only inspect the response *status code*. From their perspective both still return `503`, so pointing both a liveness and a readiness check at `/status` is effectively the same check, and during index reloading those `503` responses can cause a restart loop before the index can finish loading.

### What this PR does

- **`/livez`** — minimal liveness. Failing this should mean the instance needs to be restarted.
- **`/readyz`** — readiness. Mirrors the existing `/status` checks
- **`/status`** — left untouched for backwards compatibility.

### Migration

Example (Kubernetes):

```yaml
livenessProbe:
  httpGet:
    path: /livez
    port: 5100
readinessProbe:
  httpGet:
    path: /readyz
    port: 5100
```

## Test plan

- added unit tests
- built dev container and ran curl against all 3 status endpoints