### PR TITLE
[hma] Website: Fix packageManager hash version

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "preview": "vitepress preview"
   },
   "license": "BSD-3-Clause",
-  "packageManager": "pnpm@10.33.1+sha512.05ba3c1d5d1c18f68df06470d74055e62d41fc110a0c660db1b2dfb2785327f04cf0f68345d4609bc52089e7fa0343c31593b2f9594e2c5d5da426230acc9820",
+  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
   "devDependencies": {
     "vitepress": "2.0.0-alpha.17"
   },


### PR DESCRIPTION
This PR exists purely to trigger a re-run of the website release (deploy) once the github pages settings are fixed.

https://github.com/facebook/ThreatExchange/actions/runs/25240023616/job/74014109492

We want deploy from workflow, not deploy from gh-pages (and we can actually delete any gh-pages branch remaining on this repo)

<img width="1144" height="658" alt="image" src="https://github.com/user-attachments/assets/70f87b05-0918-4a9b-bd1b-0cc9fb29048e" />
