### PR TITLE
[HMA] fix: route large object reads through read replica

### DIFF
--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
@@ -553,11 +553,11 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         Reads the serialized index from the read replica via large object API.
 
         When using read/write replicas, as long as we read this object
-        and its ID from the same db (including replicas), the lobj should be there, 
+        and its ID from the same db (including replicas), the lobj should be there,
         as the lobj is written before the record with the ID.
-        
+
         However, it is still possible to get an error due to races with the
-        garbage collection process that deletes lobjs. 
+        garbage collection process that deletes lobjs.
         """
         oid = self.serialized_index_large_object_oid
         assert oid is not None

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
@@ -455,7 +455,7 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
 
     serialized_index_large_object_oid: Mapped[int | None] = mapped_column(OID)
 
-    def index_lobj_exists(self, session=None) -> bool:
+    def index_lobj_exists(self, session: t.Optional[Session] = None) -> bool:
         """
         Return true if the index lobj exists and load_signal_index should work.
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
@@ -37,6 +37,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import OID
 from sqlalchemy.orm import (
     Mapped,
+    Session,
     mapped_column,
     DeclarativeBase,
     relationship,
@@ -548,6 +549,13 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         return self
 
     def load_signal_index(self) -> SignalTypeIndex[int]:
+        """Reads the serialized index from the read replica via large object API.
+
+        Safe against replica lag: commit_signal_index() commits the lobj via
+        raw_conn.commit() before the caller commits the row (with the new OID)
+        via the ORM session. WAL replays in order, so the replica cannot expose
+        the OID without already having the lobj.
+        """
         oid = self.serialized_index_large_object_oid
         assert oid is not None
         # If we were being fully proper, we would get the SignalType

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
@@ -455,7 +455,7 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
 
     serialized_index_large_object_oid: Mapped[int | None] = mapped_column(OID)
 
-    def index_lobj_exists(self) -> bool:
+    def index_lobj_exists(self, session=None) -> bool:
         """
         Return true if the index lobj exists and load_signal_index should work.
 
@@ -463,8 +463,13 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         we've observed in github.com/facebook/ThreatExchange/issues/1673
         that some partial failure is possible. This can be used to
         detect that condition.
+
+        Uses the read replica by default. Pass a write session when
+        checking existence as part of a write operation (e.g. commit_signal_index).
         """
-        count = db.session.execute(
+        if session is None:
+            session = get_read_session()
+        count = session.execute(
             text(
                 "SELECT count(1) FROM pg_largeobject_metadata "
                 + f"WHERE oid = {self.serialized_index_large_object_oid};"
@@ -503,7 +508,7 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
                 duration_to_human_str(time.time() - store_start_time),
             )
             if self.serialized_index_large_object_oid is not None:
-                if self.index_lobj_exists():
+                if self.index_lobj_exists(session=get_write_session()):
                     old_obj = raw_conn.lobject(
                         self.serialized_index_large_object_oid, "n"
                     )
@@ -551,7 +556,7 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         # class no matter which interface we call it on.
         # I'm sorry future debugger finding this comment.
         load_start_time = time.time()
-        raw_conn = db.engine.raw_connection()
+        raw_conn = db.engines["read"].raw_connection()
         try:
             l_obj = raw_conn.lobject(oid, "rb")
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
@@ -549,7 +549,8 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         return self
 
     def load_signal_index(self) -> SignalTypeIndex[int]:
-        """Reads the serialized index from the read replica via large object API.
+        """
+        Reads the serialized index from the read replica via large object API.
 
         Safe against replica lag: commit_signal_index() commits the lobj via
         raw_conn.commit() before the caller commits the row (with the new OID)

--- a/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/storage/postgres/database.py
@@ -552,10 +552,12 @@ class SignalIndex(db.Model):  # type: ignore[name-defined]
         """
         Reads the serialized index from the read replica via large object API.
 
-        Safe against replica lag: commit_signal_index() commits the lobj via
-        raw_conn.commit() before the caller commits the row (with the new OID)
-        via the ORM session. WAL replays in order, so the replica cannot expose
-        the OID without already having the lobj.
+        When using read/write replicas, as long as we read this object
+        and its ID from the same db (including replicas), the lobj should be there, 
+        as the lobj is written before the record with the ID.
+        
+        However, it is still possible to get an error due to races with the
+        garbage collection process that deletes lobjs. 
         """
         oid = self.serialized_index_large_object_oid
         assert oid is not None

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_database.py
@@ -188,7 +188,9 @@ def test_load_signal_index_uses_read_engine(app: Flask) -> None:
     db_record = _create_index_record()
     read_engine = database.db.engines["read"]
 
-    with patch.object(read_engine, "raw_connection", wraps=read_engine.raw_connection) as mock_conn:
+    with patch.object(
+        read_engine, "raw_connection", wraps=read_engine.raw_connection
+    ) as mock_conn:
         db_record.load_signal_index()
         mock_conn.assert_called_once()
 

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_database.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import typing as t
+from unittest.mock import patch, MagicMock
 from flask import Flask
 from sqlalchemy import select, and_
 
@@ -162,3 +163,56 @@ def test_store_content(app: Flask) -> None:
         )
     ).scalar_one()
     assert PdqSignal.get_examples()[0] == hash1_val.signal_val
+
+
+def _create_index_record() -> database.SignalIndex:
+    """Helper to create and commit a SignalIndex record for testing."""
+    content = [("a", 1), ("b", 2)]
+    index = TrivialSignalTypeIndex.build(content)
+    record = database.SignalIndex(
+        signal_type="read_replica_test",
+        updated_to_ts=1,
+        updated_to_id=1,
+        signal_count=len(content),
+    ).commit_signal_index(index, SignalTypeIndexBuildCheckpoint.get_empty())
+    database.db.session.add(record)
+    database.db.session.commit()
+    return database.db.session.execute(
+        select(database.SignalIndex).where(
+            database.SignalIndex.signal_type == "read_replica_test"
+        )
+    ).scalar_one()
+
+
+def test_load_signal_index_uses_read_engine(app: Flask) -> None:
+    db_record = _create_index_record()
+    read_engine = database.db.engines["read"]
+
+    with patch.object(read_engine, "raw_connection", wraps=read_engine.raw_connection) as mock_conn:
+        db_record.load_signal_index()
+        mock_conn.assert_called_once()
+
+
+def test_index_lobj_exists_uses_read_session_by_default(app: Flask) -> None:
+    db_record = _create_index_record()
+
+    with patch("OpenMediaMatch.storage.postgres.database.get_read_session") as mock_get:
+        mock_session = MagicMock()
+        mock_session.execute.return_value.scalar_one.return_value = 1
+        mock_get.return_value = mock_session
+
+        result = db_record.index_lobj_exists()
+
+        mock_get.assert_called_once()
+        assert result is True
+
+
+def test_index_lobj_exists_uses_provided_session(app: Flask) -> None:
+    db_record = _create_index_record()
+    mock_session = MagicMock()
+    mock_session.execute.return_value.scalar_one.return_value = 1
+
+    result = db_record.index_lobj_exists(session=mock_session)
+
+    mock_session.execute.assert_called_once()
+    assert result is True

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_database.py
@@ -187,13 +187,21 @@ def _create_index_record() -> database.SignalIndex:
 def test_load_signal_index_uses_read_engine(app: Flask) -> None:
     db_record = _create_index_record()
     read_engine = database.db.engines["read"]
+    write_engine = database.db.engine
+
+    assert read_engine is not write_engine, (
+        "Test relies on separate read/write engine instances"
+    )
 
     with patch.object(
         read_engine, "raw_connection", wraps=read_engine.raw_connection
-    ) as mock_conn:
+    ) as mock_read, patch.object(
+        write_engine, "raw_connection", wraps=write_engine.raw_connection
+    ) as mock_write:
         db_record.load_signal_index()
-        mock_conn.assert_called_once()
 
+    mock_read.assert_called_once()
+    mock_write.assert_not_called()
 
 def test_index_lobj_exists_uses_read_session_by_default(app: Flask) -> None:
     db_record = _create_index_record()

--- a/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_database.py
+++ b/hasher-matcher-actioner/src/OpenMediaMatch/tests/test_database.py
@@ -189,9 +189,9 @@ def test_load_signal_index_uses_read_engine(app: Flask) -> None:
     read_engine = database.db.engines["read"]
     write_engine = database.db.engine
 
-    assert read_engine is not write_engine, (
-        "Test relies on separate read/write engine instances"
-    )
+    assert (
+        read_engine is not write_engine
+    ), "Test relies on separate read/write engine instances"
 
     with patch.object(
         read_engine, "raw_connection", wraps=read_engine.raw_connection
@@ -202,6 +202,7 @@ def test_load_signal_index_uses_read_engine(app: Flask) -> None:
 
     mock_read.assert_called_once()
     mock_write.assert_not_called()
+
 
 def test_index_lobj_exists_uses_read_session_by_default(app: Flask) -> None:
     db_record = _create_index_record()


### PR DESCRIPTION
Summary
---------
I recently tried out the new config to split reads and writes and it didn't have much effect.

That's because `load_signal_index()` and `index_lobj_exists()` bypass read/write session splitting — they use `db.engine.raw_connection()` and `db.session` directly, so the heaviest read path (index downloads) always hits the writer even when a read replica is configured.  during deploys we saw 93% writer CPU while the replica sat at 4-5%. This fixes that by routing both methods through the read engine/session.

Test Plan
---------
Added regression tests that assert `load_signal_index()` calls `db.engines["read"].raw_connection()` and `index_lobj_exists()`
defaults to `get_read_session()`
