### PR TITLE
Add Terms of Use and Privacy Policy links to docs site footer

### DIFF
--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -78,7 +78,7 @@ export default defineConfig({
 
     footer: {
       message:
-        'Released under the <a href="https://github.com/facebook/ThreatExchange/blob/main/LICENSE">BSD License</a>.',
+        'Released under the <a href="https://github.com/facebook/ThreatExchange/blob/main/LICENSE">BSD License</a>. | <a href="https://opensource.facebook.com/legal/terms">Terms of Use</a> | <a href="https://opensource.facebook.com/legal/privacy">Privacy Policy</a>',
       copyright: "Copyright (c) Meta Platforms, Inc. and affiliates.",
     },
 


### PR DESCRIPTION
Summary
---------

Adding in Meta's open source terms of use and privacy policy links to the home page.

Test Plan
---------

<img width="1327" height="811" alt="image" src="https://github.com/user-attachments/assets/8cbfa819-a20d-4257-a919-2fb5bdb49272" />